### PR TITLE
WIP: Use transaction in attrd_write_attribute and deprecate cib_mixed update

### DIFF
--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -153,6 +153,12 @@ do_cib_replaced(const char *event, xmlNode * msg)
         return;
     }
 
+    if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
+        crm_debug("Ignoring CIB replace notification because we're shutting "
+                  "down");
+        return;
+    }
+
     if ((crm_element_value_int(msg, F_CIB_CALLID, &call_id) == 0)
         && pcmk__str_eq(client_id, controld_globals.cib_client_id,
                         pcmk__str_none)

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -59,6 +59,8 @@ enum cib_call_options {
     cib_discard_reply   = (1 << 4),
     cib_no_children     = (1 << 5),
     cib_xpath_address   = (1 << 6),
+
+    //! \deprecated This value will be removed in a future release
     cib_mixed_update    = (1 << 7),
 
     /* @COMPAT: cib_scope_local is processed only in the legacy function

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -497,7 +497,8 @@ cib_process_modify(const char *op, int options, const char *section, xmlNode * r
         }
     }
 
-    if(options & cib_mixed_update) {
+    // @COMPAT cib_mixed_update is deprecated as of 2.1.7
+    if (pcmk_is_set(options, cib_mixed_update)) {
         int max = 0, lpc;
         xmlXPathObjectPtr xpathObj = xpath_search(*result_cib, "//@__delete__");
 


### PR DESCRIPTION
This change seems fine on the `attrd` side. However, since we use a transaction now, every attribute write replaces the entire CIB. Since transient attributes are part of the status section, the controller's CIB replace callback (`do_cib_replaced()`) triggers a new election every time any transient attribute gets changed.

It's not clear how best to deal with this.

At a basic level, I don't know why we treat CIB replacements so specially and send a notification if certain CIB sections (nodes, alerts, status) change. Other CIB operations can make the same modifications to the same sections, and we don't send a replace notification for them. (We send a diff notification, but clients typically pay less attention to those.)

And as for `do_cib_replaced()`, I don't know whether we actually need to restart the join sequence when the status section is changed. Does a replacement of lrm or transient attributes warrant a join restart? Restarting the join sequence when the nodes section is changed clearly makes sense.

If we **do** need to restart join when status changes, then we need to be more selective about which changes we care about. We can't easily distinguish the changes on the notifier side (`based`) with digests, since we'd need to get the collective digest (or multiple digests) of multiple subsections of `<status>` before and after each change.

We might be able to modify some of the `attrd` API functions to return the CIB call ID when `attrd` writes attributes to the CIB... I haven't looked closely at whether that's possible. `pcmk__attrd_api_update()` makes a synchronous API call to `attrd`, so maybe. If we did that, then we could get the call ID from `controld_attrd.c:update_attrd()` and record it as an expected replacement (`controld_record_cib_replace_call()`). If that is possible, then it would allow us to ignore CIB replacements caused by `attrd` requests that the controller makes. But it wouldn't prevent unnecessary join restarts from attribute updates that originate elsewhere.

---

Also discussed here: https://github.com/ClusterLabs/pacemaker/pull/3180#issuecomment-1667262071