### PR TITLE
Move enum action_fail_result to libcrmcommon

### DIFF
--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -158,6 +158,9 @@ enum action_fail_response {
     // @TODO Define as 30
     pcmk_on_fail_restart            = 1,    //!< Restart resource
 
+    // @TODO Define as 60
+    pcmk_on_fail_ban                = 2,    //!< Ban resource from current node
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -168,7 +171,7 @@ enum action_fail_response {
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_migrate,    // @TODO = 60
+    action_fail_migrate             = pcmk_on_fail_ban,
     action_fail_block,      // @TODO = 70
     action_fail_stop,       // @TODO = 80
     action_fail_standby,    // @TODO = 90

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -178,6 +178,14 @@ enum action_fail_response {
     // @TODO Define as 50
     pcmk_on_fail_restart_container  = 7,    //!< Restart resource's container
 
+    // @TODO Define as 40
+    /*!
+     * Fence the remote node created by the resource if fencing is enabled,
+     * otherwise attempt to restart the resource (used internally for some
+     * remote connection failures).
+     */
+    pcmk_on_fail_reset_remote       = 8,
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -199,18 +207,12 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_fence_node instead
     action_fail_fence               = pcmk_on_fail_fence_node,
+
+    //! \deprecated Use pcmk_on_fail_restart_container instead
+    action_fail_restart_container   = pcmk_on_fail_restart_container,
 #endif
     // @TODO action_fail_demote = 20,
-    // @TODO action_fail_reset_remote = 40,
 
-    action_fail_restart_container   = pcmk_on_fail_restart_container,
-
-    /* This is reserved for internal use for remote node connection resources.
-     * Fence the remote node if stonith is enabled, otherwise attempt to recover
-     * the connection resource. This allows us to specify types of connection
-     * resource failures that should result in fencing the remote node
-     * (for example, recurring monitor failures).
-     */
     action_fail_reset_remote,
 
     action_fail_demote,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -167,11 +167,13 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_restart instead
     action_fail_recover             = pcmk_on_fail_restart,
+
+    //! \deprecated Use pcmk_on_fail_ban instead
+    action_fail_migrate             = pcmk_on_fail_ban,
 #endif
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_migrate             = pcmk_on_fail_ban,
     action_fail_block,      // @TODO = 70
     action_fail_stop,       // @TODO = 80
     action_fail_standby,    // @TODO = 90

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -155,12 +155,15 @@ enum action_fail_response {
     // @TODO Define as 10
     pcmk_on_fail_ignore             = 0,    //!< Act as if failure didn't happen
 
+    // @TODO Define as 30
+    pcmk_on_fail_restart            = 1,    //!< Restart resource
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
 #endif
     // @TODO action_fail_demote = 20,
-    action_fail_recover,    // @TODO = 30
+    action_fail_recover             = pcmk_on_fail_restart,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
     action_fail_migrate,    // @TODO = 60

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -191,11 +191,13 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_standby_node instead
     action_fail_standby             = pcmk_on_fail_standby_node,
+
+    //! \deprecated Use pcmk_on_fail_fence_node instead
+    action_fail_fence               = pcmk_on_fail_fence_node,
 #endif
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_fence               = pcmk_on_fail_fence_node,
 
     // @COMPAT Values below here are out of order for API compatibility
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -173,11 +173,13 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_ban instead
     action_fail_migrate             = pcmk_on_fail_ban,
+
+    //! \deprecated Use pcmk_on_fail_block instead
+    action_fail_block               = pcmk_on_fail_block,
 #endif
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_block               = pcmk_on_fail_block,
     action_fail_stop,       // @TODO = 80
     action_fail_standby,    // @TODO = 90
     action_fail_fence,      // @TODO = 100

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -210,11 +210,11 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_restart_container instead
     action_fail_restart_container   = pcmk_on_fail_restart_container,
+
+    //! \deprecated Use pcmk_on_fail_reset_remote instead
+    action_fail_reset_remote        = pcmk_on_fail_reset_remote,
 #endif
     // @TODO action_fail_demote = 20,
-
-    action_fail_reset_remote        = pcmk_on_fail_reset_remote,
-
     action_fail_demote,
 };
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -141,17 +141,21 @@ enum action_tasks {
 //! Possible responses to a resource action failure
 enum action_fail_response {
     /* The order is (partially) significant here; the values from
-     * action_fail_ignore through action_fail_fence are in order of increasing
+     * pcmk_on_fail_ignore through action_fail_fence are in order of increasing
      * severity.
      *
      * @COMPAT The values should be ordered and numbered per the "TODO" comments
      *         below, so all values are in order of severity and there is room for
      *         future additions, but that would break API compatibility.
      * @TODO   For now, we just use a function to compare the values specially, but
-     *         at the next compatibility break, we should arrange things properly.
+     *         at the next compatibility break, we should arrange things
+     *         properly so we can compare with less than and greater than.
      */
 
-    action_fail_ignore,     // @TODO = 10
+    // @TODO Define as 10
+    pcmk_on_fail_ignore             = 0,    //!< Act as if failure didn't happen
+
+    action_fail_ignore              = pcmk_on_fail_ignore,
     // @TODO action_fail_demote = 20,
     action_fail_recover,    // @TODO = 30
     // @TODO action_fail_reset_remote = 40,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -141,8 +141,8 @@ enum action_tasks {
 //! Possible responses to a resource action failure
 enum action_fail_response {
     /* The order is (partially) significant here; the values from
-     * pcmk_on_fail_ignore through action_fail_fence are in order of increasing
-     * severity.
+     * pcmk_on_fail_ignore through pcmk_on_fail_fence_node are in order of
+     * increasing severity.
      *
      * @COMPAT The values should be ordered and numbered per the "TODO" comments
      *         below, so all values are in order of severity and there is room for
@@ -170,6 +170,9 @@ enum action_fail_response {
     // @TODO Define as 90
     pcmk_on_fail_standby_node       = 5,    //!< Put resource's node in standby
 
+    // @TODO Define as 100
+    pcmk_on_fail_fence_node         = 6,    //!< Fence resource's node
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -192,7 +195,7 @@ enum action_fail_response {
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_fence,      // @TODO = 100
+    action_fail_fence               = pcmk_on_fail_fence_node,
 
     // @COMPAT Values below here are out of order for API compatibility
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -138,6 +138,45 @@ enum action_tasks {
 #endif
 };
 
+//! Possible responses to a resource action failure
+enum action_fail_response {
+    /* The order is (partially) significant here; the values from
+     * action_fail_ignore through action_fail_fence are in order of increasing
+     * severity.
+     *
+     * @COMPAT The values should be ordered and numbered per the "TODO" comments
+     *         below, so all values are in order of severity and there is room for
+     *         future additions, but that would break API compatibility.
+     * @TODO   For now, we just use a function to compare the values specially, but
+     *         at the next compatibility break, we should arrange things properly.
+     */
+
+    action_fail_ignore,     // @TODO = 10
+    // @TODO action_fail_demote = 20,
+    action_fail_recover,    // @TODO = 30
+    // @TODO action_fail_reset_remote = 40,
+    // @TODO action_fail_restart_container = 50,
+    action_fail_migrate,    // @TODO = 60
+    action_fail_block,      // @TODO = 70
+    action_fail_stop,       // @TODO = 80
+    action_fail_standby,    // @TODO = 90
+    action_fail_fence,      // @TODO = 100
+
+    // @COMPAT Values below here are out of order for API compatibility
+
+    action_fail_restart_container,
+
+    /* This is reserved for internal use for remote node connection resources.
+     * Fence the remote node if stonith is enabled, otherwise attempt to recover
+     * the connection resource. This allows us to specify types of connection
+     * resource failures that should result in fencing the remote node
+     * (for example, recurring monitor failures).
+     */
+    action_fail_reset_remote,
+
+    action_fail_demote,
+};
+
 // For parsing various action-related string specifications
 gboolean parse_op_key(const char *key, char **rsc_id, char **op_type,
                       guint *interval_ms);

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -173,6 +173,11 @@ enum action_fail_response {
     // @TODO Define as 100
     pcmk_on_fail_fence_node         = 6,    //!< Fence resource's node
 
+    // @COMPAT Values below here are out of desired order for API compatibility
+
+    // @TODO Define as 50
+    pcmk_on_fail_restart_container  = 7,    //!< Restart resource's container
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -197,11 +202,8 @@ enum action_fail_response {
 #endif
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
-    // @TODO action_fail_restart_container = 50,
 
-    // @COMPAT Values below here are out of order for API compatibility
-
-    action_fail_restart_container,
+    action_fail_restart_container   = pcmk_on_fail_restart_container,
 
     /* This is reserved for internal use for remote node connection resources.
      * Fence the remote node if stonith is enabled, otherwise attempt to recover

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -185,11 +185,13 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_stop instead
     action_fail_stop                = pcmk_on_fail_stop,
+
+    //! \deprecated Use pcmk_on_fail_standby_node instead
+    action_fail_standby             = pcmk_on_fail_standby_node,
 #endif
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_standby             = pcmk_on_fail_standby_node,
     action_fail_fence,      // @TODO = 100
 
     // @COMPAT Values below here are out of order for API compatibility

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -213,7 +213,7 @@ enum action_fail_response {
 #endif
     // @TODO action_fail_demote = 20,
 
-    action_fail_reset_remote,
+    action_fail_reset_remote        = pcmk_on_fail_reset_remote,
 
     action_fail_demote,
 };

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -186,6 +186,9 @@ enum action_fail_response {
      */
     pcmk_on_fail_reset_remote       = 8,
 
+    // @TODO Define as 20
+    pcmk_on_fail_demote             = 9,    //!< Demote if promotable, else stop
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -214,8 +217,7 @@ enum action_fail_response {
     //! \deprecated Use pcmk_on_fail_reset_remote instead
     action_fail_reset_remote        = pcmk_on_fail_reset_remote,
 #endif
-    // @TODO action_fail_demote = 20,
-    action_fail_demote,
+    action_fail_demote              = pcmk_on_fail_demote,
 };
 
 // For parsing various action-related string specifications

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -167,6 +167,9 @@ enum action_fail_response {
     // @TODO Define as 80
     pcmk_on_fail_stop               = 4,    //!< Stop resource and leave stopped
 
+    // @TODO Define as 90
+    pcmk_on_fail_standby_node       = 5,    //!< Put resource's node in standby
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -186,7 +189,7 @@ enum action_fail_response {
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_standby,    // @TODO = 90
+    action_fail_standby             = pcmk_on_fail_standby_node,
     action_fail_fence,      // @TODO = 100
 
     // @COMPAT Values below here are out of order for API compatibility

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -161,6 +161,9 @@ enum action_fail_response {
     // @TODO Define as 60
     pcmk_on_fail_ban                = 2,    //!< Ban resource from current node
 
+    // @TODO Define as 70
+    pcmk_on_fail_block              = 3,    //!< Treat resource as unmanaged
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -174,7 +177,7 @@ enum action_fail_response {
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_block,      // @TODO = 70
+    action_fail_block               = pcmk_on_fail_block,
     action_fail_stop,       // @TODO = 80
     action_fail_standby,    // @TODO = 90
     action_fail_fence,      // @TODO = 100

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -155,7 +155,10 @@ enum action_fail_response {
     // @TODO Define as 10
     pcmk_on_fail_ignore             = 0,    //!< Act as if failure didn't happen
 
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
+#endif
     // @TODO action_fail_demote = 20,
     action_fail_recover,    // @TODO = 30
     // @TODO action_fail_reset_remote = 40,

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -161,9 +161,11 @@ enum action_fail_response {
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
+
+    //! \deprecated Use pcmk_on_fail_restart instead
+    action_fail_recover             = pcmk_on_fail_restart,
 #endif
     // @TODO action_fail_demote = 20,
-    action_fail_recover             = pcmk_on_fail_restart,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
     action_fail_migrate,    // @TODO = 60

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -164,6 +164,9 @@ enum action_fail_response {
     // @TODO Define as 70
     pcmk_on_fail_block              = 3,    //!< Treat resource as unmanaged
 
+    // @TODO Define as 80
+    pcmk_on_fail_stop               = 4,    //!< Stop resource and leave stopped
+
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_on_fail_ignore instead
     action_fail_ignore              = pcmk_on_fail_ignore,
@@ -180,7 +183,7 @@ enum action_fail_response {
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_stop,       // @TODO = 80
+    action_fail_stop                = pcmk_on_fail_stop,
     action_fail_standby,    // @TODO = 90
     action_fail_fence,      // @TODO = 100
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -179,11 +179,13 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_block instead
     action_fail_block               = pcmk_on_fail_block,
+
+    //! \deprecated Use pcmk_on_fail_stop instead
+    action_fail_stop                = pcmk_on_fail_stop,
 #endif
     // @TODO action_fail_demote = 20,
     // @TODO action_fail_reset_remote = 40,
     // @TODO action_fail_restart_container = 50,
-    action_fail_stop                = pcmk_on_fail_stop,
     action_fail_standby,    // @TODO = 90
     action_fail_fence,      // @TODO = 100
 

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -216,8 +216,10 @@ enum action_fail_response {
 
     //! \deprecated Use pcmk_on_fail_reset_remote instead
     action_fail_reset_remote        = pcmk_on_fail_reset_remote,
-#endif
+
+    //! \deprecated Use pcmk_on_fail_demote instead
     action_fail_demote              = pcmk_on_fail_demote,
+#endif
 };
 
 // For parsing various action-related string specifications

--- a/include/crm/pengine/common.h
+++ b/include/crm/pengine/common.h
@@ -22,42 +22,6 @@ extern "C" {
 extern gboolean was_processing_error;
 extern gboolean was_processing_warning;
 
-/* The order is (partially) significant here; the values from action_fail_ignore
- * through action_fail_fence are in order of increasing severity.
- *
- * @COMPAT The values should be ordered and numbered per the "TODO" comments
- *         below, so all values are in order of severity and there is room for
- *         future additions, but that would break API compatibility.
- * @TODO   For now, we just use a function to compare the values specially, but
- *         at the next compatibility break, we should arrange things properly.
- */
-enum action_fail_response {
-    action_fail_ignore,     // @TODO = 10
-    // @TODO action_fail_demote = 20,
-    action_fail_recover,    // @TODO = 30
-    // @TODO action_fail_reset_remote = 40,
-    // @TODO action_fail_restart_container = 50,
-    action_fail_migrate,    // @TODO = 60
-    action_fail_block,      // @TODO = 70
-    action_fail_stop,       // @TODO = 80
-    action_fail_standby,    // @TODO = 90
-    action_fail_fence,      // @TODO = 100
-
-    // @COMPAT Values below here are out of order for API compatibility
-
-    action_fail_restart_container,
-
-    /* This is reserved for internal use for remote node connection resources.
-     * Fence the remote node if stonith is enabled, otherwise attempt to recover
-     * the connection resource. This allows us to specify types of connection
-     * resource failures that should result in fencing the remote node
-     * (for example, recurring monitor failures).
-     */
-    action_fail_reset_remote,
-
-    action_fail_demote,
-};
-
 //! Deprecated
 enum pe_print_options {
     pe_print_log            = (1 << 0),

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -345,7 +345,7 @@ fail2text(enum action_fail_response fail)
         case pcmk_on_fail_standby_node:
             result = "standby";
             break;
-        case action_fail_restart_container:
+        case pcmk_on_fail_restart_container:
             result = "restart-container";
             break;
         case action_fail_reset_remote:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -333,7 +333,7 @@ fail2text(enum action_fail_response fail)
         case pcmk_on_fail_restart:
             result = "recover";
             break;
-        case action_fail_migrate:
+        case pcmk_on_fail_ban:
             result = "migrate";
             break;
         case action_fail_stop:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -324,7 +324,7 @@ fail2text(enum action_fail_response fail)
         case pcmk_on_fail_ignore:
             result = "ignore";
             break;
-        case action_fail_demote:
+        case pcmk_on_fail_demote:
             result = "demote";
             break;
         case pcmk_on_fail_block:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -327,7 +327,7 @@ fail2text(enum action_fail_response fail)
         case action_fail_demote:
             result = "demote";
             break;
-        case action_fail_block:
+        case pcmk_on_fail_block:
             result = "block";
             break;
         case pcmk_on_fail_restart:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -339,7 +339,7 @@ fail2text(enum action_fail_response fail)
         case pcmk_on_fail_stop:
             result = "stop";
             break;
-        case action_fail_fence:
+        case pcmk_on_fail_fence_node:
             result = "fence";
             break;
         case pcmk_on_fail_standby_node:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -330,7 +330,7 @@ fail2text(enum action_fail_response fail)
         case action_fail_block:
             result = "block";
             break;
-        case action_fail_recover:
+        case pcmk_on_fail_restart:
             result = "recover";
             break;
         case action_fail_migrate:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -321,7 +321,7 @@ fail2text(enum action_fail_response fail)
     const char *result = "<unknown>";
 
     switch (fail) {
-        case action_fail_ignore:
+        case pcmk_on_fail_ignore:
             result = "ignore";
             break;
         case action_fail_demote:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -336,7 +336,7 @@ fail2text(enum action_fail_response fail)
         case pcmk_on_fail_ban:
             result = "migrate";
             break;
-        case action_fail_stop:
+        case pcmk_on_fail_stop:
             result = "stop";
             break;
         case action_fail_fence:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -342,7 +342,7 @@ fail2text(enum action_fail_response fail)
         case action_fail_fence:
             result = "fence";
             break;
-        case action_fail_standby:
+        case pcmk_on_fail_standby_node:
             result = "standby";
             break;
         case action_fail_restart_container:

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -348,7 +348,7 @@ fail2text(enum action_fail_response fail)
         case pcmk_on_fail_restart_container:
             result = "restart-container";
             break;
-        case action_fail_reset_remote:
+        case pcmk_on_fail_reset_remote:
             result = "reset-remote";
             break;
     }

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -790,7 +790,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
             pcmk__config_err("Resetting '" XML_OP_ATTR_ON_FAIL "' for "
                              "operation '%s' to 'stop' because 'fence' is not "
                              "valid when fencing is disabled", action->uuid);
-            action->on_fail = action_fail_stop;
+            action->on_fail = pcmk_on_fail_stop;
             action->fail_role = pcmk_role_stopped;
             value = "stop resource";
         }
@@ -809,7 +809,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         value = "force migration";
 
     } else if (pcmk__str_eq(value, "stop", pcmk__str_casei)) {
-        action->on_fail = action_fail_stop;
+        action->on_fail = pcmk_on_fail_stop;
         action->fail_role = pcmk_role_stopped;
         value = "stop resource";
 
@@ -856,7 +856,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
                && !pcmk__str_eq(action->task, PCMK_ACTION_START, pcmk__str_casei)) {
 
         if (!pcmk_is_set(action->rsc->flags, pe_rsc_managed)) {
-            action->on_fail = action_fail_stop;
+            action->on_fail = pcmk_on_fail_stop;
             action->fail_role = pcmk_role_stopped;
             value = "stop unmanaged remote node (enforcing default)";
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -801,7 +801,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
 
     } else if (pcmk__strcase_any_of(value, "ignore", PCMK__VALUE_NOTHING,
                                     NULL)) {
-        action->on_fail = action_fail_ignore;
+        action->on_fail = pcmk_on_fail_ignore;
         value = "ignore";
 
     } else if (pcmk__str_eq(value, "migrate", pcmk__str_casei)) {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -819,7 +819,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
 
     } else if (pcmk__str_eq(value, "restart-container", pcmk__str_casei)) {
         if (container) {
-            action->on_fail = action_fail_restart_container;
+            action->on_fail = pcmk_on_fail_restart_container;
             value = "restart container (and possibly migrate)";
 
         } else {
@@ -837,7 +837,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
 
     /* defaults */
     if (value == NULL && container) {
-        action->on_fail = action_fail_restart_container;
+        action->on_fail = pcmk_on_fail_restart_container;
         value = "restart container (and possibly migrate) (default)";
 
     /* For remote nodes, ensure that any failure that results in dropping an

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -827,7 +827,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         }
 
     } else if (pcmk__str_eq(value, "demote", pcmk__str_casei)) {
-        action->on_fail = action_fail_demote;
+        action->on_fail = pcmk_on_fail_demote;
         value = "demote instance";
 
     } else {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -778,7 +778,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
     if (value == NULL) {
 
     } else if (pcmk__str_eq(value, "block", pcmk__str_casei)) {
-        action->on_fail = action_fail_block;
+        action->on_fail = pcmk_on_fail_block;
         g_hash_table_insert(action->meta, strdup(XML_OP_ATTR_ON_FAIL), strdup("block"));
         value = "block"; // The above could destroy the original string
 
@@ -881,7 +881,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
             value = "resource fence (default)";
 
         } else {
-            action->on_fail = action_fail_block;
+            action->on_fail = pcmk_on_fail_block;
             value = "resource block (default)";
         }
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -805,7 +805,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         value = "ignore";
 
     } else if (pcmk__str_eq(value, "migrate", pcmk__str_casei)) {
-        action->on_fail = action_fail_migrate;
+        action->on_fail = pcmk_on_fail_ban;
         value = "force migration";
 
     } else if (pcmk__str_eq(value, "stop", pcmk__str_casei)) {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -814,7 +814,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         value = "stop resource";
 
     } else if (pcmk__str_eq(value, "restart", pcmk__str_casei)) {
-        action->on_fail = action_fail_recover;
+        action->on_fail = pcmk_on_fail_restart;
         value = "restart (and possibly migrate)";
 
     } else if (pcmk__str_eq(value, "restart-container", pcmk__str_casei)) {
@@ -886,7 +886,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         }
 
     } else if (value == NULL) {
-        action->on_fail = action_fail_recover;
+        action->on_fail = pcmk_on_fail_restart;
         value = "restart (and possibly migrate) (default)";
     }
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -783,7 +783,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         value = "block"; // The above could destroy the original string
 
     } else if (pcmk__str_eq(value, "fence", pcmk__str_casei)) {
-        action->on_fail = action_fail_fence;
+        action->on_fail = pcmk_on_fail_fence_node;
         value = "node fencing";
 
         if (!pcmk_is_set(data_set->flags, pe_flag_stonith_enabled)) {
@@ -877,7 +877,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
                && pcmk__str_eq(action->task, PCMK_ACTION_STOP,
                                pcmk__str_casei)) {
         if (pcmk_is_set(data_set->flags, pe_flag_stonith_enabled)) {
-            action->on_fail = action_fail_fence;
+            action->on_fail = pcmk_on_fail_fence_node;
             value = "resource fence (default)";
 
         } else {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -870,7 +870,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
             if (action->rsc->remote_reconnect_ms) {
                 action->fail_role = pcmk_role_stopped;
             }
-            action->on_fail = action_fail_reset_remote;
+            action->on_fail = pcmk_on_fail_reset_remote;
         }
 
     } else if ((value == NULL)

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -796,7 +796,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
         }
 
     } else if (pcmk__str_eq(value, "standby", pcmk__str_casei)) {
-        action->on_fail = action_fail_standby;
+        action->on_fail = pcmk_on_fail_standby_node;
         value = "node standby";
 
     } else if (pcmk__strcase_any_of(value, "ignore", PCMK__VALUE_NOTHING,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2157,7 +2157,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             /* nothing to do */
             break;
 
-        case action_fail_demote:
+        case pcmk_on_fail_demote:
             pe__set_resource_flags(rsc, pe_rsc_failed);
             demote_action(rsc, node, FALSE);
             break;
@@ -2285,7 +2285,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
         switch (on_fail) {
             case pcmk_on_fail_ignore:
                 break;
-            case action_fail_demote:
+            case pcmk_on_fail_demote:
             case pcmk_on_fail_block:
                 pe__set_resource_flags(rsc, pe_rsc_failed);
                 break;
@@ -3341,11 +3341,11 @@ static int
 cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
 {
     switch (first) {
-        case action_fail_demote:
+        case pcmk_on_fail_demote:
             switch (second) {
                 case pcmk_on_fail_ignore:
                     return 1;
-                case action_fail_demote:
+                case pcmk_on_fail_demote:
                     return 0;
                 default:
                     return -1;
@@ -3355,7 +3355,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
         case pcmk_on_fail_reset_remote:
             switch (second) {
                 case pcmk_on_fail_ignore:
-                case action_fail_demote:
+                case pcmk_on_fail_demote:
                 case pcmk_on_fail_restart:
                     return 1;
                 case pcmk_on_fail_reset_remote:
@@ -3368,7 +3368,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
         case pcmk_on_fail_restart_container:
             switch (second) {
                 case pcmk_on_fail_ignore:
-                case action_fail_demote:
+                case pcmk_on_fail_demote:
                 case pcmk_on_fail_restart:
                 case pcmk_on_fail_reset_remote:
                     return 1;
@@ -3383,13 +3383,13 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             break;
     }
     switch (second) {
-        case action_fail_demote:
+        case pcmk_on_fail_demote:
             return (first == pcmk_on_fail_ignore)? -1 : 1;
 
         case pcmk_on_fail_reset_remote:
             switch (first) {
                 case pcmk_on_fail_ignore:
-                case action_fail_demote:
+                case pcmk_on_fail_demote:
                 case pcmk_on_fail_restart:
                     return -1;
                 default:
@@ -3400,7 +3400,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
         case pcmk_on_fail_restart_container:
             switch (first) {
                 case pcmk_on_fail_ignore:
-                case action_fail_demote:
+                case pcmk_on_fail_demote:
                 case pcmk_on_fail_restart:
                 case pcmk_on_fail_reset_remote:
                     return -1;
@@ -4182,7 +4182,7 @@ update_resource_state(struct action_history *history, int exit_status,
 
     } else if (pcmk__str_eq(history->task, PCMK_ACTION_DEMOTE,
                             pcmk__str_none)) {
-        if (*on_fail == action_fail_demote) {
+        if (*on_fail == pcmk_on_fail_demote) {
             // Demote clears an error only if on-fail=demote
             clear_past_failure = true;
         }
@@ -4219,7 +4219,7 @@ update_resource_state(struct action_history *history, int exit_status,
 
         case pcmk_on_fail_block:
         case pcmk_on_fail_ignore:
-        case action_fail_demote:
+        case pcmk_on_fail_demote:
         case pcmk_on_fail_restart:
         case pcmk_on_fail_restart_container:
             *on_fail = pcmk_on_fail_ignore;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2192,7 +2192,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
                               rsc->cluster);
             break;
 
-        case action_fail_stop:
+        case pcmk_on_fail_stop:
             pe__set_next_role(rsc, pcmk_role_stopped, "on-fail=stop");
             break;
 
@@ -4208,7 +4208,7 @@ update_resource_state(struct action_history *history, int exit_status,
     }
 
     switch (*on_fail) {
-        case action_fail_stop:
+        case pcmk_on_fail_stop:
         case action_fail_fence:
         case pcmk_on_fail_ban:
         case action_fail_standby:

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2222,7 +2222,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             }
             break;
 
-        case action_fail_reset_remote:
+        case pcmk_on_fail_reset_remote:
             pe__set_resource_flags(rsc, pe_rsc_failed|pe_rsc_stop);
             if (pcmk_is_set(rsc->cluster->flags, pe_flag_stonith_enabled)) {
                 tmpnode = NULL;
@@ -3352,13 +3352,13 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             }
             break;
 
-        case action_fail_reset_remote:
+        case pcmk_on_fail_reset_remote:
             switch (second) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case pcmk_on_fail_restart:
                     return 1;
-                case action_fail_reset_remote:
+                case pcmk_on_fail_reset_remote:
                     return 0;
                 default:
                     return -1;
@@ -3370,7 +3370,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case pcmk_on_fail_restart:
-                case action_fail_reset_remote:
+                case pcmk_on_fail_reset_remote:
                     return 1;
                 case pcmk_on_fail_restart_container:
                     return 0;
@@ -3386,7 +3386,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
         case action_fail_demote:
             return (first == pcmk_on_fail_ignore)? -1 : 1;
 
-        case action_fail_reset_remote:
+        case pcmk_on_fail_reset_remote:
             switch (first) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
@@ -3402,7 +3402,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case pcmk_on_fail_restart:
-                case action_fail_reset_remote:
+                case pcmk_on_fail_reset_remote:
                     return -1;
                 default:
                     return 1;
@@ -4227,7 +4227,7 @@ update_resource_state(struct action_history *history, int exit_status,
                               "clear past failures");
             break;
 
-        case action_fail_reset_remote:
+        case pcmk_on_fail_reset_remote:
             if (history->rsc->remote_reconnect_ms == 0) {
                 /* With no reconnect interval, the connection is allowed to
                  * start again after the remote node is fenced and

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2176,7 +2176,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             node->details->standby_onfail = TRUE;
             break;
 
-        case action_fail_block:
+        case pcmk_on_fail_block:
             /* is_managed == FALSE will prevent any
              * actions being sent for the resource
              */
@@ -2286,7 +2286,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             case pcmk_on_fail_ignore:
                 break;
             case action_fail_demote:
-            case action_fail_block:
+            case pcmk_on_fail_block:
                 pe__set_resource_flags(rsc, pe_rsc_failed);
                 break;
             default:
@@ -3528,7 +3528,7 @@ unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
         history->rsc->role = pcmk_role_promoted;
 
     } else if (strcmp(history->task, PCMK_ACTION_DEMOTE) == 0) {
-        if (action->on_fail == action_fail_block) {
+        if (action->on_fail == pcmk_on_fail_block) {
             history->rsc->role = pcmk_role_promoted;
             pe__set_next_role(history->rsc, pcmk_role_stopped,
                               "demote with on-fail=block");
@@ -4217,7 +4217,7 @@ update_resource_state(struct action_history *history, int exit_status,
                          history->rsc->id, fail2text(*on_fail), history->task);
             break;
 
-        case action_fail_block:
+        case pcmk_on_fail_block:
         case pcmk_on_fail_ignore:
         case action_fail_demote:
         case pcmk_on_fail_restart:

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2204,7 +2204,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             }
             break;
 
-        case action_fail_restart_container:
+        case pcmk_on_fail_restart_container:
             pe__set_resource_flags(rsc, pe_rsc_failed|pe_rsc_stop);
             if (rsc->container && pe_rsc_is_bundled(rsc)) {
                 /* A bundle's remote connection can run on a different node than
@@ -3365,14 +3365,14 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             }
             break;
 
-        case action_fail_restart_container:
+        case pcmk_on_fail_restart_container:
             switch (second) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case pcmk_on_fail_restart:
                 case action_fail_reset_remote:
                     return 1;
-                case action_fail_restart_container:
+                case pcmk_on_fail_restart_container:
                     return 0;
                 default:
                     return -1;
@@ -3397,7 +3397,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             }
             break;
 
-        case action_fail_restart_container:
+        case pcmk_on_fail_restart_container:
             switch (first) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
@@ -4221,7 +4221,7 @@ update_resource_state(struct action_history *history, int exit_status,
         case pcmk_on_fail_ignore:
         case action_fail_demote:
         case pcmk_on_fail_restart:
-        case action_fail_restart_container:
+        case pcmk_on_fail_restart_container:
             *on_fail = pcmk_on_fail_ignore;
             pe__set_next_role(history->rsc, pcmk_role_unknown,
                               "clear past failures");
@@ -4664,7 +4664,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
 
     failure_strategy = get_action_on_fail(&history);
     if ((failure_strategy == pcmk_on_fail_ignore)
-        || (failure_strategy == action_fail_restart_container
+        || ((failure_strategy == pcmk_on_fail_restart_container)
             && (strcmp(history.task, PCMK_ACTION_STOP) == 0))) {
 
         char *last_change_s = last_change_str(xml_op);
@@ -4684,7 +4684,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
 
         record_failed_op(&history);
 
-        if ((failure_strategy == action_fail_restart_container)
+        if ((failure_strategy == pcmk_on_fail_restart_container)
             && cmp_on_fail(*on_fail, pcmk_on_fail_restart) <= 0) {
             *on_fail = failure_strategy;
         }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2184,7 +2184,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             pe__set_resource_flags(rsc, pe_rsc_block);
             break;
 
-        case action_fail_migrate:
+        case pcmk_on_fail_ban:
             /* make sure it comes up somewhere else
              * or not at all
              */
@@ -4210,7 +4210,7 @@ update_resource_state(struct action_history *history, int exit_status,
     switch (*on_fail) {
         case action_fail_stop:
         case action_fail_fence:
-        case action_fail_migrate:
+        case pcmk_on_fail_ban:
         case action_fail_standby:
             pe_rsc_trace(history->rsc,
                          "%s (%s) is not cleared by a completed %s",
@@ -4629,7 +4629,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
                          history.execution_status, history.exit_status,
                          history.id);
                 /* Also for printing it as "FAILED" by marking it as pe_rsc_failed later */
-                *on_fail = action_fail_migrate;
+                *on_fail = pcmk_on_fail_ban;
             }
             resource_location(parent, node, -INFINITY, "hard-error",
                               rsc->cluster);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2196,7 +2196,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             pe__set_next_role(rsc, pcmk_role_stopped, "on-fail=stop");
             break;
 
-        case action_fail_recover:
+        case pcmk_on_fail_restart:
             if ((rsc->role != pcmk_role_stopped)
                 && (rsc->role != pcmk_role_unknown)) {
                 pe__set_resource_flags(rsc, pe_rsc_failed|pe_rsc_stop);
@@ -3356,7 +3356,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             switch (second) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
-                case action_fail_recover:
+                case pcmk_on_fail_restart:
                     return 1;
                 case action_fail_reset_remote:
                     return 0;
@@ -3369,7 +3369,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             switch (second) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
-                case action_fail_recover:
+                case pcmk_on_fail_restart:
                 case action_fail_reset_remote:
                     return 1;
                 case action_fail_restart_container:
@@ -3390,7 +3390,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             switch (first) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
-                case action_fail_recover:
+                case pcmk_on_fail_restart:
                     return -1;
                 default:
                     return 1;
@@ -3401,7 +3401,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
             switch (first) {
                 case pcmk_on_fail_ignore:
                 case action_fail_demote:
-                case action_fail_recover:
+                case pcmk_on_fail_restart:
                 case action_fail_reset_remote:
                     return -1;
                 default:
@@ -4122,7 +4122,7 @@ pe__target_rc_from_xml(const xmlNode *xml_op)
 static enum action_fail_response
 get_action_on_fail(struct action_history *history)
 {
-    enum action_fail_response result = action_fail_recover;
+    enum action_fail_response result = pcmk_on_fail_restart;
     pe_action_t *action = custom_action(history->rsc, strdup(history->key),
                                         history->task, NULL, TRUE, FALSE,
                                         history->rsc->cluster);
@@ -4220,7 +4220,7 @@ update_resource_state(struct action_history *history, int exit_status,
         case action_fail_block:
         case pcmk_on_fail_ignore:
         case action_fail_demote:
-        case action_fail_recover:
+        case pcmk_on_fail_restart:
         case action_fail_restart_container:
             *on_fail = pcmk_on_fail_ignore;
             pe__set_next_role(history->rsc, pcmk_role_unknown,
@@ -4536,7 +4536,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
     int old_rc = 0;
     bool expired = false;
     pe_resource_t *parent = rsc;
-    enum action_fail_response failure_strategy = action_fail_recover;
+    enum action_fail_response failure_strategy = pcmk_on_fail_restart;
 
     struct action_history history = {
         .rsc = rsc,
@@ -4685,7 +4685,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
         record_failed_op(&history);
 
         if ((failure_strategy == action_fail_restart_container)
-            && cmp_on_fail(*on_fail, action_fail_recover) <= 0) {
+            && cmp_on_fail(*on_fail, pcmk_on_fail_restart) <= 0) {
             *on_fail = failure_strategy;
         }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2066,7 +2066,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
 {
     pe_node_t *tmpnode = NULL;
     char *reason = NULL;
-    enum action_fail_response save_on_fail = action_fail_ignore;
+    enum action_fail_response save_on_fail = pcmk_on_fail_ignore;
 
     CRM_ASSERT(rsc);
     pe_rsc_trace(rsc, "Resource %s is %s on %s: on_fail=%s",
@@ -2149,11 +2149,11 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
         /* No extra processing needed
          * Also allows resources to be started again after a node is shot
          */
-        on_fail = action_fail_ignore;
+        on_fail = pcmk_on_fail_ignore;
     }
 
     switch (on_fail) {
-        case action_fail_ignore:
+        case pcmk_on_fail_ignore:
             /* nothing to do */
             break;
 
@@ -2281,9 +2281,9 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
         }
 
         native_add_running(rsc, node, rsc->cluster,
-                           (save_on_fail != action_fail_ignore));
+                           (save_on_fail != pcmk_on_fail_ignore));
         switch (on_fail) {
-            case action_fail_ignore:
+            case pcmk_on_fail_ignore:
                 break;
             case action_fail_demote:
             case action_fail_block:
@@ -2497,7 +2497,7 @@ unpack_lrm_resource(pe_node_t *node, const xmlNode *lrm_resource,
     xmlNode *rsc_op = NULL;
     xmlNode *last_failure = NULL;
 
-    enum action_fail_response on_fail = action_fail_ignore;
+    enum action_fail_response on_fail = pcmk_on_fail_ignore;
     enum rsc_role_e saved_role = pcmk_role_unknown;
 
     if (rsc_id == NULL) {
@@ -3343,7 +3343,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
     switch (first) {
         case action_fail_demote:
             switch (second) {
-                case action_fail_ignore:
+                case pcmk_on_fail_ignore:
                     return 1;
                 case action_fail_demote:
                     return 0;
@@ -3354,7 +3354,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
 
         case action_fail_reset_remote:
             switch (second) {
-                case action_fail_ignore:
+                case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case action_fail_recover:
                     return 1;
@@ -3367,7 +3367,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
 
         case action_fail_restart_container:
             switch (second) {
-                case action_fail_ignore:
+                case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case action_fail_recover:
                 case action_fail_reset_remote:
@@ -3384,11 +3384,11 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
     }
     switch (second) {
         case action_fail_demote:
-            return (first == action_fail_ignore)? -1 : 1;
+            return (first == pcmk_on_fail_ignore)? -1 : 1;
 
         case action_fail_reset_remote:
             switch (first) {
-                case action_fail_ignore:
+                case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case action_fail_recover:
                     return -1;
@@ -3399,7 +3399,7 @@ cmp_on_fail(enum action_fail_response first, enum action_fail_response second)
 
         case action_fail_restart_container:
             switch (first) {
-                case action_fail_ignore:
+                case pcmk_on_fail_ignore:
                 case action_fail_demote:
                 case action_fail_recover:
                 case action_fail_reset_remote:
@@ -3763,7 +3763,7 @@ remap_operation(struct action_history *history,
                  */
                 remap_because(history, &why, PCMK_EXEC_DONE, "exit status");
                 history->rsc->role = pcmk_role_stopped;
-                *on_fail = action_fail_ignore;
+                *on_fail = pcmk_on_fail_ignore;
                 pe__set_next_role(history->rsc, pcmk_role_unknown,
                                   "not running");
             }
@@ -4218,11 +4218,11 @@ update_resource_state(struct action_history *history, int exit_status,
             break;
 
         case action_fail_block:
-        case action_fail_ignore:
+        case pcmk_on_fail_ignore:
         case action_fail_demote:
         case action_fail_recover:
         case action_fail_restart_container:
-            *on_fail = action_fail_ignore;
+            *on_fail = pcmk_on_fail_ignore;
             pe__set_next_role(history->rsc, pcmk_role_unknown,
                               "clear past failures");
             break;
@@ -4235,7 +4235,7 @@ update_resource_state(struct action_history *history, int exit_status,
                  * for the failure to be cleared entirely before attempting
                  * to reconnect.)
                  */
-                *on_fail = action_fail_ignore;
+                *on_fail = pcmk_on_fail_ignore;
                 pe__set_next_role(history->rsc, pcmk_role_unknown,
                                   "clear past failures and reset remote");
             }
@@ -4621,7 +4621,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
 
         case PCMK_EXEC_NOT_INSTALLED:
             failure_strategy = get_action_on_fail(&history);
-            if (failure_strategy == action_fail_ignore) {
+            if (failure_strategy == pcmk_on_fail_ignore) {
                 crm_warn("Cannot ignore failed %s of %s on %s: "
                          "Resource agent doesn't exist "
                          CRM_XS " status=%d rc=%d id=%s",
@@ -4663,7 +4663,7 @@ unpack_rsc_op(pe_resource_t *rsc, pe_node_t *node, xmlNode *xml_op,
     }
 
     failure_strategy = get_action_on_fail(&history);
-    if ((failure_strategy == action_fail_ignore)
+    if ((failure_strategy == pcmk_on_fail_ignore)
         || (failure_strategy == action_fail_restart_container
             && (strcmp(history.task, PCMK_ACTION_STOP) == 0))) {
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2171,7 +2171,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             free(reason);
             break;
 
-        case action_fail_standby:
+        case pcmk_on_fail_standby_node:
             node->details->standby = TRUE;
             node->details->standby_onfail = TRUE;
             break;
@@ -4211,7 +4211,7 @@ update_resource_state(struct action_history *history, int exit_status,
         case pcmk_on_fail_stop:
         case action_fail_fence:
         case pcmk_on_fail_ban:
-        case action_fail_standby:
+        case pcmk_on_fail_standby_node:
             pe_rsc_trace(history->rsc,
                          "%s (%s) is not cleared by a completed %s",
                          history->rsc->id, fail2text(*on_fail), history->task);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2162,7 +2162,7 @@ process_rsc_state(pe_resource_t * rsc, pe_node_t * node,
             demote_action(rsc, node, FALSE);
             break;
 
-        case action_fail_fence:
+        case pcmk_on_fail_fence_node:
             /* treat it as if it is still running
              * but also mark the node as unclean
              */
@@ -4209,9 +4209,9 @@ update_resource_state(struct action_history *history, int exit_status,
 
     switch (*on_fail) {
         case pcmk_on_fail_stop:
-        case action_fail_fence:
         case pcmk_on_fail_ban:
         case pcmk_on_fail_standby_node:
+        case pcmk_on_fail_fence_node:
             pe_rsc_trace(history->rsc,
                          "%s (%s) is not cleared by a completed %s",
                          history->rsc->id, fail2text(*on_fail), history->task);


### PR DESCRIPTION
This is part of a project to merge the functionality of libpe_rules and libpe_status into libcrmcommon, bringing it up to current guidelines in the process