### PR TITLE
Move enum rsc_recovery_type to libcrmcommon

### DIFF
--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2022 the Pacemaker project contributors
+# Copyright 2004-2023 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -27,8 +27,10 @@ header_HEADERS = acl.h \
 				 mainloop_compat.h \
 				 nvpair.h \
 				 output.h \
+				 resources.h		\
 				 results.h \
 				 results_compat.h \
+				 scheduler.h		\
 				 util.h \
 				 util_compat.h \
 				 xml.h \

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -24,6 +24,7 @@ extern "C" {
 enum rsc_recovery_type {
     pcmk_multiply_active_restart    = 0,    //!< Stop on all, start on desired
     pcmk_multiply_active_stop       = 1,    //!< Stop on all and leave stopped
+    pcmk_multiply_active_block      = 2,    //!< Do nothing to resource
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_multiply_active_restart instead
@@ -32,7 +33,7 @@ enum rsc_recovery_type {
     //! \deprecated Use pcmk_multiply_active_stop instead
     recovery_stop_only              = pcmk_multiply_active_stop,
 #endif
-    recovery_block                  = 2,
+    recovery_block                  = pcmk_multiply_active_block,
     recovery_stop_unexpected        = 3,
 };
 

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -36,8 +36,10 @@ enum rsc_recovery_type {
 
     //! \deprecated Use pcmk_multiply_active_block instead
     recovery_block                  = pcmk_multiply_active_block,
-#endif
+
+    //! \deprecated Use pcmk_multiply_active_unexpected instead
     recovery_stop_unexpected        = pcmk_multiply_active_unexpected,
+#endif
 };
 
 #ifdef __cplusplus

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -25,6 +25,7 @@ enum rsc_recovery_type {
     pcmk_multiply_active_restart    = 0,    //!< Stop on all, start on desired
     pcmk_multiply_active_stop       = 1,    //!< Stop on all and leave stopped
     pcmk_multiply_active_block      = 2,    //!< Do nothing to resource
+    pcmk_multiply_active_unexpected = 3,    //!< Stop unexpected instances
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_multiply_active_restart instead
@@ -36,7 +37,7 @@ enum rsc_recovery_type {
     //! \deprecated Use pcmk_multiply_active_block instead
     recovery_block                  = pcmk_multiply_active_block,
 #endif
-    recovery_stop_unexpected        = 3,
+    recovery_stop_unexpected        = pcmk_multiply_active_unexpected,
 };
 
 #ifdef __cplusplus

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -32,8 +32,10 @@ enum rsc_recovery_type {
 
     //! \deprecated Use pcmk_multiply_active_stop instead
     recovery_stop_only              = pcmk_multiply_active_stop,
-#endif
+
+    //! \deprecated Use pcmk_multiply_active_block instead
     recovery_block                  = pcmk_multiply_active_block,
+#endif
     recovery_stop_unexpected        = 3,
 };
 

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -28,8 +28,10 @@ enum rsc_recovery_type {
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_multiply_active_restart instead
     recovery_stop_start             = pcmk_multiply_active_restart,
-#endif
+
+    //! \deprecated Use pcmk_multiply_active_stop instead
     recovery_stop_only              = pcmk_multiply_active_stop,
+#endif
     recovery_block                  = 2,
     recovery_stop_unexpected        = 3,
 };

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -22,10 +22,12 @@ extern "C" {
 
 //! How to recover a resource that is incorrectly active on multiple nodes
 enum rsc_recovery_type {
-    recovery_stop_start,
-    recovery_stop_only,
-    recovery_block,
-    recovery_stop_unexpected,
+    pcmk_multiply_active_restart    = 0,    //!< Stop on all, start on desired
+
+    recovery_stop_start             = pcmk_multiply_active_restart,
+    recovery_stop_only              = 1,
+    recovery_block                  = 2,
+    recovery_stop_unexpected        = 3,
 };
 
 #ifdef __cplusplus

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -23,12 +23,13 @@ extern "C" {
 //! How to recover a resource that is incorrectly active on multiple nodes
 enum rsc_recovery_type {
     pcmk_multiply_active_restart    = 0,    //!< Stop on all, start on desired
+    pcmk_multiply_active_stop       = 1,    //!< Stop on all and leave stopped
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_multiply_active_restart instead
     recovery_stop_start             = pcmk_multiply_active_restart,
 #endif
-    recovery_stop_only              = 1,
+    recovery_stop_only              = pcmk_multiply_active_stop,
     recovery_block                  = 2,
     recovery_stop_unexpected        = 3,
 };

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -24,7 +24,10 @@ extern "C" {
 enum rsc_recovery_type {
     pcmk_multiply_active_restart    = 0,    //!< Stop on all, start on desired
 
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated Use pcmk_multiply_active_restart instead
     recovery_stop_start             = pcmk_multiply_active_restart,
+#endif
     recovery_stop_only              = 1,
     recovery_block                  = 2,
     recovery_stop_unexpected        = 3,

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2004-2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CRM_COMMON_RESOURCES__H
+#  define PCMK__CRM_COMMON_RESOURCES__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \file
+ * \brief Scheduler API for resources
+ * \ingroup core
+ */
+
+//! How to recover a resource that is incorrectly active on multiple nodes
+enum rsc_recovery_type {
+    recovery_stop_start,
+    recovery_stop_only,
+    recovery_block,
+    recovery_stop_unexpected,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__CRM_COMMON_RESOURCES__H

--- a/include/crm/common/scheduler.h
+++ b/include/crm/common/scheduler.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2004-2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CRM_COMMON_SCHEDULER__H
+#  define PCMK__CRM_COMMON_SCHEDULER__H
+
+#include <crm/common/resources.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \file
+ * \brief Scheduler API
+ * \ingroup core
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__CRM_COMMON_SCHEDULER__H

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -13,6 +13,7 @@
 #  include <glib.h>
 #  include <regex.h>
 #  include <crm/common/iso8601.h>
+#  include <crm/common/scheduler.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,13 +74,6 @@ enum action_tasks {
     action_demoted,
     shutdown_crm,
     stonith_node
-};
-
-enum rsc_recovery_type {
-    recovery_stop_start,
-    recovery_stop_only,
-    recovery_block,
-    recovery_stop_unexpected,
 };
 
 enum rsc_start_requirement {

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -148,7 +148,7 @@ static inline const char *
 recovery2text(enum rsc_recovery_type type)
 {
     switch (type) {
-        case recovery_stop_only:
+        case pcmk_multiply_active_stop:
             return "shutting it down";
         case pcmk_multiply_active_restart:
             return "attempting recovery";

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -152,7 +152,7 @@ recovery2text(enum rsc_recovery_type type)
             return "shutting it down";
         case pcmk_multiply_active_restart:
             return "attempting recovery";
-        case recovery_block:
+        case pcmk_multiply_active_block:
             return "waiting for an administrator";
         case recovery_stop_unexpected:
             return "stopping unexpected instances";

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -154,7 +154,7 @@ recovery2text(enum rsc_recovery_type type)
             return "attempting recovery";
         case pcmk_multiply_active_block:
             return "waiting for an administrator";
-        case recovery_stop_unexpected:
+        case pcmk_multiply_active_unexpected:
             return "stopping unexpected instances";
     }
     return "Unknown";

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -150,7 +150,7 @@ recovery2text(enum rsc_recovery_type type)
     switch (type) {
         case recovery_stop_only:
             return "shutting it down";
-        case recovery_stop_start:
+        case pcmk_multiply_active_restart:
             return "attempting recovery";
         case recovery_block:
             return "waiting for an administrator";

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -747,7 +747,7 @@ pcmk__primitive_create_actions(pe_resource_t *rsc)
                    "#Resource_is_Too_Active for more information");
 
         switch (rsc->recovery_type) {
-            case recovery_stop_start:
+            case pcmk_multiply_active_restart:
                 need_stop = true;
                 break;
             case recovery_stop_unexpected:

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -750,7 +750,7 @@ pcmk__primitive_create_actions(pe_resource_t *rsc)
             case pcmk_multiply_active_restart:
                 need_stop = true;
                 break;
-            case recovery_stop_unexpected:
+            case pcmk_multiply_active_unexpected:
                 need_stop = true; // stop_resource() will skip expected node
                 pe__set_resource_flags(rsc, pe_rsc_stop_unexpected);
                 break;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -796,7 +796,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
                      (*rsc)->id);
 
     } else if (pcmk__str_eq(value, "stop_unexpected", pcmk__str_casei)) {
-        (*rsc)->recovery_type = recovery_stop_unexpected;
+        (*rsc)->recovery_type = pcmk_multiply_active_unexpected;
         pe_rsc_trace((*rsc), "%s multiple running resource recovery: "
                              "stop unexpected instances",
                      (*rsc)->id);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -791,7 +791,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
                      (*rsc)->id);
 
     } else if (pcmk__str_eq(value, "block", pcmk__str_casei)) {
-        (*rsc)->recovery_type = recovery_block;
+        (*rsc)->recovery_type = pcmk_multiply_active_block;
         pe_rsc_trace((*rsc), "%s multiple running resource recovery: block",
                      (*rsc)->id);
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -786,7 +786,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
 
     value = g_hash_table_lookup((*rsc)->meta, XML_RSC_ATTR_MULTIPLE);
     if (pcmk__str_eq(value, "stop_only", pcmk__str_casei)) {
-        (*rsc)->recovery_type = recovery_stop_only;
+        (*rsc)->recovery_type = pcmk_multiply_active_stop;
         pe_rsc_trace((*rsc), "%s multiple running resource recovery: stop only",
                      (*rsc)->id);
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -698,7 +698,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
     (*rsc)->role = RSC_ROLE_STOPPED;
     (*rsc)->next_role = RSC_ROLE_UNKNOWN;
 
-    (*rsc)->recovery_type = recovery_stop_start;
+    (*rsc)->recovery_type = pcmk_multiply_active_restart;
     (*rsc)->stickiness = 0;
     (*rsc)->migration_threshold = INFINITY;
     (*rsc)->failure_timeout = 0;
@@ -807,7 +807,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
             pe_warn("%s is not a valid value for " XML_RSC_ATTR_MULTIPLE
                     ", using default of \"stop_start\"", value);
         }
-        (*rsc)->recovery_type = recovery_stop_start;
+        (*rsc)->recovery_type = pcmk_multiply_active_restart;
         pe_rsc_trace((*rsc), "%s multiple running resource recovery: "
                              "stop/start", (*rsc)->id);
     }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -167,7 +167,9 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                     }
                 }
                 break;
-            default: // pcmk_multiply_active_restart, recovery_stop_unexpected
+
+            // pcmk_multiply_active_restart, pcmk_multiply_active_unexpected
+            default:
                 /* The scheduler will do the right thing because the relevant
                  * variables and flags are set when unpacking the history.
                  */

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -147,7 +147,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                     }
                 }
                 break;
-            case recovery_block:
+            case pcmk_multiply_active_block:
                 pe__clear_resource_flags(rsc, pe_rsc_managed);
                 pe__set_resource_flags(rsc, pe_rsc_block);
 
@@ -156,7 +156,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                  */
                 if (rsc->parent
                     && (rsc->parent->variant == pe_group || rsc->parent->variant == pe_container)
-                    && rsc->parent->recovery_type == recovery_block) {
+                    && (rsc->parent->recovery_type == pcmk_multiply_active_block)) {
                     GList *gIter = rsc->parent->children;
 
                     for (; gIter != NULL; gIter = gIter->next) {

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -131,7 +131,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
 
     if (is_multiply_active(rsc)) {
         switch (rsc->recovery_type) {
-            case recovery_stop_only:
+            case pcmk_multiply_active_stop:
                 {
                     GHashTableIter gIter;
                     pe_node_t *local_node = NULL;

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -167,7 +167,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                     }
                 }
                 break;
-            default: // recovery_stop_start, recovery_stop_unexpected
+            default: // pcmk_multiply_active_restart, recovery_stop_unexpected
                 /* The scheduler will do the right thing because the relevant
                  * variables and flags are set when unpacking the history.
                  */


### PR DESCRIPTION
This is the start of a project to merge the functionality of libpe_rules and libpe_status into libcrmcommon.