### PR TITLE
Low: python: Add tests/__init__.py.

### DIFF
--- a/python/tests/Makefile.am
+++ b/python/tests/Makefile.am
@@ -9,4 +9,4 @@
 
 MAINTAINERCLEANFILES    = Makefile.in
 
-EXTRA_DIST = $(wildcard test_*)
+EXTRA_DIST = $(wildcard test_*) __init__.py


### PR DESCRIPTION
According to the unittest module docs, we need a __init__.py file in the starting directory as well as any directory containing tests.