### PR TITLE
Fix: build: Echo one file per line in schema_files()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -623,7 +623,7 @@ schema_files() {
               files="$(ls -1 "$1"/*.rng | grep -E -v
                        '/(pacemaker|api-result|crm_mon|versions)[^/]*\.rng')"
           ])
-    echo $files
+    echo "$files"
 }
 
 # latest_schema_version <schema-dir>


### PR DESCRIPTION
Otherwise we end up with CIB_SCHEMA_VERSION = "2"