### PR TITLE
Fix: controller: do not check whether watchdog fencing is enabled for the node if `stonith-watchdog-timeout` is not even configured

### DIFF
--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -1003,12 +1003,14 @@ controld_execute_fence_action(pcmk__graph_t *graph,
 bool
 controld_verify_stonith_watchdog_timeout(const char *value)
 {
+    long st_timeout = value? crm_get_msec(value) : 0;
     const char *our_nodename = controld_globals.our_nodename;
     gboolean rv = TRUE;
 
-    if (stonith_api && (stonith_api->state != stonith_disconnected) &&
-        stonith__watchdog_fencing_enabled_for_node_api(stonith_api,
-                                                       our_nodename)) {
+    if (st_timeout == 0
+        || (stonith_api && (stonith_api->state != stonith_disconnected) &&
+            stonith__watchdog_fencing_enabled_for_node_api(stonith_api,
+                                                           our_nodename))) {
         rv = pcmk__valid_sbd_timeout(value);
     }
     return rv;


### PR DESCRIPTION
Previously controld would unconditionally keep invoking stonith__watchdog_fencing_enabled_for_node_api() even if `stonith-watchdog-timeout` was not configured, which would also keep worrying users with the log:

pacemaker-controld[...]:  notice: Cluster does not have watchdog fencing device