### PR TITLE
Move CIB transaction management to client and fix controller regression

### DIFF
--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -476,9 +476,7 @@ attrd_peer_clear_failure(pcmk__request_t *request)
     crm_xml_add(xml, PCMK__XA_TASK, PCMK__ATTRD_CMD_UPDATE);
 
     /* Make sure value is not set, so we delete */
-    if (crm_element_value(xml, PCMK__XA_ATTR_VALUE)) {
-        crm_xml_replace(xml, PCMK__XA_ATTR_VALUE, NULL);
-    }
+    xml_remove_prop(xml, PCMK__XA_ATTR_VALUE);
 
     g_hash_table_iter_init(&iter, attributes);
     while (g_hash_table_iter_next(&iter, (gpointer *) &attr, NULL)) {

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -140,12 +140,8 @@ attrd_client_clear_failure(pcmk__request_t *request)
     }
 
     /* Make sure attribute and value are not set, so we delete via regex */
-    if (crm_element_value(xml, PCMK__XA_ATTR_NAME)) {
-        crm_xml_replace(xml, PCMK__XA_ATTR_NAME, NULL);
-    }
-    if (crm_element_value(xml, PCMK__XA_ATTR_VALUE)) {
-        crm_xml_replace(xml, PCMK__XA_ATTR_VALUE, NULL);
-    }
+    xml_remove_prop(xml, PCMK__XA_ATTR_NAME);
+    xml_remove_prop(xml, PCMK__XA_ATTR_VALUE);
 
     return attrd_client_update(request);
 }
@@ -283,7 +279,7 @@ expand_regexes(xmlNode *xml, const char *attr, const char *value, const char *re
                  * regex and replace it with the name.
                  */
                 attrd_copy_xml_attributes(xml, child);
-                crm_xml_replace(child, PCMK__XA_ATTR_PATTERN, NULL);
+                xml_remove_prop(child, PCMK__XA_ATTR_PATTERN);
                 crm_xml_add(child, PCMK__XA_ATTR_NAME, attr);
             }
         }

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -1295,26 +1295,10 @@ prepare_input(const xmlNode *request, enum cib__op_type type,
             }
             break;
 
-        case cib__op_commit_transact:
-            // We're not looking for XML_TAG_CIB; we want the raw call data
-            return get_message_xml(request, F_CIB_CALLDATA);
-
         default:
             input = get_message_xml(request, F_CIB_CALLDATA);
             *section = crm_element_value(request, F_CIB_SECTION);
             break;
-    }
-
-    if (input == NULL) {
-        return NULL;
-    }
-
-    /* @TODO: Remove? F_CIB_CALLDATA shouldn't be the child of F_CIB_CALLDATA,
-     * and it probably never was.
-     */
-    if (pcmk__str_any_of((const char *) input->name, F_CRM_DATA, F_CIB_CALLDATA,
-                         NULL)) {
-        input = first_named_child(input, XML_TAG_CIB);
     }
 
     // Grab the specified section

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -463,40 +463,19 @@ cib_process_commit_transaction(const char *op, int options, const char *section,
      * replace notification if appropriate, and sync *result_cib to all nodes.
      * On failure, our caller will free *result_cib.
      */
-
+    int rc = pcmk_rc_ok;
     const char *client_id = crm_element_value(req, F_CIB_CLIENTID);
-    pcmk__client_t *client = NULL;
+    const char *origin = crm_element_value(req, F_ORIG);
+    pcmk__client_t *client = pcmk__find_client_by_id(client_id);
 
-    const char *reason = NULL;
-    int rc = pcmk_ok;
+    rc = based_commit_transaction(input, client, origin, result_cib);
 
-    if (client_id == NULL) {
-        reason = "No client ID";
-        rc = -EINVAL;
-        goto done;
-    }
-
-    client = pcmk__find_client_by_id(client_id);
-    if (client == NULL) {
-        reason = "Client not found";
-        rc = -ENXIO;
-        goto done;
-    }
-
-    rc = based_commit_transaction(input, client, result_cib);
     if (rc != pcmk_rc_ok) {
-        reason = pcmk_rc_str(rc);
-        rc = pcmk_rc2legacy(rc);
-    }
+        char *source = based_transaction_source_str(client, origin);
 
-done:
-    if (rc != pcmk_ok) {
-        const char *client_name = crm_element_value(req, F_CIB_CLIENTNAME);
-
-        crm_err("Could not commit transaction for client %s (%s): %s",
-                pcmk__s(client_name, "unspecified"),
-                pcmk__s(client_id, "unknown"),
-                pcmk__s(reason, "unknown reason (bug?)"));
+        crm_err("Could not commit transaction for %s: %s",
+                source, pcmk_rc_str(rc));
+        free(source);
     }
-    return rc;
+    return pcmk_rc2legacy(rc);
 }

