### PR TITLE
Use a single cib__operation_t table for pacemaker-based and libcib

### DIFF
--- a/daemons/based/Makefile.am
+++ b/daemons/based/Makefile.am
@@ -29,10 +29,10 @@ pacemaker_based_LDADD	= $(top_builddir)/lib/cluster/libcrmcluster.la \
 
 pacemaker_based_SOURCES	= pacemaker-based.c \
 			  based_callbacks.c \
-			  based_common.c \
 			  based_io.c \
 			  based_messages.c \
 			  based_notify.c \
+			  based_operation.c \
 			  based_remote.c \
 			  based_transaction.c
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -59,7 +59,7 @@ qb_ipcs_service_t *ipcs_rw = NULL;
 qb_ipcs_service_t *ipcs_shm = NULL;
 
 static int cib_process_command(xmlNode *request,
-                               const cib_operation_t *operation,
+                               const cib__operation_t *operation,
                                cib__op_fn_t op_function, xmlNode **reply,
                                xmlNode **cib_diff, bool privileged);
 
@@ -572,7 +572,7 @@ queue_local_notify(xmlNode * notify_src, const char *client_id, gboolean sync_re
 
 static void
 parse_local_options_v1(const pcmk__client_t *cib_client,
-                       const cib_operation_t *operation, int call_options,
+                       const cib__operation_t *operation, int call_options,
                        const char *host, const char *op, gboolean *local_notify,
                        gboolean *needs_reply, gboolean *process,
                        gboolean *needs_forward)
@@ -616,7 +616,7 @@ parse_local_options_v1(const pcmk__client_t *cib_client,
 
 static void
 parse_local_options_v2(const pcmk__client_t *cib_client,
-                       const cib_operation_t *operation, int call_options,
+                       const cib__operation_t *operation, int call_options,
                        const char *host, const char *op, gboolean *local_notify,
                        gboolean *needs_reply, gboolean *process,
                        gboolean *needs_forward)
@@ -676,7 +676,7 @@ parse_local_options_v2(const pcmk__client_t *cib_client,
 
 static void
 parse_local_options(const pcmk__client_t *cib_client,
-                    const cib_operation_t *operation, int call_options,
+                    const cib__operation_t *operation, int call_options,
                     const char *host, const char *op, gboolean *local_notify,
                     gboolean *needs_reply, gboolean *process,
                     gboolean *needs_forward)
@@ -706,7 +706,7 @@ parse_local_options(const pcmk__client_t *cib_client,
 }
 
 static gboolean
-parse_peer_options_v1(const cib_operation_t *operation, xmlNode *request,
+parse_peer_options_v1(const cib__operation_t *operation, xmlNode *request,
                       gboolean *local_notify, gboolean *needs_reply,
                       gboolean *process)
 {
@@ -804,7 +804,7 @@ parse_peer_options_v1(const cib_operation_t *operation, xmlNode *request,
 }
 
 static gboolean
-parse_peer_options_v2(const cib_operation_t *operation, xmlNode *request,
+parse_peer_options_v2(const cib__operation_t *operation, xmlNode *request,
                       gboolean *local_notify, gboolean *needs_reply,
                       gboolean *process)
 {
@@ -925,7 +925,7 @@ parse_peer_options_v2(const cib_operation_t *operation, xmlNode *request,
 }
 
 static gboolean
-parse_peer_options(const cib_operation_t *operation, xmlNode *request,
+parse_peer_options(const cib__operation_t *operation, xmlNode *request,
                    gboolean *local_notify, gboolean *needs_reply,
                    gboolean *process)
 {
@@ -1076,7 +1076,7 @@ cib_process_request(xmlNode *request, gboolean privileged,
     const char *client_name = crm_element_value(request, F_CIB_CLIENTNAME);
     const char *reply_to = crm_element_value(request, F_CIB_ISREPLY);
 
-    const cib_operation_t *operation = NULL;
+    const cib__operation_t *operation = NULL;
     cib__op_fn_t op_function = NULL;
 
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
@@ -1426,7 +1426,7 @@ get_change_sections(const struct digest_data *before,
  */
 static bool
 should_replace_notify(const struct digest_data *before_digests,
-                      xmlNode *after_cib, const cib_operation_t *operation,
+                      xmlNode *after_cib, const cib__operation_t *operation,
                       int call_options, uint32_t *change_sections)
 {
     struct digest_data after_digests = { 0, };
@@ -1473,7 +1473,7 @@ contains_config_change(xmlNode *diff)
 }
 
 static int
-cib_process_command(xmlNode *request, const cib_operation_t *operation,
+cib_process_command(xmlNode *request, const cib__operation_t *operation,
                     cib__op_fn_t op_function, xmlNode **reply,
                     xmlNode **cib_diff, bool privileged)
 {

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1618,11 +1618,10 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
                                   output);
     }
 
-    crm_trace("cleanup");
-    operation->cleanup(call_options, &input, &output);
-
+    if (output != the_cib) {
+        free_xml(output);
+    }
     free_digests(&before_digests);
-
     crm_trace("done");
     return rc;
 }

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -577,7 +577,7 @@ parse_local_options_v1(const pcmk__client_t *cib_client,
                        gboolean *needs_reply, gboolean *process,
                        gboolean *needs_forward)
 {
-    if (pcmk_is_set(operation->flags, cib_op_attr_modifies)
+    if (pcmk_is_set(operation->flags, cib__op_attr_modifies)
         && !pcmk_is_set(call_options, cib_inhibit_bcast)) {
         /* we need to send an update anyway */
         *needs_reply = TRUE;
@@ -627,8 +627,8 @@ parse_local_options_v2(const pcmk__client_t *cib_client,
     *local_notify = TRUE;
     *needs_forward = FALSE;
 
-    if (pcmk_is_set(operation->flags, cib_op_attr_local)) {
-        /* Always process locally if cib_op_attr_local is set.
+    if (pcmk_is_set(operation->flags, cib__op_attr_local)) {
+        /* Always process locally if cib__op_attr_local is set.
          *
          * @COMPAT: Currently host is ignored. At a compatibility break, throw
          * an error (from cib_process_request() or earlier) if host is not NULL or
@@ -647,7 +647,7 @@ parse_local_options_v2(const pcmk__client_t *cib_client,
         return;
     }
 
-    if (pcmk_is_set(operation->flags, cib_op_attr_modifies)
+    if (pcmk_is_set(operation->flags, cib__op_attr_modifies)
         || !pcmk__str_eq(host, OUR_NODENAME,
                          pcmk__str_casei|pcmk__str_null_matches)) {
 
@@ -874,7 +874,7 @@ parse_peer_options_v2(const cib_operation_t *operation, xmlNode *request,
         return FALSE;
 
     } else if (is_reply
-               && pcmk_is_set(operation->flags, cib_op_attr_modifies)) {
+               && pcmk_is_set(operation->flags, cib__op_attr_modifies)) {
         crm_trace("Ignoring legacy %s reply sent from %s to local clients", op, originator);
         return FALSE;
 
@@ -1120,10 +1120,10 @@ cib_process_request(xmlNode *request, gboolean privileged,
 
     if (pcmk_is_set(call_options, cib_transaction)) {
         /* We're committing a transaction now, processing each request. If
-         * cib_op_attr_transaction is not set, based_extend_transaction() should
+         * cib__op_attr_transaction is not set, based_extend_transaction() should
          * have blocked the request from being added to the transaction.
          */
-        CRM_CHECK(pcmk_is_set(operation->flags, cib_op_attr_transaction),
+        CRM_CHECK(pcmk_is_set(operation->flags, cib__op_attr_transaction),
                   return -EOPNOTSUPP);
     }
 
@@ -1137,7 +1137,7 @@ cib_process_request(xmlNode *request, gboolean privileged,
         return rc;
     }
 
-    is_update = pcmk_is_set(operation->flags, cib_op_attr_modifies);
+    is_update = pcmk_is_set(operation->flags, cib__op_attr_modifies);
 
     if (pcmk_is_set(call_options, cib_discard_reply)) {
         /* If the request will modify the CIB, and we are in legacy mode, we
@@ -1433,7 +1433,7 @@ should_replace_notify(const struct digest_data *before_digests,
 
     *change_sections = cib_change_section_none;
 
-    if (!pcmk_is_set(operation->flags, cib_op_attr_replaces)
+    if (!pcmk_is_set(operation->flags, cib__op_attr_replaces)
         || pcmk_is_set(call_options, cib_inhibit_notify)) {
         return false;
     }
@@ -1512,7 +1512,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     op = crm_element_value(request, F_CIB_OPERATION);
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
 
-    if (!privileged && pcmk_is_set(operation->flags, cib_op_attr_privileged)) {
+    if (!privileged && pcmk_is_set(operation->flags, cib__op_attr_privileged)) {
         rc = -EACCES;
         crm_trace("Failed due to lack of privileges: %s", pcmk_strerror(rc));
         goto done;
@@ -1520,7 +1520,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
 
     input = prepare_input(request, operation->type, &section);
 
-    if (!pcmk_is_set(operation->flags, cib_op_attr_modifies)) {
+    if (!pcmk_is_set(operation->flags, cib__op_attr_modifies)) {
         rc = cib_perform_op(op, call_options, op_function, true, section,
                             request, input, false, &config_changed, &the_cib,
                             &result_cib, NULL, &output);
@@ -1554,7 +1554,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
     }
 
     // Calculate the digests of relevant sections before the operation
-    if (pcmk_is_set(operation->flags, cib_op_attr_replaces)
+    if (pcmk_is_set(operation->flags, cib__op_attr_replaces)
         && !pcmk_any_flags_set(call_options,
                                cib_dryrun|cib_inhibit_notify|cib_transaction)) {
 
@@ -1588,7 +1588,7 @@ cib_process_command(xmlNode *request, const cib_operation_t *operation,
      * negates the need to detect ordering changes.
      */
     if ((rc == pcmk_ok)
-        && pcmk_is_set(operation->flags, cib_op_attr_writes_through)) {
+        && pcmk_is_set(operation->flags, cib__op_attr_writes_through)) {
 
         config_changed = true;
     }

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -20,6 +20,9 @@
 #include <fcntl.h>
 #include <inttypes.h>   // PRIu64
 
+#include <glib.h>
+#include <libxml/tree.h>
+
 #include <crm/crm.h>
 #include <crm/cib.h>
 #include <crm/msg_xml.h>

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -109,54 +109,21 @@ cib_prepare_diff(xmlNode * request, xmlNode ** data, const char **section)
     return pcmk_ok;
 }
 
-static int
-cib_cleanup_query(int options, xmlNode ** data, xmlNode ** output)
-{
-    CRM_LOG_ASSERT(*data == NULL);
-    if (*output != the_cib) {
-        free_xml(*output);
-    }
-    return pcmk_ok;
-}
-
-static int
-cib_cleanup_data(int options, xmlNode ** data, xmlNode ** output)
-{
-    free_xml(*output);
-    *data = NULL;
-    return pcmk_ok;
-}
-
-static int
-cib_cleanup_output(int options, xmlNode ** data, xmlNode ** output)
-{
-    free_xml(*output);
-    return pcmk_ok;
-}
-
-static int
-cib_cleanup_none(int options, xmlNode ** data, xmlNode ** output)
-{
-    CRM_LOG_ASSERT(*data == NULL);
-    CRM_LOG_ASSERT(*output == NULL);
-    return pcmk_ok;
-}
-
 static const cib_operation_t cib_server_ops[] = {
     {
         PCMK__CIB_REQUEST_QUERY,
         cib_op_attr_none,
-        cib_prepare_none, cib_cleanup_query, cib_process_query
+        cib_prepare_none, cib_process_query
     },
     {
         PCMK__CIB_REQUEST_MODIFY,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_prepare_data, cib_cleanup_data, cib_process_modify
+        cib_prepare_data, cib_process_modify
     },
     {
         PCMK__CIB_REQUEST_APPLY_PATCH,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_prepare_diff, cib_cleanup_data, cib_server_process_diff
+        cib_prepare_diff, cib_server_process_diff
     },
     {
         PCMK__CIB_REQUEST_REPLACE,
@@ -165,27 +132,27 @@ static const cib_operation_t cib_server_ops[] = {
         |cib_op_attr_replaces
         |cib_op_attr_writes_through
         |cib_op_attr_transaction,
-        cib_prepare_data, cib_cleanup_data, cib_process_replace_svr
+        cib_prepare_data, cib_process_replace_svr
     },
     {
         PCMK__CIB_REQUEST_CREATE,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_prepare_data, cib_cleanup_data, cib_process_create
+        cib_prepare_data, cib_process_create
     },
     {
         PCMK__CIB_REQUEST_DELETE,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_prepare_data, cib_cleanup_data, cib_process_delete
+        cib_prepare_data, cib_process_delete
     },
     {
         PCMK__CIB_REQUEST_SYNC_TO_ALL,
         cib_op_attr_privileged,
-        cib_prepare_sync, cib_cleanup_none, cib_process_sync
+        cib_prepare_sync, cib_process_sync
     },
     {
         PCMK__CIB_REQUEST_BUMP,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_prepare_none, cib_cleanup_output, cib_process_bump
+        cib_prepare_none, cib_process_bump
     },
     {
         PCMK__CIB_REQUEST_ERASE,
@@ -193,17 +160,17 @@ static const cib_operation_t cib_server_ops[] = {
         |cib_op_attr_privileged
         |cib_op_attr_replaces
         |cib_op_attr_transaction,
-        cib_prepare_none, cib_cleanup_output, cib_process_erase
+        cib_prepare_none, cib_process_erase
     },
     {
         PCMK__CIB_REQUEST_NOOP,
         cib_op_attr_none,
-        cib_prepare_none, cib_cleanup_none, cib_process_noop
+        cib_prepare_none, cib_process_noop
     },
     {
         PCMK__CIB_REQUEST_ABS_DELETE,
         cib_op_attr_modifies|cib_op_attr_privileged,
-        cib_prepare_data, cib_cleanup_data, cib_process_delete_absolute
+        cib_prepare_data, cib_process_delete_absolute
     },
     {
         PCMK__CIB_REQUEST_UPGRADE,
@@ -211,38 +178,38 @@ static const cib_operation_t cib_server_ops[] = {
         |cib_op_attr_privileged
         |cib_op_attr_writes_through
         |cib_op_attr_transaction,
-        cib_prepare_none, cib_cleanup_output, cib_process_upgrade_server
+        cib_prepare_none, cib_process_upgrade_server
     },
     {
         PCMK__CIB_REQUEST_SECONDARY,
         cib_op_attr_privileged|cib_op_attr_local,
-        cib_prepare_none, cib_cleanup_none, cib_process_readwrite
+        cib_prepare_none, cib_process_readwrite
     },
     {
         PCMK__CIB_REQUEST_SYNC_TO_ONE,
         cib_op_attr_privileged,
-        cib_prepare_sync, cib_cleanup_none, cib_process_sync_one
+        cib_prepare_sync, cib_process_sync_one
     },
     {
         // @COMPAT: Drop cib_op_attr_modifies when we drop legacy mode support
         PCMK__CIB_REQUEST_PRIMARY,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_local,
-        cib_prepare_data, cib_cleanup_data, cib_process_readwrite
+        cib_prepare_data, cib_process_readwrite
     },
     {
         PCMK__CIB_REQUEST_IS_PRIMARY,
         cib_op_attr_privileged,
-        cib_prepare_none, cib_cleanup_none, cib_process_readwrite
+        cib_prepare_none, cib_process_readwrite
     },
     {
         PCMK__CIB_REQUEST_SHUTDOWN,
         cib_op_attr_privileged,
-        cib_prepare_sync, cib_cleanup_none, cib_process_shutdown_req
+        cib_prepare_sync, cib_process_shutdown_req
     },
     {
         CRM_OP_PING,
         cib_op_attr_none,
-        cib_prepare_none, cib_cleanup_output, cib_process_ping
+        cib_prepare_none, cib_process_ping
     },
 
     /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
@@ -252,7 +219,7 @@ static const cib_operation_t cib_server_ops[] = {
     {
         PCMK__CIB_REQUEST_INIT_TRANSACT,
         cib_op_attr_privileged|cib_op_attr_local,
-        cib_prepare_none, cib_cleanup_none, cib_process_init_transaction,
+        cib_prepare_none, cib_process_init_transaction,
     },
     {
         PCMK__CIB_REQUEST_COMMIT_TRANSACT,
@@ -261,12 +228,12 @@ static const cib_operation_t cib_server_ops[] = {
         |cib_op_attr_local
         |cib_op_attr_replaces
         |cib_op_attr_writes_through,
-        cib_prepare_none, cib_cleanup_none, cib_process_commit_transaction,
+        cib_prepare_none, cib_process_commit_transaction,
     },
     {
         PCMK__CIB_REQUEST_DISCARD_TRANSACT,
         cib_op_attr_privileged|cib_op_attr_local,
-        cib_prepare_none, cib_cleanup_none, cib_process_discard_transaction,
+        cib_prepare_none, cib_process_discard_transaction,
     },
 };
 

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -18,6 +18,9 @@
 #include <errno.h>
 #include <fcntl.h>
 
+#include <glib.h>
+#include <libxml/tree.h>
+
 #include <crm/crm.h>
 #include <crm/cib.h>
 #include <crm/msg_xml.h>

--- a/daemons/based/based_common.c
+++ b/daemons/based/based_common.c
@@ -111,22 +111,22 @@ cib_prepare_diff(xmlNode * request, xmlNode ** data, const char **section)
 
 static const cib_operation_t cib_server_ops[] = {
     {
-        PCMK__CIB_REQUEST_QUERY,
+        PCMK__CIB_REQUEST_QUERY, cib__op_query,
         cib_op_attr_none,
         cib_prepare_none, cib_process_query
     },
     {
-        PCMK__CIB_REQUEST_MODIFY,
+        PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_data, cib_process_modify
     },
     {
-        PCMK__CIB_REQUEST_APPLY_PATCH,
+        PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_diff, cib_server_process_diff
     },
     {
-        PCMK__CIB_REQUEST_REPLACE,
+        PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
         cib_op_attr_modifies
         |cib_op_attr_privileged
         |cib_op_attr_replaces
@@ -135,27 +135,27 @@ static const cib_operation_t cib_server_ops[] = {
         cib_prepare_data, cib_process_replace_svr
     },
     {
-        PCMK__CIB_REQUEST_CREATE,
+        PCMK__CIB_REQUEST_CREATE, cib__op_create,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_data, cib_process_create
     },
     {
-        PCMK__CIB_REQUEST_DELETE,
+        PCMK__CIB_REQUEST_DELETE, cib__op_delete,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_data, cib_process_delete
     },
     {
-        PCMK__CIB_REQUEST_SYNC_TO_ALL,
+        PCMK__CIB_REQUEST_SYNC_TO_ALL, cib__op_sync_all,
         cib_op_attr_privileged,
         cib_prepare_sync, cib_process_sync
     },
     {
-        PCMK__CIB_REQUEST_BUMP,
+        PCMK__CIB_REQUEST_BUMP, cib__op_bump,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
         cib_prepare_none, cib_process_bump
     },
     {
-        PCMK__CIB_REQUEST_ERASE,
+        PCMK__CIB_REQUEST_ERASE, cib__op_erase,
         cib_op_attr_modifies
         |cib_op_attr_privileged
         |cib_op_attr_replaces
@@ -163,17 +163,17 @@ static const cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_process_erase
     },
     {
-        PCMK__CIB_REQUEST_NOOP,
+        PCMK__CIB_REQUEST_NOOP, cib__op_noop,
         cib_op_attr_none,
         cib_prepare_none, cib_process_noop
     },
     {
-        PCMK__CIB_REQUEST_ABS_DELETE,
+        PCMK__CIB_REQUEST_ABS_DELETE, cib__op_abs_delete,
         cib_op_attr_modifies|cib_op_attr_privileged,
         cib_prepare_data, cib_process_delete_absolute
     },
     {
-        PCMK__CIB_REQUEST_UPGRADE,
+        PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
         cib_op_attr_modifies
         |cib_op_attr_privileged
         |cib_op_attr_writes_through
@@ -181,33 +181,33 @@ static const cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_process_upgrade_server
     },
     {
-        PCMK__CIB_REQUEST_SECONDARY,
+        PCMK__CIB_REQUEST_SECONDARY, cib__op_secondary,
         cib_op_attr_privileged|cib_op_attr_local,
         cib_prepare_none, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_SYNC_TO_ONE,
+        PCMK__CIB_REQUEST_SYNC_TO_ONE, cib__op_sync_one,
         cib_op_attr_privileged,
         cib_prepare_sync, cib_process_sync_one
     },
     {
         // @COMPAT: Drop cib_op_attr_modifies when we drop legacy mode support
-        PCMK__CIB_REQUEST_PRIMARY,
+        PCMK__CIB_REQUEST_PRIMARY, cib__op_primary,
         cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_local,
         cib_prepare_data, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_IS_PRIMARY,
+        PCMK__CIB_REQUEST_IS_PRIMARY, cib__op_is_primary,
         cib_op_attr_privileged,
         cib_prepare_none, cib_process_readwrite
     },
     {
-        PCMK__CIB_REQUEST_SHUTDOWN,
+        PCMK__CIB_REQUEST_SHUTDOWN, cib__op_shutdown,
         cib_op_attr_privileged,
         cib_prepare_sync, cib_process_shutdown_req
     },
     {
-        CRM_OP_PING,
+        CRM_OP_PING, cib__op_ping,
         cib_op_attr_none,
         cib_prepare_none, cib_process_ping
     },
@@ -217,12 +217,12 @@ static const cib_operation_t cib_server_ops[] = {
      * other nodes would likely be problematic in many other ways as well.
      */
     {
-        PCMK__CIB_REQUEST_INIT_TRANSACT,
+        PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
         cib_op_attr_privileged|cib_op_attr_local,
         cib_prepare_none, cib_process_init_transaction,
     },
     {
-        PCMK__CIB_REQUEST_COMMIT_TRANSACT,
+        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
         cib_op_attr_modifies
         |cib_op_attr_privileged
         |cib_op_attr_local
@@ -231,7 +231,7 @@ static const cib_operation_t cib_server_ops[] = {
         cib_prepare_none, cib_process_commit_transaction,
     },
     {
-        PCMK__CIB_REQUEST_DISCARD_TRANSACT,
+        PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
         cib_op_attr_privileged|cib_op_attr_local,
         cib_prepare_none, cib_process_discard_transaction,
     },

--- a/daemons/based/based_io.c
+++ b/daemons/based/based_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -21,6 +21,9 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+
+#include <glib.h>
+#include <libxml/tree.h>
 
 #include <crm/crm.h>
 

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -19,6 +19,9 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#include <glib.h>
+#include <libxml/tree.h>
+
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -21,6 +21,9 @@
 
 #include <time.h>
 
+#include <glib.h>
+#include <libxml/tree.h>
+
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>

--- a/daemons/based/based_operation.c
+++ b/daemons/based/based_operation.c
@@ -31,157 +31,52 @@
 
 #include <pacemaker-based.h>
 
-static const cib_operation_t cib_server_ops[] = {
-    {
-        PCMK__CIB_REQUEST_QUERY, cib__op_query,
-        cib_op_attr_none,
-        cib_process_query
-    },
-    {
-        PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_process_modify
-    },
-    {
-        PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_server_process_diff
-    },
-    {
-        PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_replaces
-        |cib_op_attr_writes_through
-        |cib_op_attr_transaction,
-        cib_process_replace_svr
-    },
-    {
-        PCMK__CIB_REQUEST_CREATE, cib__op_create,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_process_create
-    },
-    {
-        PCMK__CIB_REQUEST_DELETE, cib__op_delete,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_process_delete
-    },
-    {
-        PCMK__CIB_REQUEST_SYNC_TO_ALL, cib__op_sync_all,
-        cib_op_attr_privileged,
-        cib_process_sync
-    },
-    {
-        PCMK__CIB_REQUEST_BUMP, cib__op_bump,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_transaction,
-        cib_process_bump
-    },
-    {
-        PCMK__CIB_REQUEST_ERASE, cib__op_erase,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_replaces
-        |cib_op_attr_transaction,
-        cib_process_erase
-    },
-    {
-        PCMK__CIB_REQUEST_NOOP, cib__op_noop,
-        cib_op_attr_none,
-        cib_process_noop
-    },
-    {
-        PCMK__CIB_REQUEST_ABS_DELETE, cib__op_abs_delete,
-        cib_op_attr_modifies|cib_op_attr_privileged,
-        cib_process_delete_absolute
-    },
-    {
-        PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_writes_through
-        |cib_op_attr_transaction,
-        cib_process_upgrade_server
-    },
-    {
-        PCMK__CIB_REQUEST_SECONDARY, cib__op_secondary,
-        cib_op_attr_privileged|cib_op_attr_local,
-        cib_process_readwrite
-    },
-    {
-        PCMK__CIB_REQUEST_SYNC_TO_ONE, cib__op_sync_one,
-        cib_op_attr_privileged,
-        cib_process_sync_one
-    },
-    {
-        // @COMPAT: Drop cib_op_attr_modifies when we drop legacy mode support
-        PCMK__CIB_REQUEST_PRIMARY, cib__op_primary,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_local,
-        cib_process_readwrite
-    },
-    {
-        PCMK__CIB_REQUEST_IS_PRIMARY, cib__op_is_primary,
-        cib_op_attr_privileged,
-        cib_process_readwrite
-    },
-    {
-        PCMK__CIB_REQUEST_SHUTDOWN, cib__op_shutdown,
-        cib_op_attr_privileged,
-        cib_process_shutdown_req
-    },
-    {
-        CRM_OP_PING, cib__op_ping,
-        cib_op_attr_none,
-        cib_process_ping
-    },
+static const cib__op_fn_t cib_op_functions[] = {
+    [cib__op_abs_delete]  = cib_process_delete_absolute,
+    [cib__op_apply_patch] = cib_server_process_diff,
+    [cib__op_bump]        = cib_process_bump,
+    [cib__op_create]      = cib_process_create,
+    [cib__op_delete]      = cib_process_delete,
+    [cib__op_erase]       = cib_process_erase,
+    [cib__op_is_primary]  = cib_process_readwrite,
+    [cib__op_modify]      = cib_process_modify,
+    [cib__op_noop]        = cib_process_noop,
+    [cib__op_ping]        = cib_process_ping,
+    [cib__op_primary]     = cib_process_readwrite,
+    [cib__op_query]       = cib_process_query,
+    [cib__op_replace]     = cib_process_replace_svr,
+    [cib__op_secondary]   = cib_process_readwrite,
+    [cib__op_shutdown]    = cib_process_shutdown_req,
+    [cib__op_sync_all]    = cib_process_sync,
+    [cib__op_sync_one]    = cib_process_sync_one,
+    [cib__op_upgrade]     = cib_process_upgrade_server,
 
     /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
      * they depend on the client table. Requests that manage transactions on
      * other nodes would likely be problematic in many other ways as well.
      */
-    {
-        PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
-        cib_op_attr_privileged|cib_op_attr_local,
-        cib_process_init_transaction,
-    },
-    {
-        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_local
-        |cib_op_attr_replaces
-        |cib_op_attr_writes_through,
-        cib_process_commit_transaction,
-    },
-    {
-        PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
-        cib_op_attr_privileged|cib_op_attr_local,
-        cib_process_discard_transaction,
-    },
+    [cib__op_init_transact]    = cib_process_init_transaction,
+    [cib__op_commit_transact]  = cib_process_commit_transaction,
+    [cib__op_discard_transact] = cib_process_discard_transaction,
 };
 
-int
-cib_get_operation(const char *op, const cib_operation_t **operation)
+/*!
+ * \internal
+ * \brief Get the function that performs a given server-side CIB operation
+ *
+ * \param[in] operation  Operation whose function to look up
+ *
+ * \return Function that performs \p operation within \c pacemaker-based
+ */
+cib__op_fn_t
+based_get_op_function(const cib_operation_t *operation)
 {
-    static GHashTable *operation_hash = NULL;
+    enum cib__op_type type = operation->type;
 
-    CRM_ASSERT((op != NULL) && (operation != NULL));
+    CRM_ASSERT(type >= 0);
 
-    if (operation_hash == NULL) {
-        operation_hash = pcmk__strkey_table(NULL, NULL);
-
-        for (int lpc = 0; lpc < PCMK__NELEM(cib_server_ops); lpc++) {
-            const cib_operation_t *oper = &(cib_server_ops[lpc]);
-
-            g_hash_table_insert(operation_hash, (gpointer) oper->name,
-                                (gpointer) oper);
-        }
+    if (type >= PCMK__NELEM(cib_op_functions)) {
+        return NULL;
     }
-
-    *operation = g_hash_table_lookup(operation_hash, op);
-
-    if (*operation == NULL) {
-        crm_err("Operation %s is not valid", op);
-        return -EINVAL;
-    }
-    return pcmk_ok;
+    return cib_op_functions[type];
 }

--- a/daemons/based/based_operation.c
+++ b/daemons/based/based_operation.c
@@ -9,26 +9,10 @@
 
 #include <crm_internal.h>
 
-#include <sys/param.h>
-#include <stdio.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include <stdlib.h>
-#include <errno.h>
-#include <fcntl.h>
-
 #include <glib.h>
-#include <libxml/tree.h>
 
 #include <crm/crm.h>
 #include <crm/cib.h>
-#include <crm/msg_xml.h>
-#include <crm/common/ipc.h>
-#include <crm/cluster.h>
-
-#include <crm/common/xml.h>
-
 #include <pacemaker-based.h>
 
 static const cib__op_fn_t cib_op_functions[] = {

--- a/daemons/based/based_operation.c
+++ b/daemons/based/based_operation.c
@@ -31,8 +31,6 @@
 
 #include <pacemaker-based.h>
 
-gboolean stand_alone = FALSE;
-
 static const cib_operation_t cib_server_ops[] = {
     {
         PCMK__CIB_REQUEST_QUERY, cib__op_query,

--- a/daemons/based/based_operation.c
+++ b/daemons/based/based_operation.c
@@ -53,7 +53,7 @@ static const cib__op_fn_t cib_op_functions[] = {
  * \return Function that performs \p operation within \c pacemaker-based
  */
 cib__op_fn_t
-based_get_op_function(const cib_operation_t *operation)
+based_get_op_function(const cib__operation_t *operation)
 {
     enum cib__op_type type = operation->type;
 

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,7 +23,9 @@
 
 #include <stdlib.h>
 #include <errno.h>
+
 #include <glib.h>
+#include <libxml/tree.h>
 
 #include <crm/msg_xml.h>
 #include <crm/common/ipc.h>

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -153,7 +153,7 @@ validate_transaction_request(const xmlNode *request)
     const char *op = crm_element_value(request, F_CIB_OPERATION);
     const char *host = crm_element_value(request, F_CIB_HOST);
 
-    const cib_operation_t *operation = NULL;
+    const cib__operation_t *operation = NULL;
     int rc = cib__get_operation(op, &operation);
 
     if (rc != pcmk_rc_ok) {

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -154,9 +154,8 @@ validate_transaction_request(const xmlNode *request)
     const char *host = crm_element_value(request, F_CIB_HOST);
 
     const cib_operation_t *operation = NULL;
-    int rc = cib_get_operation(op, &operation);
+    int rc = cib__get_operation(op, &operation);
 
-    rc = pcmk_legacy2rc(rc);
     if (rc != pcmk_rc_ok) {
         // cib_get_operation() logs error
         return rc;

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -161,7 +161,7 @@ validate_transaction_request(const xmlNode *request)
         return rc;
     }
 
-    if (!pcmk_is_set(operation->flags, cib_op_attr_transaction)) {
+    if (!pcmk_is_set(operation->flags, cib__op_attr_transaction)) {
         crm_err("Operation '%s' is not supported in CIB transaction", op);
         return EOPNOTSUPP;
     }

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -43,6 +43,7 @@ gchar *cib_root = NULL;
 static gboolean preserve_status = FALSE;
 
 gboolean cib_writes_enabled = TRUE;
+gboolean stand_alone = FALSE;
 
 int remote_fd = 0;
 int remote_tls_fd = 0;

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -16,7 +16,8 @@
 #include <bzlib.h>
 #include <sys/types.h>
 
-#include <libxml/parser.h>
+#include <glib.h>
+#include <libxml/tree.h>
 
 #include <crm/crm.h>
 #include <crm/cib/internal.h>

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -135,7 +135,7 @@ int cib_process_discard_transaction(const char *op, int options,
 void send_sync_request(const char *host);
 int sync_our_cib(xmlNode *request, gboolean all);
 
-cib__op_fn_t based_get_op_function(const cib_operation_t *operation);
+cib__op_fn_t based_get_op_function(const cib__operation_t *operation);
 void cib_diff_notify(const char *op, int result, const char *call_id,
                      const char *client_id, const char *client_name,
                      const char *origin, xmlNode *update, xmlNode *diff);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -135,7 +135,7 @@ int cib_process_discard_transaction(const char *op, int options,
 void send_sync_request(const char *host);
 int sync_our_cib(xmlNode *request, gboolean all);
 
-int cib_get_operation(const char *op, const cib_operation_t **operation);
+cib__op_fn_t based_get_op_function(const cib_operation_t *operation);
 void cib_diff_notify(const char *op, int result, const char *call_id,
                      const char *client_id, const char *client_name,
                      const char *origin, xmlNode *update, xmlNode *diff);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -18,6 +18,9 @@
 #include <errno.h>
 #include <fcntl.h>
 
+#include <glib.h>
+#include <libxml/tree.h>
+
 #include <crm/crm.h>
 #include <crm/cib.h>
 #include <crm/common/xml.h>

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -152,11 +152,11 @@ gboolean cib_read_config(GHashTable * options, xmlNode * current_cib);
 typedef int (*cib__op_fn_t)(const char *, int, const char *, xmlNode *,
                             xmlNode *, xmlNode *, xmlNode **, xmlNode **);
 
-typedef struct cib_operation_s {
+typedef struct cib__operation_s {
     const char *name;
     enum cib__op_type type;
     uint32_t flags; //!< Group of <tt>enum cib__op_attr</tt> flags
-} cib_operation_t;
+} cib__operation_t;
 
 typedef struct cib_notify_client_s {
     const char *event;
@@ -209,7 +209,7 @@ xmlNode *cib_create_op(int call_id, const char *op, const char *host,
 void cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc);
 void cib_native_notify(gpointer data, gpointer user_data);
 
-int cib__get_operation(const char *op, const cib_operation_t **operation);
+int cib__get_operation(const char *op, const cib__operation_t **operation);
 
 int cib_process_query(const char *op, int options, const char *section, xmlNode * req,
                       xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -156,7 +156,6 @@ typedef struct cib_operation_s {
     const char *name;
     enum cib__op_type type;
     uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
-    int (*prepare) (xmlNode *, xmlNode **, const char **);
     cib__op_fn_t fn;
 } cib_operation_t;
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -149,15 +149,15 @@ gboolean cib_diff_version_details(xmlNode * diff, int *admin_epoch, int *epoch, 
 
 gboolean cib_read_config(GHashTable * options, xmlNode * current_cib);
 
-typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
-                         xmlNode *, xmlNode *, xmlNode **, xmlNode **);
+typedef int (*cib__op_fn_t)(const char *, int, const char *, xmlNode *,
+                            xmlNode *, xmlNode *, xmlNode **, xmlNode **);
 
 typedef struct cib_operation_s {
     const char *name;
     enum cib__op_type type;
     uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
     int (*prepare) (xmlNode *, xmlNode **, const char **);
-    cib_op_t fn;
+    cib__op_fn_t fn;
 } cib_operation_t;
 
 typedef struct cib_notify_client_s {
@@ -198,7 +198,7 @@ struct timer_rec_s {
 
 cib_t *cib_new_variant(void);
 
-int cib_perform_op(const char *op, int call_options, cib_op_t fn,
+int cib_perform_op(const char *op, int call_options, cib__op_fn_t fn,
                    bool is_query, const char *section, xmlNode *req,
                    xmlNode *input, bool manage_counters, bool *config_changed,
                    xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -86,17 +86,17 @@ enum cib_change_section_info {
 
 /*!
  * \internal
- * \enum cib_op_attr
+ * \enum cib__op_attr
  * \brief Flags for CIB operation attributes
  */
-enum cib_op_attr {
-    cib_op_attr_none           = 0,         //!< No special attributes
-    cib_op_attr_modifies       = (1 << 1),  //!< Modifies CIB
-    cib_op_attr_privileged     = (1 << 2),  //!< Requires privileges
-    cib_op_attr_local          = (1 << 3),  //!< Must only be processed locally
-    cib_op_attr_replaces       = (1 << 4),  //!< Replaces CIB
-    cib_op_attr_writes_through = (1 << 5),  //!< Writes to disk on success
-    cib_op_attr_transaction    = (1 << 6),  //!< Supported in a transaction
+enum cib__op_attr {
+    cib__op_attr_none           = 0,        //!< No special attributes
+    cib__op_attr_modifies       = (1 << 1), //!< Modifies CIB
+    cib__op_attr_privileged     = (1 << 2), //!< Requires privileges
+    cib__op_attr_local          = (1 << 3), //!< Must only be processed locally
+    cib__op_attr_replaces       = (1 << 4), //!< Replaces CIB
+    cib__op_attr_writes_through = (1 << 5), //!< Writes to disk on success
+    cib__op_attr_transaction    = (1 << 6), //!< Supported in a transaction
 };
 
 /*!
@@ -155,7 +155,7 @@ typedef int (*cib__op_fn_t)(const char *, int, const char *, xmlNode *,
 typedef struct cib_operation_s {
     const char *name;
     enum cib__op_type type;
-    uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
+    uint32_t flags; //!< Group of <tt>enum cib__op_attr</tt> flags
 } cib_operation_t;
 
 typedef struct cib_notify_client_s {

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -125,7 +125,6 @@ typedef struct cib_operation_s {
     const char *name;
     uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
     int (*prepare) (xmlNode *, xmlNode **, const char **);
-    int (*cleanup) (int, xmlNode **, xmlNode **);
     cib_op_t fn;
 } cib_operation_t;
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -156,7 +156,6 @@ typedef struct cib_operation_s {
     const char *name;
     enum cib__op_type type;
     uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
-    cib__op_fn_t fn;
 } cib_operation_t;
 
 typedef struct cib_notify_client_s {
@@ -209,6 +208,8 @@ xmlNode *cib_create_op(int call_id, const char *op, const char *host,
 
 void cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc);
 void cib_native_notify(gpointer data, gpointer user_data);
+
+int cib__get_operation(const char *op, const cib_operation_t **operation);
 
 int cib_process_query(const char *op, int options, const char *section, xmlNode * req,
                       xmlNode * input, xmlNode * existing_cib, xmlNode ** result_cib,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -154,6 +154,7 @@ typedef int (*cib_op_t) (const char *, int, const char *, xmlNode *,
 
 typedef struct cib_operation_s {
     const char *name;
+    enum cib__op_type type;
     uint32_t flags; //!< Group of <tt>enum cib_op_attr</tt> flags
     int (*prepare) (xmlNode *, xmlNode **, const char **);
     cib_op_t fn;

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -101,6 +101,37 @@ enum cib_op_attr {
 
 /*!
  * \internal
+ * \enum cib__op_type
+ * \brief Types of CIB operations
+ */
+enum cib__op_type {
+    cib__op_abs_delete,
+    cib__op_apply_patch,
+    cib__op_bump,
+    cib__op_create,
+    cib__op_delete,
+    cib__op_erase,
+    cib__op_is_primary,
+    cib__op_modify,
+    cib__op_noop,
+    cib__op_ping,
+    cib__op_primary,
+    cib__op_query,
+    cib__op_replace,
+    cib__op_secondary,
+    cib__op_shutdown,
+    cib__op_sync_all,
+    cib__op_sync_one,
+    cib__op_upgrade,
+
+    // @TODO: Refactor transactions and remove these
+    cib__op_init_transact,
+    cib__op_commit_transact,
+    cib__op_discard_transact,
+};
+
+/*!
+ * \internal
  * \brief Set given <tt>enum cib_change_section_info</tt> flags
  *
  * \param[in,out] flags_orig    Group of flags to update

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -52,8 +52,6 @@ typedef const xmlChar *pcmkXmlStr;
 gboolean add_message_xml(xmlNode * msg, const char *field, xmlNode * xml);
 xmlNode *get_message_xml(const xmlNode *msg, const char *field);
 
-xmlDoc *getDocPtr(xmlNode * node);
-
 /*
  * \brief xmlCopyPropList ACLs-sensitive replacement expading i++ notation
  *

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -258,7 +258,7 @@ xmlNode *first_named_child(const xmlNode *parent, const char *name);
 xmlNode *crm_next_same_xml(const xmlNode *sibling);
 
 xmlNode *sorted_xml(xmlNode * input, xmlNode * parent, gboolean recursive);
-xmlXPathObjectPtr xpath_search(xmlNode * xml_top, const char *path);
+xmlXPathObjectPtr xpath_search(const xmlNode *xml_top, const char *path);
 void crm_foreach_xpath_result(xmlNode *xml, const char *xpath,
                               void (*helper)(xmlNode*, void*), void *user_data);
 xmlNode *expand_idref(xmlNode * input, xmlNode * top);

--- a/include/crm/common/xml_compat.h
+++ b/include/crm/common/xml_compat.h
@@ -31,6 +31,9 @@ extern "C" {
 #define XML_PARANOIA_CHECKS 0
 
 //! \deprecated This function will be removed in a future release
+xmlDoc *getDocPtr(xmlNode *node);
+
+//! \deprecated This function will be removed in a future release
 int add_node_nocopy(xmlNode * parent, const char *name, xmlNode * child);
 
 //! \deprecated This function will be removed in a future release

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -174,62 +174,62 @@ static const cib_operation_t cib_file_ops[] = {
     {
         PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_diff
+        cib_process_diff
     },
     {
         PCMK__CIB_REQUEST_BUMP, cib__op_bump,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_bump
+        cib_process_bump
     },
     {
         PCMK__CIB_REQUEST_CREATE, cib__op_create,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_create
+        cib_process_create
     },
     {
         PCMK__CIB_REQUEST_DELETE, cib__op_delete,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_delete
+        cib_process_delete
     },
     {
         PCMK__CIB_REQUEST_ERASE, cib__op_erase,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_erase
+        cib_process_erase
     },
     {
         PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_modify
+        cib_process_modify
     },
     {
         PCMK__CIB_REQUEST_QUERY, cib__op_query,
         cib_op_attr_none,
-        NULL, cib_process_query
+        cib_process_query
     },
     {
         PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_replace
+        cib_process_replace
     },
     {
         PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, cib_process_upgrade
+        cib_process_upgrade
     },
     {
         PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
         cib_op_attr_none,
-        NULL, cib_file_process_init_transaction
+        cib_file_process_init_transaction
     },
     {
         PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
         cib_op_attr_modifies,
-        NULL, cib_file_process_commit_transaction
+        cib_file_process_commit_transaction
     },
     {
         PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
         cib_op_attr_none,
-        NULL, cib_file_process_discard_transaction
+        cib_file_process_discard_transaction
     },
 };
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -54,7 +54,7 @@ typedef struct cib_file_opaque_s {
 } cib_file_opaque_t;
 
 static int cib_file_extend_transaction(cib_t *cib,
-                                       const cib_operation_t *operation,
+                                       const cib__operation_t *operation,
                                        xmlNode *request);
 
 static void cib_file_discard_transaction(cib_t *cib);
@@ -189,7 +189,7 @@ static gboolean cib_do_chown = FALSE;
  * \return Function that performs \p operation for a CIB file client
  */
 static cib__op_fn_t
-file_get_op_function(const cib_operation_t *operation)
+file_get_op_function(const cib__operation_t *operation)
 {
     enum cib__op_type type = operation->type;
 
@@ -236,7 +236,7 @@ static int
 cib_file_process_request(cib_t *cib, xmlNode *request, xmlNode **output)
 {
     int rc = pcmk_ok;
-    const cib_operation_t *operation = NULL;
+    const cib__operation_t *operation = NULL;
     cib__op_fn_t op_function = NULL;
 
     int call_id = 0;
@@ -322,7 +322,7 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
     xmlNode *output = NULL;
     cib_file_opaque_t *private = cib->variant_opaque;
 
-    const cib_operation_t *operation = NULL;
+    const cib__operation_t *operation = NULL;
 
     crm_info("Handling %s operation for %s as %s",
              pcmk__s(op, "invalid"), pcmk__s(section, "entire CIB"),
@@ -1115,7 +1115,7 @@ cib_file_init_transaction(cib_t *cib)
  * \return Standard Pacemaker return code
  */
 static int
-cib_file_extend_transaction(cib_t *cib, const cib_operation_t *operation,
+cib_file_extend_transaction(cib_t *cib, const cib__operation_t *operation,
                             xmlNode *request)
 {
     cib_file_opaque_t *private = cib->variant_opaque;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -174,62 +174,62 @@ static const cib_operation_t cib_file_ops[] = {
     {
         PCMK__CIB_REQUEST_APPLY_PATCH,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_diff
+        NULL, cib_process_diff
     },
     {
         PCMK__CIB_REQUEST_BUMP,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_bump
+        NULL, cib_process_bump
     },
     {
         PCMK__CIB_REQUEST_CREATE,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_create
+        NULL, cib_process_create
     },
     {
         PCMK__CIB_REQUEST_DELETE,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_delete
+        NULL, cib_process_delete
     },
     {
         PCMK__CIB_REQUEST_ERASE,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_erase
+        NULL, cib_process_erase
     },
     {
         PCMK__CIB_REQUEST_MODIFY,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_modify
+        NULL, cib_process_modify
     },
     {
         PCMK__CIB_REQUEST_QUERY,
         cib_op_attr_none,
-        NULL, NULL, cib_process_query
+        NULL, cib_process_query
     },
     {
         PCMK__CIB_REQUEST_REPLACE,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_replace
+        NULL, cib_process_replace
     },
     {
         PCMK__CIB_REQUEST_UPGRADE,
         cib_op_attr_modifies|cib_op_attr_transaction,
-        NULL, NULL, cib_process_upgrade
+        NULL, cib_process_upgrade
     },
     {
         PCMK__CIB_REQUEST_INIT_TRANSACT,
         cib_op_attr_none,
-        NULL, NULL, cib_file_process_init_transaction
+        NULL, cib_file_process_init_transaction
     },
     {
         PCMK__CIB_REQUEST_COMMIT_TRANSACT,
         cib_op_attr_modifies,
-        NULL, NULL, cib_file_process_commit_transaction
+        NULL, cib_file_process_commit_transaction
     },
     {
         PCMK__CIB_REQUEST_DISCARD_TRANSACT,
         cib_op_attr_none,
-        NULL, NULL, cib_file_process_discard_transaction
+        NULL, cib_file_process_discard_transaction
     },
 };
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -172,62 +172,62 @@ get_client(const char *client_id)
  */
 static const cib_operation_t cib_file_ops[] = {
     {
-        PCMK__CIB_REQUEST_APPLY_PATCH,
+        PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_diff
     },
     {
-        PCMK__CIB_REQUEST_BUMP,
+        PCMK__CIB_REQUEST_BUMP, cib__op_bump,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_bump
     },
     {
-        PCMK__CIB_REQUEST_CREATE,
+        PCMK__CIB_REQUEST_CREATE, cib__op_create,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_create
     },
     {
-        PCMK__CIB_REQUEST_DELETE,
+        PCMK__CIB_REQUEST_DELETE, cib__op_delete,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_delete
     },
     {
-        PCMK__CIB_REQUEST_ERASE,
+        PCMK__CIB_REQUEST_ERASE, cib__op_erase,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_erase
     },
     {
-        PCMK__CIB_REQUEST_MODIFY,
+        PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_modify
     },
     {
-        PCMK__CIB_REQUEST_QUERY,
+        PCMK__CIB_REQUEST_QUERY, cib__op_query,
         cib_op_attr_none,
         NULL, cib_process_query
     },
     {
-        PCMK__CIB_REQUEST_REPLACE,
+        PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_replace
     },
     {
-        PCMK__CIB_REQUEST_UPGRADE,
+        PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
         cib_op_attr_modifies|cib_op_attr_transaction,
         NULL, cib_process_upgrade
     },
     {
-        PCMK__CIB_REQUEST_INIT_TRANSACT,
+        PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
         cib_op_attr_none,
         NULL, cib_file_process_init_transaction
     },
     {
-        PCMK__CIB_REQUEST_COMMIT_TRANSACT,
+        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
         cib_op_attr_modifies,
         NULL, cib_file_process_commit_transaction
     },
     {
-        PCMK__CIB_REQUEST_DISCARD_TRANSACT,
+        PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
         cib_op_attr_none,
         NULL, cib_file_process_discard_transaction
     },

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -40,9 +40,6 @@
 // key: client ID (const char *) -> value: client (cib_t *)
 static GHashTable *client_table = NULL;
 
-// key: op name (const char *) -> value: operation (const cib_operation_t *)
-static GHashTable *op_table = NULL;
-
 enum cib_file_flags {
     cib_file_flag_dirty = (1 << 0),
     cib_file_flag_live  = (1 << 1),
@@ -116,22 +113,12 @@ unregister_client(const cib_t *cib)
 
     g_hash_table_remove(client_table, private->id);
 
-    /* There's no clean way to free the tables at program exit time. We can't
-     * create a cleanup function in this file and add it to crm_exit(), which is
-     * in libcrmcommon. libcrmcommon doesn't link against libcib.
-     *
-     * As a hack for now, free the common tables when there are no more clients.
-     *
-     * @COMPAT: If libcib and libcrmcommon are merged, add this to crm_exit().
+    /* @COMPAT: Add to crm_exit() when libcib and libcrmcommon are merged,
+     * instead of destroying the client table when there are no more clients.
      */
     if (g_hash_table_size(client_table) == 0) {
         g_hash_table_destroy(client_table);
         client_table = NULL;
-
-        if (op_table != NULL) {
-            g_hash_table_destroy(op_table);
-            op_table = NULL;
-        }
     }
 }
 
@@ -152,85 +139,19 @@ get_client(const char *client_id)
     return g_hash_table_lookup(client_table, (gpointer) client_id);
 }
 
-/* This table is adapted from cib_server_ops in pacemaker-based. Flags that are
- * not used in cib_file.c (for example, cib_op_attr_replaces) are not currently
- * included. Also, cib_file.c does not use prepare or cleanup functions.
- *
- * @TODO: Try to create a shared table that merges cib_server_ops with
- * cib_file_ops. We would want a new cib_op_attr_file enum value (for an
- * operation that supports running against a file). We can easily ignore the
- * prepare and cleanup functions.
- *
- * The main challenge is that the fn member (cib__op_fn_t) may differ depending
- * on whether we're processing the request on the server side or with the
- * file-based client. Processor functions defined in pacemaker-based shouldn't
- * be declared in libcib, but we need them accessible via the table somehow.
- *
- * Maybe use an enum that indexes into an array of cib__op_fn_t functions. That
- * would be obnoxiously similar to the call_type (index) argument that we
- * eliminated in c13bf8b2.
- */
-static const cib_operation_t cib_file_ops[] = {
-    {
-        PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_diff
-    },
-    {
-        PCMK__CIB_REQUEST_BUMP, cib__op_bump,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_bump
-    },
-    {
-        PCMK__CIB_REQUEST_CREATE, cib__op_create,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_create
-    },
-    {
-        PCMK__CIB_REQUEST_DELETE, cib__op_delete,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_delete
-    },
-    {
-        PCMK__CIB_REQUEST_ERASE, cib__op_erase,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_erase
-    },
-    {
-        PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_modify
-    },
-    {
-        PCMK__CIB_REQUEST_QUERY, cib__op_query,
-        cib_op_attr_none,
-        cib_process_query
-    },
-    {
-        PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_replace
-    },
-    {
-        PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
-        cib_op_attr_modifies|cib_op_attr_transaction,
-        cib_process_upgrade
-    },
-    {
-        PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
-        cib_op_attr_none,
-        cib_file_process_init_transaction
-    },
-    {
-        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
-        cib_op_attr_modifies,
-        cib_file_process_commit_transaction
-    },
-    {
-        PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
-        cib_op_attr_none,
-        cib_file_process_discard_transaction
-    },
+static const cib__op_fn_t cib_op_functions[] = {
+    [cib__op_apply_patch]      = cib_process_diff,
+    [cib__op_bump]             = cib_process_bump,
+    [cib__op_create]           = cib_process_create,
+    [cib__op_delete]           = cib_process_delete,
+    [cib__op_erase]            = cib_process_erase,
+    [cib__op_modify]           = cib_process_modify,
+    [cib__op_query]            = cib_process_query,
+    [cib__op_replace]          = cib_process_replace,
+    [cib__op_upgrade]          = cib_process_upgrade,
+    [cib__op_init_transact]    = cib_file_process_init_transaction,
+    [cib__op_commit_transact]  = cib_file_process_commit_transaction,
+    [cib__op_discard_transact] = cib_file_process_discard_transaction,
 };
 
 /* cib_file_backup() and cib_file_write_with_digest() need to chown the
@@ -259,35 +180,25 @@ static gboolean cib_do_chown = FALSE;
                                                 #flags_to_clear);       \
     } while (0)
 
-static int
-get_operation(const char *op, const cib_operation_t **operation)
+/*!
+ * \internal
+ * \brief Get the function that performs a given CIB file operation
+ *
+ * \param[in] operation  Operation whose function to look up
+ *
+ * \return Function that performs \p operation for a CIB file client
+ */
+static cib__op_fn_t
+file_get_op_function(const cib_operation_t *operation)
 {
-    CRM_CHECK(op != NULL, return -EINVAL);
+    enum cib__op_type type = operation->type;
 
-    if (op_table == NULL) {
-        op_table = pcmk__strkey_table(NULL, NULL);
+    CRM_ASSERT(type >= 0);
 
-        for (int lpc = 0; lpc < PCMK__NELEM(cib_file_ops); lpc++) {
-            const cib_operation_t *oper = &(cib_file_ops[lpc]);
-
-            g_hash_table_insert(op_table, (gpointer) oper->name,
-                                (gpointer) oper);
-        }
+    if (type >= PCMK__NELEM(cib_op_functions)) {
+        return NULL;
     }
-
-    *operation = g_hash_table_lookup(op_table, op);
-
-    if (*operation == NULL) {
-        /* @COMPAT: EOPNOTSUPP makes more sense but would change existing
-         * behavior. If we merge the server and file ops tables in the future,
-         * then EINVAL makes sense: if we didn't find the op, it doesn't exist.
-         * Only an internal bug gets us to that point.
-         */
-        crm_err("Operation %s is invalid or unsupported for CIB file clients",
-                op);
-        return -EPROTONOSUPPORT;
-    }
-    return pcmk_ok;
+    return cib_op_functions[type];
 }
 
 /*!
@@ -326,6 +237,7 @@ cib_file_process_request(cib_t *cib, xmlNode *request, xmlNode **output)
 {
     int rc = pcmk_ok;
     const cib_operation_t *operation = NULL;
+    cib__op_fn_t op_function = NULL;
 
     int call_id = 0;
     int call_options = cib_none;
@@ -340,10 +252,9 @@ cib_file_process_request(cib_t *cib, xmlNode *request, xmlNode **output)
 
     cib_file_opaque_t *private = cib->variant_opaque;
 
-    rc = get_operation(op, &operation);
-    if (rc != pcmk_ok) {
-        goto done;
-    }
+    // We error checked these in callers
+    cib__get_operation(op, &operation);
+    op_function = file_get_op_function(operation);
 
     crm_element_value_int(request, F_CIB_CALLID, &call_id);
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
@@ -357,7 +268,7 @@ cib_file_process_request(cib_t *cib, xmlNode *request, xmlNode **output)
         data = pcmk_find_cib_element(data, section);
     }
 
-    rc = cib_perform_op(op, call_options, operation->fn, read_only, section,
+    rc = cib_perform_op(op, call_options, op_function, read_only, section,
                         request, data, true, &changed, &private->cib_xml,
                         &result_cib, &cib_diff, output);
 
@@ -425,9 +336,17 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
         return -ENOTCONN;
     }
 
-    rc = get_operation(op, &operation);
+    rc = cib__get_operation(op, &operation);
+    rc = pcmk_rc2legacy(rc);
     if (rc != pcmk_ok) {
-        return rc;
+        // @COMPAT: At compatibility break, use rc directly
+        return -EPROTONOSUPPORT;
+    }
+
+    if (file_get_op_function(operation) == NULL) {
+        // @COMPAT: At compatibility break, use EOPNOTSUPP
+        crm_err("Operation %s is not supported by CIB file clients", op);
+        return -EPROTONOSUPPORT;
     }
 
     cib->call_id++;
@@ -1204,13 +1123,16 @@ cib_file_extend_transaction(cib_t *cib, const cib_operation_t *operation,
     if (private->transaction == NULL) {
         return pcmk_rc_no_transaction;
     }
-
     if (!pcmk_is_set(operation->flags, cib_op_attr_transaction)) {
         crm_err("Operation '%s' is not supported in CIB transaction",
                 operation->name);
         return EOPNOTSUPP;
     }
-
+    if (file_get_op_function(operation) == NULL) {
+        crm_err("Operation %s is not supported by CIB file clients",
+                operation->name);
+        return EOPNOTSUPP;
+    }
     g_queue_push_tail(private->transaction, copy_xml(request));
     return pcmk_rc_ok;
 }

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -161,12 +161,12 @@ get_client(const char *client_id)
  * operation that supports running against a file). We can easily ignore the
  * prepare and cleanup functions.
  *
- * The main challenge is that the fn member (cib_op_t) may differ depending on
- * whether we're processing the request on the server side or with the
+ * The main challenge is that the fn member (cib__op_fn_t) may differ depending
+ * on whether we're processing the request on the server side or with the
  * file-based client. Processor functions defined in pacemaker-based shouldn't
  * be declared in libcib, but we need them accessible via the table somehow.
  *
- * Maybe use an enum that indexes into an array of cib_op_t functions. That
+ * Maybe use an enum that indexes into an array of cib__op_fn_t functions. That
  * would be obnoxiously similar to the call_type (index) argument that we
  * eliminated in c13bf8b2.
  */

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -259,7 +259,7 @@ cib_file_process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     crm_element_value_int(request, F_CIB_CALLID, &call_id);
     crm_element_value_int(request, F_CIB_CALLOPTS, &call_options);
 
-    read_only = !pcmk_is_set(operation->flags, cib_op_attr_modifies);
+    read_only = !pcmk_is_set(operation->flags, cib__op_attr_modifies);
 
     // Mirror the logic in cib_prepare_common()
     if ((section != NULL) && (data != NULL)
@@ -1123,7 +1123,7 @@ cib_file_extend_transaction(cib_t *cib, const cib_operation_t *operation,
     if (private->transaction == NULL) {
         return pcmk_rc_no_transaction;
     }
-    if (!pcmk_is_set(operation->flags, cib_op_attr_transaction)) {
+    if (!pcmk_is_set(operation->flags, cib__op_attr_transaction)) {
         crm_err("Operation '%s' is not supported in CIB transaction",
                 operation->name);
         return EOPNOTSUPP;

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -35,89 +35,90 @@ static GHashTable *operation_table = NULL;
 static const cib_operation_t cib_ops[] = {
     {
         PCMK__CIB_REQUEST_ABS_DELETE, cib__op_abs_delete,
-        cib_op_attr_modifies|cib_op_attr_privileged
+        cib__op_attr_modifies|cib__op_attr_privileged
     },
     {
         PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_transaction
     },
     {
         PCMK__CIB_REQUEST_BUMP, cib__op_bump,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_transaction
     },
     {
         PCMK__CIB_REQUEST_CREATE, cib__op_create,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_transaction
     },
     {
         PCMK__CIB_REQUEST_DELETE, cib__op_delete,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_transaction
     },
     {
         PCMK__CIB_REQUEST_ERASE, cib__op_erase,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_replaces
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_replaces
+        |cib__op_attr_transaction
     },
     {
-        PCMK__CIB_REQUEST_IS_PRIMARY, cib__op_is_primary, cib_op_attr_privileged
+        PCMK__CIB_REQUEST_IS_PRIMARY, cib__op_is_primary,
+        cib__op_attr_privileged
     },
     {
         PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_transaction
     },
     {
-        PCMK__CIB_REQUEST_NOOP, cib__op_noop, cib_op_attr_none
+        PCMK__CIB_REQUEST_NOOP, cib__op_noop, cib__op_attr_none
     },
     {
-        CRM_OP_PING, cib__op_ping, cib_op_attr_none
+        CRM_OP_PING, cib__op_ping, cib__op_attr_none
     },
     {
-        // @COMPAT: Drop cib_op_attr_modifies when we drop legacy mode support
+        // @COMPAT: Drop cib__op_attr_modifies when we drop legacy mode support
         PCMK__CIB_REQUEST_PRIMARY, cib__op_primary,
-        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_local
+        cib__op_attr_modifies|cib__op_attr_privileged|cib__op_attr_local
     },
     {
-        PCMK__CIB_REQUEST_QUERY, cib__op_query, cib_op_attr_none
+        PCMK__CIB_REQUEST_QUERY, cib__op_query, cib__op_attr_none
     },
     {
         PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_replaces
-        |cib_op_attr_writes_through
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_replaces
+        |cib__op_attr_writes_through
+        |cib__op_attr_transaction
     },
     {
         PCMK__CIB_REQUEST_SECONDARY, cib__op_secondary,
-        cib_op_attr_privileged|cib_op_attr_local
+        cib__op_attr_privileged|cib__op_attr_local
     },
     {
-        PCMK__CIB_REQUEST_SHUTDOWN, cib__op_shutdown, cib_op_attr_privileged
+        PCMK__CIB_REQUEST_SHUTDOWN, cib__op_shutdown, cib__op_attr_privileged
     },
     {
-        PCMK__CIB_REQUEST_SYNC_TO_ALL, cib__op_sync_all, cib_op_attr_privileged
+        PCMK__CIB_REQUEST_SYNC_TO_ALL, cib__op_sync_all, cib__op_attr_privileged
     },
     {
-        PCMK__CIB_REQUEST_SYNC_TO_ONE, cib__op_sync_one, cib_op_attr_privileged
+        PCMK__CIB_REQUEST_SYNC_TO_ONE, cib__op_sync_one, cib__op_attr_privileged
     },
     {
         PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_writes_through
-        |cib_op_attr_transaction
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_writes_through
+        |cib__op_attr_transaction
     },
 
     /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
@@ -126,19 +127,19 @@ static const cib_operation_t cib_ops[] = {
      */
     {
         PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
-        cib_op_attr_privileged|cib_op_attr_local
+        cib__op_attr_privileged|cib__op_attr_local
     },
     {
         PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
-        cib_op_attr_modifies
-        |cib_op_attr_privileged
-        |cib_op_attr_local
-        |cib_op_attr_replaces
-        |cib_op_attr_writes_through
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_local
+        |cib__op_attr_replaces
+        |cib__op_attr_writes_through
     },
     {
         PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
-        cib_op_attr_privileged|cib_op_attr_local
+        cib__op_attr_privileged|cib__op_attr_local
     },
 };
 

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -32,7 +32,7 @@
 // @TODO: Free this via crm_exit() when libcib gets merged with libcrmcommon
 static GHashTable *operation_table = NULL;
 
-static const cib_operation_t cib_ops[] = {
+static const cib__operation_t cib_ops[] = {
     {
         PCMK__CIB_REQUEST_ABS_DELETE, cib__op_abs_delete,
         cib__op_attr_modifies|cib__op_attr_privileged
@@ -145,7 +145,7 @@ static const cib_operation_t cib_ops[] = {
 
 /*!
  * \internal
- * \brief Get the \c cib_operation_t object for a given CIB operation name
+ * \brief Get the \c cib__operation_t object for a given CIB operation name
  *
  * \param[in]  op         CIB operation name
  * \param[out] operation  Where to store CIB operation object
@@ -153,7 +153,7 @@ static const cib_operation_t cib_ops[] = {
  * \return Standard Pacemaker return code
  */
 int
-cib__get_operation(const char *op, const cib_operation_t **operation)
+cib__get_operation(const char *op, const cib__operation_t **operation)
 {
     CRM_ASSERT((op != NULL) && (operation != NULL));
 
@@ -161,7 +161,7 @@ cib__get_operation(const char *op, const cib_operation_t **operation)
         operation_table = pcmk__strkey_table(NULL, NULL);
 
         for (int lpc = 0; lpc < PCMK__NELEM(cib_ops); lpc++) {
-            const cib_operation_t *oper = &(cib_ops[lpc]);
+            const cib__operation_t *oper = &(cib_ops[lpc]);
 
             g_hash_table_insert(operation_table, (gpointer) oper->name,
                                 (gpointer) oper);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -19,12 +19,161 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#include <glib.h>
+#include <libxml/tree.h>
+
 #include <crm/crm.h>
 #include <crm/cib/internal.h>
 #include <crm/msg_xml.h>
 
 #include <crm/common/xml.h>
 #include <crm/common/xml_internal.h>
+
+// @TODO: Free this via crm_exit() when libcib gets merged with libcrmcommon
+static GHashTable *operation_table = NULL;
+
+static const cib_operation_t cib_ops[] = {
+    {
+        PCMK__CIB_REQUEST_ABS_DELETE, cib__op_abs_delete,
+        cib_op_attr_modifies|cib_op_attr_privileged
+    },
+    {
+        PCMK__CIB_REQUEST_APPLY_PATCH, cib__op_apply_patch,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_BUMP, cib__op_bump,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_CREATE, cib__op_create,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_DELETE, cib__op_delete,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_ERASE, cib__op_erase,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_replaces
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_IS_PRIMARY, cib__op_is_primary, cib_op_attr_privileged
+    },
+    {
+        PCMK__CIB_REQUEST_MODIFY, cib__op_modify,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_NOOP, cib__op_noop, cib_op_attr_none
+    },
+    {
+        CRM_OP_PING, cib__op_ping, cib_op_attr_none
+    },
+    {
+        // @COMPAT: Drop cib_op_attr_modifies when we drop legacy mode support
+        PCMK__CIB_REQUEST_PRIMARY, cib__op_primary,
+        cib_op_attr_modifies|cib_op_attr_privileged|cib_op_attr_local
+    },
+    {
+        PCMK__CIB_REQUEST_QUERY, cib__op_query, cib_op_attr_none
+    },
+    {
+        PCMK__CIB_REQUEST_REPLACE, cib__op_replace,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_replaces
+        |cib_op_attr_writes_through
+        |cib_op_attr_transaction
+    },
+    {
+        PCMK__CIB_REQUEST_SECONDARY, cib__op_secondary,
+        cib_op_attr_privileged|cib_op_attr_local
+    },
+    {
+        PCMK__CIB_REQUEST_SHUTDOWN, cib__op_shutdown, cib_op_attr_privileged
+    },
+    {
+        PCMK__CIB_REQUEST_SYNC_TO_ALL, cib__op_sync_all, cib_op_attr_privileged
+    },
+    {
+        PCMK__CIB_REQUEST_SYNC_TO_ONE, cib__op_sync_one, cib_op_attr_privileged
+    },
+    {
+        PCMK__CIB_REQUEST_UPGRADE, cib__op_upgrade,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_writes_through
+        |cib_op_attr_transaction
+    },
+
+    /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
+     * they depend on the client table. Requests that manage transactions on
+     * other nodes would likely be problematic in many other ways as well.
+     */
+    {
+        PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
+        cib_op_attr_privileged|cib_op_attr_local
+    },
+    {
+        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
+        cib_op_attr_modifies
+        |cib_op_attr_privileged
+        |cib_op_attr_local
+        |cib_op_attr_replaces
+        |cib_op_attr_writes_through
+    },
+    {
+        PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
+        cib_op_attr_privileged|cib_op_attr_local
+    },
+};
+
+/*!
+ * \internal
+ * \brief Get the \c cib_operation_t object for a given CIB operation name
+ *
+ * \param[in]  op         CIB operation name
+ * \param[out] operation  Where to store CIB operation object
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+cib__get_operation(const char *op, const cib_operation_t **operation)
+{
+    CRM_ASSERT((op != NULL) && (operation != NULL));
+
+    if (operation_table == NULL) {
+        operation_table = pcmk__strkey_table(NULL, NULL);
+
+        for (int lpc = 0; lpc < PCMK__NELEM(cib_ops); lpc++) {
+            const cib_operation_t *oper = &(cib_ops[lpc]);
+
+            g_hash_table_insert(operation_table, (gpointer) oper->name,
+                                (gpointer) oper);
+        }
+    }
+
+    *operation = g_hash_table_lookup(operation_table, op);
+    if (*operation == NULL) {
+        crm_err("Operation %s is invalid", op);
+        return EINVAL;
+    }
+    return pcmk_rc_ok;
+}
 
 int
 cib_process_query(const char *op, int options, const char *section, xmlNode * req, xmlNode * input,

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -190,7 +190,7 @@ should_copy_cib(const char *op, const char *section, int call_options)
 }
 
 int
-cib_perform_op(const char *op, int call_options, cib_op_t fn, bool is_query,
+cib_perform_op(const char *op, int call_options, cib__op_fn_t fn, bool is_query,
                const char *section, xmlNode *req, xmlNode *input,
                bool manage_counters, bool *config_changed,
                xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -152,7 +152,7 @@ html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy
      * anything else that the user could add, and we want it done last to pick up
      * any options that may have been given.
      */
-    head_node = xmlNewNode(NULL, (pcmkXmlStr) "head");
+    head_node = xmlNewDocRawNode(NULL, NULL, (pcmkXmlStr) "head", NULL);
 
     if (title != NULL ) {
         pcmk_create_xml_text_node(head_node, "title", title);
@@ -458,7 +458,7 @@ pcmk__html_add_header(const char *name, ...) {
 
     va_start(ap, name);
 
-    header_node = xmlNewNode(NULL, (pcmkXmlStr) name);
+    header_node = xmlNewDocRawNode(NULL, NULL, (pcmkXmlStr) name, NULL);
     while (1) {
         char *key = va_arg(ap, char *);
         char *value;

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -287,7 +287,10 @@ xml_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
     CRM_ASSERT(out != NULL);
 
     parent = pcmk__output_create_xml_node(out, name, NULL);
-    cdata_node = xmlNewCDataBlock(getDocPtr(parent), (pcmkXmlStr) buf, strlen(buf));
+    if (parent == NULL) {
+        return;
+    }
+    cdata_node = xmlNewCDataBlock(parent->doc, (pcmkXmlStr) buf, strlen(buf));
     xmlAddChild(parent, cdata_node);
 }
 

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -592,37 +592,36 @@ crm_schema_cleanup(void)
 static gboolean
 validate_with(xmlNode *xml, int method, gboolean to_logs)
 {
-    xmlDocPtr doc = NULL;
     gboolean valid = FALSE;
     char *file = NULL;
+    struct schema_s *schema = NULL;
+    relaxng_ctx_cache_t **cache = NULL;
 
     if (method < 0) {
         return FALSE;
     }
 
-    if (known_schemas[method].validator == schema_validator_none) {
+    schema = &(known_schemas[method]);
+    if (schema->validator == schema_validator_none) {
         return TRUE;
     }
 
     CRM_CHECK(xml != NULL, return FALSE);
 
-    if (pcmk__str_eq(known_schemas[method].name, "pacemaker-next",
-                     pcmk__str_none)) {
+    if (pcmk__str_eq(schema->name, "pacemaker-next", pcmk__str_none)) {
         crm_warn("The pacemaker-next schema is deprecated and will be removed "
                  "in a future release.");
     }
 
-    doc = getDocPtr(xml);
     file = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_legacy_rng,
-                                   known_schemas[method].name);
+                                   schema->name);
 
     crm_trace("Validating with %s (type=%d)",
-              pcmk__s(file, "missing schema"), known_schemas[method].validator);
-    switch (known_schemas[method].validator) {
+              pcmk__s(file, "missing schema"), schema->validator);
+    switch (schema->validator) {
         case schema_validator_rng:
-            valid =
-                validate_with_relaxng(doc, to_logs, file,
-                                      (relaxng_ctx_cache_t **) & (known_schemas[method].cache));
+            cache = (relaxng_ctx_cache_t **) &(schema->cache);
+            valid = validate_with_relaxng(xml->doc, to_logs, file, cache);
             break;
         default:
             crm_err("Unknown validator type: %d",
@@ -909,7 +908,6 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
     char *xform = NULL;
     xmlNode *out = NULL;
     xmlDocPtr res = NULL;
-    xmlDocPtr doc = NULL;
     xsltStylesheet *xslt = NULL;
 #if PCMK_SCHEMAS_EMERGENCY_XSLT != 0
     xmlChar *emergency_result;
@@ -918,7 +916,6 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
 #endif
 
     CRM_CHECK(xml != NULL, return FALSE);
-    doc = getDocPtr(xml);
     xform = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_legacy_xslt,
                                     transform);
 
@@ -935,7 +932,7 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
     xslt = xsltParseStylesheetFile((pcmkXmlStr) xform);
     CRM_CHECK(xslt != NULL, goto cleanup);
 
-    res = xsltApplyStylesheet(xslt, doc, NULL);
+    res = xsltApplyStylesheet(xslt, xml->doc, NULL);
     CRM_CHECK(res != NULL, goto cleanup);
 
     xsltSetGenericErrorFunc(NULL, NULL);  /* restore default one */

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -606,8 +606,6 @@ validate_with(xmlNode *xml, int method, gboolean to_logs)
         return TRUE;
     }
 
-    CRM_CHECK(xml != NULL, return FALSE);
-
     if (pcmk__str_eq(schema->name, "pacemaker-next", pcmk__str_none)) {
         crm_warn("The pacemaker-next schema is deprecated and will be removed "
                  "in a future release.");
@@ -706,6 +704,8 @@ gboolean
 validate_xml(xmlNode *xml_blob, const char *validation, gboolean to_logs)
 {
     int version = 0;
+
+    CRM_CHECK((xml_blob != NULL) && (xml_blob->doc != NULL), return FALSE);
 
     if (validation == NULL) {
         validation = crm_element_value(xml_blob, XML_ATTR_VALIDATION);
@@ -915,7 +915,6 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
     int emergency_res;
 #endif
 
-    CRM_CHECK(xml != NULL, return FALSE);
     xform = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_legacy_xslt,
                                     transform);
 
@@ -1056,8 +1055,9 @@ update_validation(xmlNode **xml_blob, int *best, int max, gboolean transform,
     CRM_CHECK(best != NULL, return -EINVAL);
     *best = 0;
 
-    CRM_CHECK(xml_blob != NULL, return -EINVAL);
-    CRM_CHECK(*xml_blob != NULL, return -EINVAL);
+    CRM_CHECK((xml_blob != NULL) && (*xml_blob != NULL)
+              && ((*xml_blob)->doc != NULL),
+              return -EINVAL);
 
     xml = *xml_blob;
     value = crm_element_value_copy(xml, XML_ATTR_VALIDATION);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -623,21 +623,6 @@ pcmk__xe_remove_matching_attrs(xmlNode *element,
     }
 }
 
-xmlDoc *
-getDocPtr(xmlNode * node)
-{
-    xmlDoc *doc = NULL;
-
-    CRM_CHECK(node != NULL, return NULL);
-
-    doc = node->doc;
-    if (doc == NULL) {
-        doc = xmlNewDoc((pcmkXmlStr) "1.0");
-        xmlDocSetRootElement(doc, node);
-    }
-    return doc;
-}
-
 xmlNode *
 add_node_copy(xmlNode * parent, xmlNode * src_node)
 {
@@ -2751,6 +2736,21 @@ void
 crm_destroy_xml(gpointer data)
 {
     free_xml(data);
+}
+
+xmlDoc *
+getDocPtr(xmlNode *node)
+{
+    xmlDoc *doc = NULL;
+
+    CRM_CHECK(node != NULL, return NULL);
+
+    doc = node->doc;
+    if (doc == NULL) {
+        doc = xmlNewDoc((pcmkXmlStr) "1.0");
+        xmlDocSetRootElement(doc, node);
+    }
+    return doc;
 }
 
 int

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -691,11 +691,10 @@ create_xml_node(xmlNode * parent, const char *name)
             return NULL;
         }
 
-        node = xmlNewDocRawNode(doc, NULL, (pcmkXmlStr) name, NULL);
+        node = xmlNewChild(parent, NULL, (pcmkXmlStr) name, NULL);
         if (node == NULL) {
             return NULL;
         }
-        xmlAddChild(parent, node);
     }
     pcmk__mark_xml_created(node);
     return node;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -641,21 +641,14 @@ getDocPtr(xmlNode * node)
 xmlNode *
 add_node_copy(xmlNode * parent, xmlNode * src_node)
 {
-    xmlDoc *doc = NULL;
     xmlNode *child = NULL;
 
     CRM_CHECK((parent != NULL) && (src_node != NULL), return NULL);
 
-    doc = getDocPtr(parent);
-    if (doc == NULL) {
-        return NULL;
-    }
-
-    child = xmlDocCopyNode(src_node, doc, 1);
+    child = xmlDocCopyNode(src_node, parent->doc, 1);
     if (child == NULL) {
         return NULL;
     }
-
     xmlAddChild(parent, child);
     pcmk__mark_xml_created(child);
     return child;
@@ -686,11 +679,6 @@ create_xml_node(xmlNode * parent, const char *name)
         xmlDocSetRootElement(doc, node);
 
     } else {
-        doc = getDocPtr(parent);
-        if (doc == NULL) {
-            return NULL;
-        }
-
         node = xmlNewChild(parent, NULL, (pcmkXmlStr) name, NULL);
         if (node == NULL) {
             return NULL;
@@ -1601,14 +1589,8 @@ pcmk__xml2text(xmlNodePtr data, uint32_t options, GString *buffer, int depth)
 #if (PCMK__XMLDUMP_STATS - 0)
         time_t next, new = time(NULL);
 #endif
-        xmlDoc *doc;
-        xmlOutputBuffer *xml_buffer;
+        xmlOutputBuffer *xml_buffer = xmlAllocOutputBuffer(NULL);
 
-        doc = getDocPtr(data);
-        /* doc will only be NULL if data is */
-        CRM_CHECK(doc != NULL, return);
-
-        xml_buffer = xmlAllocOutputBuffer(NULL);
         CRM_ASSERT(xml_buffer != NULL);
 
         /* XXX we could setup custom allocation scheme for the particular
@@ -1621,7 +1603,7 @@ pcmk__xml2text(xmlNodePtr data, uint32_t options, GString *buffer, int depth)
                parsed tree (but those would need to be strictly used as
                opposed to libxml's raw functions) */
 
-        xmlNodeDumpOutput(xml_buffer, doc, data, 0,
+        xmlNodeDumpOutput(xml_buffer, data->doc, data, 0,
                           pcmk_is_set(options, pcmk__xml_fmt_pretty), NULL);
         /* attempt adding final NL - failing shouldn't be fatal here */
         (void) xmlOutputBufferWrite(xml_buffer, sizeof("\n") - 1, "\n");
@@ -1750,7 +1732,6 @@ pcmk__xml2fd(int fd, xmlNode *cur)
 
     fsync(fd);
     return pcmk_rc_ok;
-    
 }
 
 gboolean

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -138,7 +138,6 @@ dedupXpathResults(xmlXPathObjectPtr xpathObj)
 xmlXPathObjectPtr
 xpath_search(const xmlNode *xml_top, const char *path)
 {
-    xmlDocPtr doc = NULL;
     xmlXPathObjectPtr xpathObj = NULL;
     xmlXPathContextPtr xpathCtx = NULL;
     const xmlChar *xpathExpr = (pcmkXmlStr) path;
@@ -147,9 +146,7 @@ xpath_search(const xmlNode *xml_top, const char *path)
     CRM_CHECK(xml_top != NULL, return NULL);
     CRM_CHECK(strlen(path) > 0, return NULL);
 
-    doc = getDocPtr(xml_top);
-
-    xpathCtx = xmlXPathNewContext(doc);
+    xpathCtx = xmlXPathNewContext(xml_top->doc);
     CRM_ASSERT(xpathCtx != NULL);
 
     xpathObj = xmlXPathEvalExpression(xpathExpr, xpathCtx);

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -136,7 +136,7 @@ dedupXpathResults(xmlXPathObjectPtr xpathObj)
 
 /* the caller needs to check if the result contains a xmlDocPtr or xmlNodePtr */
 xmlXPathObjectPtr
-xpath_search(xmlNode * xml_top, const char *path)
+xpath_search(const xmlNode *xml_top, const char *path)
 {
     xmlDocPtr doc = NULL;
     xmlXPathObjectPtr xpathObj = NULL;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -276,7 +276,7 @@ pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pe_working_set_t *data_set)
                     const char *obj_ref = iter->data;
                     xmlNode *new_rsc_ref = NULL;
 
-                    new_rsc_ref = xmlNewDocRawNode(getDocPtr(set), NULL,
+                    new_rsc_ref = xmlNewDocRawNode(set->doc, NULL,
                                                    (pcmkXmlStr)
                                                    XML_TAG_RESOURCE_REF,
                                                    NULL);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -575,9 +575,7 @@ pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
 
     xml_node = pcmk__output_xml_peek_parent(out);
     CRM_ASSERT(xml_node != NULL);
-    xml_node = is_list
-        ? create_xml_node(xml_node, tag_name)
-        : xmlNewChild(xml_node, NULL, (pcmkXmlStr) tag_name, NULL);
+    xml_node = create_xml_node(xml_node, tag_name);
 
     va_start(args, pairs_count);
     while(pairs_count--) {


### PR DESCRIPTION
This allows us to deduplicate the shared data (op name and op attributes). We introduce a new `enum cib__op_type` to use as a key for accessing `cib_op_fn_t` functions. This is a step toward a cleaner CIB transaction implementation, which is coming soon.

We drop `cib_operation_t:prepare` and `cib_operation_t:cleanup` as well.

I was going to go farther with the XML stuff but dropped that for now. I included in this PR what I had already done. Getting rid of `getDocPtr()` doesn't actually allow all that many switches to const (I only checked `xml.c` so I'm sure I missed a bunch that we can update later). Most of the barriers to const come from libxml2 itself.