### PR TITLE
Move enum pe_obj_types to libcrmcommon

### DIFF
--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -735,7 +735,7 @@ cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
 
     /* Check whether our node is allowed for this resource (and its parent if in a group) */
     node = our_node_allowed_for(rsc);
-    if (rsc->parent && (rsc->parent->variant == pe_group)) {
+    if (rsc->parent && (rsc->parent->variant == pcmk_rsc_variant_group)) {
         parent = our_node_allowed_for(rsc->parent);
     }
 

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -41,8 +41,10 @@ enum pe_obj_types {
 
     //! \deprecated Use pcmk_rsc_variant_clone instead
     pe_clone        = pcmk_rsc_variant_clone,
-#endif
+
+    //! \deprecated Use pcmk_rsc_variant_bundle instead
     pe_container    = pcmk_rsc_variant_bundle,
+#endif
 };
 
 //! What resource needs before it can be recovered from a failed node

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -29,8 +29,10 @@ enum pe_obj_types {
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_rsc_variant_unknown instead
     pe_unknown      = pcmk_rsc_variant_unknown,
-#endif
+
+    //! \deprecated Use pcmk_rsc_variant_primitive instead
     pe_native       = pcmk_rsc_variant_primitive,
+#endif
     pe_group = 1,
     pe_clone = 2,
     pe_container = 3,

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -37,8 +37,10 @@ enum pe_obj_types {
 
     //! \deprecated Use pcmk_rsc_variant_group instead
     pe_group        = pcmk_rsc_variant_group,
-#endif
+
+    //! \deprecated Use pcmk_rsc_variant_clone instead
     pe_clone        = pcmk_rsc_variant_clone,
+#endif
     pe_container = 3,
 };
 

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -23,7 +23,9 @@ extern "C" {
 //! Resource variants supported by Pacemaker
 enum pe_obj_types {
     // Order matters: some code compares greater or lesser than
-    pe_unknown = -1,
+    pcmk_rsc_variant_unknown    = -1,   //!< Unknown resource variant
+
+    pe_unknown      = pcmk__rsc_type_unknown,
     pe_native = 0,
     pe_group = 1,
     pe_clone = 2,

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -26,6 +26,7 @@ enum pe_obj_types {
     pcmk_rsc_variant_unknown    = -1,   //!< Unknown resource variant
     pcmk_rsc_variant_primitive  = 0,    //!< Primitive resource
     pcmk_rsc_variant_group      = 1,    //!< Group resource
+    pcmk_rsc_variant_clone      = 2,    //!< Clone resource
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_rsc_variant_unknown instead
@@ -37,7 +38,7 @@ enum pe_obj_types {
     //! \deprecated Use pcmk_rsc_variant_group instead
     pe_group        = pcmk_rsc_variant_group,
 #endif
-    pe_clone = 2,
+    pe_clone        = pcmk_rsc_variant_clone,
     pe_container = 3,
 };
 

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -25,6 +25,7 @@ enum pe_obj_types {
     // Order matters: some code compares greater or lesser than
     pcmk_rsc_variant_unknown    = -1,   //!< Unknown resource variant
     pcmk_rsc_variant_primitive  = 0,    //!< Primitive resource
+    pcmk_rsc_variant_group      = 1,    //!< Group resource
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_rsc_variant_unknown instead
@@ -33,7 +34,7 @@ enum pe_obj_types {
     //! \deprecated Use pcmk_rsc_variant_primitive instead
     pe_native       = pcmk_rsc_variant_primitive,
 #endif
-    pe_group = 1,
+    pe_group        = pcmk_rsc_variant_group,
     pe_clone = 2,
     pe_container = 3,
 };

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -20,6 +20,16 @@ extern "C" {
  * \ingroup core
  */
 
+//! Resource variants supported by Pacemaker
+enum pe_obj_types {
+    // Order matters: some code compares greater or lesser than
+    pe_unknown = -1,
+    pe_native = 0,
+    pe_group = 1,
+    pe_clone = 2,
+    pe_container = 3,
+};
+
 //! What resource needs before it can be recovered from a failed node
 enum rsc_start_requirement {
     pcmk_requires_nothing   = 0,    //!< Resource can be recovered immediately

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -24,12 +24,13 @@ extern "C" {
 enum pe_obj_types {
     // Order matters: some code compares greater or lesser than
     pcmk_rsc_variant_unknown    = -1,   //!< Unknown resource variant
+    pcmk_rsc_variant_primitive  = 0,    //!< Primitive resource
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_rsc_variant_unknown instead
     pe_unknown      = pcmk_rsc_variant_unknown,
 #endif
-    pe_native = 0,
+    pe_native       = pcmk_rsc_variant_primitive,
     pe_group = 1,
     pe_clone = 2,
     pe_container = 3,

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -33,8 +33,10 @@ enum pe_obj_types {
 
     //! \deprecated Use pcmk_rsc_variant_primitive instead
     pe_native       = pcmk_rsc_variant_primitive,
-#endif
+
+    //! \deprecated Use pcmk_rsc_variant_group instead
     pe_group        = pcmk_rsc_variant_group,
+#endif
     pe_clone = 2,
     pe_container = 3,
 };

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -25,7 +25,10 @@ enum pe_obj_types {
     // Order matters: some code compares greater or lesser than
     pcmk_rsc_variant_unknown    = -1,   //!< Unknown resource variant
 
-    pe_unknown      = pcmk__rsc_type_unknown,
+#if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
+    //! \deprecated Use pcmk_rsc_variant_unknown instead
+    pe_unknown      = pcmk_rsc_variant_unknown,
+#endif
     pe_native = 0,
     pe_group = 1,
     pe_clone = 2,

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -27,6 +27,7 @@ enum pe_obj_types {
     pcmk_rsc_variant_primitive  = 0,    //!< Primitive resource
     pcmk_rsc_variant_group      = 1,    //!< Group resource
     pcmk_rsc_variant_clone      = 2,    //!< Clone resource
+    pcmk_rsc_variant_bundle     = 3,    //!< Bundle resource
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
     //! \deprecated Use pcmk_rsc_variant_unknown instead
@@ -41,7 +42,7 @@ enum pe_obj_types {
     //! \deprecated Use pcmk_rsc_variant_clone instead
     pe_clone        = pcmk_rsc_variant_clone,
 #endif
-    pe_container = 3,
+    pe_container    = pcmk_rsc_variant_bundle,
 };
 
 //! What resource needs before it can be recovered from a failed node

--- a/include/crm/compatibility.h
+++ b/include/crm/compatibility.h
@@ -196,7 +196,7 @@ extern "C" {
 /* Clone terminology definitions */
 
 // These can no longer be used in a switch together
-#define pe_master pe_clone
+#define pe_master pcmk_rsc_variant_clone
 
 static inline enum pe_obj_types
 get_resource_type(const char *name)
@@ -209,7 +209,7 @@ get_resource_type(const char *name)
 
     } else if (safe_str_eq(name, XML_CIB_TAG_INCARNATION)
                 || safe_str_eq(name, PCMK_XE_PROMOTABLE_LEGACY)) {
-        return pe_clone;
+        return pcmk_rsc_variant_clone;
 
     } else if (safe_str_eq(name, XML_CIB_TAG_CONTAINER)) {
         return pe_container;
@@ -226,7 +226,7 @@ get_resource_typename(enum pe_obj_types type)
             return XML_CIB_TAG_RESOURCE;
         case pcmk_rsc_variant_group:
             return XML_CIB_TAG_GROUP;
-        case pe_clone:
+        case pcmk_rsc_variant_clone:
             return XML_CIB_TAG_INCARNATION;
         case pe_container:
             return XML_CIB_TAG_CONTAINER;

--- a/include/crm/compatibility.h
+++ b/include/crm/compatibility.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -215,7 +215,7 @@ get_resource_type(const char *name)
         return pe_container;
     }
 
-    return pe_unknown;
+    return pcmk_rsc_variant_unknown;
 }
 
 static inline const char *
@@ -230,7 +230,7 @@ get_resource_typename(enum pe_obj_types type)
             return XML_CIB_TAG_INCARNATION;
         case pe_container:
             return XML_CIB_TAG_CONTAINER;
-        case pe_unknown:
+        case pcmk_rsc_variant_unknown:
             return "unknown";
     }
     return "<unknown>";

--- a/include/crm/compatibility.h
+++ b/include/crm/compatibility.h
@@ -202,7 +202,7 @@ static inline enum pe_obj_types
 get_resource_type(const char *name)
 {
     if (safe_str_eq(name, XML_CIB_TAG_RESOURCE)) {
-        return pe_native;
+        return pcmk_rsc_variant_primitive;
 
     } else if (safe_str_eq(name, XML_CIB_TAG_GROUP)) {
         return pe_group;
@@ -222,7 +222,7 @@ static inline const char *
 get_resource_typename(enum pe_obj_types type)
 {
     switch (type) {
-        case pe_native:
+        case pcmk_rsc_variant_primitive:
             return XML_CIB_TAG_RESOURCE;
         case pe_group:
             return XML_CIB_TAG_GROUP;

--- a/include/crm/compatibility.h
+++ b/include/crm/compatibility.h
@@ -205,7 +205,7 @@ get_resource_type(const char *name)
         return pcmk_rsc_variant_primitive;
 
     } else if (safe_str_eq(name, XML_CIB_TAG_GROUP)) {
-        return pe_group;
+        return pcmk_rsc_variant_group;
 
     } else if (safe_str_eq(name, XML_CIB_TAG_INCARNATION)
                 || safe_str_eq(name, PCMK_XE_PROMOTABLE_LEGACY)) {
@@ -224,7 +224,7 @@ get_resource_typename(enum pe_obj_types type)
     switch (type) {
         case pcmk_rsc_variant_primitive:
             return XML_CIB_TAG_RESOURCE;
-        case pe_group:
+        case pcmk_rsc_variant_group:
             return XML_CIB_TAG_GROUP;
         case pe_clone:
             return XML_CIB_TAG_INCARNATION;

--- a/include/crm/compatibility.h
+++ b/include/crm/compatibility.h
@@ -212,7 +212,7 @@ get_resource_type(const char *name)
         return pcmk_rsc_variant_clone;
 
     } else if (safe_str_eq(name, XML_CIB_TAG_CONTAINER)) {
-        return pe_container;
+        return pcmk_rsc_variant_bundle;
     }
 
     return pcmk_rsc_variant_unknown;
@@ -228,7 +228,7 @@ get_resource_typename(enum pe_obj_types type)
             return XML_CIB_TAG_GROUP;
         case pcmk_rsc_variant_clone:
             return XML_CIB_TAG_INCARNATION;
-        case pe_container:
+        case pcmk_rsc_variant_bundle:
             return XML_CIB_TAG_CONTAINER;
         case pcmk_rsc_variant_unknown:
             return "unknown";

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -16,6 +16,7 @@
 #  include <libxml/tree.h>          // xmlNode
 #  include <glib.h>                 // gboolean, guint, GList, GHashTable
 #  include <crm/common/iso8601.h>
+#  include <crm/common/scheduler.h>
 #  include <crm/pengine/common.h>
 
 #ifdef __cplusplus
@@ -32,14 +33,6 @@ typedef struct pe_node_s pe_node_t;
 typedef struct pe_action_s pe_action_t;
 typedef struct pe_resource_s pe_resource_t;
 typedef struct pe_working_set_s pe_working_set_t;
-
-enum pe_obj_types {
-    pe_unknown = -1,
-    pe_native = 0,
-    pe_group = 1,
-    pe_clone = 2,
-    pe_container = 3,
-};
 
 typedef struct resource_object_functions_s {
     gboolean (*unpack) (pe_resource_t*, pe_working_set_t*);

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -57,7 +57,7 @@ int pe_bundle_replicas(const pe_resource_t *rsc);
 static inline bool
 pe_rsc_is_clone(const pe_resource_t *rsc)
 {
-    return rsc && (rsc->variant == pe_clone);
+    return (rsc != NULL) && (rsc->variant == pcmk_rsc_variant_clone);
 }
 
 /*!

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -102,7 +102,7 @@ pe_rsc_is_bundled(const pe_resource_t *rsc)
     while (rsc->parent != NULL) {
         rsc = rsc->parent;
     }
-    return rsc->variant == pe_container;
+    return rsc->variant == pcmk_rsc_variant_bundle;
 }
 
 #ifdef __cplusplus

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -346,7 +346,8 @@ add_action_attributes(pe_action_t *action, xmlNode *action_xml)
 
         g_hash_table_foreach(params, hash2smartfield, args_xml);
 
-    } else if ((action->rsc != NULL) && (action->rsc->variant <= pe_native)) {
+    } else if ((action->rsc != NULL)
+               && (action->rsc->variant <= pcmk_rsc_variant_primitive)) {
         GHashTable *params = pe_rsc_params(action->rsc, NULL,
                                            action->rsc->cluster);
 

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -127,7 +127,7 @@ pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
     if ((out == NULL) || (rsc == NULL) || (node == NULL)) {
         return EINVAL;
     }
-    if (rsc->variant != pe_native) {
+    if (rsc->variant != pcmk_rsc_variant_primitive) {
         // Only primitives get operation digests
         return EOPNOTSUPP;
     }

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -136,15 +136,11 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
     }
 
     if (remapped_task != pcmk_action_unspecified) {
-        /* If a (clone) resource has notifications enabled, we want to order
-         * relative to when all notifications have been sent for the remapped
-         * task. Only outermost resources or those in bundles have
-         * notifications.
+        /* If a clone or bundle has notifications enabled, the ordering will be
+         * relative to when notifications have been sent for the remapped task.
          */
         if (pcmk_is_set(first_rsc->flags, pe_rsc_notify)
-            && ((first_rsc->parent == NULL)
-                || (pe_rsc_is_clone(first_rsc)
-                    && (first_rsc->parent->variant == pe_container)))) {
+            && (pe_rsc_is_clone(first_rsc) || pe_rsc_is_bundled(first_rsc))) {
             uuid = pcmk__notify_key(rid, "confirmed-post",
                                     task2text(remapped_task));
         } else {

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -667,7 +667,8 @@ pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
 static inline bool
 is_primitive_action(const pe_action_t *action)
 {
-    return action && action->rsc && (action->rsc->variant == pe_native);
+    return (action != NULL) && (action->rsc != NULL)
+           && (action->rsc->variant == pcmk_rsc_variant_primitive);
 }
 
 /*!
@@ -1552,7 +1553,7 @@ schedule_reload(gpointer data, gpointer user_data)
     pe_action_t *reload = NULL;
 
     // For collective resources, just call recursively for children
-    if (rsc->variant > pe_native) {
+    if (rsc->variant > pcmk_rsc_variant_primitive) {
         g_list_foreach(rsc->children, schedule_reload, user_data);
         return;
     }
@@ -1873,7 +1874,7 @@ process_node_history(pe_node_t *node, const xmlNode *lrm_rscs)
             for (GList *iter = result; iter != NULL; iter = iter->next) {
                 pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
-                if (rsc->variant == pe_native) {
+                if (rsc->variant == pcmk_rsc_variant_primitive) {
                     process_rsc_history(rsc_entry, rsc, node);
                 }
             }

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -100,7 +100,7 @@ action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
 
     // Only non-notify actions for collective resources need remapping
     if ((strstr(first_uuid, PCMK_ACTION_NOTIFY) != NULL)
-        || (first_rsc->variant < pe_group)) {
+        || (first_rsc->variant < pcmk_rsc_variant_group)) {
         goto done;
     }
 
@@ -187,7 +187,8 @@ action_for_ordering(pe_action_t *action)
     pe_action_t *result = action;
     pe_resource_t *rsc = action->rsc;
 
-    if ((rsc != NULL) && (rsc->variant >= pe_group) && (action->uuid != NULL)) {
+    if ((rsc != NULL) && (rsc->variant >= pcmk_rsc_variant_group)
+        && (action->uuid != NULL)) {
         char *uuid = action_uuid_for_ordering(action->uuid, rsc);
 
         result = find_first_action(rsc->actions, uuid, NULL, NULL);
@@ -533,7 +534,7 @@ pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
         pe_node_t *first_node = first->node;
 
         if ((first->rsc != NULL)
-            && (first->rsc->variant == pe_group)
+            && (first->rsc->variant == pcmk_rsc_variant_group)
             && pcmk__str_eq(first->task, PCMK_ACTION_START, pcmk__str_none)) {
 
             first_node = first->rsc->fns->location(first->rsc, NULL, FALSE);
@@ -544,7 +545,7 @@ pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
         }
 
         if ((then->rsc != NULL)
-            && (then->rsc->variant == pe_group)
+            && (then->rsc->variant == pcmk_rsc_variant_group)
             && pcmk__str_eq(then->task, PCMK_ACTION_START, pcmk__str_none)) {
 
             then_node = then->rsc->fns->location(then->rsc, NULL, FALSE);

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -541,7 +541,7 @@ pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
     /* If the constraint dependent is a clone or bundle, "dependent" here is one
      * of its instances. Look for a compatible instance of this bundle.
      */
-    if (colocation->dependent->variant > pe_group) {
+    if (colocation->dependent->variant > pcmk_rsc_variant_group) {
         const pe_resource_t *primary_container = compatible_container(dependent,
                                                                       primary);
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -523,7 +523,8 @@ pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
      * primitive and call the apply_coloc_score() method for them as dependents.
      */
     CRM_ASSERT((primary != NULL) && (primary->variant == pe_container)
-               && (dependent != NULL) && (dependent->variant == pe_native)
+               && (dependent != NULL)
+               && (dependent->variant == pcmk_rsc_variant_primitive)
                && (colocation != NULL) && !for_dependent);
 
     if (pcmk_is_set(primary->flags, pe_rsc_provisional)) {

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -115,7 +115,7 @@ pcmk__bundle_assign(pe_resource_t *rsc, const pe_node_t *prefer,
     pe_resource_t *bundled_resource = NULL;
     struct assign_data assign_data = { prefer, stop_if_fail };
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
     pe_rsc_trace(rsc, "Assigning bundle %s", rsc->id);
     pe__set_resource_flags(rsc, pe_rsc_allocating);
@@ -190,7 +190,7 @@ pcmk__bundle_create_actions(pe_resource_t *rsc)
     GList *containers = NULL;
     pe_resource_t *bundled_resource = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
     pe__foreach_bundle_replica(rsc, create_replica_actions, NULL);
 
@@ -295,7 +295,7 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 {
     pe_resource_t *bundled_resource = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
     pe__foreach_bundle_replica(rsc, replica_internal_constraints, rsc);
 
@@ -522,7 +522,8 @@ pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
      * Instead, we add its colocation constraints to its containers and bundled
      * primitive and call the apply_coloc_score() method for them as dependents.
      */
-    CRM_ASSERT((primary != NULL) && (primary->variant == pe_container)
+    CRM_ASSERT((primary != NULL)
+               && (primary->variant == pcmk_rsc_variant_bundle)
                && (dependent != NULL)
                && (dependent->variant == pcmk_rsc_variant_primitive)
                && (colocation != NULL) && !for_dependent);
@@ -582,7 +583,7 @@ pcmk__with_bundle_colocations(const pe_resource_t *rsc,
 {
     const pe_resource_t *bundled_rsc = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle)
                && (orig_rsc != NULL) && (list != NULL));
 
     // The bundle itself and its containers always get its colocations
@@ -626,7 +627,7 @@ pcmk__bundle_with_colocations(const pe_resource_t *rsc,
 {
     const pe_resource_t *bundled_rsc = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle)
                && (orig_rsc != NULL) && (list != NULL));
 
     // The bundle itself and its containers always get its colocations
@@ -680,7 +681,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
     pe_resource_t *bundled_resource = NULL;
 
     CRM_ASSERT((action != NULL) && (action->rsc != NULL)
-               && (action->rsc->variant == pe_container));
+               && (action->rsc->variant == pcmk_rsc_variant_bundle));
 
     bundled_resource = pe__bundled_resource(action->rsc);
     if (bundled_resource != NULL) {
@@ -742,7 +743,7 @@ pcmk__bundle_apply_location(pe_resource_t *rsc, pe__location_t *location)
 {
     pe_resource_t *bundled_resource = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle)
                && (location != NULL));
 
     pcmk__apply_location(rsc, location);
@@ -840,7 +841,7 @@ pcmk__bundle_add_actions_to_graph(pe_resource_t *rsc)
 {
     pe_resource_t *bundled_resource = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
     bundled_resource = pe__bundled_resource(rsc);
     if (bundled_resource != NULL) {
@@ -972,7 +973,7 @@ pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node)
 {
     struct probe_data probe_data = { rsc, node, false };
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
     pe__foreach_bundle_replica(rsc, create_replica_probes, &probe_data);
     return probe_data.any_created;
 }
@@ -1013,7 +1014,7 @@ output_replica_actions(pe__bundle_replica_t *replica, void *user_data)
 void
 pcmk__output_bundle_actions(pe_resource_t *rsc)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
     pe__foreach_bundle_replica(rsc, output_replica_actions, NULL);
 }
 
@@ -1025,7 +1026,7 @@ pcmk__bundle_add_utilization(const pe_resource_t *rsc,
 {
     pe_resource_t *container = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         return;
@@ -1046,6 +1047,6 @@ pcmk__bundle_add_utilization(const pe_resource_t *rsc,
 void
 pcmk__bundle_shutdown_lock(pe_resource_t *rsc)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_container));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
     // Bundles currently don't support shutdown locks
 }

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -203,7 +203,7 @@ can_interleave(const pcmk__colocation_t *colocation)
     const pe_resource_t *dependent = colocation->dependent;
 
     // Only colocations between clone or bundle resources use interleaving
-    if (dependent->variant <= pe_group) {
+    if (dependent->variant <= pcmk_rsc_variant_group) {
         return false;
     }
 

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -255,7 +255,8 @@ pcmk__clone_apply_coloc_score(pe_resource_t *dependent,
     CRM_ASSERT(!for_dependent);
 
     CRM_ASSERT((colocation != NULL) && pe_rsc_is_clone(primary)
-               && (dependent != NULL) && (dependent->variant == pe_native));
+               && (dependent != NULL)
+               && (dependent->variant == pcmk_rsc_variant_primitive));
 
     if (pcmk_is_set(primary->flags, pe_rsc_provisional)) {
         pe_rsc_trace(primary,

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -92,7 +92,7 @@ cmp_colocation_priority(const pcmk__colocation_t *colocation1,
      * clones (probably unnecessary, but avoids having to update regression
      * tests)
      */
-    if (rsc1->variant == pe_clone) {
+    if (rsc1->variant == pcmk_rsc_variant_clone) {
         if (pcmk_is_set(rsc1->flags, pe_rsc_promotable)
             && !pcmk_is_set(rsc2->flags, pe_rsc_promotable)) {
             return -1;
@@ -1798,7 +1798,7 @@ pcmk__add_dependent_scores(gpointer data, gpointer user_data)
     if (!pcmk__colocation_has_influence(colocation, NULL)) {
         return;
     }
-    if (target_rsc->variant == pe_clone) {
+    if (target_rsc->variant == pcmk_rsc_variant_clone) {
         flags |= pcmk__coloc_select_nonnegative;
     }
     pe_rsc_trace(target_rsc,

--- a/lib/pacemaker/pcmk_sched_fencing.c
+++ b/lib/pacemaker/pcmk_sched_fencing.c
@@ -31,7 +31,7 @@ rsc_is_known_on(const pe_resource_t *rsc, const pe_node_t *node)
    if (g_hash_table_lookup(rsc->known_on, node->details->id) != NULL) {
        return TRUE;
 
-   } else if ((rsc->variant == pe_native)
+   } else if ((rsc->variant == pcmk_rsc_variant_primitive)
               && pe_rsc_is_anon_clone(rsc->parent)
               && (g_hash_table_lookup(rsc->parent->known_on,
                                       node->details->id) != NULL)) {

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -466,7 +466,7 @@ pcmk__group_apply_coloc_score(pe_resource_t *dependent,
 
     } else {
         // Method should only be called for primitive dependents
-        CRM_ASSERT(dependent->variant == pe_native);
+        CRM_ASSERT(dependent->variant == pcmk_rsc_variant_primitive);
 
         colocate_with_group(dependent, primary, colocation);
     }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -41,7 +41,7 @@ pcmk__group_assign(pe_resource_t *rsc, const pe_node_t *prefer,
     pe_node_t *first_assigned_node = NULL;
     pe_resource_t *first_member = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
         return rsc->allocated_to; // Assignment already done
@@ -113,7 +113,7 @@ create_group_pseudo_op(pe_resource_t *group, const char *action)
 void
 pcmk__group_create_actions(pe_resource_t *rsc)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
     pe_rsc_trace(rsc, "Creating actions for group %s", rsc->id);
 
@@ -306,7 +306,7 @@ pcmk__group_internal_constraints(pe_resource_t *rsc)
     struct member_data member_data = { false, };
     const pe_resource_t *top = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
     /* Order group pseudo-actions relative to each other for restarting:
      * stop group -> group is stopped -> start group -> group is started
@@ -609,7 +609,7 @@ pcmk__group_apply_location(pe_resource_t *rsc, pe__location_t *location)
     GList *node_list_copy = NULL;
     bool reset_scores = true;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
                && (location != NULL));
 
     node_list_orig = location->node_list_rh;
@@ -647,7 +647,7 @@ pcmk__group_colocated_resources(const pe_resource_t *rsc,
 {
     const pe_resource_t *member = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
     if (orig_rsc == NULL) {
         orig_rsc = rsc;
@@ -685,7 +685,7 @@ pcmk__with_group_colocations(const pe_resource_t *rsc,
                              const pe_resource_t *orig_rsc, GList **list)
 
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
                && (orig_rsc != NULL) && (list != NULL));
 
     // Ignore empty groups
@@ -735,7 +735,7 @@ pcmk__group_with_colocations(const pe_resource_t *rsc,
 {
     const pe_resource_t *member = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
                && (orig_rsc != NULL) && (list != NULL));
 
     // Ignore empty groups
@@ -845,7 +845,8 @@ pcmk__group_add_colocated_node_scores(pe_resource_t *source_rsc,
 {
     pe_resource_t *member = NULL;
 
-    CRM_ASSERT((source_rsc != NULL) && (source_rsc->variant == pe_group)
+    CRM_ASSERT((source_rsc != NULL)
+               && (source_rsc->variant == pcmk_rsc_variant_group)
                && (nodes != NULL)
                && ((colocation != NULL)
                    || ((target_rsc == NULL) && (*nodes == NULL))));
@@ -897,7 +898,7 @@ pcmk__group_add_utilization(const pe_resource_t *rsc,
 {
     pe_resource_t *member = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
                && (orig_rsc != NULL) && (utilization != NULL));
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
@@ -936,7 +937,7 @@ pcmk__group_add_utilization(const pe_resource_t *rsc,
 void
 pcmk__group_shutdown_lock(pe_resource_t *rsc)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
         pe_resource_t *member = (pe_resource_t *) iter->data;

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -1031,7 +1031,7 @@ pcmk__create_instance_actions(pe_resource_t *collective, GList *instances)
 static inline GList *
 get_instance_list(const pe_resource_t *rsc)
 {
-    if (rsc->variant == pe_container) {
+    if (rsc->variant == pcmk_rsc_variant_bundle) {
         return pe__bundle_containers(rsc);
     } else {
         return rsc->children;

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -895,7 +895,7 @@ check_instance_state(const pe_resource_t *instance, uint32_t *state)
     }
 
     // If instance is a collective (a cloned group), check its children instead
-    if (instance->variant > pe_native) {
+    if (instance->variant > pcmk_rsc_variant_primitive) {
         for (iter = instance->children;
              (iter != NULL) && !pcmk_all_flags_set(*state, instance_all);
              iter = iter->next) {
@@ -1622,7 +1622,7 @@ pcmk__collective_action_flags(pe_action_t *action, const GList *instances,
         uint32_t instance_flags;
 
         // Node is relevant only to primitive instances
-        if (instance->variant == pe_native) {
+        if (instance->variant == pcmk_rsc_variant_primitive) {
             instance_node = node;
         }
 

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -1011,7 +1011,7 @@ pcmk__create_instance_actions(pe_resource_t *collective, GList *instances)
         pe__set_action_flags(stop, pe_action_migrate_runnable);
     }
 
-    if (collective->variant == pe_clone) {
+    if (collective->variant == pcmk_rsc_variant_clone) {
         pe__create_clone_notif_pseudo_ops(collective, start, started, stop,
                                           stopped);
     }
@@ -1450,7 +1450,8 @@ can_interleave_actions(const pe_action_t *first, const pe_action_t *then)
         return false;
     }
 
-    if ((first->rsc->variant < pe_clone) || (then->rsc->variant < pe_clone)) {
+    if ((first->rsc->variant < pcmk_rsc_variant_clone)
+        || (then->rsc->variant < pcmk_rsc_variant_clone)) {
         crm_trace("Not interleaving %s with %s: not clones or bundles",
                   first->uuid, then->uuid);
         return false;

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -391,7 +391,7 @@ pcmk__primitive_assign(pe_resource_t *rsc, const pe_node_t *prefer,
     GList *iter = NULL;
     pcmk__colocation_t *colocation = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive));
 
     // Never assign a child without parent being assigned first
     if ((rsc->parent != NULL)
@@ -685,7 +685,7 @@ pcmk__primitive_create_actions(pe_resource_t *rsc)
     unsigned int num_clean_active = 0;
     const char *next_role_source = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive));
 
     next_role_source = set_default_next_role(rsc);
     pe_rsc_trace(rsc,
@@ -897,7 +897,7 @@ pcmk__primitive_internal_constraints(pe_resource_t *rsc)
     bool check_unfencing = false;
     bool check_utilization = false;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive));
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_managed)) {
         pe_rsc_trace(rsc,
@@ -1113,7 +1113,8 @@ void
 pcmk__with_primitive_colocations(const pe_resource_t *rsc,
                                  const pe_resource_t *orig_rsc, GList **list)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native) && (list != NULL));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive)
+               && (list != NULL));
 
     if (rsc == orig_rsc) {
         /* For the resource itself, add all of its own colocations and relevant
@@ -1142,7 +1143,8 @@ void
 pcmk__primitive_with_colocations(const pe_resource_t *rsc,
                                  const pe_resource_t *orig_rsc, GList **list)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native) && (list != NULL));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive)
+               && (list != NULL));
 
     if (rsc == orig_rsc) {
         /* For the resource itself, add all of its own colocations and relevant
@@ -1475,7 +1477,8 @@ pcmk__primitive_add_graph_meta(const pe_resource_t *rsc, xmlNode *xml)
     char *value = NULL;
     const pe_resource_t *parent = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native) && (xml != NULL));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive)
+               && (xml != NULL));
 
     /* Clone instance numbers get set internally as meta-attributes, and are
      * needed in the transition graph (for example, to tell unique clone
@@ -1523,7 +1526,7 @@ pcmk__primitive_add_utilization(const pe_resource_t *rsc,
                                 const pe_resource_t *orig_rsc, GList *all_rscs,
                                 GHashTable *utilization)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native)
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive)
                && (orig_rsc != NULL) && (utilization != NULL));
 
     if (!pcmk_is_set(rsc->flags, pe_rsc_provisional)) {
@@ -1584,7 +1587,7 @@ pcmk__primitive_shutdown_lock(pe_resource_t *rsc)
 {
     const char *class = NULL;
 
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive));
 
     class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
 

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -481,7 +481,7 @@ add_start_orderings_for_probe(pe_action_t *probe, pe_action_wrapper_t *after)
      * starting unless the probe is runnable so that we don't risk starting too
      * many instances before we know the state on all nodes.
      */
-    if ((after->action->rsc->variant <= pe_group)
+    if ((after->action->rsc->variant <= pcmk_rsc_variant_group)
         || pcmk_is_set(probe->flags, pe_action_runnable)
         // The order type is already enforced for its parent.
         || pcmk_is_set(after->type, pe_order_runnable_left)
@@ -593,7 +593,7 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after)
      * to add orderings only for the relevant instance.
      */
     if ((after->rsc != NULL)
-        && (after->rsc->variant > pe_group)) {
+        && (after->rsc->variant > pcmk_rsc_variant_group)) {
         const char *interleave_s = g_hash_table_lookup(after->rsc->meta,
                                                        XML_RSC_ATTR_INTERLEAVE);
 
@@ -630,10 +630,10 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after)
              * its children.
              */
             if ((after->rsc == NULL)
-                || (after->rsc->variant < pe_group)
+                || (after->rsc->variant < pcmk_rsc_variant_group)
                 || (probe->rsc->parent == after->rsc)
                 || (after_wrapper->action->rsc == NULL)
-                || (after_wrapper->action->rsc->variant > pe_group)
+                || (after_wrapper->action->rsc->variant > pcmk_rsc_variant_group)
                 || (after->rsc != after_wrapper->action->rsc->parent)) {
                 continue;
             }
@@ -641,7 +641,7 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after)
             /* Proceed to the children of a group or a non-interleaved clone.
              * For an interleaved clone, proceed only to the relevant child.
              */
-            if ((after->rsc->variant > pe_group) && interleave
+            if ((after->rsc->variant > pcmk_rsc_variant_group) && interleave
                 && ((compatible_rsc == NULL)
                     || (compatible_rsc != after_wrapper->action->rsc))) {
                 continue;

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -544,7 +544,7 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after)
 
     // Validate that this is a resource probe followed by some action
     if ((after == NULL) || (probe == NULL) || (probe->rsc == NULL)
-        || (probe->rsc->variant != pe_native)
+        || (probe->rsc->variant != pcmk_rsc_variant_primitive)
         || !pcmk__str_eq(probe->task, PCMK_ACTION_MONITOR, pcmk__str_none)) {
         return;
     }
@@ -562,7 +562,8 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after)
     /* Add restart orderings if "then" is for a different primitive.
      * Orderings for collective resources will be added later.
      */
-    if ((after->rsc != NULL) && (after->rsc->variant == pe_native)
+    if ((after->rsc != NULL)
+        && (after->rsc->variant == pcmk_rsc_variant_primitive)
         && (probe->rsc != after->rsc)) {
 
             GList *then_actions = NULL;
@@ -688,7 +689,7 @@ add_start_restart_orderings_for_rsc(gpointer data, gpointer user_data)
     GList *probes = NULL;
 
     // For collective resources, order each instance recursively
-    if (rsc->variant != pe_native) {
+    if (rsc->variant != pcmk_rsc_variant_primitive) {
         g_list_foreach(rsc->children, add_start_restart_orderings_for_rsc,
                        NULL);
         return;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -80,7 +80,7 @@ typedef struct pe__bundle_variant_data_s {
 
 #define get_bundle_variant_data(data, rsc)                      \
     CRM_ASSERT(rsc != NULL);                                    \
-    CRM_ASSERT(rsc->variant == pe_container);                   \
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_bundle);        \
     CRM_ASSERT(rsc->variant_opaque != NULL);                    \
     data = (pe__bundle_variant_data_t *) rsc->variant_opaque;
 
@@ -133,7 +133,7 @@ pe__get_rsc_in_container(const pe_resource_t *instance)
     const pe__bundle_variant_data_t *data = NULL;
     const pe_resource_t *top = pe__const_top_resource(instance, true);
 
-    if ((top == NULL) || (top->variant != pe_container)) {
+    if ((top == NULL) || (top->variant != pcmk_rsc_variant_bundle)) {
         return NULL;
     }
     get_bundle_variant_data(data, top);
@@ -2026,7 +2026,7 @@ pe__bundle_resource_state(const pe_resource_t *rsc, gboolean current)
 int
 pe_bundle_replicas(const pe_resource_t *rsc)
 {
-    if ((rsc == NULL) || (rsc->variant != pe_container)) {
+    if ((rsc == NULL) || (rsc->variant != pcmk_rsc_variant_bundle)) {
         return 0;
     } else {
         pe__bundle_variant_data_t *bundle_data = NULL;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -47,8 +47,8 @@ typedef struct clone_variant_data_s {
     xmlNode *xml_obj_child;
 } clone_variant_data_t;
 
-#define get_clone_variant_data(data, rsc)                       \
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_clone));    \
+#define get_clone_variant_data(data, rsc)                                  \
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_clone)); \
     data = (clone_variant_data_t *) rsc->variant_opaque;
 
 /*!

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -98,7 +98,7 @@ get_resource_type(const char *name)
         return pcmk_rsc_variant_clone;
 
     } else if (pcmk__str_eq(name, XML_CIB_TAG_CONTAINER, pcmk__str_casei)) {
-        return pe_container;
+        return pcmk_rsc_variant_bundle;
     }
 
     return pcmk_rsc_variant_unknown;
@@ -930,7 +930,8 @@ uber_parent(pe_resource_t * rsc)
     if (parent == NULL) {
         return NULL;
     }
-    while (parent->parent != NULL && parent->parent->variant != pe_container) {
+    while ((parent->parent != NULL)
+           && (parent->parent->variant != pcmk_rsc_variant_bundle)) {
         parent = parent->parent;
     }
     return parent;
@@ -956,7 +957,8 @@ pe__const_top_resource(const pe_resource_t *rsc, bool include_bundle)
         return NULL;
     }
     while (parent->parent != NULL) {
-        if (!include_bundle && (parent->parent->variant == pe_container)) {
+        if (!include_bundle
+            && (parent->parent->variant == pcmk_rsc_variant_bundle)) {
             break;
         }
         parent = parent->parent;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -101,7 +101,7 @@ get_resource_type(const char *name)
         return pe_container;
     }
 
-    return pe_unknown;
+    return pcmk_rsc_variant_unknown;
 }
 
 static void
@@ -655,7 +655,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
     (*rsc)->ops_xml = expand_idref(ops, data_set->input);
 
     (*rsc)->variant = get_resource_type((const char *) (*rsc)->xml->name);
-    if ((*rsc)->variant == pe_unknown) {
+    if ((*rsc)->variant == pcmk_rsc_variant_unknown) {
         pe_err("Ignoring resource '%s' of unknown type '%s'",
                id, (*rsc)->xml->name);
         common_free(*rsc);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -85,7 +85,7 @@ static enum pe_obj_types
 get_resource_type(const char *name)
 {
     if (pcmk__str_eq(name, XML_CIB_TAG_RESOURCE, pcmk__str_casei)) {
-        return pe_native;
+        return pcmk_rsc_variant_primitive;
 
     } else if (pcmk__str_eq(name, XML_CIB_TAG_GROUP, pcmk__str_casei)) {
         return pe_group;
@@ -522,7 +522,7 @@ unpack_requires(pe_resource_t *rsc, const char *value, bool is_default)
         if (pcmk_is_set(rsc->flags, pe_rsc_fence_device)) {
             value = PCMK__VALUE_QUORUM;
 
-        } else if ((rsc->variant == pe_native)
+        } else if ((rsc->variant == pcmk_rsc_variant_primitive)
                    && xml_contains_remote_node(rsc->xml)) {
             value = PCMK__VALUE_QUORUM;
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -91,11 +91,11 @@ get_resource_type(const char *name)
         return pcmk_rsc_variant_group;
 
     } else if (pcmk__str_eq(name, XML_CIB_TAG_INCARNATION, pcmk__str_casei)) {
-        return pe_clone;
+        return pcmk_rsc_variant_clone;
 
     } else if (pcmk__str_eq(name, PCMK_XE_PROMOTABLE_LEGACY, pcmk__str_casei)) {
         // @COMPAT deprecated since 2.0.0
-        return pe_clone;
+        return pcmk_rsc_variant_clone;
 
     } else if (pcmk__str_eq(name, XML_CIB_TAG_CONTAINER, pcmk__str_casei)) {
         return pe_container;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -88,7 +88,7 @@ get_resource_type(const char *name)
         return pcmk_rsc_variant_primitive;
 
     } else if (pcmk__str_eq(name, XML_CIB_TAG_GROUP, pcmk__str_casei)) {
-        return pe_group;
+        return pcmk_rsc_variant_group;
 
     } else if (pcmk__str_eq(name, XML_CIB_TAG_INCARNATION, pcmk__str_casei)) {
         return pe_clone;

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -37,7 +37,7 @@ pe_resource_t *
 pe__last_group_member(const pe_resource_t *group)
 {
     if (group != NULL) {
-        CRM_CHECK((group->variant == pe_group)
+        CRM_CHECK((group->variant == pcmk_rsc_variant_group)
                   && (group->variant_opaque != NULL), return NULL);
         return ((group_variant_data_t *) group->variant_opaque)->last_child;
     }
@@ -58,7 +58,7 @@ pe__group_flag_is_set(const pe_resource_t *group, uint32_t flags)
 {
     group_variant_data_t *group_data = NULL;
 
-    CRM_CHECK((group != NULL) && (group->variant == pe_group)
+    CRM_CHECK((group != NULL) && (group->variant == pcmk_rsc_variant_group)
               && (group->variant_opaque != NULL), return false);
     group_data = (group_variant_data_t *) group->variant_opaque;
     return pcmk_all_flags_set(group_data->flags, flags);
@@ -531,6 +531,6 @@ pe__group_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
 unsigned int
 pe__group_max_per_node(const pe_resource_t *rsc)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_group));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
     return 1U;
 }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -157,7 +157,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                  */
                 if (rsc->parent
                     && ((rsc->parent->variant == pcmk_rsc_variant_group)
-                        || (rsc->parent->variant == pe_container))
+                        || (rsc->parent->variant == pcmk_rsc_variant_bundle))
                     && (rsc->parent->recovery_type == pcmk_multiply_active_block)) {
                     GList *gIter = rsc->parent->children;
 

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -34,7 +34,7 @@ is_multiply_active(const pe_resource_t *rsc)
 {
     unsigned int count = 0;
 
-    if (rsc->variant == pe_native) {
+    if (rsc->variant == pcmk_rsc_variant_primitive) {
         pe__find_active_requires(rsc, &count);
     }
     return count > 1;
@@ -104,13 +104,14 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                  pcmk_is_set(rsc->flags, pe_rsc_managed)? "" : "(unmanaged)");
 
     rsc->running_on = g_list_append(rsc->running_on, node);
-    if (rsc->variant == pe_native) {
+    if (rsc->variant == pcmk_rsc_variant_primitive) {
         node->details->running_rsc = g_list_append(node->details->running_rsc, rsc);
 
         native_priority_to_node(rsc, node, failed);
     }
 
-    if (rsc->variant == pe_native && node->details->maintenance) {
+    if ((rsc->variant == pcmk_rsc_variant_primitive)
+        && node->details->maintenance) {
         pe__clear_resource_flags(rsc, pe_rsc_managed);
         pe__set_resource_flags(rsc, pe_rsc_maintenance);
     }
@@ -559,7 +560,7 @@ pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
     GString *outstr = NULL;
     bool have_flags = false;
 
-    if (rsc->variant != pe_native) {
+    if (rsc->variant != pcmk_rsc_variant_primitive) {
         return NULL;
     }
 
@@ -712,7 +713,7 @@ pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
     xmlNodePtr list_node = NULL;
     const char *cl = NULL;
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
     CRM_ASSERT(kind != NULL);
 
     if (rsc->meta) {
@@ -733,7 +734,8 @@ pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
     } else if (pcmk_is_set(rsc->flags, pe_rsc_failed)) {
         cl = "rsc-failed";
 
-    } else if (rsc->variant == pe_native && (rsc->running_on == NULL)) {
+    } else if ((rsc->variant == pcmk_rsc_variant_primitive)
+               && (rsc->running_on == NULL)) {
         cl = "rsc-failed";
 
     } else if (pcmk__list_of_multiple(rsc->running_on)) {
@@ -765,7 +767,7 @@ pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
 {
     const char *target_role = NULL;
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
 
     if (rsc->meta) {
         const char *is_internal = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_INTERNAL_RSC);
@@ -800,7 +802,7 @@ common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
 {
     const char *target_role = NULL;
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
 
     if (rsc->meta) {
         const char *is_internal = g_hash_table_lookup(rsc->meta,
@@ -920,7 +922,7 @@ native_print(pe_resource_t *rsc, const char *pre_text, long options,
 {
     const pe_node_t *node = NULL;
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
     if (options & pe_print_xml) {
         native_print_xml(rsc, pre_text, options, print_data);
         return;
@@ -963,7 +965,7 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
        target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
     }
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
 
     if (rsc->fns->is_filtered(rsc, only_rsc, TRUE)) {
         return pcmk_rc_no_output;
@@ -1033,7 +1035,7 @@ pe__resource_html(pcmk__output_t *out, va_list args)
         return pcmk_rc_no_output;
     }
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
 
     if (node == NULL) {
         // This is set only if a non-probe action is pending on this node
@@ -1053,7 +1055,7 @@ pe__resource_text(pcmk__output_t *out, va_list args)
 
     const pe_node_t *node = pe__current_node(rsc);
 
-    CRM_ASSERT(rsc->variant == pe_native);
+    CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
 
     if (rsc->fns->is_filtered(rsc, only_rsc, TRUE)) {
         return pcmk_rc_no_output;
@@ -1163,7 +1165,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
         int *rsc_counter = NULL;
         int *active_counter = NULL;
 
-        if (rsc->variant != pe_native) {
+        if (rsc->variant != pcmk_rsc_variant_primitive) {
             continue;
         }
 
@@ -1432,6 +1434,6 @@ pe__native_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
 unsigned int
 pe__primitive_max_per_node(const pe_resource_t *rsc)
 {
-    CRM_ASSERT((rsc != NULL) && (rsc->variant == pe_native));
+    CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive));
     return 1U;
 }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -156,7 +156,8 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
                  * multiple-active=block, block the entire entity.
                  */
                 if (rsc->parent
-                    && (rsc->parent->variant == pe_group || rsc->parent->variant == pe_container)
+                    && ((rsc->parent->variant == pcmk_rsc_variant_group)
+                        || (rsc->parent->variant == pe_container))
                     && (rsc->parent->recovery_type == pcmk_multiply_active_block)) {
                     GList *gIter = rsc->parent->children;
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1277,7 +1277,7 @@ get_complex_task(const pe_resource_t *rsc, const char *name)
 {
     enum action_tasks task = text2task(name);
 
-    if ((rsc != NULL) && (rsc->variant == pe_native)) {
+    if ((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive)) {
         switch (task) {
             case pcmk_action_stopped:
             case pcmk_action_started:

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2221,7 +2221,7 @@ node_history_list(pcmk__output_t *out, va_list args) {
          *
          * For other resource types, is_filtered is okay.
          */
-        if (parent->variant == pe_group) {
+        if (parent->variant == pcmk_rsc_variant_group) {
             if (!pcmk__str_in_list(rsc_printable_id(rsc), only_rsc,
                                    pcmk__str_star_matches)
                 && !pcmk__str_in_list(rsc_printable_id(parent), only_rsc,

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2792,7 +2792,8 @@ resource_list(pcmk__output_t *out, va_list args)
             }
 
         /* Skip primitives already counted in a brief summary */
-        } else if (pcmk_is_set(show_opts, pcmk_show_brief) && (rsc->variant == pe_native)) {
+        } else if (pcmk_is_set(show_opts, pcmk_show_brief)
+                   && (rsc->variant == pcmk_rsc_variant_primitive)) {
             continue;
 
         /* Skip resources that aren't at least partially active,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2003,7 +2003,7 @@ unpack_find_resource(pe_working_set_t *data_set, const pe_node_t *node,
         }
         free(clone0_id);
 
-    } else if (rsc->variant > pe_native) {
+    } else if (rsc->variant > pcmk_rsc_variant_primitive) {
         crm_trace("Resource history for %s is orphaned because it is no longer primitive",
                   rsc_id);
         return NULL;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -859,7 +859,7 @@ pe__failed_probe_for_rsc(const pe_resource_t *rsc, const char *name)
     const pe_resource_t *parent = pe__const_top_resource(rsc, false);
     const char *rsc_id = rsc->id;
 
-    if (parent->variant == pe_clone) {
+    if (parent->variant == pcmk_rsc_variant_clone) {
         rsc_id = pe__clone_child_id(parent);
     }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -175,7 +175,7 @@ find_matching_attr_resources_recursive(pcmk__output_t *out, GList/* <pe_resource
                                                rsc_id, attr_set, attr_set_type,
                                                attr_id, attr_name, cib, cmd, depth+1);
         /* do it only once for clones */
-        if(pe_clone == rsc->variant) {
+        if (rsc->variant == pcmk_rsc_variant_clone) {
             break;
         }
     }
@@ -212,7 +212,8 @@ find_matching_attr_resources(pcmk__output_t *out, pe_resource_t * rsc,
     if(force == TRUE) {
         return g_list_append(result, rsc);
     }
-    if(rsc->parent && pe_clone == rsc->parent->variant) {
+    if ((rsc->parent != NULL)
+        && (rsc->parent->variant == pcmk_rsc_variant_clone)) {
         int rc = pcmk_rc_ok;
         char *local_attr_id = NULL;
         rc = find_resource_attr(out, cib, XML_ATTR_ID, rsc_id, attr_set_type,
@@ -225,7 +226,9 @@ find_matching_attr_resources(pcmk__output_t *out, pe_resource_t * rsc,
                       cmd, attr_name, rsc->id, rsc_id);
         }
         return g_list_append(result, rsc);
-    } else if(rsc->parent == NULL && rsc->children && pe_clone == rsc->variant) {
+
+    } else if ((rsc->parent == NULL) && (rsc->children != NULL)
+               && (rsc->variant == pcmk_rsc_variant_clone)) {
         pe_resource_t *child = rsc->children->data;
 
         if (child->variant == pcmk_rsc_variant_primitive) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1138,7 +1138,7 @@ get_active_resources(const char *host, GList *rsc_list)
          * other than the first, we can't otherwise tell which resources are
          * stopping and starting.
          */
-        if (rsc->variant == pe_group) {
+        if (rsc->variant == pcmk_rsc_variant_group) {
             active = g_list_concat(active,
                                    get_active_resources(host, rsc->children));
         } else if (resource_is_running_on(rsc, host)) {
@@ -2035,7 +2035,7 @@ cli_resource_execute(pe_resource_t *rsc, const char *requested_name,
         rsc = rsc->children->data;
     }
 
-    if(rsc->variant == pe_group) {
+    if (rsc->variant == pcmk_rsc_variant_group) {
         out->err(out, "Sorry, the %s option doesn't support group resources", rsc_action);
         return CRM_EX_UNIMPLEMENT_FEATURE;
     } else if (rsc->variant == pe_container || pe_rsc_is_bundled(rsc)) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -2041,7 +2041,7 @@ cli_resource_execute(pe_resource_t *rsc, const char *requested_name,
     if (rsc->variant == pcmk_rsc_variant_group) {
         out->err(out, "Sorry, the %s option doesn't support group resources", rsc_action);
         return CRM_EX_UNIMPLEMENT_FEATURE;
-    } else if (rsc->variant == pe_container || pe_rsc_is_bundled(rsc)) {
+    } else if (pe_rsc_is_bundled(rsc)) {
         out->err(out, "Sorry, the %s option doesn't support bundled resources", rsc_action);
         return CRM_EX_UNIMPLEMENT_FEATURE;
     }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -228,7 +228,7 @@ find_matching_attr_resources(pcmk__output_t *out, pe_resource_t * rsc,
     } else if(rsc->parent == NULL && rsc->children && pe_clone == rsc->variant) {
         pe_resource_t *child = rsc->children->data;
 
-        if(child->variant == pe_native) {
+        if (child->variant == pcmk_rsc_variant_primitive) {
             lookup_id = clone_strip(child->id); /* Could be a cloned group! */
             rc = find_resource_attr(out, cib, XML_ATTR_ID, lookup_id, attr_set_type,
                                     attr_set, attr_id, attr_name, &local_attr_id);
@@ -550,7 +550,7 @@ send_lrm_rsc_op(pcmk_ipc_api_t *controld_api, bool do_fail_resource,
         out->err(out, "Resource %s not found", rsc_id);
         return ENXIO;
 
-    } else if (rsc->variant != pe_native) {
+    } else if (rsc->variant != pcmk_rsc_variant_primitive) {
         out->err(out, "We can only process primitive resources, not %s", rsc_id);
         return EINVAL;
     }


### PR DESCRIPTION
This is part of a project to merge the functionality of libpe_status and libpe_rules into libcrmcommon, bringing it up to current guidelines in the process