--- a/daemons/based/based_operation.c
+++ b/daemons/based/based_operation.c
@@ -16,32 +16,25 @@
 #include <pacemaker-based.h>
 
 static const cib__op_fn_t cib_op_functions[] = {
-    [cib__op_abs_delete]  = cib_process_delete_absolute,
-    [cib__op_apply_patch] = cib_server_process_diff,
-    [cib__op_bump]        = cib_process_bump,
-    [cib__op_create]      = cib_process_create,
-    [cib__op_delete]      = cib_process_delete,
-    [cib__op_erase]       = cib_process_erase,
-    [cib__op_is_primary]  = cib_process_readwrite,
-    [cib__op_modify]      = cib_process_modify,
-    [cib__op_noop]        = cib_process_noop,
-    [cib__op_ping]        = cib_process_ping,
-    [cib__op_primary]     = cib_process_readwrite,
-    [cib__op_query]       = cib_process_query,
-    [cib__op_replace]     = cib_process_replace_svr,
-    [cib__op_secondary]   = cib_process_readwrite,
-    [cib__op_shutdown]    = cib_process_shutdown_req,
-    [cib__op_sync_all]    = cib_process_sync,
-    [cib__op_sync_one]    = cib_process_sync_one,
-    [cib__op_upgrade]     = cib_process_upgrade_server,
-
-    /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
-     * they depend on the client table. Requests that manage transactions on
-     * other nodes would likely be problematic in many other ways as well.
-     */
-    [cib__op_init_transact]    = cib_process_init_transaction,
+    [cib__op_abs_delete]       = cib_process_delete_absolute,
+    [cib__op_apply_patch]      = cib_server_process_diff,
+    [cib__op_bump]             = cib_process_bump,
     [cib__op_commit_transact]  = cib_process_commit_transaction,
-    [cib__op_discard_transact] = cib_process_discard_transaction,
+    [cib__op_create]           = cib_process_create,
+    [cib__op_delete]           = cib_process_delete,
+    [cib__op_erase]            = cib_process_erase,
+    [cib__op_is_primary]       = cib_process_readwrite,
+    [cib__op_modify]           = cib_process_modify,
+    [cib__op_noop]             = cib_process_noop,
+    [cib__op_ping]             = cib_process_ping,
+    [cib__op_primary]          = cib_process_readwrite,
+    [cib__op_query]            = cib_process_query,
+    [cib__op_replace]          = cib_process_replace_svr,
+    [cib__op_secondary]        = cib_process_readwrite,
+    [cib__op_shutdown]         = cib_process_shutdown_req,
+    [cib__op_sync_all]         = cib_process_sync,
+    [cib__op_sync_one]         = cib_process_sync_one,
+    [cib__op_upgrade]          = cib_process_upgrade_server,
 };
 
 /*!

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -224,7 +224,7 @@ cib_remote_auth(xmlNode * login)
         return FALSE;
     }
 
-    if (!pcmk__xe_is(login, "cib_command")) {
+    if (!pcmk__xe_is(login, T_CIB_COMMAND)) {
         crm_err("Unrecognizable message from remote client");
         crm_log_xml_info(login, "bad");
         return FALSE;
@@ -414,7 +414,7 @@ cib_handle_remote_msg(pcmk__client_t *client, xmlNode *command)
 {
     const char *value = NULL;
 
-    if (!pcmk__xe_is(command, "cib_command")) {
+    if (!pcmk__xe_is(command, T_CIB_COMMAND)) {
         crm_log_xml_trace(command, "bad");
         return;
     }

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -398,7 +398,6 @@ cib_remote_connection_destroy(gpointer user_data)
         close(csock);
     }
 
-    based_discard_transaction(client);
     pcmk__free_client(client);
 
     crm_trace("Freed the cib client");

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -336,8 +336,8 @@ based_commit_transaction(const pcmk__client_t *client, xmlNodePtr *result_cib)
 
     rc = process_transaction_requests(transaction, client_name, client_id);
 
-    crm_trace("Transaction commit %s for client %s (%s); discarding queue",
-              ((rc != pcmk_rc_ok)? "succeeded" : "failed"), client_name,
+    crm_trace("Transaction commit %s for client %s (%s)",
+              ((rc == pcmk_rc_ok)? "succeeded" : "failed"), client_name,
               client_id);
 
     // Free the transaction and (if aborted) free any remaining requests

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -14,231 +14,6 @@
 
 #include "pacemaker-based.h"
 
-struct request_data {
-    pcmk__client_t *client;
-    xmlNodePtr request;
-    bool privileged;
-};
-
-/* Table of uncommitted CIB transactions
- * key: client ID (const char *), value: GQueue of struct request_data
- */
-static GHashTable *transactions = NULL;
-
-/*!
- * \internal
- * \brief Create a new a CIB request data object
- *
- * \param[in] client      CIB client
- * \param[in] request     CIB request
- * \param[in] privileged  If \p true, the request has write privileges
- */
-static struct request_data *
-create_request_data(pcmk__client_t *client, xmlNodePtr request,
-                    bool privileged)
-{
-    struct request_data *data = calloc(1, sizeof(struct request_data));
-
-    if (data == NULL) {
-        return NULL;
-    }
-
-    /* Caller owns client and request. The client's transaction is always
-     * discarded before the client is freed, so we can safely use it when
-     * processing requests in the transaction. The request is freed before we
-     * use it, so make a copy.
-     */
-    data->client = client;
-    data->request = copy_xml(request);
-    data->privileged = privileged;
-
-    return data;
-}
-
-/*!
- * \internal
- * \brief Free a CIB request data object
- *
- * \param[in,out] data  Request data object to free
- */
-static void
-free_request_data(gpointer data)
-{
-    struct request_data *req_data = (struct request_data *) data;
-
-    if (req_data != NULL) {
-        // req_data doesn't own req_data->client
-        free_xml(req_data->request);
-        free(req_data);
-    }
-}
-
-/*!
- * \internal
- * \brief Free a CIB transaction and the requests it contains
- *
- * \param[in,out] data  Transaction to free
- */
-static inline void
-free_transaction(gpointer data)
-{
-    g_queue_free_full((GQueue *) data, (GDestroyNotify) free_request_data);
-}
-
-/*!
- * \internal
- * \brief Get a CIB client's uncommitted transaction, if any
- *
- * \param[in] client  Client to look up
- *
- * \return The client's uncommitted transaction, if any
- *
- * \note The caller must not free the return value directly. Transactions must
- *       be freed by \p based_discard_transaction() or by
- *       \p based_free_transaction_table().
- */
-static inline GQueue *
-get_transaction(const pcmk__client_t *client)
-{
-    if (transactions == NULL) {
-        return NULL;
-    }
-    return g_hash_table_lookup(transactions, client->id);
-}
-
-/*!
- * \internal
- * \brief Create a new transaction for a given CIB client
- *
- * \param[in] client  Client to initiate a transaction for
- *
- * \return Standard Pacemaker return code
- */
-int
-based_init_transaction(const pcmk__client_t *client)
-{
-    CRM_ASSERT(client != NULL);
-
-    if (client->id == NULL) {
-        crm_warn("Can't initiate transaction for client without id");
-        return EINVAL;
-    }
-
-    // A client can have at most one transaction at a time
-    if (get_transaction(client) != NULL) {
-        return pcmk_rc_already;
-    }
-
-    crm_trace("Initiating transaction for client %s (%s)",
-              pcmk__client_name(client), client->id);
-
-    if (transactions == NULL) {
-        transactions = pcmk__strkey_table(NULL, free_transaction);
-    }
-    g_hash_table_insert(transactions, client->id, g_queue_new());
-    return pcmk_rc_ok;
-}
-
-/*!
- * \internal
- * \brief Validate that a CIB request is supported in a transaction
- *
- * \param[in] request  CIB request
- *
- * \return Standard Pacemaker return code
- */
-static int
-validate_transaction_request(const xmlNode *request)
-{
-    const char *op = crm_element_value(request, F_CIB_OPERATION);
-    const char *host = crm_element_value(request, F_CIB_HOST);
-
-    const cib__operation_t *operation = NULL;
-    int rc = cib__get_operation(op, &operation);
-
-    if (rc != pcmk_rc_ok) {
-        // cib_get_operation() logs error
-        return rc;
-    }
-
-    if (!pcmk_is_set(operation->flags, cib__op_attr_transaction)) {
-        crm_err("Operation '%s' is not supported in CIB transaction", op);
-        return EOPNOTSUPP;
-    }
-
-    if (!pcmk__str_eq(host, OUR_NODENAME,
-                      pcmk__str_casei|pcmk__str_null_matches)) {
-        crm_err("Operation targeting another node (%s) is not supported in CIB "
-                "transaction",
-                host);
-        return EOPNOTSUPP;
-    }
-
-    return pcmk_rc_ok;
-}
-
-/*!
- * \internal
- * \brief Add a new CIB request to an existing transaction
- *
- * \param[in] client      Client whose transaction to extend
- * \param[in] request     CIB request
- * \param[in] privileged  If \p true, the request has write privileges
- *
- * \return Standard Pacemaker return code
- */
-int
-based_extend_transaction(pcmk__client_t *client, xmlNodePtr request,
-                         bool privileged)
-{
-    struct request_data *data = NULL;
-    GQueue *transaction = NULL;
-    int rc = pcmk_rc_ok;
-
-    CRM_ASSERT((client != NULL) && (request != NULL));
-
-    transaction = get_transaction(client);
-    if (transaction == NULL) {
-        return pcmk_rc_no_transaction;
-    }
-
-    rc = validate_transaction_request(request);
-    if (rc != pcmk_rc_ok) {
-        return rc;
-    }
-
-    data = create_request_data(client, request, privileged);
-    if (data == NULL) {
-        return ENOMEM;
-    }
-
-    g_queue_push_tail(transaction, data);
-    return pcmk_rc_ok;
-}
-
-/*!
- * \internal
- * \brief Free a CIB client's transaction (if any) and its requests
- *
- * \param[in] client  Client whose transaction to discard
- */
-void
-based_discard_transaction(const pcmk__client_t *client)
-{
-    bool found = false;
-
-    CRM_ASSERT(client != NULL);
-
-    if (transactions != NULL) {
-        found = g_hash_table_remove(transactions, client->id);
-    }
-
-    crm_trace("%s for client %s (%s)",
-              (found? "Found and removed transaction" : "No transaction found"),
-              pcmk__client_name(client),
-              pcmk__s(client->id, "unidentified"));
-}
-
 /*!
  * \internal
  * \brief Process requests in a transaction
@@ -246,38 +21,50 @@ based_discard_transaction(const pcmk__client_t *client)
  * Stop when a request fails or when all requests have been processed.
  *
  * \param[in,out] transaction  Transaction to process
- * \param[in]     client_name  Client name (for logging only)
- * \param[in]     client_id    Client ID (for logging only)
+ * \param[in]     client       CIB client
  *
  * \return Standard Pacemaker return code
  */
 static int
