### PR TITLE
Move enum action_tasks to libcrmcommon

### DIFF
--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -96,8 +96,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_start instead
     start_rsc               = pcmk_action_start,
-#endif
+
+    //! \deprecated Use pcmk_action_started instead
     started_rsc             = pcmk_action_started,
+#endif
     action_notify,
     action_notified,
     action_promote,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -76,6 +76,7 @@ enum action_tasks {
     // Each "completed" action must be the regular action plus 1
 
     pcmk_action_stop,               //!< Stop
+    pcmk_action_stopped,            //!< Stop completed
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
@@ -87,7 +88,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_stop instead
     stop_rsc                = pcmk_action_stop,
 #endif
-    stopped_rsc,
+    stopped_rsc             = pcmk_action_stopped,
     start_rsc,
     started_rsc,
     action_notify,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -70,7 +70,9 @@ extern "C" {
 
 //! Possible actions (including some pseudo-actions)
 enum action_tasks {
-    no_action,
+    pcmk_action_unspecified = 0,    //!< Unspecified or unknown action
+
+    no_action               = pcmk_action_unspecified,
     monitor_rsc,
 
     // Each "completed" action must be the regular action plus 1

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -85,6 +85,7 @@ enum action_tasks {
     pcmk_action_notified,           //!< Notify completed
 
     pcmk_action_promote,            //!< Promote
+    pcmk_action_promoted,           //!< Promoted
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
@@ -114,7 +115,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_promote instead
     action_promote          = pcmk_action_promote,
 #endif
-    action_promoted,
+    action_promoted         = pcmk_action_promoted,
     action_demote,
     action_demoted,
     shutdown_crm,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -87,6 +87,8 @@ enum action_tasks {
     pcmk_action_promote,            //!< Promote
     pcmk_action_promoted,           //!< Promoted
 
+    pcmk_action_demote,             //!< Demote
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
@@ -118,7 +120,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_promoted instead
     action_promoted         = pcmk_action_promoted,
 #endif
-    action_demote,
+    action_demote           = pcmk_action_demote,
     action_demoted,
     shutdown_crm,
     stonith_node

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -92,8 +92,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_stopped instead
     stopped_rsc             = pcmk_action_stopped,
-#endif
+
+    //! \deprecated Use pcmk_action_start instead
     start_rsc               = pcmk_action_start,
+#endif
     started_rsc,
     action_notify,
     action_notified,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -132,8 +132,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_shutdown instead
     shutdown_crm            = pcmk_action_shutdown,
-#endif
+
+    //! \deprecated Use pcmk_action_fence instead
     stonith_node            = pcmk_action_fence,
+#endif
 };
 
 // For parsing various action-related string specifications

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -81,6 +81,8 @@ enum action_tasks {
     pcmk_action_start,              //!< Start
     pcmk_action_started,            //!< Start completed
 
+    pcmk_action_notify,             //!< Notify
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
@@ -100,7 +102,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_started instead
     started_rsc             = pcmk_action_started,
 #endif
-    action_notify,
+    action_notify           = pcmk_action_notify,
     action_notified,
     action_promote,
     action_promoted,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -110,8 +110,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_notified instead
     action_notified         = pcmk_action_notified,
-#endif
+
+    //! \deprecated Use pcmk_action_promote instead
     action_promote          = pcmk_action_promote,
+#endif
     action_promoted,
     action_demote,
     action_demoted,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -101,8 +101,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_started instead
     started_rsc             = pcmk_action_started,
-#endif
+
+    //! \deprecated Use pcmk_action_notify instead
     action_notify           = pcmk_action_notify,
+#endif
     action_notified,
     action_promote,
     action_promoted,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -76,8 +76,10 @@ enum action_tasks {
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
-#endif
+
+    //! \deprecated Use pcmk_action_monitor instead
     monitor_rsc             = pcmk_action_monitor,
+#endif
 
     // Each "completed" action must be the regular action plus 1
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -90,6 +90,8 @@ enum action_tasks {
     pcmk_action_demote,             //!< Demote
     pcmk_action_demoted,            //!< Demoted
 
+    pcmk_action_shutdown,           //!< Shut down node
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
@@ -127,7 +129,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_demoted instead
     action_demoted          = pcmk_action_demoted,
 #endif
-    shutdown_crm,
+    shutdown_crm            = pcmk_action_shutdown,
     stonith_node
 };
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -79,6 +79,7 @@ enum action_tasks {
     pcmk_action_stopped,            //!< Stop completed
 
     pcmk_action_start,              //!< Start
+    pcmk_action_started,            //!< Start completed
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
@@ -96,7 +97,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_start instead
     start_rsc               = pcmk_action_start,
 #endif
-    started_rsc,
+    started_rsc             = pcmk_action_started,
     action_notify,
     action_notified,
     action_promote,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -123,8 +123,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_demote instead
     action_demote           = pcmk_action_demote,
-#endif
+
+    //! \deprecated Use pcmk_action_demoted instead
     action_demoted          = pcmk_action_demoted,
+#endif
     shutdown_crm,
     stonith_node
 };

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -82,6 +82,7 @@ enum action_tasks {
     pcmk_action_started,            //!< Start completed
 
     pcmk_action_notify,             //!< Notify
+    pcmk_action_notified,           //!< Notify completed
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
@@ -105,7 +106,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_notify instead
     action_notify           = pcmk_action_notify,
 #endif
-    action_notified,
+    action_notified         = pcmk_action_notified,
     action_promote,
     action_promoted,
     action_demote,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -71,12 +71,13 @@ extern "C" {
 //! Possible actions (including some pseudo-actions)
 enum action_tasks {
     pcmk_action_unspecified = 0,    //!< Unspecified or unknown action
+    pcmk_action_monitor,            //!< Monitor
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
 #endif
-    monitor_rsc,
+    monitor_rsc             = pcmk_action_monitor,
 
     // Each "completed" action must be the regular action plus 1
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -83,8 +83,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_monitor instead
     monitor_rsc             = pcmk_action_monitor,
-#endif
+
+    //! \deprecated Use pcmk_action_stop instead
     stop_rsc                = pcmk_action_stop,
+#endif
     stopped_rsc,
     start_rsc,
     started_rsc,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -72,7 +72,10 @@ extern "C" {
 enum action_tasks {
     pcmk_action_unspecified = 0,    //!< Unspecified or unknown action
 
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
+#endif
     monitor_rsc,
 
     // Each "completed" action must be the regular action plus 1

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -119,8 +119,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_promoted instead
     action_promoted         = pcmk_action_promoted,
-#endif
+
+    //! \deprecated Use pcmk_action_demote instead
     action_demote           = pcmk_action_demote,
+#endif
     action_demoted,
     shutdown_crm,
     stonith_node

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -84,6 +84,8 @@ enum action_tasks {
     pcmk_action_notify,             //!< Notify
     pcmk_action_notified,           //!< Notify completed
 
+    pcmk_action_promote,            //!< Promote
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
@@ -109,7 +111,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_notified instead
     action_notified         = pcmk_action_notified,
 #endif
-    action_promote,
+    action_promote          = pcmk_action_promote,
     action_promoted,
     action_demote,
     action_demoted,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -88,6 +88,7 @@ enum action_tasks {
     pcmk_action_promoted,           //!< Promoted
 
     pcmk_action_demote,             //!< Demote
+    pcmk_action_demoted,            //!< Demoted
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
@@ -123,7 +124,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_demote instead
     action_demote           = pcmk_action_demote,
 #endif
-    action_demoted,
+    action_demoted          = pcmk_action_demoted,
     shutdown_crm,
     stonith_node
 };

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -68,6 +68,27 @@ extern "C" {
 #define PCMK_ACTION_STOPPED             "stopped"
 #define PCMK_ACTION_VALIDATE_ALL        "validate-all"
 
+//! Possible actions (including some pseudo-actions)
+enum action_tasks {
+    no_action,
+    monitor_rsc,
+
+    // Each "completed" action must be the regular action plus 1
+
+    stop_rsc,
+    stopped_rsc,
+    start_rsc,
+    started_rsc,
+    action_notify,
+    action_notified,
+    action_promote,
+    action_promoted,
+    action_demote,
+    action_demoted,
+    shutdown_crm,
+    stonith_node
+};
+
 // For parsing various action-related string specifications
 gboolean parse_op_key(const char *key, char **rsc_id, char **op_type,
                       guint *interval_ms);

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -73,6 +73,10 @@ enum action_tasks {
     pcmk_action_unspecified = 0,    //!< Unspecified or unknown action
     pcmk_action_monitor,            //!< Monitor
 
+    // Each "completed" action must be the regular action plus 1
+
+    pcmk_action_stop,               //!< Stop
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
@@ -80,10 +84,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_monitor instead
     monitor_rsc             = pcmk_action_monitor,
 #endif
-
-    // Each "completed" action must be the regular action plus 1
-
-    stop_rsc,
+    stop_rsc                = pcmk_action_stop,
     stopped_rsc,
     start_rsc,
     started_rsc,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -87,8 +87,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_stop instead
     stop_rsc                = pcmk_action_stop,
-#endif
+
+    //! \deprecated Use pcmk_action_stopped instead
     stopped_rsc             = pcmk_action_stopped,
+#endif
     start_rsc,
     started_rsc,
     action_notify,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -105,8 +105,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_notify instead
     action_notify           = pcmk_action_notify,
-#endif
+
+    //! \deprecated Use pcmk_action_notified instead
     action_notified         = pcmk_action_notified,
+#endif
     action_promote,
     action_promoted,
     action_demote,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -128,8 +128,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_demoted instead
     action_demoted          = pcmk_action_demoted,
-#endif
+
+    //! \deprecated Use pcmk_action_shutdown instead
     shutdown_crm            = pcmk_action_shutdown,
+#endif
     stonith_node
 };
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -78,6 +78,8 @@ enum action_tasks {
     pcmk_action_stop,               //!< Stop
     pcmk_action_stopped,            //!< Stop completed
 
+    pcmk_action_start,              //!< Start
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
     no_action               = pcmk_action_unspecified,
@@ -91,7 +93,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_stopped instead
     stopped_rsc             = pcmk_action_stopped,
 #endif
-    start_rsc,
+    start_rsc               = pcmk_action_start,
     started_rsc,
     action_notify,
     action_notified,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -114,8 +114,10 @@ enum action_tasks {
 
     //! \deprecated Use pcmk_action_promote instead
     action_promote          = pcmk_action_promote,
-#endif
+
+    //! \deprecated Use pcmk_action_promoted instead
     action_promoted         = pcmk_action_promoted,
+#endif
     action_demote,
     action_demoted,
     shutdown_crm,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -91,6 +91,7 @@ enum action_tasks {
     pcmk_action_demoted,            //!< Demoted
 
     pcmk_action_shutdown,           //!< Shut down node
+    pcmk_action_fence,              //!< Fence node
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_action_unspecified instead
@@ -132,7 +133,7 @@ enum action_tasks {
     //! \deprecated Use pcmk_action_shutdown instead
     shutdown_crm            = pcmk_action_shutdown,
 #endif
-    stonith_node
+    stonith_node            = pcmk_action_fence,
 };
 
 // For parsing various action-related string specifications

--- a/include/crm/common/scheduler.h
+++ b/include/crm/common/scheduler.h
@@ -10,6 +10,7 @@
 #ifndef PCMK__CRM_COMMON_SCHEDULER__H
 #  define PCMK__CRM_COMMON_SCHEDULER__H
 
+#include <crm/common/actions.h>
 #include <crm/common/resources.h>
 #include <crm/common/roles.h>
 

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -58,24 +58,6 @@ enum action_fail_response {
     action_fail_demote,
 };
 
-/* the "done" action must be the "pre" action +1 */
-enum action_tasks {
-    no_action,
-    monitor_rsc,
-    stop_rsc,
-    stopped_rsc,
-    start_rsc,
-    started_rsc,
-    action_notify,
-    action_notified,
-    action_promote,
-    action_promoted,
-    action_demote,
-    action_demoted,
-    shutdown_crm,
-    stonith_node
-};
-
 //! Deprecated
 enum pe_print_options {
     pe_print_log            = (1 << 0),

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -95,8 +95,8 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
     char *uuid = NULL;
     char *rid = NULL;
     char *first_task_str = NULL;
-    enum action_tasks first_task = no_action;
-    enum action_tasks remapped_task = no_action;
+    enum action_tasks first_task = pcmk_action_unspecified;
+    enum action_tasks remapped_task = pcmk_action_unspecified;
 
     // Only non-notify actions for collective resources need remapping
     if ((strstr(first_uuid, PCMK_ACTION_NOTIFY) != NULL)
@@ -135,7 +135,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
             break;
     }
 
-    if (remapped_task != no_action) {
+    if (remapped_task != pcmk_action_unspecified) {
         /* If a (clone) resource has notifications enabled, we want to order
          * relative to when all notifications have been sent for the remapped
          * task. Only outermost resources or those in bundles have

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -116,7 +116,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
         case pcmk_action_start:
         case pcmk_action_notify:
         case pcmk_action_promote:
-        case action_demote:
+        case pcmk_action_demote:
             remapped_task = first_task + 1;
             break;
         case pcmk_action_stopped:

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -126,7 +126,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
         case action_demoted:
             remapped_task = first_task;
             break;
-        case monitor_rsc:
+        case pcmk_action_monitor:
         case shutdown_crm:
         case stonith_node:
             break;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -113,7 +113,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
     first_task = text2task(first_task_str);
     switch (first_task) {
         case pcmk_action_stop:
-        case start_rsc:
+        case pcmk_action_start:
         case action_notify:
         case action_promote:
         case action_demote:

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -123,7 +123,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
         case pcmk_action_started:
         case pcmk_action_notified:
         case pcmk_action_promoted:
-        case action_demoted:
+        case pcmk_action_demoted:
             remapped_task = first_task;
             break;
         case pcmk_action_monitor:

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -112,7 +112,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
 
     first_task = text2task(first_task_str);
     switch (first_task) {
-        case stop_rsc:
+        case pcmk_action_stop:
         case start_rsc:
         case action_notify:
         case action_promote:

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -120,7 +120,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
             remapped_task = first_task + 1;
             break;
         case pcmk_action_stopped:
-        case started_rsc:
+        case pcmk_action_started:
         case action_notified:
         case action_promoted:
         case action_demoted:

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -114,7 +114,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
     switch (first_task) {
         case pcmk_action_stop:
         case pcmk_action_start:
-        case action_notify:
+        case pcmk_action_notify:
         case action_promote:
         case action_demote:
             remapped_task = first_task + 1;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -121,7 +121,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
             break;
         case pcmk_action_stopped:
         case pcmk_action_started:
-        case action_notified:
+        case pcmk_action_notified:
         case action_promoted:
         case action_demoted:
             remapped_task = first_task;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -128,7 +128,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
             break;
         case pcmk_action_monitor:
         case pcmk_action_shutdown:
-        case stonith_node:
+        case pcmk_action_fence:
             break;
         default:
             crm_err("Unknown action '%s' in ordering", first_task_str);
@@ -966,7 +966,7 @@ pcmk__log_action(const char *pre_text, const pe_action_t *action, bool details)
     }
 
     switch (text2task(action->task)) {
-        case stonith_node:
+        case pcmk_action_fence:
         case pcmk_action_shutdown:
             if (pcmk_is_set(action->flags, pe_action_pseudo)) {
                 desc = "Pseudo ";

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -115,7 +115,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
         case pcmk_action_stop:
         case pcmk_action_start:
         case pcmk_action_notify:
-        case action_promote:
+        case pcmk_action_promote:
         case action_demote:
             remapped_task = first_task + 1;
             break;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -127,7 +127,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
             remapped_task = first_task;
             break;
         case pcmk_action_monitor:
-        case shutdown_crm:
+        case pcmk_action_shutdown:
         case stonith_node:
             break;
         default:
@@ -967,7 +967,7 @@ pcmk__log_action(const char *pre_text, const pe_action_t *action, bool details)
 
     switch (text2task(action->task)) {
         case stonith_node:
-        case shutdown_crm:
+        case pcmk_action_shutdown:
             if (pcmk_is_set(action->flags, pe_action_pseudo)) {
                 desc = "Pseudo ";
             } else if (pcmk_is_set(action->flags, pe_action_optional)) {

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -122,7 +122,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
         case pcmk_action_stopped:
         case pcmk_action_started:
         case pcmk_action_notified:
-        case action_promoted:
+        case pcmk_action_promoted:
         case action_demoted:
             remapped_task = first_task;
             break;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -119,7 +119,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
         case action_demote:
             remapped_task = first_task + 1;
             break;
-        case stopped_rsc:
+        case pcmk_action_stopped:
         case started_rsc:
         case action_notified:
         case action_promoted:

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -686,7 +686,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
         // Clone actions are done on the bundled clone resource, not container
         switch (get_complex_task(bundled_resource, action->task)) {
             case pcmk_action_unspecified:
-            case action_notify:
+            case pcmk_action_notify:
             case action_notified:
             case action_promote:
             case action_promoted:

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -687,7 +687,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
         switch (get_complex_task(bundled_resource, action->task)) {
             case pcmk_action_unspecified:
             case pcmk_action_notify:
-            case action_notified:
+            case pcmk_action_notified:
             case action_promote:
             case action_promoted:
             case action_demote:

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -691,7 +691,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
             case pcmk_action_promote:
             case pcmk_action_promoted:
             case pcmk_action_demote:
-            case action_demoted:
+            case pcmk_action_demoted:
                 return pcmk__collective_action_flags(action,
                                                      bundled_resource->children,
                                                      node);

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -688,7 +688,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
             case pcmk_action_unspecified:
             case pcmk_action_notify:
             case pcmk_action_notified:
-            case action_promote:
+            case pcmk_action_promote:
             case action_promoted:
             case action_demote:
             case action_demoted:

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -685,7 +685,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
     if (bundled_resource != NULL) {
         // Clone actions are done on the bundled clone resource, not container
         switch (get_complex_task(bundled_resource, action->task)) {
-            case no_action:
+            case pcmk_action_unspecified:
             case action_notify:
             case action_notified:
             case action_promote:

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -689,7 +689,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
             case pcmk_action_notify:
             case pcmk_action_notified:
             case pcmk_action_promote:
-            case action_promoted:
+            case pcmk_action_promoted:
             case action_demote:
             case action_demoted:
                 return pcmk__collective_action_flags(action,

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -690,7 +690,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
             case pcmk_action_notified:
             case pcmk_action_promote:
             case pcmk_action_promoted:
-            case action_demote:
+            case pcmk_action_demote:
             case action_demoted:
                 return pcmk__collective_action_flags(action,
                                                      bundled_resource->children,

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -528,7 +528,7 @@ pcmk__group_action_flags(pe_action_t *action, const pe_node_t *node)
         /* Group (pseudo-)actions other than stop or demote are unrunnable
          * unless every member will do it.
          */
-        } else if ((task != stop_rsc) && (task != action_demote)) {
+        } else if ((task != pcmk_action_stop) && (task != action_demote)) {
             pe_rsc_trace(action->rsc,
                          "%s is not runnable because %s will not %s",
                          action->uuid, member->id, task_s);

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -528,7 +528,7 @@ pcmk__group_action_flags(pe_action_t *action, const pe_node_t *node)
         /* Group (pseudo-)actions other than stop or demote are unrunnable
          * unless every member will do it.
          */
-        } else if ((task != pcmk_action_stop) && (task != action_demote)) {
+        } else if ((task != pcmk_action_stop) && (task != pcmk_action_demote)) {
             pe_rsc_trace(action->rsc,
                          "%s is not runnable because %s will not %s",
                          action->uuid, member->id, task_s);

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -1323,15 +1323,16 @@ orig_action_name(const pe_action_t *action)
     const pe_resource_t *instance = action->rsc->children->data; // Any instance
     char *action_type = NULL;
     const char *action_name = action->task;
-    enum action_tasks orig_task = no_action;
+    enum action_tasks orig_task = pcmk_action_unspecified;
 
     if (pcmk__strcase_any_of(action->task, PCMK_ACTION_NOTIFY,
                              PCMK_ACTION_NOTIFIED, NULL)) {
         // action->uuid is RSC_(confirmed-){pre,post}_notify_ACTION_INTERVAL
         CRM_CHECK(parse_op_key(action->uuid, NULL, &action_type, NULL),
-                  return task2text(no_action));
+                  return task2text(pcmk_action_unspecified));
         action_name = strstr(action_type, "_notify_");
-        CRM_CHECK(action_name != NULL, return task2text(no_action));
+        CRM_CHECK(action_name != NULL,
+                  return task2text(pcmk_action_unspecified));
         action_name += strlen("_notify_");
     }
     orig_task = get_complex_task(instance, action_name);

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -241,7 +241,7 @@ apply_remote_ordering(pe_action_t *action)
             }
             break;
 
-        case action_demote:
+        case pcmk_action_demote:
             /* Only order this demote relative to the connection start if the
              * connection isn't being torn down. Otherwise, the demote would be
              * blocked because the connection start would not be allowed.
@@ -347,7 +347,7 @@ apply_container_ordering(pe_action_t *action)
             break;
 
         case pcmk_action_stop:
-        case action_demote:
+        case pcmk_action_demote:
             if (pcmk_is_set(container->flags, pe_rsc_failed)) {
                 /* When the container representing a guest node fails, any stop
                  * or demote actions for resources running on the guest node
@@ -694,7 +694,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
     switch (task) {
         case pcmk_action_stop:
         case pcmk_action_stopped:
-        case action_demote:
+        case pcmk_action_demote:
         case action_demoted:
             // "Down" actions take place on guest's current host
             host = pe__current_node(guest->details->remote_rsc->container);

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -701,7 +701,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
             break;
 
         case pcmk_action_start:
-        case started_rsc:
+        case pcmk_action_started:
         case pcmk_action_monitor:
         case action_promote:
         case action_promoted:

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -191,7 +191,7 @@ apply_remote_ordering(pe_action_t *action)
         /* Migration ops map to pcmk_action_unspecified, but we need to apply
          * the same ordering as for stop or demote (see get_router_node()).
          */
-        task = stop_rsc;
+        task = pcmk_action_stop;
     }
 
     switch (task) {
@@ -208,7 +208,7 @@ apply_remote_ordering(pe_action_t *action)
             order_start_then_action(remote_rsc, action, order_opts);
             break;
 
-        case stop_rsc:
+        case pcmk_action_stop:
             if (state == remote_state_alive) {
                 order_action_then_stop(action, remote_rsc,
                                        pe_order_implies_first);
@@ -333,7 +333,7 @@ apply_container_ordering(pe_action_t *action)
         /* Migration ops map to pcmk_action_unspecified, but we need to apply
          * the same ordering as for stop or demote (see get_router_node()).
          */
-        task = stop_rsc;
+        task = pcmk_action_stop;
     }
 
     switch (task) {
@@ -346,7 +346,7 @@ apply_container_ordering(pe_action_t *action)
             order_start_then_action(remote_rsc, action, pe_order_none);
             break;
 
-        case stop_rsc:
+        case pcmk_action_stop:
         case action_demote:
             if (pcmk_is_set(container->flags, pe_rsc_failed)) {
                 /* When the container representing a guest node fails, any stop
@@ -692,7 +692,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
     }
 
     switch (task) {
-        case stop_rsc:
+        case pcmk_action_stop:
         case stopped_rsc:
         case action_demote:
         case action_demoted:

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -266,7 +266,7 @@ apply_remote_ordering(pe_action_t *action)
             } else {
                 pe_node_t *cluster_node = pe__current_node(remote_rsc);
 
-                if ((task == monitor_rsc) && (state == remote_state_failed)) {
+                if ((task == pcmk_action_monitor) && (state == remote_state_failed)) {
                     /* We would only be here if we do not know the state of the
                      * resource on the remote node. Since we have no way to find
                      * out, it is necessary to fence the node.
@@ -702,7 +702,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
 
         case start_rsc:
         case started_rsc:
-        case monitor_rsc:
+        case pcmk_action_monitor:
         case action_promote:
         case action_promoted:
             // "Up" actions take place on guest's next host

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -695,7 +695,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
         case pcmk_action_stop:
         case pcmk_action_stopped:
         case pcmk_action_demote:
-        case action_demoted:
+        case pcmk_action_demoted:
             // "Down" actions take place on guest's current host
             host = pe__current_node(guest->details->remote_rsc->container);
             break;

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -704,7 +704,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
         case pcmk_action_started:
         case pcmk_action_monitor:
         case pcmk_action_promote:
-        case action_promoted:
+        case pcmk_action_promoted:
             // "Up" actions take place on guest's next host
             host = guest->details->remote_rsc->container->allocated_to;
             break;

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -687,7 +687,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
     }
 
     task = text2task(action->task);
-    if ((task == action_notify) || (task == action_notified)) {
+    if ((task == pcmk_action_notify) || (task == action_notified)) {
         task = text2task(g_hash_table_lookup(action->meta, "notify_operation"));
     }
 

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -195,7 +195,7 @@ apply_remote_ordering(pe_action_t *action)
     }
 
     switch (task) {
-        case start_rsc:
+        case pcmk_action_start:
         case action_promote:
             order_opts = pe_order_none;
 
@@ -337,7 +337,7 @@ apply_container_ordering(pe_action_t *action)
     }
 
     switch (task) {
-        case start_rsc:
+        case pcmk_action_start:
         case action_promote:
             // Force resource recovery if the container is recovered
             order_start_then_action(container, action, pe_order_implies_then);
@@ -700,7 +700,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
             host = pe__current_node(guest->details->remote_rsc->container);
             break;
 
-        case start_rsc:
+        case pcmk_action_start:
         case started_rsc:
         case pcmk_action_monitor:
         case action_promote:

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -693,7 +693,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
 
     switch (task) {
         case pcmk_action_stop:
-        case stopped_rsc:
+        case pcmk_action_stopped:
         case action_demote:
         case action_demoted:
             // "Down" actions take place on guest's current host

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -188,8 +188,8 @@ apply_remote_ordering(pe_action_t *action)
 
     if (pcmk__strcase_any_of(action->task, PCMK_ACTION_MIGRATE_TO,
                              PCMK_ACTION_MIGRATE_FROM, NULL)) {
-        /* Migration ops map to "no_action", but we need to apply the same
-         * ordering as for stop or demote (see get_router_node()).
+        /* Migration ops map to pcmk_action_unspecified, but we need to apply
+         * the same ordering as for stop or demote (see get_router_node()).
          */
         task = stop_rsc;
     }
@@ -330,8 +330,8 @@ apply_container_ordering(pe_action_t *action)
 
     if (pcmk__strcase_any_of(action->task, PCMK_ACTION_MIGRATE_TO,
                              PCMK_ACTION_MIGRATE_FROM, NULL)) {
-        /* Migration ops map to "no_action", but we need to apply the same
-         * ordering as for stop or demote (see get_router_node()).
+        /* Migration ops map to pcmk_action_unspecified, but we need to apply
+         * the same ordering as for stop or demote (see get_router_node()).
          */
         task = stop_rsc;
     }
@@ -375,7 +375,7 @@ apply_container_ordering(pe_action_t *action)
                  * recurring monitors to be restarted, even if just
                  * the connection was re-established
                  */
-                if (task != no_action) {
+                if (task != pcmk_action_unspecified) {
                     order_start_then_action(remote_rsc, action,
                                             pe_order_implies_then);
                 }

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -196,7 +196,7 @@ apply_remote_ordering(pe_action_t *action)
 
     switch (task) {
         case pcmk_action_start:
-        case action_promote:
+        case pcmk_action_promote:
             order_opts = pe_order_none;
 
             if (state == remote_state_failed) {
@@ -338,7 +338,7 @@ apply_container_ordering(pe_action_t *action)
 
     switch (task) {
         case pcmk_action_start:
-        case action_promote:
+        case pcmk_action_promote:
             // Force resource recovery if the container is recovered
             order_start_then_action(container, action, pe_order_implies_then);
 
@@ -703,7 +703,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
         case pcmk_action_start:
         case pcmk_action_started:
         case pcmk_action_monitor:
-        case action_promote:
+        case pcmk_action_promote:
         case action_promoted:
             // "Up" actions take place on guest's next host
             host = guest->details->remote_rsc->container->allocated_to;

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -687,7 +687,7 @@ pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
     }
 
     task = text2task(action->task);
-    if ((task == pcmk_action_notify) || (task == action_notified)) {
+    if ((task == pcmk_action_notify) || (task == pcmk_action_notified)) {
         task = text2task(g_hash_table_lookup(action->meta, "notify_operation"));
     }
 

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -379,7 +379,8 @@ text2task(const char *task)
         return pcmk_action_monitor;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_NOTIFY, pcmk__str_casei)) {
-        return action_notify;
+        return pcmk_action_notify;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_NOTIFIED, pcmk__str_casei)) {
         return action_notified;
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTE, pcmk__str_casei)) {
@@ -424,7 +425,7 @@ task2text(enum action_tasks task)
         case pcmk_action_monitor:
             result = PCMK_ACTION_MONITOR;
             break;
-        case action_notify:
+        case pcmk_action_notify:
             result = PCMK_ACTION_NOTIFY;
             break;
         case action_notified:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -382,7 +382,8 @@ text2task(const char *task)
         return pcmk_action_notify;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_NOTIFIED, pcmk__str_casei)) {
-        return action_notified;
+        return pcmk_action_notified;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTE, pcmk__str_casei)) {
         return action_promote;
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTE, pcmk__str_casei)) {
@@ -428,7 +429,7 @@ task2text(enum action_tasks task)
         case pcmk_action_notify:
             result = PCMK_ACTION_NOTIFY;
             break;
-        case action_notified:
+        case pcmk_action_notified:
             result = PCMK_ACTION_NOTIFIED;
             break;
         case action_promote:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -374,7 +374,7 @@ text2task(const char *task)
         return pcmk_action_shutdown;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_STONITH, pcmk__str_casei)) {
-        return stonith_node;
+        return pcmk_action_fence;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_MONITOR, pcmk__str_casei)) {
         return pcmk_action_monitor;
@@ -424,7 +424,7 @@ task2text(enum action_tasks task)
         case pcmk_action_shutdown:
             result = PCMK_ACTION_DO_SHUTDOWN;
             break;
-        case stonith_node:
+        case pcmk_action_fence:
             result = PCMK_ACTION_STONITH;
             break;
         case pcmk_action_monitor:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -371,7 +371,8 @@ text2task(const char *task)
         return pcmk_action_started;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_DO_SHUTDOWN, pcmk__str_casei)) {
-        return shutdown_crm;
+        return pcmk_action_shutdown;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_STONITH, pcmk__str_casei)) {
         return stonith_node;
 
@@ -420,7 +421,7 @@ task2text(enum action_tasks task)
         case pcmk_action_started:
             result = PCMK_ACTION_RUNNING;
             break;
-        case shutdown_crm:
+        case pcmk_action_shutdown:
             result = PCMK_ACTION_DO_SHUTDOWN;
             break;
         case stonith_node:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -370,8 +370,10 @@ text2task(const char *task)
         return shutdown_crm;
     } else if (pcmk__str_eq(task, PCMK_ACTION_STONITH, pcmk__str_casei)) {
         return stonith_node;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_MONITOR, pcmk__str_casei)) {
-        return monitor_rsc;
+        return pcmk_action_monitor;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_NOTIFY, pcmk__str_casei)) {
         return action_notify;
     } else if (pcmk__str_eq(task, PCMK_ACTION_NOTIFIED, pcmk__str_casei)) {
@@ -415,7 +417,7 @@ task2text(enum action_tasks task)
         case stonith_node:
             result = PCMK_ACTION_STONITH;
             break;
-        case monitor_rsc:
+        case pcmk_action_monitor:
             result = PCMK_ACTION_MONITOR;
             break;
         case action_notify:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -385,7 +385,8 @@ text2task(const char *task)
         return pcmk_action_notified;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTE, pcmk__str_casei)) {
-        return action_promote;
+        return pcmk_action_promote;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTE, pcmk__str_casei)) {
         return action_demote;
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTED, pcmk__str_casei)) {
@@ -432,7 +433,7 @@ task2text(enum action_tasks task)
         case pcmk_action_notified:
             result = PCMK_ACTION_NOTIFIED;
             break;
-        case action_promote:
+        case pcmk_action_promote:
             result = PCMK_ACTION_PROMOTE;
             break;
         case action_promoted:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -385,22 +385,7 @@ text2task(const char *task)
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTED, pcmk__str_casei)) {
         return action_demoted;
     }
-#if SUPPORT_TRACING
-    if (pcmk__str_eq(task, PCMK_ACTION_CANCEL, pcmk__str_casei)) {
-        return no_action;
-    } else if (pcmk__str_eq(task, PCMK_ACTION_DELETE, pcmk__str_casei)) {
-        return no_action;
-    } else if (pcmk__str_eq(task, PCMK_ACTION_MONITOR, pcmk__str_casei)) {
-        return no_action;
-    } else if (pcmk__str_eq(task, PCMK_ACTION_MIGRATE_TO, pcmk__str_casei)) {
-        return no_action;
-    } else if (pcmk__str_eq(task, PCMK_ACTION_MIGRATE_FROM, pcmk__str_casei)) {
-        return no_action;
-    }
-    crm_trace("Unsupported action: %s", task);
-#endif
-
-    return no_action;
+    return pcmk_action_unspecified;
 }
 
 const char *
@@ -409,7 +394,7 @@ task2text(enum action_tasks task)
     const char *result = "<unknown>";
 
     switch (task) {
-        case no_action:
+        case pcmk_action_unspecified:
             result = "no_action";
             break;
         case stop_rsc:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -368,7 +368,8 @@ text2task(const char *task)
         return pcmk_action_start;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_RUNNING, pcmk__str_casei)) {
-        return started_rsc;
+        return pcmk_action_started;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_DO_SHUTDOWN, pcmk__str_casei)) {
         return shutdown_crm;
     } else if (pcmk__str_eq(task, PCMK_ACTION_STONITH, pcmk__str_casei)) {
@@ -411,7 +412,7 @@ task2text(enum action_tasks task)
         case pcmk_action_start:
             result = PCMK_ACTION_START;
             break;
-        case started_rsc:
+        case pcmk_action_started:
             result = PCMK_ACTION_RUNNING;
             break;
         case shutdown_crm:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -365,7 +365,8 @@ text2task(const char *task)
         return pcmk_action_stopped;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_START, pcmk__str_casei)) {
-        return start_rsc;
+        return pcmk_action_start;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_RUNNING, pcmk__str_casei)) {
         return started_rsc;
     } else if (pcmk__str_eq(task, PCMK_ACTION_DO_SHUTDOWN, pcmk__str_casei)) {
@@ -407,7 +408,7 @@ task2text(enum action_tasks task)
         case pcmk_action_stopped:
             result = PCMK_ACTION_STOPPED;
             break;
-        case start_rsc:
+        case pcmk_action_start:
             result = PCMK_ACTION_START;
             break;
         case started_rsc:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -392,8 +392,9 @@ text2task(const char *task)
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTED, pcmk__str_casei)) {
         return pcmk_action_promoted;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTED, pcmk__str_casei)) {
-        return action_demoted;
+        return pcmk_action_demoted;
     }
     return pcmk_action_unspecified;
 }
