### PR TITLE
Convert crm_node to formatted output

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -7667,7 +7667,7 @@ Diff: +++ 0.1.0 (null)
 -- /cib/status/node_state[@id='1']
 -- /cib/status/node_state[@id='httpd-bundle-0']
 -- /cib/status/node_state[@id='httpd-bundle-1']
-+  /cib:  @crm_feature_set=3.18.0, @num_updates=0, @admin_epoch=0
++  /cib:  @crm_feature_set=3.18.1, @num_updates=0, @admin_epoch=0
 -- /cib:  @cib-last-written, @update-origin, @update-client, @update-user, @have-quorum, @dc-uuid
 =#=#=#= End test: Get active shadow instance's diff (empty CIB) - Error occurred (1) =#=#=#=
 * Passed: crm_shadow     - Get active shadow instance's diff (empty CIB)
@@ -7701,7 +7701,7 @@ Diff: +++ 0.1.0 (null)
   <change operation="delete" path="/cib/status/node_state[@id='httpd-bundle-1']"/>
   <change operation="modify" path="/cib">
     <change-list>
-      <change-attr name="crm_feature_set" operation="set" value="3.18.0"/>
+      <change-attr name="crm_feature_set" operation="set" value="3.18.1"/>
       <change-attr name="num_updates" operation="set" value="0"/>
       <change-attr name="admin_epoch" operation="set" value="0"/>
       <change-attr name="cib-last-written" operation="unset"/>

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -66,7 +66,7 @@ extern "C" {
  * >=3.0.13: Fail counts include operation name and interval
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  */
-#  define CRM_FEATURE_SET		"3.18.0"
+#  define CRM_FEATURE_SET		"3.18.1"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1333,12 +1333,12 @@ node_action_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-info", "int", "const char *", "const char *",
+PCMK__OUTPUT_ARGS("node-info", "uint32_t", "const char *", "const char *",
                   "const char *", "bool", "bool")
 static int
 node_info_default(pcmk__output_t *out, va_list args)
 {
-    int node_id = va_arg(args, int);
+    uint32_t node_id = va_arg(args, uint32_t);
     const char *node_name = va_arg(args, const char *);
     const char *uuid = va_arg(args, const char *);
     const char *state = va_arg(args, const char *);
@@ -1346,26 +1346,26 @@ node_info_default(pcmk__output_t *out, va_list args)
     bool is_remote = (bool) va_arg(args, int);
 
     return out->info(out,
-                     "Node %d: %s "
+                     "Node %" PRIu32 ": %s "
                      "(uuid=%s, state=%s, have_quorum=%s, is_remote=%s)",
                      node_id, pcmk__s(node_name, "unknown"),
                      pcmk__s(uuid, "unknown"), pcmk__s(state, "unknown"),
                      pcmk__btoa(have_quorum), pcmk__btoa(is_remote));
 }
 
-PCMK__OUTPUT_ARGS("node-info", "int", "const char *", "const char *",
+PCMK__OUTPUT_ARGS("node-info", "uint32_t", "const char *", "const char *",
                   "const char *", "bool", "bool")
 static int
 node_info_xml(pcmk__output_t *out, va_list args)
 {
-    int node_id = va_arg(args, int);
+    uint32_t node_id = va_arg(args, uint32_t);
     const char *node_name = va_arg(args, const char *);
     const char *uuid = va_arg(args, const char *);
     const char *state = va_arg(args, const char *);
     bool have_quorum = (bool) va_arg(args, int);
     bool is_remote = (bool) va_arg(args, int);
 
-    char *id_s = crm_strdup_printf("%d", node_id);
+    char *id_s = crm_strdup_printf("%" PRIu32, node_id);
 
     pcmk__output_create_xml_node(out, "node-info",
                                  "nodeid", id_s,

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -89,7 +89,8 @@ crm_shadow_LDADD	= $(top_builddir)/lib/cib/libcib.la		\
 			  $(top_builddir)/lib/common/libcrmcommon.la
 
 crm_node_SOURCES	= crm_node.c
-crm_node_LDADD		= $(top_builddir)/lib/cib/libcib.la		\
+crm_node_LDADD	= $(top_builddir)/lib/pacemaker/libpacemaker.la	\
+			  $(top_builddir)/lib/cib/libcib.la		\
 			  $(top_builddir)/lib/common/libcrmcommon.la
 
 crm_simulate_SOURCES	= crm_simulate.c

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -42,6 +42,7 @@ gboolean command_cb(const gchar *option_name, const gchar *optarg, gpointer data
 gboolean name_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
 gboolean remove_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
 
+static GError *error = NULL;
 static GMainLoop *mainloop = NULL;
 static crm_exit_t exit_code = CRM_EX_OK;
 
@@ -533,8 +534,6 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup *group) {
 int
 main(int argc, char **argv)
 {
-    GError *error = NULL;
-
     GOptionGroup *output_group = NULL;
     pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
     gchar **processed_args = pcmk__cmdline_preproc(argv, "NR");

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -385,7 +385,7 @@ done:
 }
 
 static void
-run_controller_mainloop(uint32_t nodeid, bool list_nodes)
+run_controller_mainloop(void)
 {
     pcmk_ipc_api_t *controld_api = NULL;
     int rc;
@@ -413,11 +413,8 @@ run_controller_mainloop(uint32_t nodeid, bool list_nodes)
         return;
     }
 
-    if (list_nodes) {
-        rc = pcmk_controld_api_list_nodes(controld_api);
-    } else {
-        rc = pcmk_controld_api_node_info(controld_api, nodeid);
-    }
+    rc = pcmk_controld_api_list_nodes(controld_api);
+
     if (rc != pcmk_rc_ok) {
         pcmk_disconnect_ipc(controld_api);
         exit_code = pcmk_rc2exitc(rc);
@@ -835,7 +832,7 @@ main(int argc, char **argv)
 
         case 'l':
         case 'p':
-            run_controller_mainloop(0, true);
+            run_controller_mainloop();
             break;
 
         default:

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -105,7 +105,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
     } else if (pcmk__str_eq("-q", option_name, pcmk__str_casei) || pcmk__str_eq("--quorum", option_name, pcmk__str_casei)) {
         options.command = 'q';
     } else {
-        g_set_error(error, PCMK__EXITC_ERROR, CRM_EX_INVALID_PARAM, "Unknown param passed to command_cb: %s\n", option_name);
+        g_set_error(error, PCMK__EXITC_ERROR, CRM_EX_INVALID_PARAM, "Unknown param passed to command_cb: %s", option_name);
         return FALSE;
     }
 

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2022 the Pacemaker project contributors
+# Copyright 2004-2023 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -58,6 +58,7 @@ API_request_base	= command-output	\
 			  crm_attribute 	\
 			  crm_error 	\
 			  crm_mon		\
+			  crm_node 		\
 			  crm_resource		\
 			  crm_rule \
 			  crm_shadow		\

--- a/xml/api/crm_node-2.32.rng
+++ b/xml/api/crm_node-2.32.rng
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <!-- Output of the crm_node command -->
+    <start>
+        <ref name="element-crm-node" />
+    </start>
+
+    <define name="element-crm-node">
+        <choice>
+            <ref name="cluster-info" />
+            <ref name="node-info" />
+            <ref name="node-list" />
+        </choice>
+    </define>
+
+    <define name="cluster-info">
+        <element name="cluster-info">
+            <attribute name="quorum"> <data type="boolean" /> </attribute>
+        </element>
+    </define>
+
+    <define name="node-info">
+        <element name="node-info">
+            <attribute name="nodeid"> <data type="nonNegativeInteger" /> </attribute>
+            <optional>
+                <attribute name="uname"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="node-list">
+        <element name="nodes">
+            <oneOrMore>
+                <ref name="element-node" />
+            </oneOrMore>
+        </element>
+    </define>
+
+    <define name="element-node">
+        <element name="node">
+            <attribute name="id"> <data type="nonNegativeInteger" /> </attribute>
+            <optional>
+                <attribute name="name"> <text/> </attribute>
+            </optional>
+            <optional>
+                <attribute name="state"> <text/> </attribute>
+            </optional>
+        </element>
+    </define>
+
+</grammar>


### PR DESCRIPTION
Some parts of this are a little weird.  Hopefully, the commit messages and comments explain why.  The extremely brief idea was that I wanted to use existing formatted output messages as much as possible, within the constraint that text output can't change right now.  So that resulted in some strange stuff around the output messages.

I've also not added an XML schema yet because I want to get everything else figured out first.  Here's what the XML output looks like at the moment:
```
[root@rhel9-cluster-1 ~]# ./test.sh 
+ crm_node -i --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -i --output-as=xml">
  <node-info nodeid="1" have-quorum="true" remote_node="false"/>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -l --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -l --output-as=xml">
  <nodes>
    <node id="1" name="rhel9-cluster-1" state="member"/>
    <node id="2" name="rhel9-cluster-2" state="member"/>
  </nodes>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -n --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -n --output-as=xml">
  <node-info nodeid="0" uname="rhel9-cluster-1" have-quorum="true" remote_node="false"/>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -p --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -p --output-as=xml">
  <nodes>
    <node id="1" name="rhel9-cluster-1" state="member"/>
    <node id="2" name="rhel9-cluster-2" state="member"/>
  </nodes>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -q --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -q --output-as=xml">
  <node-info nodeid="0" have-quorum="true" remote_node="false"/>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -N 0 --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -N 0 --output-as=xml">
  <node-info nodeid="0" uname="rhel9-cluster-1" have-quorum="true" remote_node="false"/>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -N 1 --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -N 1 --output-as=xml">
  <node-info nodeid="0" uname="rhel9-cluster-1" have-quorum="true" remote_node="false"/>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -N 2 --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -N 2 --output-as=xml">
  <node-info nodeid="0" uname="rhel9-cluster-2" have-quorum="true" remote_node="false"/>
  <status code="0" message="OK"/>
</pacemaker-result>
+ crm_node -N 3 --output-as=xml
<pacemaker-result api-version="2.30" request="crm_node -N 3 --output-as=xml">
  <status code="0" message="OK">
    <errors>
      <error>Node is not known to cluster</error>
    </errors>
  </status>
</pacemaker-result>
```