-process_transaction_requests(GQueue *transaction, const char *client_name,
-                             const char *client_id)
+process_transaction_requests(xmlNodePtr transaction, const pcmk__client_t *client)
 {
-    for (struct request_data *data = g_queue_pop_head(transaction);
-         data != NULL; data = g_queue_pop_head(transaction)) {
+    const char *client_name = pcmk__client_name(client);
+    const char *client_id = pcmk__s(client->id, "unidentified");
 
-        const char *op = crm_element_value(data->request, F_CIB_OPERATION);
+    for (xmlNodePtr request = first_named_child(transaction, T_CIB_COMMAND);
+         request != NULL; request = crm_next_same_xml(request)) {
 
-        int rc = cib_process_request(data->request, data->privileged,
-                                     data->client);
+        const char *op = crm_element_value(request, F_CIB_OPERATION);
+        const char *host = crm_element_value(request, F_CIB_HOST);
+        const cib__operation_t *operation = NULL;
+        int rc = cib__get_operation(op, &operation);
 
-        rc = pcmk_legacy2rc(rc);
+        if (rc == pcmk_rc_ok) {
+            if (!pcmk_is_set(operation->flags, cib__op_attr_transaction)
+                || (host != NULL)) {
+
+                rc = EOPNOTSUPP;
+            } else {
+                /* Commit-transaction is a privileged operation. If we reached
+                 * this point, the request came from a privileged connection.
+                 */
+                rc = cib_process_request(request, TRUE, client);
+                rc = pcmk_legacy2rc(rc);
+            }
+        }
+
         if (rc != pcmk_rc_ok) {
             crm_err("Aborting CIB transaction for client %s (%s) due to failed "
                     "%s request: %s",
                     client_name, client_id, op, pcmk_rc_str(rc));
-            crm_log_xml_info(data->request, "Failed request");
-            free_request_data(data);
+            crm_log_xml_info(request, "Failed request");
             return rc;
         }
 
         crm_trace("Applied %s request to transaction working CIB for client %s "
                   "(%s)",
                   op, client_name, client_id);
-        crm_log_xml_trace(data->request, "Successful request");
-        free_request_data(data);
+        crm_log_xml_trace(request, "Successful request");
     }
 
     return pcmk_rc_ok;
@@ -287,8 +74,9 @@ process_transaction_requests(GQueue *transaction, const char *client_name,
  * \internal
  * \brief Commit a given CIB client's transaction to a working CIB copy
  *
- * \param[in]     client      Client whose transaction to commit
- * \param[in,out] result_cib  Where to store result CIB
+ * \param[in]     transaction  Transaction to commit
+ * \param[in]     client       CIB client
+ * \param[in,out] result_cib   Where to store result CIB
  *
  * \return Standard Pacemaker return code
  *
@@ -300,15 +88,18 @@ process_transaction_requests(GQueue *transaction, const char *client_name,
  *       success, and for freeing it on failure.
  */
 int
-based_commit_transaction(const pcmk__client_t *client, xmlNodePtr *result_cib)
+based_commit_transaction(xmlNodePtr transaction, const pcmk__client_t *client,
+                         xmlNodePtr *result_cib)
 {
-    GQueue *transaction = NULL;
     const char *client_name = NULL;
     const char *client_id = NULL;
     xmlNodePtr saved_cib = the_cib;
     int rc = pcmk_rc_ok;
 
     CRM_ASSERT((client != NULL) && (result_cib != NULL));
+
+    CRM_CHECK(pcmk__xe_is(transaction, T_CIB_TRANSACTION),
+              return pcmk_rc_no_transaction);
 
     /* *result_cib should be a copy of the_cib (created by cib_perform_op()). If
      * not, make a copy now. Change tracking isn't strictly required here
@@ -320,11 +111,6 @@ based_commit_transaction(const pcmk__client_t *client, xmlNodePtr *result_cib)
     CRM_CHECK((*result_cib != NULL) && (*result_cib != the_cib),
               *result_cib = copy_xml(the_cib));
 
-    transaction = get_transaction(client);
-    if (transaction == NULL) {
-        return pcmk_rc_no_transaction;
-    }
-
     client_name = pcmk__client_name(client);
     client_id = pcmk__s(client->id, "unidentified");
 
@@ -334,14 +120,11 @@ based_commit_transaction(const pcmk__client_t *client, xmlNodePtr *result_cib)
     // Apply all changes to a working copy of the CIB
     the_cib = *result_cib;
 
-    rc = process_transaction_requests(transaction, client_name, client_id);
+    rc = process_transaction_requests(transaction, client);
 
     crm_trace("Transaction commit %s for client %s (%s)",
               ((rc == pcmk_rc_ok)? "succeeded" : "failed"), client_name,
               client_id);
-
-    // Free the transaction and (if aborted) free any remaining requests
-    based_discard_transaction(client);
 
     /* Some request types (for example, erase) may have freed the_cib (the
      * working copy) and pointed it at a new XML object. In that case, it
@@ -355,16 +138,4 @@ based_commit_transaction(const pcmk__client_t *client, xmlNodePtr *result_cib)
     the_cib = saved_cib;
 
     return rc;
-}
-
-/*!
- * \internal
- * \brief Free the transaction table and any uncommitted transactions
- */
-void
-based_free_transaction_table(void)
-{
-    if (transactions != NULL) {
-        g_hash_table_destroy(transactions);
-    }
 }

--- a/daemons/based/based_transaction.h
+++ b/daemons/based/based_transaction.h
@@ -14,8 +14,11 @@
 
 #include <libxml/tree.h>
 
+char *based_transaction_source_str(const pcmk__client_t *client,
+                                   const char *origin);
+
 int based_commit_transaction(xmlNodePtr transaction,
                              const pcmk__client_t *client,
-                             xmlNodePtr *result_cib);
+                             const char *origin, xmlNodePtr *result_cib);
 
 #endif // BASED_TRANSACTION__H

--- a/daemons/based/based_transaction.h
+++ b/daemons/based/based_transaction.h
@@ -14,12 +14,8 @@
 
 #include <libxml/tree.h>
 
-int based_init_transaction(const pcmk__client_t *client);
-int based_extend_transaction(pcmk__client_t *client, xmlNodePtr request,
-                             bool privileged);
-void based_discard_transaction(const pcmk__client_t *client);
-int based_commit_transaction(const pcmk__client_t *client,
+int based_commit_transaction(xmlNodePtr transaction,
+                             const pcmk__client_t *client,
                              xmlNodePtr *result_cib);
-void based_free_transaction_table(void);
 
 #endif // BASED_TRANSACTION__H

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -294,7 +294,6 @@ done:
     if (config_hash != NULL) {
         g_hash_table_destroy(config_hash);
     }
-    based_free_transaction_table();
     pcmk__client_cleanup();
     pcmk_cluster_free(crm_cluster);
     g_free(cib_root);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -120,18 +120,10 @@ int cib_process_upgrade_server(const char *op, int options, const char *section,
                                xmlNode *req, xmlNode *input,
                                xmlNode *existing_cib, xmlNode **result_cib,
                                xmlNode **answer);
-int cib_process_init_transaction(const char *op, int options,
-                                 const char *section, xmlNode *req,
-                                 xmlNode *input, xmlNode *existing_cib,
-                                 xmlNode **result_cib, xmlNode **answer);
 int cib_process_commit_transaction(const char *op, int options,
                                    const char *section, xmlNode *req,
                                    xmlNode *input, xmlNode *existing_cib,
                                    xmlNode **result_cib, xmlNode **answer);
-int cib_process_discard_transaction(const char *op, int options,
-                                    const char *section, xmlNode *req,
-                                    xmlNode *input, xmlNode *existing_cib,
-                                    xmlNode **result_cib, xmlNode **answer);
 void send_sync_request(const char *host);
 int sync_our_cib(xmlNode *request, gboolean all);
 

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -908,8 +908,6 @@ should_preserve_lock(lrmd_event_data_t *op)
  * \param[in]     data       New XML of CIB section to update
  * \param[in]     options    CIB call options
  * \param[in]     callback   If not \c NULL, set this as the operation callback
- * \param[in,out] user_data  Data to pass to \p callback (must be freeable using
- *                           \c free())
  *
  * \return Standard Pacemaker return code
  *
@@ -918,12 +916,11 @@ should_preserve_lock(lrmd_event_data_t *op)
  */
 int
 controld_update_cib(const char *section, xmlNode *data, int options,
-                    void (*callback)(xmlNode *, int, int, xmlNode *, void *),
-                    void *user_data)
+                    void (*callback)(xmlNode *, int, int, xmlNode *, void *))
 {
     int cib_rc = -ENOTCONN;
 
-    CRM_ASSERT((data != NULL) && ((callback != NULL) || (user_data == NULL)));
+    CRM_ASSERT(data != NULL);
 
     if (controld_globals.cib_conn != NULL) {
         cib_rc = cib_internal_op(controld_globals.cib_conn,
@@ -949,7 +946,7 @@ controld_update_cib(const char *section, xmlNode *data, int options,
              */
             pending_rsc_update = cib_rc;
         }
-        fsa_register_cib_callback(cib_rc, user_data, callback);
+        fsa_register_cib_callback(cib_rc, NULL, callback);
     }
 
     return (cib_rc >= 0)? pcmk_rc_ok : pcmk_legacy2rc(cib_rc);
@@ -1043,8 +1040,7 @@ controld_update_resource_history(const char *node_name,
      * fenced for running a resource it isn't.
      */
     crm_log_xml_trace(update, __func__);
-    controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, cib_rsc_callback,
-                        NULL);
+    controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, cib_rsc_callback);
     free_xml(update);
 }
 

--- a/daemons/controld/controld_cib.h
+++ b/daemons/controld/controld_cib.h
@@ -50,8 +50,7 @@ void controld_destroy_cib_replacements_table(void);
 
 int controld_update_cib(const char *section, xmlNode *data, int options,
                         void (*callback)(xmlNode *, int, int, xmlNode *,
-                                         void *),
-                        void *user_data);
+                                         void *));
 unsigned int cib_op_timeout(void);
 
 // Subsections of node_state

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -228,8 +228,7 @@ do_dc_takeover(long long action,
 
     cib = create_xml_node(NULL, XML_TAG_CIB);
     crm_xml_add(cib, XML_ATTR_CRM_VERSION, CRM_FEATURE_SET);
-    controld_update_cib(XML_TAG_CIB, cib, cib_none, feature_update_callback,
-                        NULL);
+    controld_update_cib(XML_TAG_CIB, cib, cib_none, feature_update_callback);
 
     dc_takeover_update_attr(XML_ATTR_HAVE_WATCHDOG, pcmk__btoa(watchdog));
     dc_takeover_update_attr("dc-version", PACEMAKER_VERSION "-" BUILD_VERSION);

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -765,7 +765,7 @@ do_dc_join_ack(long long action,
      *
      * The delete and modify requests are part of an atomic transaction.
      */
-    rc = cib->cmds->init_transaction(cib, cib_scope_local);
+    rc = cib->cmds->init_transaction(cib);
     if (rc != pcmk_ok) {
         goto done;
     }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -367,7 +367,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
     crm_trace("Populating <nodes> section from %s", from_hashtable ? "hashtable" : "cluster");
 
     if ((controld_update_cib(XML_CIB_TAG_NODES, node_list, cib_scope_local,
-                             node_list_update_callback, NULL) == pcmk_rc_ok)
+                             node_list_update_callback) == pcmk_rc_ok)
          && (crm_peer_cache != NULL) && AM_I_DC) {
         /*
          * There is no need to update the local CIB with our values if
@@ -392,7 +392,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
         }
 
         controld_update_cib(XML_CIB_TAG_STATUS, node_list, cib_scope_local,
-                            crmd_node_update_complete, NULL);
+                            crmd_node_update_complete);
     }
     free_xml(node_list);
 }
@@ -437,7 +437,7 @@ crm_update_quorum(gboolean quorum, gboolean force_update)
 
         crm_debug("Updating quorum status to %s", pcmk__btoa(quorum));
         controld_update_cib(XML_TAG_CIB, update, cib_scope_local,
-                            cib_quorum_update_complete, NULL);
+                            cib_quorum_update_complete);
         free_xml(update);
 
         /* Quorum changes usually cause a new transition via other activity:

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -341,7 +341,7 @@ remote_node_up(const char *node_name)
      * actual fencing or allow recurring monitor failures to be cleared too
      * soon. Ideally, we wouldn't rely on the CIB for the fenced status.
      */
-    controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, NULL, NULL);
+    controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, NULL);
     free_xml(update);
 }
 
