### PR TITLE
Fix: build: Fix API and CIB versions in RPM build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,17 @@ AC_CHECK_SIZEOF(long long)
 dnl ===============================================
 dnl Helpers
 dnl ===============================================
+# latest_schema_version $schema_dir
+#
+# Use git if available to list managed RNGs, in case there are leftover schema
+# files from an earlier build of a different version. Otherwise, check all RNGs.
+latest_schema_version() {
+    local files=$(git ls-files "$1"/*.rng 2>/dev/null)
+    AS_IF([test x"$files" = x""], [files=$(ls -1 "$1"/*.rng)])
+    echo "$files" | sed -n -e 's/^.*-\([[0-9]][[0-9.]]*\).rng$/\1/p' dnl
+                  | sort -V | tail -1
+}
+
 cc_supports_flag() {
     local CFLAGS="-Werror $@"
     AC_MSG_CHECKING([whether $CC supports $@])
@@ -355,17 +366,13 @@ VERSION_ARG(VERSION_NUMBER)
 PACKAGE_VERSION=$PACEMAKER_VERSION
 VERSION=$PACEMAKER_VERSION
 
-# Detect highest API schema version (use git if available to list managed RNGs,
-# in case there are leftover schema files from an earlier build of a different
-# version, otherwise check all RNGs)
-API_VERSION=$({ git ls-files xml/api/*.rng 2>/dev/null || ls -1 xml/api/*.rng ; } dnl
-              | sed -n -e 's/^.*-\([[0-9]][[0-9.]]*\).rng$/\1/p' | sort -V | tail -1)
+# Detect highest API schema version
+API_VERSION=$(latest_schema_version "xml/api")
 AC_DEFINE_UNQUOTED([PCMK__API_VERSION], ["$API_VERSION"],
                    [Highest API schema version])
 
 # Detect highest CIB schema version
-CIB_VERSION=$({ git ls-files xml/*.rng 2>/dev/null || ls -1 xml/*.rng ; } dnl
-              | sed -n -e 's/^.*-\([[0-9]][[0-9.]]*\).rng$/\1/p' | sort -V | tail -1)
+CIB_VERSION=$(latest_schema_version "xml")
 AC_SUBST(CIB_VERSION)
 
 # Re-run configure at next make if any RNG changes, to re-detect highest


### PR DESCRIPTION
When running `configure` from within the RPM build directory, the relative paths that set `API_VERSION` and `CIB_VERSION` don't match anything in the git index. However, the `git ls-files` command returns success even if its output is empty. So we never fall back to the `ls` command if the `git ls-files` output is empty. As a result, the `API_VERSION` and `CIB_VERSION` variables get set to empty strings in an RPM build.

This causes `cts-lab` to fail in an RPM installation. The `validate-with` attribute in the empty CIB is set based on the value of `CIB_VERSION`. If `CIB_VERSION` is empty, `validate-with` gets set to `"pacemaker-"`, which is invalid.

---

If there's a better way to do this, I'm all ears. Ideally we'd find a way to make `git ls-files` match the files we want. That way we don't risk any extraneous files.

However, `abs_top_builddir` and `abs_top_srcdir` are both set to `<real_srcdir>/rpm/BUILD/pacemaker-<hash>` when the `rpm` target is being built. I'm not sure how to cleanly get back to the "real" source tree.

Edit: On second thought, extraneous files might not be an issue for RPM builds anyway. I've been burned in the past: anything not committed gets ignored, at least for compilation purposes.