### PR TITLE
API: libpacemaker: Add function for listing resource agents.

### DIFF
--- a/include/pacemaker-internal.h
+++ b/include/pacemaker-internal.h
@@ -11,6 +11,7 @@
 #  define PACEMAKER_INTERNAL__H
 
 #  include <pcmki/pcmki_acl.h>
+#  include <pcmki/pcmki_agents.h>
 #  include <pcmki/pcmki_cluster_queries.h>
 #  include <pcmki/pcmki_fence.h>
 #  include <pcmki/pcmki_output.h>

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -338,6 +338,16 @@ int pcmk_list_result_codes(xmlNodePtr *xml, enum pcmk_result_type type,
                            uint32_t flags);
 
 /*!
+ * \brief List available providers for the given OCF agent
+ *
+ * \param[in,out] xml        The destination for the result, as an XML tree
+ * \param[in]     agent_spec Resource agent name
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk_list_alternatives(xmlNodePtr *xml, const char *agent_spec);
+
+/*!
  * \brief List all agents available for the named standard and/or provider
  *
  * \param[in,out] xml        The destination for the result, as an XML tree
@@ -346,6 +356,25 @@ int pcmk_list_result_codes(xmlNodePtr *xml, enum pcmk_result_type type,
  * \return Standard Pacemaker return code
  */
 int pcmk_list_agents(xmlNodePtr *xml, char *agent_spec);
+
+/*!
+ * \brief List all available OCF providers for the given agent
+ *
+ * \param[in,out] xml        The destination for the result, as an XML tree
+ * \param[in]     agent_spec Resource agent name
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk_list_providers(xmlNodePtr *xml, const char *agent_spec);
+
+/*!
+ * \brief List all available resource agent standards
+ *
+ * \param[in,out] xml        The destination for the result, as an XML tree
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk_list_standards(xmlNodePtr *xml);
 
 #ifdef BUILD_PUBLIC_LIBPACEMAKER
 

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -337,6 +337,16 @@ int pcmk_show_result_code(xmlNodePtr *xml, int code, enum pcmk_result_type type,
 int pcmk_list_result_codes(xmlNodePtr *xml, enum pcmk_result_type type,
                            uint32_t flags);
 
+/*!
+ * \brief List all agents available for the named standard and/or provider
+ *
+ * \param[in,out] xml        The destination for the result, as an XML tree
+ * \param[in]     agent_spec STD[:PROV]
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk_list_agents(xmlNodePtr *xml, char *agent_spec);
+
 #ifdef BUILD_PUBLIC_LIBPACEMAKER
 
 /*!

--- a/include/pcmki/pcmki_agents.h
+++ b/include/pcmki/pcmki_agents.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+#ifndef PCMK__PCMKI_PCMKI_AGENTS__H
+#define PCMK__PCMKI_PCMKI_AGENTS__H
+
+#include <crm/common/output_internal.h>
+
+int pcmk__list_agents(pcmk__output_t *out, char *agent_spec);
+
+#endif /* PCMK__PCMKI_PCMKI_AGENTS__H */

--- a/include/pcmki/pcmki_agents.h
+++ b/include/pcmki/pcmki_agents.h
@@ -11,6 +11,9 @@
 
 #include <crm/common/output_internal.h>
 
+int pcmk__list_alternatives(pcmk__output_t *out, const char *agent_spec);
 int pcmk__list_agents(pcmk__output_t *out, char *agent_spec);
+int pcmk__list_providers(pcmk__output_t *out, const char *agent_spec);
+int pcmk__list_standards(pcmk__output_t *out);
 
 #endif /* PCMK__PCMKI_PCMKI_AGENTS__H */

--- a/lib/pacemaker/Makefile.am
+++ b/lib/pacemaker/Makefile.am
@@ -34,6 +34,7 @@ libpacemaker_la_LIBADD += $(top_builddir)/lib/common/libcrmcommon.la
 # Use += rather than backlashed continuation lines for parsing by bumplibs
 libpacemaker_la_SOURCES	=
 libpacemaker_la_SOURCES += pcmk_acl.c
