### PR TITLE
Test: python: Specify a path to python tests.

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST = pylintrc
 SUBDIRS	= pacemaker tests
 
 check-local:
-	$(PYTHON) -m unittest discover -v -s tests
+	PYTHONPATH=$(top_srcdir)/python:$(top_builddir)/python $(PYTHON) -m unittest discover -v -s $(top_srcdir)/python/tests $(top_builddir)/python/tests
 
 pylint:
 	pylint $(SUBDIRS)


### PR DESCRIPTION
The tests and the Makefiles might be in different locations.  For instance, built Makefiles could end up in a build directory while the test files themselves (which do not require building) stay in the source directory.

Note that if we ever write python tests that require building (whose filenames end with .in, for instance) then we will need to augment the paths searched.

Fixes T693