@@ -443,7 +444,7 @@ task2text(enum action_tasks task)
         case pcmk_action_demote:
             result = PCMK_ACTION_DEMOTE;
             break;
-        case action_demoted:
+        case pcmk_action_demoted:
             result = PCMK_ACTION_DEMOTED;
             break;
     }

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -388,7 +388,7 @@ text2task(const char *task)
         return pcmk_action_promote;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTE, pcmk__str_casei)) {
-        return action_demote;
+        return pcmk_action_demote;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTED, pcmk__str_casei)) {
         return pcmk_action_promoted;
@@ -440,7 +440,7 @@ task2text(enum action_tasks task)
         case pcmk_action_promoted:
             result = PCMK_ACTION_PROMOTED;
             break;
-        case action_demote:
+        case pcmk_action_demote:
             result = PCMK_ACTION_DEMOTE;
             break;
         case action_demoted:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -362,7 +362,8 @@ text2task(const char *task)
         return pcmk_action_stop;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_STOPPED, pcmk__str_casei)) {
-        return stopped_rsc;
+        return pcmk_action_stopped;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_START, pcmk__str_casei)) {
         return start_rsc;
     } else if (pcmk__str_eq(task, PCMK_ACTION_RUNNING, pcmk__str_casei)) {
@@ -403,7 +404,7 @@ task2text(enum action_tasks task)
         case pcmk_action_stop:
             result = PCMK_ACTION_STOP;
             break;
-        case stopped_rsc:
+        case pcmk_action_stopped:
             result = PCMK_ACTION_STOPPED;
             break;
         case start_rsc:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -389,8 +389,9 @@ text2task(const char *task)
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTE, pcmk__str_casei)) {
         return action_demote;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_PROMOTED, pcmk__str_casei)) {
-        return action_promoted;
+        return pcmk_action_promoted;
     } else if (pcmk__str_eq(task, PCMK_ACTION_DEMOTED, pcmk__str_casei)) {
         return action_demoted;
     }