+libpacemaker_la_SOURCES += pcmk_agents.c
 libpacemaker_la_SOURCES += pcmk_cluster_queries.c
 libpacemaker_la_SOURCES += pcmk_fence.c
 libpacemaker_la_SOURCES += pcmk_graph_consumer.c

--- a/lib/pacemaker/pcmk_agents.c
+++ b/lib/pacemaker/pcmk_agents.c
@@ -13,6 +13,57 @@
 #include <pacemaker.h>
 #include <pacemaker-internal.h>
 
+int
+pcmk__list_alternatives(pcmk__output_t *out, const char *agent_spec)
+{
+    int rc = pcmk_rc_ok;
+    lrmd_t *lrmd_conn = NULL;
+    lrmd_list_t *list = NULL;
+
+    CRM_ASSERT(out != NULL && agent_spec != NULL);
+
+    rc = lrmd__new(&lrmd_conn, NULL, NULL, 0);
+    if (rc != pcmk_rc_ok) {
+        goto error;
+    }
+
+    rc = lrmd_conn->cmds->list_ocf_providers(lrmd_conn, agent_spec, &list);
+
+    if (rc > 0) {
+        rc = out->message(out, "alternatives-list", list, agent_spec);
+    } else {
+        rc = pcmk_rc_error;
+    }
+
+error:
+    if (rc != pcmk_rc_ok) {
+       out->err(out, _("No %s found for %s"), "OCF providers", agent_spec);
+       rc = ENXIO;
+    }
+
+    lrmd_api_delete(lrmd_conn);
+    return rc;
+}
+
+// Documented in pacemaker.h
+int
+pcmk_list_alternatives(xmlNodePtr *xml, const char *agent_spec)
+{
+    pcmk__output_t *out = NULL;
+    int rc = pcmk_rc_ok;
+
+    rc = pcmk__xml_output_new(&out, xml);
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    lrmd__register_messages(out);
+
+    rc = pcmk__list_alternatives(out, agent_spec);
+    pcmk__xml_output_finish(out, xml);
+    return rc;
+}
+
 /*!
  * \internal
  * \brief List all agents available for the named standard and/or provider
@@ -80,6 +131,113 @@ pcmk_list_agents(xmlNodePtr *xml, char *agent_spec)
     lrmd__register_messages(out);
 
     rc = pcmk__list_agents(out, agent_spec);
+    pcmk__xml_output_finish(out, xml);
+    return rc;
+}
+
+int
+pcmk__list_providers(pcmk__output_t *out, const char *agent_spec)
+{
+    int rc = pcmk_rc_ok;
+    lrmd_t *lrmd_conn = NULL;
+    lrmd_list_t *list = NULL;
+
+    CRM_ASSERT(out != NULL);
+
+    rc = lrmd__new(&lrmd_conn, NULL, NULL, 0);
+    if (rc != pcmk_rc_ok) {
+        goto error;
+    }
+
+    rc = lrmd_conn->cmds->list_ocf_providers(lrmd_conn, agent_spec, &list);
+
+    if (rc > 0) {
+        rc = out->message(out, "providers-list", list, agent_spec);
+    } else {
+        rc = pcmk_rc_error;
+    }
+
+error:
+    if (rc != pcmk_rc_ok) {
+        if (agent_spec == NULL) {
+           out->err(out, _("No %s found"), "OCF providers");
+        } else {
+           out->err(out, _("No %s found for %s"), "OCF providers", agent_spec);
+        }
+
+        rc = ENXIO;
+    }
+
+    lrmd_api_delete(lrmd_conn);
+    return rc;
+}
+
+// Documented in pacemaker.h
+int
+pcmk_list_providers(xmlNodePtr *xml, const char *agent_spec)
+{
+    pcmk__output_t *out = NULL;
+    int rc = pcmk_rc_ok;
+
+    rc = pcmk__xml_output_new(&out, xml);
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    lrmd__register_messages(out);
+
+    rc = pcmk__list_providers(out, agent_spec);
+    pcmk__xml_output_finish(out, xml);
+    return rc;
+}
+
+int
+pcmk__list_standards(pcmk__output_t *out)
+{
+    int rc = pcmk_rc_ok;
+    lrmd_t *lrmd_conn = NULL;
+    lrmd_list_t *list = NULL;
+
+    CRM_ASSERT(out != NULL);
+
+    rc = lrmd__new(&lrmd_conn, NULL, NULL, 0);
+    if (rc != pcmk_rc_ok) {
+        goto error;
+    }
+
+    rc = lrmd_conn->cmds->list_standards(lrmd_conn, &list);
+
+    if (rc > 0) {
+        rc = out->message(out, "standards-list", list);
+    } else {
+        rc = pcmk_rc_error;
+    }
+
+error:
+    if (rc != pcmk_rc_ok) {
+       out->err(out, _("No %s found"), "standards");
+       rc = ENXIO;
+    }
+
+    lrmd_api_delete(lrmd_conn);
+    return rc;
+}
+
+// Documented in pacemaker.h
+int
+pcmk_list_standards(xmlNodePtr *xml)
+{
+    pcmk__output_t *out = NULL;
+    int rc = pcmk_rc_ok;
+
+    rc = pcmk__xml_output_new(&out, xml);
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    lrmd__register_messages(out);
+
+    rc = pcmk__list_standards(out);
     pcmk__xml_output_finish(out, xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_agents.c
+++ b/lib/pacemaker/pcmk_agents.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/lrmd_internal.h>
+#include <pacemaker.h>
+#include <pacemaker-internal.h>
+
+/*!
+ * \internal
+ * \brief List all agents available for the named standard and/or provider
+ *
+ * \param[in,out] out           Output object
+ * \param[in]     agent_spec    STD[:PROV]
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__list_agents(pcmk__output_t *out, char *agent_spec)
+{
+    int rc = pcmk_rc_ok;
+    char *provider = NULL;
+    lrmd_t *lrmd_conn = NULL;
+    lrmd_list_t *list = NULL;
+
+    CRM_ASSERT(out != NULL && agent_spec != NULL);
+
+    rc = lrmd__new(&lrmd_conn, NULL, NULL, 0);
+    if (rc != pcmk_rc_ok) {
+        goto error;
+    }
+
+    provider = strchr(agent_spec, ':');
+
+    if (provider) {
+        *provider++ = 0;
+    }
+
+    rc = lrmd_conn->cmds->list_agents(lrmd_conn, &list, agent_spec, provider);
+
+    if (rc > 0) {
+        rc = out->message(out, "agents-list", list, agent_spec, provider);
+    } else {
+        rc = pcmk_rc_error;
+    }
+
+error:
+    if (rc != pcmk_rc_ok) {
+        if (provider == NULL) {
+           out->err(out, _("No agents found for standard '%s'"), agent_spec);
+        } else {
+           out->err(out, _("No agents found for standard '%s' and provider '%s'"),
+                    agent_spec, provider);
+        }
+    }
+
+    lrmd_api_delete(lrmd_conn);
+    return rc;
+}
+
+// Documented in pacemaker.h
+int
+pcmk_list_agents(xmlNodePtr *xml, char *agent_spec)
+{
+    pcmk__output_t *out = NULL;
+    int rc = pcmk_rc_ok;
+
+    rc = pcmk__xml_output_new(&out, xml);
+    if (rc != pcmk_rc_ok) {
+        return rc;
+    }
+
+    lrmd__register_messages(out);
+
+    rc = pcmk__list_agents(out, agent_spec);
+    pcmk__xml_output_finish(out, xml);
+    return rc;
+}

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1137,47 +1137,6 @@ delete(void)
 }
 
 static int
-list_agents(pcmk__output_t *out, const char *agent_spec)
-{
-    int rc = pcmk_rc_ok;
-    char *provider = strchr(agent_spec, ':');
-    lrmd_t *lrmd_conn = NULL;
-    lrmd_list_t *list = NULL;
-
-    rc = lrmd__new(&lrmd_conn, NULL, NULL, 0);
-    if (rc != pcmk_rc_ok) {
-        goto error;
-    }
-
-    if (provider) {
-        *provider++ = 0;
-    }
-
-    rc = lrmd_conn->cmds->list_agents(lrmd_conn, &list, agent_spec, provider);
-
-    if (rc > 0) {
-        rc = out->message(out, "agents-list", list, agent_spec, provider);
-    } else {
-        rc = pcmk_rc_error;
-    }
-
-error:
-    if (rc != pcmk_rc_ok) {
-        if (provider == NULL) {
-            g_set_error(&error, PCMK__RC_ERROR, rc,
-                        _("No agents found for standard '%s'"), agent_spec);
-        } else {
-            g_set_error(&error, PCMK__RC_ERROR, rc,
-                        _("No agents found for standard '%s' and provider '%s'"),
-                        agent_spec, provider);
-        }
-    }
-
-    lrmd_api_delete(lrmd_conn);
-    return rc;
-}
-
-static int
 list_providers(pcmk__output_t *out, const char *agent_spec)
 {
     int rc;
@@ -1860,7 +1819,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_agents:
-            rc = list_agents(out, options.agent_spec);
+            rc = pcmk__list_agents(out, options.agent_spec);
             break;
 
         case cmd_metadata:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1137,77 +1137,6 @@ delete(void)
 }
 
 static int
-list_providers(pcmk__output_t *out, const char *agent_spec)
-{
-    int rc;
-    const char *text = NULL;
-    lrmd_t *lrmd_conn = NULL;
-    lrmd_list_t *list = NULL;
-
-    rc = lrmd__new(&lrmd_conn, NULL, NULL, 0);
-    if (rc != pcmk_rc_ok) {
-        goto error;
-    }
-
-    switch (options.rsc_cmd) {
-        case cmd_list_alternatives:
-            rc = lrmd_conn->cmds->list_ocf_providers(lrmd_conn, agent_spec, &list);
-
-            if (rc > 0) {
-                rc = out->message(out, "alternatives-list", list, agent_spec);
-            } else {
-                rc = pcmk_rc_error;
-            }
-
-            text = "OCF providers";
-            break;
-        case cmd_list_standards:
-            rc = lrmd_conn->cmds->list_standards(lrmd_conn, &list);
-
-            if (rc > 0) {
-                rc = out->message(out, "standards-list", list);
-            } else {
-                rc = pcmk_rc_error;
-            }
-
-            text = "standards";
-            break;
-        case cmd_list_providers:
-            rc = lrmd_conn->cmds->list_ocf_providers(lrmd_conn, agent_spec, &list);
-
-            if (rc > 0) {
-                rc = out->message(out, "providers-list", list, agent_spec);
-            } else {
-                rc = pcmk_rc_error;
-            }
-
-            text = "OCF providers";
-            break;
-        default:
-            g_set_error(&error, PCMK__RC_ERROR, pcmk_rc_error, "Bug");
-            lrmd_api_delete(lrmd_conn);
-            return pcmk_rc_error;
-    }
-
-error:
-    if (rc != pcmk_rc_ok) {
-        if (agent_spec != NULL) {
-            rc = ENXIO;
-            g_set_error(&error, PCMK__RC_ERROR, rc,
-                        _("No %s found for %s"), text, agent_spec);
-
-        } else {
-            rc = ENXIO;
-            g_set_error(&error, PCMK__RC_ERROR, rc,
-                        _("No %s found"), text);
-        }
-    }
-
-    lrmd_api_delete(lrmd_conn);
-    return rc;
-}
-
-static int
 populate_working_set(xmlNodePtr *cib_xml_copy)
 {
     int rc = pcmk_rc_ok;
@@ -1812,14 +1741,20 @@ main(int argc, char **argv)
 
             break;
 
-        case cmd_list_standards:
-        case cmd_list_providers:
         case cmd_list_alternatives:
-            rc = list_providers(out, options.agent_spec);
+            rc = pcmk__list_alternatives(out, options.agent_spec);
             break;
 
         case cmd_list_agents:
             rc = pcmk__list_agents(out, options.agent_spec);
+            break;
+
+        case cmd_list_standards:
+            rc = pcmk__list_standards(out);
+            break;
+
+        case cmd_list_providers:
+            rc = pcmk__list_providers(out, options.agent_spec);
             break;
 
         case cmd_metadata:


### PR DESCRIPTION
This is the same functionality as "crm_resource --list-agents", but in a pair of public and private functions.  crm_resource has then been modified to just call the private function instead of doing this on its own.

Ref T44