### PR TITLE
Refactor: Remove code commented out with "#if 0".

### DIFF
--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -263,13 +263,6 @@ do_dc_release(long long action,
 
     } else if (action & A_DC_RELEASED) {
         crm_info("DC role released");
-#if 0
-        if (are there errors) {
-            /* we can't stay up if not healthy */
-            /* or perhaps I_ERROR and go to S_RECOVER? */
-            result = I_SHUTDOWN;
-        }
-#endif
         if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
             xmlNode *update = NULL;
             crm_node_t *node = crm_get_peer(0, controld_globals.our_nodename);

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -620,11 +620,6 @@ do_state_transition(enum crmd_fsa_state cur_state,
     if (next_state != S_ELECTION && cur_state != S_RELEASE_DC) {
         controld_stop_current_election_timeout();
     }
-#if 0
-    if ((controld_globals.fsa_input_register & R_SHUTDOWN)) {
-        controld_set_fsa_action_flags(A_DC_TIMER_STOP);
-    }
-#endif
     if (next_state == S_INTEGRATION) {
         controld_set_fsa_action_flags(A_INTEGRATE_TIMER_START);
     } else {

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -112,15 +112,6 @@ do_cl_join_offer_respond(long long action,
 
     CRM_CHECK(input != NULL, return);
 
-#if 0
-    if (we are sick) {
-        log error;
-
-        /* save the request for later? */
-        return;
-    }
-#endif
-
     welcome_from = crm_element_value(input->msg, F_CRM_HOST_FROM);
     join_id = crm_element_value(input->msg, F_CRM_JOIN_ID);
     crm_trace("Accepting cluster join offer from node %s "CRM_XS" join-%s",

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1062,11 +1062,6 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
         if (controld_globals.fsa_state == S_HALT) {
             crm_debug("Forcing an election from S_HALT");
             return I_ELECTION;
-#if 0
-        } else if (AM_I_DC) {
-            /* This is the old way of doing things but what is gained? */
-            return I_ELECTION;
-#endif
         }
 
     } else if (strcmp(op, CRM_OP_JOIN_OFFER) == 0) {

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -393,16 +393,6 @@ mainloop_add_signal(int sig, void (*dispatch) (int sig))
         mainloop_destroy_signal_entry(sig);
         return FALSE;
     }
-#if 0
-    /* If we want signals to interrupt mainloop's poll(), instead of waiting for
-     * the timeout, then we should call siginterrupt() below
-     *
-     * For now, just enforce a low timeout
-     */
-    if (siginterrupt(sig, 1) < 0) {
-        crm_perror(LOG_INFO, "Could not enable system call interruptions for signal %d", sig);
-    }
-#endif
 
     return TRUE;
 }

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -432,32 +432,6 @@ crm_schema_init(void)
                NULL, NULL, FALSE, -1);
 }
 
-#if 0
-static void
-relaxng_invalid_stderr(void *userData, xmlErrorPtr error)
-{
-    /*
-       Structure xmlError
-       struct _xmlError {
-       int      domain  : What part of the library raised this er
-       int      code    : The error code, e.g. an xmlParserError
-       char *   message : human-readable informative error messag
-       xmlErrorLevel    level   : how consequent is the error
-       char *   file    : the filename
-       int      line    : the line number if available
-       char *   str1    : extra string information
-       char *   str2    : extra string information
-       char *   str3    : extra string information
-       int      int1    : extra number information
-       int      int2    : column number of the error or 0 if N/A
-       void *   ctxt    : the parser context if available
-       void *   node    : the node in the tree
-       }
-     */
-    crm_err("Structured error: line=%d, level=%d %s", error->line, error->level, error->message);
-}
-#endif
-
 static gboolean
 validate_with_relaxng(xmlDocPtr doc, gboolean to_logs, const char *relaxng_file,
                       relaxng_ctx_cache_t **cached_ctx)
@@ -512,9 +486,6 @@ validate_with_relaxng(xmlDocPtr doc, gboolean to_logs, const char *relaxng_file,
                                      stderr);
         }
     }
-
-    /* xmlRelaxNGSetValidStructuredErrors( */
-    /*  valid, relaxng_invalid_stderr, valid); */
 
     xmlLineNumbersDefault(1);
     rc = xmlRelaxNGValidateDoc(ctx->valid, doc);


### PR DESCRIPTION
Anything that's been commented out since early last decade (or before) is clearly not important enough to get around to figuring out, so it's cut.  Other uses remain, including a bunch that are commented out because we're waiting on a compatibility break.