@@ -436,7 +437,7 @@ task2text(enum action_tasks task)
         case pcmk_action_promote:
             result = PCMK_ACTION_PROMOTE;
             break;
-        case action_promoted:
+        case pcmk_action_promoted:
             result = PCMK_ACTION_PROMOTED;
             break;
         case action_demote:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -359,7 +359,8 @@ enum action_tasks
 text2task(const char *task)
 {
     if (pcmk__str_eq(task, PCMK_ACTION_STOP, pcmk__str_casei)) {
-        return stop_rsc;
+        return pcmk_action_stop;
+
     } else if (pcmk__str_eq(task, PCMK_ACTION_STOPPED, pcmk__str_casei)) {
         return stopped_rsc;
     } else if (pcmk__str_eq(task, PCMK_ACTION_START, pcmk__str_casei)) {
@@ -399,7 +400,7 @@ task2text(enum action_tasks task)
         case pcmk_action_unspecified:
             result = "no_action";
             break;
-        case stop_rsc:
+        case pcmk_action_stop:
             result = PCMK_ACTION_STOP;
             break;
         case stopped_rsc:

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1279,7 +1279,7 @@ get_complex_task(const pe_resource_t *rsc, const char *name)
 
     if ((rsc != NULL) && (rsc->variant == pe_native)) {
         switch (task) {
-            case stopped_rsc:
+            case pcmk_action_stopped:
             case started_rsc:
             case action_demoted:
             case action_promoted:

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1280,7 +1280,7 @@ get_complex_task(const pe_resource_t *rsc, const char *name)
     if ((rsc != NULL) && (rsc->variant == pe_native)) {
         switch (task) {
             case pcmk_action_stopped:
-            case started_rsc:
+            case pcmk_action_started:
             case action_demoted:
             case action_promoted:
                 crm_trace("Folding %s back into its atomic counterpart for %s",

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1282,7 +1282,7 @@ get_complex_task(const pe_resource_t *rsc, const char *name)
             case pcmk_action_stopped:
             case pcmk_action_started:
             case action_demoted:
-            case action_promoted:
+            case pcmk_action_promoted:
                 crm_trace("Folding %s back into its atomic counterpart for %s",
                           name, rsc->id);
                 --task;

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1281,7 +1281,7 @@ get_complex_task(const pe_resource_t *rsc, const char *name)
         switch (task) {
             case pcmk_action_stopped:
             case pcmk_action_started:
-            case action_demoted:
+            case pcmk_action_demoted:
             case pcmk_action_promoted:
                 crm_trace("Folding %s back into its atomic counterpart for %s",
                           name, rsc->id);

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -625,7 +625,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
                 case pcmk_action_stop:
                     n_data->stop = g_list_prepend(n_data->stop, entry);
                     break;
-                case action_promote:
+                case pcmk_action_promote:
                     n_data->promote = g_list_prepend(n_data->promote, entry);
                     break;
                 case action_demote:
@@ -821,7 +821,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
             switch (text2task(op->task)) {
                 case pcmk_action_start:
                 case pcmk_action_stop:
-                case action_promote:
+                case pcmk_action_promote:
                 case action_demote:
                     add_notify_data_to_action_meta(n_data, op);
                     break;
@@ -841,7 +841,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
             }
             break;
 
-        case action_promote:
+        case pcmk_action_promote:
             if (n_data->promote == NULL) {
                 pe_rsc_trace(rsc, "No notify action needed for %s %s",
                              rsc->id, n_data->action);
@@ -895,7 +895,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
 
     // Create notify actions for start or promote
     if ((rsc->next_role != pcmk_role_stopped)
-        && ((task == pcmk_action_start) || (task == action_promote))) {
+        && ((task == pcmk_action_start) || (task == pcmk_action_promote))) {
 
         start = find_first_action(rsc->actions, NULL, PCMK_ACTION_START, NULL);
         if (start != NULL) {

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -619,7 +619,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
             entry = new_notify_entry(rsc, op->node);
 
             switch (task) {
-                case start_rsc:
+                case pcmk_action_start:
                     n_data->start = g_list_prepend(n_data->start, entry);
                     break;
                 case pcmk_action_stop:
@@ -819,7 +819,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
 
         if (!pcmk_is_set(op->flags, pe_action_optional) && (op->node != NULL)) {
             switch (text2task(op->task)) {
-                case start_rsc:
+                case pcmk_action_start:
                 case pcmk_action_stop:
                 case action_promote:
                 case action_demote:
@@ -833,7 +833,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
 
     // Skip notify action itself if original action was not needed
     switch (task) {
-        case start_rsc:
+        case pcmk_action_start:
             if (n_data->start == NULL) {
                 pe_rsc_trace(rsc, "No notify action needed for %s %s",
                              rsc->id, n_data->action);
@@ -895,7 +895,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
 
     // Create notify actions for start or promote
     if ((rsc->next_role != pcmk_role_stopped)
-        && ((task == start_rsc) || (task == action_promote))) {
+        && ((task == pcmk_action_start) || (task == action_promote))) {
 
         start = find_first_action(rsc->actions, NULL, PCMK_ACTION_START, NULL);
         if (start != NULL) {
@@ -916,7 +916,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
                         role2text(rsc->next_role), rsc->id);
             return;
         }
-        if ((task != start_rsc) || (start == NULL)
+        if ((task != pcmk_action_start) || (start == NULL)
             || pcmk_is_set(start->flags, pe_action_optional)) {
 
             new_notify_action(rsc, rsc->allocated_to, n_data->pre,

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -628,7 +628,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
                 case pcmk_action_promote:
                     n_data->promote = g_list_prepend(n_data->promote, entry);
                     break;
-                case action_demote:
+                case pcmk_action_demote:
                     n_data->demote = g_list_prepend(n_data->demote, entry);
                     break;
                 default:
@@ -822,7 +822,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
                 case pcmk_action_start:
                 case pcmk_action_stop:
                 case pcmk_action_promote:
-                case action_demote:
+                case pcmk_action_demote:
                     add_notify_data_to_action_meta(n_data, op);
                     break;
                 default:
@@ -849,7 +849,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
             }
             break;
 
-        case action_demote:
+        case pcmk_action_demote:
             if (n_data->demote == NULL) {
                 pe_rsc_trace(rsc, "No notify action needed for %s %s",
                              rsc->id, n_data->action);
@@ -867,7 +867,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
 
     // Create notify actions for stop or demote
     if ((rsc->role != pcmk_role_stopped)
-        && ((task == pcmk_action_stop) || (task == action_demote))) {
+        && ((task == pcmk_action_stop) || (task == pcmk_action_demote))) {
 
         stop = find_first_action(rsc->actions, NULL, PCMK_ACTION_STOP, NULL);
 
@@ -886,7 +886,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
             new_notify_action(rsc, current_node, n_data->pre,
                               n_data->pre_done, n_data);
 
-            if ((task == action_demote) || (stop == NULL)
+            if ((task == pcmk_action_demote) || (stop == NULL)
                 || pcmk_is_set(stop->flags, pe_action_optional)) {
                 new_post_notify_action(rsc, current_node, n_data);
             }

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -610,7 +610,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
         if (!pcmk_is_set(op->flags, pe_action_optional) && (op->node != NULL)) {
             enum action_tasks task = text2task(op->task);
 
-            if ((task == stop_rsc) && op->node->details->unclean) {
+            if ((task == pcmk_action_stop) && op->node->details->unclean) {
                 // Create anyway (additional noise if node can't be fenced)
             } else if (!pcmk_is_set(op->flags, pe_action_runnable)) {
                 continue;
@@ -622,7 +622,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
                 case start_rsc:
                     n_data->start = g_list_prepend(n_data->start, entry);
                     break;
-                case stop_rsc:
+                case pcmk_action_stop:
                     n_data->stop = g_list_prepend(n_data->stop, entry);
                     break;
                 case action_promote:
@@ -820,7 +820,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
         if (!pcmk_is_set(op->flags, pe_action_optional) && (op->node != NULL)) {
             switch (text2task(op->task)) {
                 case start_rsc:
-                case stop_rsc:
+                case pcmk_action_stop:
                 case action_promote:
                 case action_demote:
                     add_notify_data_to_action_meta(n_data, op);
@@ -867,7 +867,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
 
     // Create notify actions for stop or demote
     if ((rsc->role != pcmk_role_stopped)
-        && ((task == stop_rsc) || (task == action_demote))) {
+        && ((task == pcmk_action_stop) || (task == action_demote))) {
 
         stop = find_first_action(rsc->actions, NULL, PCMK_ACTION_STOP, NULL);
 


### PR DESCRIPTION
This is part of a project to merge the functionality of libpe_rules/libpe_status into libcrmcommon, bringing it up to current guidelines as we go