@@ -389,7 +389,7 @@ remote_node_down(const char *node_name, const enum down_opts opts)
     /* Update CIB node state */
     update = create_xml_node(NULL, XML_CIB_TAG_STATUS);
     create_node_state_update(node, node_update_cluster, update, __func__);
-    controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, NULL, NULL);
+    controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, NULL);
     free_xml(update);
 }
 
@@ -1404,7 +1404,7 @@ remote_ra_maintenance(lrm_state_t * lrm_state, gboolean maintenance)
     state = create_node_state_update(node, node_update_none, update,
                                      __func__);
     crm_xml_add(state, XML_NODE_IS_MAINTENANCE, maintenance?"1":"0");
-    if (controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt, NULL,
+    if (controld_update_cib(XML_CIB_TAG_STATUS, update, call_opt,
                             NULL) == pcmk_rc_ok) {
         /* TODO: still not 100% sure that async update will succeed ... */
         if (maintenance) {

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -325,6 +325,8 @@ struct cib_s {
                          xmlNode *output);
 
     cib_api_operations_t *cmds;
+
+    xmlNode *transaction;
 };
 
 #ifdef __cplusplus

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -277,12 +277,10 @@ typedef struct cib_api_operations_s {
      * An \c init_transaction() call is always synchronous.
      *
      * \param[in,out] cib           CIB connection
-     * \param[in]     call_options  Group of <tt>enum cib_call_options</tt>
-     *                              flags
      *
      * \return Legacy Pacemaker return code
      */
-    int (*init_transaction)(cib_t *cib, int call_options);
+    int (*init_transaction)(cib_t *cib);
 
     /*!
      * \brief End and optionally commit this client's CIB transaction

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -88,9 +88,8 @@ enum cib_call_options {
      * it immediately. If the client has no active transaction, or if the
      * request is not supported in transactions, the call will fail.
      *
-     * Any callback is triggered when adding the request to the transaction;
-     * callbacks and notifications are not triggered when processing the
-     * request.
+     * The request is added to the transaction synchronously, and the return
+     * value indicates whether it was added successfully.
      *
      * Refer to \p cib_api_operations_t:init_transaction() and
      * \p cib_api_operations_t:end_transaction() for more details on CIB
@@ -273,8 +272,9 @@ typedef struct cib_api_operations_s {
      * Because the transaction is atomic, individual requests do not trigger
      * callbacks or notifications when they are processed, and they do not
      * receive output XML. The commit request itself can trigger callbacks and
-     * notifications if any are registered. The init and discard requests can
-     * also trigger a callback.
+     * notifications if any are registered.
+     *
+     * An \c init_transaction() call is always synchronous.
      *
      * \param[in,out] cib           CIB connection
      * \param[in]     call_options  Group of <tt>enum cib_call_options</tt>
@@ -287,7 +287,7 @@ typedef struct cib_api_operations_s {
     /*!
      * \brief End and optionally commit this client's CIB transaction
      *
-     * When a client commits a transaction, all requests in the queue are
+     * When a client commits a transaction, all requests in the transaction are
      * processed in a FIFO manner until either a request fails or all requests
      * have been processed. Changes are applied to a working copy of the CIB.
      * If a request fails, the transaction and working CIB copy are discarded,
@@ -296,6 +296,9 @@ typedef struct cib_api_operations_s {
      *
      * Callbacks and notifications can be triggered by the commit request itself
      * but not by the individual requests in a transaction.
+     *
+     * An \c end_transaction() call with \p commit set to \c false is always
+     * synchronous.
      *
      * \param[in,out] cib           CIB connection
      * \param[in]     commit        If \p true, commit transaction; otherwise,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -202,9 +202,9 @@ int cib_perform_op(const char *op, int call_options, cib__op_fn_t fn,
                    xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
                    xmlNode **output);
 
-xmlNode *cib_create_op(int call_id, const char *op, const char *host,
-                       const char *section, xmlNode * data, int call_options,
-                       const char *user_name);
+xmlNode *cib__create_op(cib_t *cib, const char *op, const char *host,
+                        const char *section, xmlNode *data, int call_options,
+                        const char *user_name, const char *client_name);
 
 void cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc);
 void cib_native_notify(gpointer data, gpointer user_data);

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -202,9 +202,10 @@ int cib_perform_op(const char *op, int call_options, cib__op_fn_t fn,
                    xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
                    xmlNode **output);
 
-xmlNode *cib__create_op(cib_t *cib, const char *op, const char *host,
-                        const char *section, xmlNode *data, int call_options,
-                        const char *user_name, const char *client_name);
+int cib__create_op(cib_t *cib, const char *op, const char *host,
+                   const char *section, xmlNode *data, int call_options,
+                   const char *user_name, const char *client_name,
+                   xmlNode **op_msg);
 
 void cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc);
 void cib_native_notify(gpointer data, gpointer user_data);

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -65,6 +65,7 @@
 #  define F_CIB_CHANGE_SECTION  "cib_change_section"
 
 #  define T_CIB			"cib"
+#  define T_CIB_COMMAND		"cib_command"
 #  define T_CIB_NOTIFY		"cib_notify"
 /* notify sub-types */
 #  define T_CIB_PRE_NOTIFY	"cib_pre_notify"

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -209,6 +209,8 @@ int cib__create_op(cib_t *cib, const char *op, const char *host,
                    const char *user_name, const char *client_name,
                    xmlNode **op_msg);
 
+int cib__extend_transaction(cib_t *cib, xmlNode *request);
+
 void cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc);
 void cib_native_notify(gpointer data, gpointer user_data);
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -70,6 +70,7 @@
 /* notify sub-types */
 #  define T_CIB_PRE_NOTIFY	"cib_pre_notify"
 #  define T_CIB_POST_NOTIFY	"cib_post_notify"
+#  define T_CIB_TRANSACTION	"cib_transaction"
 #  define T_CIB_UPDATE_CONFIRM	"cib_update_confirmation"
 #  define T_CIB_REPLACE_NOTIFY	"cib_refresh_notify"
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -31,9 +31,7 @@
 #define PCMK__CIB_REQUEST_ABS_DELETE    "cib_delete_alt"
 #define PCMK__CIB_REQUEST_NOOP          "noop"
 #define PCMK__CIB_REQUEST_SHUTDOWN      "cib_shutdown_req"
-#define PCMK__CIB_REQUEST_INIT_TRANSACT     "cib_init_transact"
 #define PCMK__CIB_REQUEST_COMMIT_TRANSACT   "cib_commit_transact"
-#define PCMK__CIB_REQUEST_DISCARD_TRANSACT  "cib_discard_transact"
 
 #  define F_CIB_CLIENTID  "cib_clientid"
 #  define F_CIB_CALLOPTS  "cib_callopt"
@@ -110,6 +108,7 @@ enum cib__op_type {
     cib__op_abs_delete,
     cib__op_apply_patch,
     cib__op_bump,
+    cib__op_commit_transact,
     cib__op_create,
     cib__op_delete,
     cib__op_erase,
@@ -125,11 +124,6 @@ enum cib__op_type {
     cib__op_sync_all,
     cib__op_sync_one,
     cib__op_upgrade,
-
-    // @TODO: Refactor transactions and remove these
-    cib__op_init_transact,
-    cib__op_commit_transact,
-    cib__op_discard_transact,
 };
 
 /*!

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -46,7 +46,6 @@ void hash2smartfield(gpointer key, gpointer value, gpointer user_data);
 GHashTable *xml2list(const xmlNode *parent);
 
 const char *crm_xml_add(xmlNode *node, const char *name, const char *value);
-const char *crm_xml_replace(xmlNode *node, const char *name, const char *value);
 const char *crm_xml_add_int(xmlNode *node, const char *name, int value);
 const char *crm_xml_add_ll(xmlNode *node, const char *name, long long value);
 const char *crm_xml_add_ms(xmlNode *node, const char *name, guint ms);

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -11,6 +11,7 @@
 #  define PCMK__CRM_COMMON_UTIL_COMPAT__H
 
 #  include <glib.h>
+#  include <libxml/tree.h>
 #  include <crm/common/util.h>
 
 #ifdef __cplusplus
@@ -71,6 +72,9 @@ int pcmk_scan_nvpair(const char *input, char **name, char **value);
 //! \deprecated Use a standard printf()-style function instead
 char *pcmk_format_nvpair(const char *name, const char *value,
                          const char *units);
+
+//! \deprecated Use \c crm_xml_add() or \c xml_remove_prop() instead
+const char *crm_xml_replace(xmlNode *node, const char *name, const char *value);
 
 //! \deprecated Use a standard printf()-style function instead
 char *pcmk_format_named_time(const char *name, time_t epoch_time);

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -388,7 +388,7 @@ cib_client_erase(cib_t * cib, xmlNode ** output_data, int call_options)
 }
 
 static int
-cib_client_init_transaction(cib_t *cib, int call_options)
+cib_client_init_transaction(cib_t *cib)
 {
     int rc = pcmk_rc_ok;
 

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -412,12 +412,8 @@ cib_client_init_transaction(cib_t *cib, int call_options)
         cib->cmds->client_id(cib, NULL, &client_id);
         crm_err("Failed to initialize CIB transaction for client %s: %s",
                 client_id, pcmk_rc_str(rc));
-        return pcmk_rc2legacy(rc);
     }
-
-    // @TODO: Drop this when transactions have been removed from based
-    return cib_internal_op(cib, PCMK__CIB_REQUEST_INIT_TRANSACT, NULL,
-                           NULL, NULL, NULL, call_options, NULL);
+    return pcmk_rc2legacy(rc);
 }
 
 static int
@@ -439,18 +435,15 @@ cib_client_end_transaction(cib_t *cib, bool commit, int call_options)
             return pcmk_rc2legacy(rc);
         }
         rc = cib_internal_op(cib, PCMK__CIB_REQUEST_COMMIT_TRANSACT, NULL, NULL,
-                             NULL, NULL, call_options, NULL);
+                             cib->transaction, NULL, call_options, NULL);
 
     } else {
+        // Discard always succeeds
         if (cib->transaction != NULL) {
             crm_trace("Discarded transaction for CIB client %s", client_id);
         } else {
             crm_trace("No transaction found for CIB client %s", client_id);
         }
-
-        // @TODO: Drop this when transactions have been removed from based
-        rc = cib_internal_op(cib, PCMK__CIB_REQUEST_DISCARD_TRANSACT, NULL,
-                             NULL, NULL, NULL, call_options, NULL);
     }
     free_xml(cib->transaction);
     cib->transaction = NULL;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -390,23 +390,71 @@ cib_client_erase(cib_t * cib, xmlNode ** output_data, int call_options)
 static int
 cib_client_init_transaction(cib_t *cib, int call_options)
 {
+    int rc = pcmk_rc_ok;
+
     op_common(cib);
-    return cib_internal_op(cib, PCMK__CIB_REQUEST_INIT_TRANSACT, NULL, NULL,
-                           NULL, NULL, call_options, NULL);
+
+    if (cib->transaction != NULL) {
+        // A client can have at most one transaction at a time
+        rc = pcmk_rc_already;
+    }
+
+    if (rc == pcmk_rc_ok) {
+        cib->transaction = create_xml_node(NULL, T_CIB_TRANSACTION);
+        if (cib->transaction == NULL) {
+            rc = ENOMEM;
+        }
+    }
+
+    if (rc != pcmk_rc_ok) {
+        const char *client_id = NULL;
+
+        cib->cmds->client_id(cib, NULL, &client_id);
+        crm_err("Failed to initialize CIB transaction for client %s: %s",
+                client_id, pcmk_rc_str(rc));
+        return pcmk_rc2legacy(rc);
+    }
+
+    // @TODO: Drop this when transactions have been removed from based
+    return cib_internal_op(cib, PCMK__CIB_REQUEST_INIT_TRANSACT, NULL,
+                           NULL, NULL, NULL, call_options, NULL);
 }
 
 static int
 cib_client_end_transaction(cib_t *cib, bool commit, int call_options)
 {
+    const char *client_id = NULL;
+    int rc = pcmk_ok;
+
     op_common(cib);
+    cib->cmds->client_id(cib, NULL, &client_id);
+    client_id = pcmk__s(client_id, "(unidentified)");
 
     if (commit) {
-        return cib_internal_op(cib, PCMK__CIB_REQUEST_COMMIT_TRANSACT, NULL,
-                               NULL, NULL, NULL, call_options, NULL);
+        if (cib->transaction == NULL) {
+            rc = pcmk_rc_no_transaction;
+
+            crm_err("Failed to commit transaction for CIB client %s: %s",
+                    client_id, pcmk_rc_str(rc));
+            return pcmk_rc2legacy(rc);
+        }
+        rc = cib_internal_op(cib, PCMK__CIB_REQUEST_COMMIT_TRANSACT, NULL, NULL,
+                             NULL, NULL, call_options, NULL);
+
     } else {
-        return cib_internal_op(cib, PCMK__CIB_REQUEST_DISCARD_TRANSACT, NULL,
-                               NULL, NULL, NULL, call_options, NULL);
+        if (cib->transaction != NULL) {
+            crm_trace("Discarded transaction for CIB client %s", client_id);
+        } else {
+            crm_trace("No transaction found for CIB client %s", client_id);
+        }
+
+        // @TODO: Drop this when transactions have been removed from based
+        rc = cib_internal_op(cib, PCMK__CIB_REQUEST_DISCARD_TRANSACT, NULL,
+                             NULL, NULL, NULL, call_options, NULL);
     }
+    free_xml(cib->transaction);
+    cib->transaction = NULL;
+    return rc;
 }
 
 static void

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -350,11 +350,10 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
 
     cib__set_call_options(call_options, "file operation", cib_no_mtime);
 
-    request = cib__create_op(cib, op, host, section, data, call_options,
-                             user_name, NULL);
-    if (request == NULL) {
-        // @COMPAT Use more appropriate return code
-        return -EPROTO;
+    rc = cib__create_op(cib, op, host, section, data, call_options, user_name,
+                        NULL, &request);
+    if (rc != pcmk_ok) {
+        return rc;
     }
     crm_xml_add(request, XML_ACL_TAG_USER, user_name);
     crm_xml_add(request, F_CIB_CLIENTID, private->id);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -348,11 +348,14 @@ cib_file_perform_op_delegate(cib_t *cib, const char *op, const char *host,
         return -EPROTONOSUPPORT;
     }
 
-    cib->call_id++;
     cib__set_call_options(call_options, "file operation", cib_no_mtime);
 
-    request = cib_create_op(cib->call_id, op, host, section, data, call_options,
-                            user_name);
+    request = cib__create_op(cib, op, host, section, data, call_options,
+                             user_name, NULL);
+    if (request == NULL) {
+        // @COMPAT Use more appropriate return code
+        return -EPROTO;
+    }
     crm_xml_add(request, XML_ACL_TAG_USER, user_name);
     crm_xml_add(request, F_CIB_CLIENTID, private->id);
 

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -76,11 +76,8 @@ cib_native_perform_op_delegate(cib_t *cib, const char *op, const char *host,
     }
 
     if (pcmk_is_set(call_options, cib_transaction)) {
-        // @TODO: Return here when transactions are fully implemented in client
         rc = cib__extend_transaction(cib, op_msg);
-        if (rc != pcmk_ok) {
-            goto done;
-        }
+        goto done;
     }
 
     crm_trace("Sending %s message to the CIB manager (timeout=%ds)", op, cib->call_timeout);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -49,18 +49,10 @@ static const cib__operation_t cib_ops[] = {
         |cib__op_attr_privileged
         |cib__op_attr_transaction
     },
-
-    /* PCMK__CIB_REQUEST_COMMIT_TRANSACT requests must be processed locally
-     * because they depend on the client table. Requests that manage
-     * transactions on other nodes would likely be problematic in many other
-     * ways as well.
-     */
     {
-        // @TODO: Consider removing local
         PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
         cib__op_attr_modifies
         |cib__op_attr_privileged
-        |cib__op_attr_local
         |cib__op_attr_replaces
         |cib__op_attr_writes_through
     },

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -49,6 +49,21 @@ static const cib__operation_t cib_ops[] = {
         |cib__op_attr_privileged
         |cib__op_attr_transaction
     },
+
+    /* PCMK__CIB_REQUEST_COMMIT_TRANSACT requests must be processed locally
+     * because they depend on the client table. Requests that manage
+     * transactions on other nodes would likely be problematic in many other
+     * ways as well.
+     */
+    {
+        // @TODO: Consider removing local
+        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
+        cib__op_attr_modifies
+        |cib__op_attr_privileged
+        |cib__op_attr_local
+        |cib__op_attr_replaces
+        |cib__op_attr_writes_through
+    },
     {
         PCMK__CIB_REQUEST_CREATE, cib__op_create,
         cib__op_attr_modifies
@@ -119,27 +134,6 @@ static const cib__operation_t cib_ops[] = {
         |cib__op_attr_privileged
         |cib__op_attr_writes_through
         |cib__op_attr_transaction
-    },
-
-    /* PCMK__CIB_REQUEST_*_TRANSACT requests must be processed locally because
-     * they depend on the client table. Requests that manage transactions on
-     * other nodes would likely be problematic in many other ways as well.
-     */
-    {
-        PCMK__CIB_REQUEST_INIT_TRANSACT, cib__op_init_transact,
-        cib__op_attr_privileged|cib__op_attr_local
-    },
-    {
-        PCMK__CIB_REQUEST_COMMIT_TRANSACT, cib__op_commit_transact,
-        cib__op_attr_modifies
-        |cib__op_attr_privileged
-        |cib__op_attr_local
-        |cib__op_attr_replaces
-        |cib__op_attr_writes_through
-    },
-    {
-        PCMK__CIB_REQUEST_DISCARD_TRANSACT, cib__op_discard_transact,
-        cib__op_attr_privileged|cib__op_attr_local
     },
 };
 

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -87,12 +87,9 @@ cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
     }
 
     if (pcmk_is_set(call_options, cib_transaction)) {
-        // @TODO: Return here when transactions are fully implemented in client
         rc = cib__extend_transaction(cib, op_msg);
-        if (rc != pcmk_ok) {
-            free_xml(op_msg);
-            return rc;
-        }
+        free_xml(op_msg);
+        return rc;
     }
 
     crm_trace("Sending %s message to the CIB manager", op);

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -374,7 +374,7 @@ cib_tls_signon(cib_t *cib, pcmk__remote_t *connection, gboolean event_channel)
     }
 
     /* login to server */
-    login = create_xml_node(NULL, "cib_command");
+    login = create_xml_node(NULL, T_CIB_COMMAND);
     crm_xml_add(login, "op", "authenticate");
     crm_xml_add(login, "user", private->user);
     crm_xml_add(login, "password", private->passwd);
@@ -530,7 +530,7 @@ cib_remote_inputfd(cib_t * cib)
 static int
 cib_remote_register_notification(cib_t * cib, const char *callback, int enabled)
 {
-    xmlNode *notify_msg = create_xml_node(NULL, "cib_command");
+    xmlNode *notify_msg = create_xml_node(NULL, T_CIB_COMMAND);
     cib_remote_opaque_t *private = cib->variant_opaque;
 
     crm_xml_add(notify_msg, F_CIB_OPERATION, T_CIB_NOTIFY);

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -86,6 +86,15 @@ cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
         return rc;
     }
 
+    if (pcmk_is_set(call_options, cib_transaction)) {
+        // @TODO: Return here when transactions are fully implemented in client
+        rc = cib__extend_transaction(cib, op_msg);
+        if (rc != pcmk_ok) {
+            free_xml(op_msg);
+            return rc;
+        }
+    }
+
     crm_trace("Sending %s message to the CIB manager", op);
     if (!(call_options & cib_sync_call)) {
         pcmk__remote_send_xml(&private->callback, op_msg);
@@ -490,6 +499,7 @@ cib_remote_signoff(cib_t *cib)
     cib_tls_close(cib);
 #endif
 
+    cib->cmds->end_transaction(cib, false, cib_none);
     cib->state = cib_disconnected;
     cib->type = cib_no_connection;
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -534,24 +534,31 @@ cib_perform_op(const char *op, int call_options, cib__op_fn_t fn, bool is_query,
 }
 
 xmlNode *
-cib_create_op(int call_id, const char *op, const char *host,
-              const char *section, xmlNode *data, int call_options,
-              const char *user_name)
+cib__create_op(cib_t *cib, const char *op, const char *host,
+               const char *section, xmlNode *data, int call_options,
+               const char *user_name, const char *client_name)
 {
-    xmlNode *op_msg = create_xml_node(NULL, "cib_command");
+    xmlNode *op_msg = NULL;
 
+    CRM_CHECK(cib != NULL, return NULL);
+
+    op_msg = create_xml_node(NULL, "cib_command");
     CRM_CHECK(op_msg != NULL, return NULL);
 
-    crm_xml_add(op_msg, F_XML_TAGNAME, "cib_command");
+    cib->call_id++;
+    if (cib->call_id < 1) {
+        cib->call_id = 1;
+    }
 
+    crm_xml_add(op_msg, F_XML_TAGNAME, "cib_command");
     crm_xml_add(op_msg, F_TYPE, T_CIB);
     crm_xml_add(op_msg, F_CIB_OPERATION, op);
     crm_xml_add(op_msg, F_CIB_HOST, host);
     crm_xml_add(op_msg, F_CIB_SECTION, section);
-    crm_xml_add_int(op_msg, F_CIB_CALLID, call_id);
-    if (user_name) {
-        crm_xml_add(op_msg, F_CIB_USER, user_name);
-    }
+    crm_xml_add(op_msg, F_CIB_USER, user_name);
+    crm_xml_add(op_msg, F_CIB_CLIENTNAME, client_name);
+    crm_xml_add_int(op_msg, F_CIB_CALLID, cib->call_id);
+
     crm_trace("Sending call options: %.8lx, %d", (long)call_options, call_options);
     crm_xml_add_int(op_msg, F_CIB_CALLOPTS, call_options);
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -541,7 +541,7 @@ cib__create_op(cib_t *cib, const char *op, const char *host,
 {
     CRM_CHECK((cib != NULL) && (op_msg != NULL), return -EPROTO);
 
-    *op_msg = create_xml_node(NULL, "cib_command");
+    *op_msg = create_xml_node(NULL, T_CIB_COMMAND);
     if (*op_msg == NULL) {
         return -EPROTO;
     }
@@ -551,7 +551,7 @@ cib__create_op(cib_t *cib, const char *op, const char *host,
         cib->call_id = 1;
     }
 
-    crm_xml_add(*op_msg, F_XML_TAGNAME, "cib_command");
+    crm_xml_add(*op_msg, F_XML_TAGNAME, T_CIB_COMMAND);
     crm_xml_add(*op_msg, F_TYPE, T_CIB);
     crm_xml_add(*op_msg, F_CIB_OPERATION, op);
     crm_xml_add(*op_msg, F_CIB_HOST, host);

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -533,43 +533,45 @@ cib_perform_op(const char *op, int call_options, cib__op_fn_t fn, bool is_query,
     return rc;
 }
 
-xmlNode *
+int
 cib__create_op(cib_t *cib, const char *op, const char *host,
                const char *section, xmlNode *data, int call_options,
-               const char *user_name, const char *client_name)
+               const char *user_name, const char *client_name,
+               xmlNode **op_msg)
 {
-    xmlNode *op_msg = NULL;
+    CRM_CHECK((cib != NULL) && (op_msg != NULL), return -EPROTO);
 
-    CRM_CHECK(cib != NULL, return NULL);
-
-    op_msg = create_xml_node(NULL, "cib_command");
-    CRM_CHECK(op_msg != NULL, return NULL);
+    *op_msg = create_xml_node(NULL, "cib_command");
+    if (*op_msg == NULL) {
+        return -EPROTO;
+    }
 
     cib->call_id++;
     if (cib->call_id < 1) {
         cib->call_id = 1;
     }
 
-    crm_xml_add(op_msg, F_XML_TAGNAME, "cib_command");
-    crm_xml_add(op_msg, F_TYPE, T_CIB);
-    crm_xml_add(op_msg, F_CIB_OPERATION, op);
-    crm_xml_add(op_msg, F_CIB_HOST, host);
-    crm_xml_add(op_msg, F_CIB_SECTION, section);
-    crm_xml_add(op_msg, F_CIB_USER, user_name);
-    crm_xml_add(op_msg, F_CIB_CLIENTNAME, client_name);
-    crm_xml_add_int(op_msg, F_CIB_CALLID, cib->call_id);
+    crm_xml_add(*op_msg, F_XML_TAGNAME, "cib_command");
+    crm_xml_add(*op_msg, F_TYPE, T_CIB);
+    crm_xml_add(*op_msg, F_CIB_OPERATION, op);
+    crm_xml_add(*op_msg, F_CIB_HOST, host);
+    crm_xml_add(*op_msg, F_CIB_SECTION, section);
+    crm_xml_add(*op_msg, F_CIB_USER, user_name);
+    crm_xml_add(*op_msg, F_CIB_CLIENTNAME, client_name);
+    crm_xml_add_int(*op_msg, F_CIB_CALLID, cib->call_id);
 
     crm_trace("Sending call options: %.8lx, %d", (long)call_options, call_options);
-    crm_xml_add_int(op_msg, F_CIB_CALLOPTS, call_options);
+    crm_xml_add_int(*op_msg, F_CIB_CALLOPTS, call_options);
 
     if (data != NULL) {
-        add_message_xml(op_msg, F_CIB_CALLDATA, data);
+        add_message_xml(*op_msg, F_CIB_CALLDATA, data);
     }
 
-    if (call_options & cib_inhibit_bcast) {
-        CRM_CHECK((call_options & cib_scope_local), return NULL);
+    if (pcmk_is_set(call_options, cib_inhibit_bcast)) {
+        CRM_CHECK(pcmk_is_set(call_options, cib_scope_local),
+                  free_xml(*op_msg); return -EPROTO);
     }
-    return op_msg;
+    return pcmk_ok;
 }
 
 void

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -485,13 +485,29 @@ cib_perform_op(const char *op, int call_options, cib__op_fn_t fn, bool is_query,
 
             /* Does the CIB support the "update-*" attributes... */
             if (current_schema >= minimum_schema) {
+                /* Ensure values of origin, client, and user in scratch match
+                 * the values in req
+                 */
                 const char *origin = crm_element_value(req, F_ORIG);
+                const char *client = crm_element_value(req, F_CIB_CLIENTNAME);
 
-                CRM_LOG_ASSERT(origin != NULL);
-                crm_xml_replace(scratch, XML_ATTR_UPDATE_ORIG, origin);
-                crm_xml_replace(scratch, XML_ATTR_UPDATE_CLIENT,
-                                crm_element_value(req, F_CIB_CLIENTNAME));
-                crm_xml_replace(scratch, XML_ATTR_UPDATE_USER, crm_element_value(req, F_CIB_USER));
+                if (origin != NULL) {
+                    crm_xml_add(scratch, XML_ATTR_UPDATE_ORIG, origin);
+                } else {
+                    xml_remove_prop(scratch, XML_ATTR_UPDATE_ORIG);
+                }
+
+                if (client != NULL) {
+                    crm_xml_add(scratch, XML_ATTR_UPDATE_CLIENT, user);
+                } else {
+                    xml_remove_prop(scratch, XML_ATTR_UPDATE_CLIENT);
+                }
+
+                if (user != NULL) {
+                    crm_xml_add(scratch, XML_ATTR_UPDATE_USER, user);
+                } else {
+                    xml_remove_prop(scratch, XML_ATTR_UPDATE_USER);
+                }
             }
         }
     }

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -334,55 +334,6 @@ crm_xml_add(xmlNode *node, const char *name, const char *value)
 }
 
 /*!
- * \brief Replace an XML attribute with specified name and (possibly NULL) value
- *
- * \param[in,out] node   XML node to modify
- * \param[in]     name   Attribute name to set
- * \param[in]     value  Attribute value to set
- *
- * \return New value on success, \c NULL otherwise
- * \note This does nothing if node or name is \c NULL or empty.
- */
-const char *
-crm_xml_replace(xmlNode *node, const char *name, const char *value)
-{
-    bool dirty = FALSE;
-    xmlAttr *attr = NULL;
-    const char *old_value = NULL;
-
-    CRM_CHECK(node != NULL, return NULL);
-    CRM_CHECK(name != NULL && name[0] != 0, return NULL);
-
-    old_value = crm_element_value(node, name);
-
-    /* Could be re-setting the same value */
-    CRM_CHECK(old_value != value, return value);
-
-    if (pcmk__check_acl(node, name, pcmk__xf_acl_write) == FALSE) {
-        /* Create a fake object linked to doc->_private instead? */
-        crm_trace("Cannot replace %s=%s to %s", name, value, node->name);
-        return NULL;
-
-    } else if (old_value && !value) {
-        xml_remove_prop(node, name);
-        return NULL;
-    }
-
-    if (pcmk__tracking_xml_changes(node, FALSE)) {
-        if (!old_value || !value || !strcmp(old_value, value)) {
-            dirty = TRUE;
-        }
-    }
-
-    attr = xmlSetProp(node, (pcmkXmlStr) name, (pcmkXmlStr) value);
-    if (dirty) {
-        pcmk__mark_xml_attr_dirty(attr);
-    }
-    CRM_CHECK(attr && attr->children && attr->children->content, return NULL);
-    return (char *) attr->children->content;
-}
-
-/*!
  * \brief Create an XML attribute with specified name and integer value
  *
  * This is like \c crm_xml_add() but taking an integer value.
@@ -986,6 +937,45 @@ pcmk_format_named_time(const char *name, time_t epoch_time)
 
     free(now_s);
     return result;
+}
+
+const char *
+crm_xml_replace(xmlNode *node, const char *name, const char *value)
+{
+    bool dirty = FALSE;
+    xmlAttr *attr = NULL;
+    const char *old_value = NULL;
+
+    CRM_CHECK(node != NULL, return NULL);
+    CRM_CHECK(name != NULL && name[0] != 0, return NULL);
+
+    old_value = crm_element_value(node, name);
+
+    /* Could be re-setting the same value */
+    CRM_CHECK(old_value != value, return value);
+
+    if (pcmk__check_acl(node, name, pcmk__xf_acl_write) == FALSE) {
+        /* Create a fake object linked to doc->_private instead? */
+        crm_trace("Cannot replace %s=%s to %s", name, value, node->name);
+        return NULL;
+
+    } else if (old_value && !value) {
+        xml_remove_prop(node, name);
+        return NULL;
+    }
+
+    if (pcmk__tracking_xml_changes(node, FALSE)) {
+        if (!old_value || !value || !strcmp(old_value, value)) {
+            dirty = TRUE;
+        }
+    }
+
+    attr = xmlSetProp(node, (pcmkXmlStr) name, (pcmkXmlStr) value);
+    if (dirty) {
+        pcmk__mark_xml_attr_dirty(attr);
+    }
+    CRM_CHECK(attr && attr->children && attr->children->content, return NULL);
+    return (char *) attr->children->content;
 }
 
 // LCOV_EXCL_STOP

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1714,6 +1714,10 @@ pcmk__xml2fd(int fd, xmlNode *cur)
 void
 xml_remove_prop(xmlNode * obj, const char *name)
 {
+    if (crm_element_value(obj, name) == NULL) {
+        return;
+    }
+
     if (pcmk__check_acl(obj, NULL, pcmk__xf_acl_write) == FALSE) {
         crm_trace("Cannot remove %s from %s", name, obj->name);
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -297,7 +297,7 @@ unpack_template(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * d
 
     new_xml = copy_xml(template);
     xmlNodeSetName(new_xml, xml_obj->name);
-    crm_xml_replace(new_xml, XML_ATTR_ID, id);
+    crm_xml_add(new_xml, XML_ATTR_ID, id);
 
     clone = crm_element_value(xml_obj, XML_RSC_ATTR_INCARNATION);
     if(clone) {


### PR DESCRIPTION
This fixes a regression in the controller join sequence introduced by https://github.com/ClusterLabs/pacemaker/commit/5e3b3d142cc41376e8a1a88faa12d6062e726035. As of that commit, there are multiple asynchronous calls when building each transaction in do_dc_join_ack(). If multiple nodes were joining in parallel, the DC may try to initiate a transaction for one node while a transaction was already open for another node. However, the DC's CIB client can have only one active transaction at a time.

Now, the transaction is created, sent to the CIB manager, and freed synchronously. There is no opportunity for another node's join ack to try to initiate a transaction in the meantime.

Fixes [T690](https://projects.clusterlabs.org/T690)