### PR TITLE
Improve handling of node-pending-timeout

### DIFF
--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -351,7 +351,7 @@
     </parameter>
     <parameter name="node-pending-timeout">
       <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes.</longdesc>
-      <shortdesc lang="en">How long to wait for a node that has joined the cluster to join the process group</shortdesc>
+      <shortdesc lang="en">How long to wait for a node that has joined the cluster to join the controller process group</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="cluster-delay">

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -350,7 +350,7 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="node-pending-timeout">
-      <longdesc lang="en">A node that has joined the cluster can be pending on joining the process group. We wait up to this much time for it. If it times out, fencing targeting the node will be issued if enabled.</longdesc>
+      <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes.</longdesc>
       <shortdesc lang="en">How long to wait for a node that has joined the cluster to join the process group</shortdesc>
       <content type="time" default=""/>
     </parameter>

--- a/cts/scheduler/summary/migrate-fencing.summary
+++ b/cts/scheduler/summary/migrate-fencing.summary
@@ -23,7 +23,7 @@ Current cluster status:
       * Unpromoted: [ pcmk-1 pcmk-2 pcmk-3 ]
 
 Transition Summary:
-  * Fence (reboot) pcmk-4 'termination was requested'
+  * Fence (reboot) pcmk-4 'fencing was requested'
   * Stop       FencingChild:0     (                        pcmk-4 )  due to node availability
   * Move       r192.168.101.181   (              pcmk-4 -> pcmk-1 )
   * Move       r192.168.101.182   (              pcmk-4 -> pcmk-1 )

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -852,7 +852,7 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
      */
     crm_trace("Updating node name and UUID in CIB for %s", join_to);
     tmp1 = create_xml_node(NULL, XML_CIB_TAG_NODE);
-    set_uuid(tmp1, XML_ATTR_ID, join_node);
+    crm_xml_add(tmp1, XML_ATTR_ID, crm_peer_uuid(join_node));
     crm_xml_add(tmp1, XML_ATTR_UNAME, join_to);
     fsa_cib_anon_update(XML_CIB_TAG_NODES, tmp1);
     free_xml(tmp1);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -138,10 +138,8 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
         pcmk__xe_set_bool_attr(node_state, XML_NODE_IS_REMOTE, true);
     }
 
-    set_uuid(node_state, XML_ATTR_ID, node);
-
-    if (crm_element_value(node_state, XML_ATTR_ID) == NULL) {
-        crm_info("Node update for %s cancelled: no id", node->uname);
+    if (crm_xml_add(node_state, XML_ATTR_ID, crm_peer_uuid(node)) == NULL) {
+        crm_info("Node update for %s cancelled: no ID", node->uname);
         free_xml(node_state);
         return NULL;
     }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -182,7 +182,7 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
             } else {
                 value = CRMD_JOINSTATE_MEMBER;
             }
-            crm_xml_add(node_state, XML_NODE_JOIN_STATE, value);
+            crm_xml_add(node_state, PCMK__XA_JOIN, value);
         }
 
         if (flags & node_update_expected) {

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -186,7 +186,7 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
         }
 
         if (flags & node_update_expected) {
-            crm_xml_add(node_state, XML_NODE_EXPECTED, node->expected);
+            crm_xml_add(node_state, PCMK__XA_EXPECTED, node->expected);
         }
     }
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -164,15 +164,15 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
         if (flags & node_update_peer) {
             if (compare_version(controld_globals.dc_version, "3.18.0") >= 0) {
                 // A value 0 means the peer is offline in CPG.
-                crm_xml_add_ll(node_state, XML_NODE_IS_PEER,
-                               node->when_online);
+                crm_xml_add_ll(node_state, PCMK__XA_CRMD, node->when_online);
 
             } else {
+                // @COMPAT DCs < 2.1.7 use online/offline rather than timestamp
                 value = OFFLINESTATUS;
                 if (pcmk_is_set(node->processes, crm_get_cluster_proc())) {
                     value = ONLINESTATUS;
                 }
-                crm_xml_add(node_state, XML_NODE_IS_PEER, value);
+                crm_xml_add(node_state, PCMK__XA_CRMD, value);
             }
         }
 

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -151,10 +151,10 @@ create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
     if ((flags & node_update_cluster) && node->state) {
         if (compare_version(controld_globals.dc_version, "3.18.0") >= 0) {
             // A value 0 means the node is not a cluster member.
-            crm_xml_add_ll(node_state, XML_NODE_IN_CLUSTER, node->when_member);
+            crm_xml_add_ll(node_state, PCMK__XA_IN_CCM, node->when_member);
 
         } else {
-            pcmk__xe_set_bool_attr(node_state, XML_NODE_IN_CLUSTER,
+            pcmk__xe_set_bool_attr(node_state, PCMK__XA_IN_CCM,
                                    pcmk__str_eq(node->state, CRM_NODE_MEMBER,
                                                 pcmk__str_casei));
         }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -764,7 +764,7 @@ handle_remote_state(const xmlNode *msg)
     bool remote_is_up = false;
     int rc = pcmk_rc_ok;
 
-    rc = pcmk__xe_get_bool_attr(msg, XML_NODE_IN_CLUSTER, &remote_is_up);
+    rc = pcmk__xe_get_bool_attr(msg, PCMK__XA_IN_CCM, &remote_is_up);
 
     CRM_CHECK(remote_uname && rc == pcmk_rc_ok, return I_NULL);
 
@@ -850,7 +850,7 @@ handle_node_list(const xmlNode *request)
 
         crm_xml_add_ll(xml, XML_ATTR_ID, (long long) node->id); // uint32_t
         crm_xml_add(xml, XML_ATTR_UNAME, node->uname);
-        crm_xml_add(xml, XML_NODE_IN_CLUSTER, node->state);
+        crm_xml_add(xml, PCMK__XA_IN_CCM, node->state);
     }
 
     // Create and send reply
@@ -1324,7 +1324,7 @@ broadcast_remote_state_message(const char *node_name, bool node_up)
              node_name, node_up? "coming up" : "going down");
 
     crm_xml_add(msg, XML_ATTR_ID, node_name);
-    pcmk__xe_set_bool_attr(msg, XML_NODE_IN_CLUSTER, node_up);
+    pcmk__xe_set_bool_attr(msg, PCMK__XA_IN_CCM, node_up);
 
     if (node_up) {
         crm_xml_add(msg, PCMK__XA_CONN_HOST, controld_globals.our_nodename);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -907,7 +907,7 @@ handle_node_info_request(const xmlNode *msg)
     if (node) {
         crm_xml_add(reply_data, XML_ATTR_ID, node->uuid);
         crm_xml_add(reply_data, XML_ATTR_UNAME, node->uname);
-        crm_xml_add(reply_data, XML_NODE_IS_PEER, node->state);
+        crm_xml_add(reply_data, PCMK__XA_CRMD, node->state);
         pcmk__xe_set_bool_attr(reply_data, XML_NODE_IS_REMOTE,
                                pcmk_is_set(node->flags, crm_remote_node));
     }

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -267,7 +267,7 @@ controld_node_pending_timer(const crm_node_t *node)
      * node-pending-timeout is disabled, free any node pending timer for it.
      */
     if (pcmk_is_set(node->flags, crm_remote_node)
-        || (node->when_member <= 0) || (node->when_online != 0)
+        || (node->when_member <= 0) || (node->when_online > 0)
         || (controld_globals.node_pending_timeout == 0)) {
         remove_node_pending_timer(node->uuid);
         return;

--- a/doc/sphinx/Pacemaker_Explained/options.rst
+++ b/doc/sphinx/Pacemaker_Explained/options.rst
@@ -581,11 +581,11 @@ values, by running the ``man pacemaker-schedulerd`` and
    | node-pending-timeout      | 10min   | .. index::                                         |
    |                           |         |    pair: cluster option; node-pending-timeout      |
    |                           |         |                                                    |
-   |                           |         | A node that has joined the cluster can be pending  |
-   |                           |         | on joining the process group. We wait up to this   |
-   |                           |         | much time for it. If it times out, fencing         |
-   |                           |         | targeting the node will be issued if enabled.      |
-   |                           |         | *(since 2.1.7)*                                    |
+   |                           |         | Fence nodes that do not join the controller        |
+   |                           |         | process group within this much time after joining  |
+   |                           |         | the cluster, to allow the cluster to continue      |
+   |                           |         | managing resources. A value of 0 means never fence |
+   |                           |         | pending nodes. *(since 2.1.7)*                     |
    +---------------------------+---------+----------------------------------------------------+
    | cluster-delay             | 60s     | .. index::                                         |
    |                           |         |    pair: cluster option; cluster-delay             |

--- a/doc/sphinx/Pacemaker_Explained/options.rst
+++ b/doc/sphinx/Pacemaker_Explained/options.rst
@@ -578,7 +578,7 @@ values, by running the ``man pacemaker-schedulerd`` and
    |                           |         | greater than (safely twice) the maximum delay from |
    |                           |         | those parameters. *(since 2.0.4)*                  |
    +---------------------------+---------+----------------------------------------------------+
-   | node-pending-timeout      | 10min   | .. index::                                         |
+   | node-pending-timeout      | 2h      | .. index::                                         |
    |                           |         |    pair: cluster option; node-pending-timeout      |
    |                           |         |                                                    |
    |                           |         | Fence nodes that do not join the controller        |

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -177,7 +177,6 @@ char *pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid,
 
 const char *crm_peer_uuid(crm_node_t *node);
 const char *crm_peer_uname(const char *uuid);
-void set_uuid(xmlNode *xml, const char *attr, crm_node_t *node);
 
 enum crm_status_type {
     crm_status_uname,

--- a/include/crm/cluster/compat.h
+++ b/include/crm/cluster/compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2021 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,6 +9,9 @@
 
 #ifndef PCMK__CRM_CLUSTER_COMPAT__H
 #  define PCMK__CRM_CLUSTER_COMPAT__H
+
+#include <libxml/tree.h>    // xmlNode
+#include <crm/cluster.h>    // crm_node_t
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,6 +32,9 @@ int crm_terminate_member(int nodeid, const char *uname, void *unused);
 // \deprecated Use stonith_api_kick() from libstonithd instead
 int crm_terminate_member_no_mainloop(int nodeid, const char *uname,
                                      int *connection);
+
+// \deprecated Use crm_xml_add(xml, attr, crm_peer_uuid(node)) instead
+void set_uuid(xmlNode *xml, const char *attr, crm_node_t *node);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/nodes.h
+++ b/include/crm/common/nodes.h
@@ -20,6 +20,11 @@ extern "C" {
  * \ingroup core
  */
 
+// Special node attributes
+
+#define PCMK_NODE_ATTR_TERMINATE    "terminate"
+
+
 //! Possible node types
 enum node_type {
     pcmk_node_variant_cluster  = 1,     //!< Cluster layer node

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -108,6 +108,7 @@ extern char *crm_system_name;
 #  define CRM_SYSTEM_MCP	"pacemakerd"
 
 // Names of internally generated node attributes
+// @TODO Replace these with PCMK_NODE_ATTR_*
 #  define CRM_ATTR_UNAME            "#uname"
 #  define CRM_ATTR_ID               "#id"
 #  define CRM_ATTR_KIND             "#kind"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -285,7 +285,6 @@ extern "C" {
 
 #  define XML_CIB_ATTR_PRIORITY     	"priority"
 
-#  define XML_NODE_EXPECTED     	"expected"
 #  define XML_NODE_IS_REMOTE    	"remote_node"
 #  define XML_NODE_IS_FENCED		"node_fenced"
 #  define XML_NODE_IS_MAINTENANCE   "node_in_maintenance"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -288,7 +288,6 @@ extern "C" {
 #  define XML_NODE_JOIN_STATE    	"join"
 #  define XML_NODE_EXPECTED     	"expected"
 #  define XML_NODE_IN_CLUSTER        	"in_ccm"
-#  define XML_NODE_IS_PEER    	"crmd"
 #  define XML_NODE_IS_REMOTE    	"remote_node"
 #  define XML_NODE_IS_FENCED		"node_fenced"
 #  define XML_NODE_IS_MAINTENANCE   "node_in_maintenance"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -287,7 +287,6 @@ extern "C" {
 
 #  define XML_NODE_JOIN_STATE    	"join"
 #  define XML_NODE_EXPECTED     	"expected"
-#  define XML_NODE_IN_CLUSTER        	"in_ccm"
 #  define XML_NODE_IS_REMOTE    	"remote_node"
 #  define XML_NODE_IS_FENCED		"node_fenced"
 #  define XML_NODE_IS_MAINTENANCE   "node_in_maintenance"

--- a/include/crm/msg_xml.h
+++ b/include/crm/msg_xml.h
@@ -285,7 +285,6 @@ extern "C" {
 
 #  define XML_CIB_ATTR_PRIORITY     	"priority"
 
-#  define XML_NODE_JOIN_STATE    	"join"
 #  define XML_NODE_EXPECTED     	"expected"
 #  define XML_NODE_IS_REMOTE    	"remote_node"
 #  define XML_NODE_IS_FENCED		"node_fenced"

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -97,6 +97,9 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_NODE_IS_PEER "crmd"
 
+//! \deprecated Do not use
+#define XML_NODE_JOIN_STATE "join"
+
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_RSC_OP_LAST_RUN "last-run"
 

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -90,6 +90,9 @@ extern "C" {
 
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_CIB_ATTR_SOURCE "source"
+
+//! \deprecated Do not use
+#define XML_NODE_IS_PEER "crmd"
 
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_RSC_OP_LAST_RUN "last-run"

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -92,6 +92,9 @@ extern "C" {
 #define XML_CIB_ATTR_SOURCE "source"
 
 //! \deprecated Do not use
+#define XML_NODE_EXPECTED "expected"
+
+//! \deprecated Do not use
 #define XML_NODE_IN_CLUSTER "in_ccm"
 
 //! \deprecated Do not use

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -92,6 +92,9 @@ extern "C" {
 #define XML_CIB_ATTR_SOURCE "source"
 
 //! \deprecated Do not use
+#define XML_NODE_IN_CLUSTER "in_ccm"
+
+//! \deprecated Do not use
 #define XML_NODE_IS_PEER "crmd"
 
 //! \deprecated Do not use (will be removed in a future release)

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -84,6 +84,7 @@
 #define PCMK__XA_CRMD                   "crmd"
 #define PCMK__XA_GRAPH_ERRORS           "graph-errors"
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
+#define PCMK__XA_IN_CCM                 "in_ccm"
 #define PCMK__XA_MODE                   "mode"
 #define PCMK__XA_NODE_START_STATE       "node_start_state"
 #define PCMK__XA_TASK                   "task"

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -82,6 +82,7 @@
 #define PCMK__XA_CONFIG_WARNINGS        "config-warnings"
 #define PCMK__XA_CONFIRM                "confirm"
 #define PCMK__XA_CRMD                   "crmd"
+#define PCMK__XA_EXPECTED               "expected"
 #define PCMK__XA_GRAPH_ERRORS           "graph-errors"
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_IN_CCM                 "in_ccm"

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -85,6 +85,7 @@
 #define PCMK__XA_GRAPH_ERRORS           "graph-errors"
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_IN_CCM                 "in_ccm"
+#define PCMK__XA_JOIN                   "join"
 #define PCMK__XA_MODE                   "mode"
 #define PCMK__XA_NODE_START_STATE       "node_start_state"
 #define PCMK__XA_TASK                   "task"

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -81,6 +81,7 @@
 #define PCMK__XA_CONFIG_ERRORS          "config-errors"
 #define PCMK__XA_CONFIG_WARNINGS        "config-warnings"
 #define PCMK__XA_CONFIRM                "confirm"
+#define PCMK__XA_CRMD                   "crmd"
 #define PCMK__XA_GRAPH_ERRORS           "graph-errors"
 #define PCMK__XA_GRAPH_WARNINGS         "graph-warnings"
 #define PCMK__XA_MODE                   "mode"

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -294,19 +294,6 @@ crm_peer_uname(const char *uuid)
 }
 
 /*!
- * \brief Add a node's UUID as an XML attribute
- *
- * \param[in,out] xml   XML element to add UUID to
- * \param[in]     attr  XML attribute name to set
- * \param[in,out] node  Node whose UUID should be used as attribute value
- */
-void
-set_uuid(xmlNode *xml, const char *attr, crm_node_t *node)
-{
-    crm_xml_add(xml, attr, crm_peer_uuid(node));
-}
-
-/*!
  * \brief  Get a log-friendly string equivalent of a cluster type
  *
  * \param[in] type  Cluster type
@@ -403,3 +390,17 @@ is_corosync_cluster(void)
 {
     return get_cluster_type() == pcmk_cluster_corosync;
 }
+
+// Deprecated functions kept only for backward API compatibility
+// LCOV_EXCL_START
+
+#include <crm/cluster/compat.h>
+
+void
+set_uuid(xmlNode *xml, const char *attr, crm_node_t *node)
+{
+    crm_xml_add(xml, attr, crm_peer_uuid(node));
+}
+
+// LCOV_EXCL_STOP
+// End deprecated API

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -157,7 +157,7 @@ crm_remote_peer_cache_remove(const char *node_name)
  *
  * \param[in] node_state  XML of node state
  *
- * \return CRM_NODE_LOST if XML_NODE_IN_CLUSTER is false in node_state,
+ * \return CRM_NODE_LOST if PCMK__XA_IN_CCM is false in node_state,
  *         CRM_NODE_MEMBER otherwise
  * \note Unlike most boolean XML attributes, this one defaults to true, for
  *       backward compatibility with older controllers that don't set it.
@@ -167,7 +167,8 @@ remote_state_from_cib(const xmlNode *node_state)
 {
     bool status = false;
 
-    if (pcmk__xe_get_bool_attr(node_state, XML_NODE_IN_CLUSTER, &status) == pcmk_rc_ok && !status) {
+    if ((pcmk__xe_get_bool_attr(node_state, PCMK__XA_IN_CCM,
+                                &status) == pcmk_rc_ok) && !status) {
         return CRM_NODE_LOST;
     } else {
         return CRM_NODE_MEMBER;

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -135,7 +135,7 @@ set_node_info_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
 
     data->data.node_info.uuid = crm_element_value(msg_data, XML_ATTR_ID);
     data->data.node_info.uname = crm_element_value(msg_data, XML_ATTR_UNAME);
-    data->data.node_info.state = crm_element_value(msg_data, XML_NODE_IS_PEER);
+    data->data.node_info.state = crm_element_value(msg_data, PCMK__XA_CRMD);
 }
 
 static void

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -169,7 +169,7 @@ set_nodes_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
             node_info->id = id_ll;
         }
         node_info->uname = crm_element_value(node, XML_ATTR_UNAME);
-        node_info->state = crm_element_value(node, XML_NODE_IN_CLUSTER);
+        node_info->state = crm_element_value(node, PCMK__XA_IN_CCM);
         data->data.nodes = g_list_prepend(data->data.nodes, node_info);
     }
 }

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -323,14 +323,14 @@ pcmk__inject_node_state_change(cib_t *cib_conn, const char *node, bool up)
                            PCMK__XA_IN_CCM, XML_BOOLEAN_YES,
                            PCMK__XA_CRMD, ONLINESTATUS,
                            PCMK__XA_JOIN, CRMD_JOINSTATE_MEMBER,
-                           XML_NODE_EXPECTED, CRMD_JOINSTATE_MEMBER,
+                           PCMK__XA_EXPECTED, CRMD_JOINSTATE_MEMBER,
                            NULL);
     } else {
         pcmk__xe_set_props(cib_node,
                            PCMK__XA_IN_CCM, XML_BOOLEAN_NO,
                            PCMK__XA_CRMD, OFFLINESTATUS,
                            PCMK__XA_JOIN, CRMD_JOINSTATE_DOWN,
-                           XML_NODE_EXPECTED, CRMD_JOINSTATE_DOWN,
+                           PCMK__XA_EXPECTED, CRMD_JOINSTATE_DOWN,
                            NULL);
     }
     crm_xml_add(cib_node, XML_ATTR_ORIGIN, crm_system_name);

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -320,14 +320,14 @@ pcmk__inject_node_state_change(cib_t *cib_conn, const char *node, bool up)
 
     if (up) {
         pcmk__xe_set_props(cib_node,
-                           XML_NODE_IN_CLUSTER, XML_BOOLEAN_YES,
+                           PCMK__XA_IN_CCM, XML_BOOLEAN_YES,
                            PCMK__XA_CRMD, ONLINESTATUS,
                            XML_NODE_JOIN_STATE, CRMD_JOINSTATE_MEMBER,
                            XML_NODE_EXPECTED, CRMD_JOINSTATE_MEMBER,
                            NULL);
     } else {
         pcmk__xe_set_props(cib_node,
-                           XML_NODE_IN_CLUSTER, XML_BOOLEAN_NO,
+                           PCMK__XA_IN_CCM, XML_BOOLEAN_NO,
                            PCMK__XA_CRMD, OFFLINESTATUS,
                            XML_NODE_JOIN_STATE, CRMD_JOINSTATE_DOWN,
                            XML_NODE_EXPECTED, CRMD_JOINSTATE_DOWN,
@@ -711,7 +711,7 @@ pcmk__inject_scheduler_input(pe_working_set_t *data_set, cib_t *cib,
         out->message(out, "inject-modify-node", "Failing", node);
 
         cib_node = pcmk__inject_node_state_change(cib, node, true);
-        crm_xml_add(cib_node, XML_NODE_IN_CLUSTER, XML_BOOLEAN_NO);
+        crm_xml_add(cib_node, PCMK__XA_IN_CCM, XML_BOOLEAN_NO);
         CRM_ASSERT(cib_node != NULL);
 
         rc = cib->cmds->modify(cib, XML_CIB_TAG_STATUS, cib_node,

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -321,14 +321,14 @@ pcmk__inject_node_state_change(cib_t *cib_conn, const char *node, bool up)
     if (up) {
         pcmk__xe_set_props(cib_node,
                            XML_NODE_IN_CLUSTER, XML_BOOLEAN_YES,
-                           XML_NODE_IS_PEER, ONLINESTATUS,
+                           PCMK__XA_CRMD, ONLINESTATUS,
                            XML_NODE_JOIN_STATE, CRMD_JOINSTATE_MEMBER,
                            XML_NODE_EXPECTED, CRMD_JOINSTATE_MEMBER,
                            NULL);
     } else {
         pcmk__xe_set_props(cib_node,
                            XML_NODE_IN_CLUSTER, XML_BOOLEAN_NO,
-                           XML_NODE_IS_PEER, OFFLINESTATUS,
+                           PCMK__XA_CRMD, OFFLINESTATUS,
                            XML_NODE_JOIN_STATE, CRMD_JOINSTATE_DOWN,
                            XML_NODE_EXPECTED, CRMD_JOINSTATE_DOWN,
                            NULL);

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -322,14 +322,14 @@ pcmk__inject_node_state_change(cib_t *cib_conn, const char *node, bool up)
         pcmk__xe_set_props(cib_node,
                            PCMK__XA_IN_CCM, XML_BOOLEAN_YES,
                            PCMK__XA_CRMD, ONLINESTATUS,
-                           XML_NODE_JOIN_STATE, CRMD_JOINSTATE_MEMBER,
+                           PCMK__XA_JOIN, CRMD_JOINSTATE_MEMBER,
                            XML_NODE_EXPECTED, CRMD_JOINSTATE_MEMBER,
                            NULL);
     } else {
         pcmk__xe_set_props(cib_node,
                            PCMK__XA_IN_CCM, XML_BOOLEAN_NO,
                            PCMK__XA_CRMD, OFFLINESTATUS,
-                           XML_NODE_JOIN_STATE, CRMD_JOINSTATE_DOWN,
+                           PCMK__XA_JOIN, CRMD_JOINSTATE_DOWN,
                            XML_NODE_EXPECTED, CRMD_JOINSTATE_DOWN,
                            NULL);
     }

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1375,7 +1375,7 @@ node_info_xml(pcmk__output_t *out, va_list args)
                                  "nodeid", id_s,
                                  XML_ATTR_UNAME, node_name,
                                  XML_ATTR_ID, uuid,
-                                 XML_NODE_IS_PEER, state,
+                                 PCMK__XA_CRMD, state,
                                  XML_ATTR_HAVE_QUORUM, pcmk__btoa(have_quorum),
                                  XML_NODE_IS_REMOTE, pcmk__btoa(is_remote),
                                  NULL);

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -161,7 +161,7 @@ static pcmk__cluster_option_t pe_opts[] = {
 
     {
         XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT, NULL, "time", NULL,
-        "10min", pcmk__valid_interval_spec,
+        "2h", pcmk__valid_interval_spec,
         N_("How long to wait for a node that has joined the cluster to join "
            "the process group"),
         N_("Fence nodes that do not join the controller process group within "

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -163,7 +163,7 @@ static pcmk__cluster_option_t pe_opts[] = {
         XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT, NULL, "time", NULL,
         "2h", pcmk__valid_interval_spec,
         N_("How long to wait for a node that has joined the cluster to join "
-           "the process group"),
+           "the controller process group"),
         N_("Fence nodes that do not join the controller process group within "
            "this much time after joining the cluster, to allow the cluster "
            "to continue managing resources. A value of 0 means never fence "

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -164,9 +164,10 @@ static pcmk__cluster_option_t pe_opts[] = {
         "10min", pcmk__valid_interval_spec,
         N_("How long to wait for a node that has joined the cluster to join "
            "the process group"),
-        N_("A node that has joined the cluster can be pending on joining the "
-           "process group. We wait up to this much time for it. If it times "
-           "out, fencing targeting the node will be issued if enabled.")
+        N_("Fence nodes that do not join the controller process group within "
+           "this much time after joining the cluster, to allow the cluster "
+           "to continue managing resources. A value of 0 means never fence "
+           "pending nodes.")
     },
     {
         "cluster-delay", NULL, "time", NULL,

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -30,8 +30,9 @@ pe__resource_description(const pe_resource_t *rsc, uint32_t show_opts)
 }
 
 /* Never display node attributes whose name starts with one of these prefixes */
-#define FILTER_STR { PCMK__FAIL_COUNT_PREFIX, PCMK__LAST_FAILURE_PREFIX,   \
-                     "shutdown", "terminate", "standby", "#", NULL }
+#define FILTER_STR { PCMK__FAIL_COUNT_PREFIX, PCMK__LAST_FAILURE_PREFIX,    \
+                     "shutdown", PCMK_NODE_ATTR_TERMINATE, "standby", "#",  \
+                     NULL }
 
 static int
 compare_attribute(gconstpointer a, gconstpointer b)

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1377,7 +1377,7 @@ determine_online_status_no_fencing(pe_working_set_t *data_set,
     gboolean online = FALSE;
     const char *join = crm_element_value(node_state, XML_NODE_JOIN_STATE);
     const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
-    const char *in_cluster = crm_element_value(node_state, XML_NODE_IN_CLUSTER);
+    const char *in_cluster = crm_element_value(node_state, PCMK__XA_IN_CCM);
     const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
     int member = false;
     bool crmd_online = false;
@@ -1437,7 +1437,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     bool crmd_online = FALSE;
     const char *join = crm_element_value(node_state, XML_NODE_JOIN_STATE);
     const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
-    const char *in_cluster = crm_element_value(node_state, XML_NODE_IN_CLUSTER);
+    const char *in_cluster = crm_element_value(node_state, PCMK__XA_IN_CCM);
     const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
     const char *terminate = pe_node_attribute_raw(this_node, "terminate");
     int member = false;
@@ -1449,11 +1449,11 @@ determine_online_status_fencing(pe_working_set_t *data_set,
   - XML_NODE_EXPECTED      ::= member|down
 
   @COMPAT with entries recorded for DCs < 2.1.7
-  - XML_NODE_IN_CLUSTER    ::= true|false
+  - PCMK__XA_IN_CCM        ::= true|false
   - PCMK__XA_CRMD          ::= online|offline
 
   Since crm_feature_set 3.18.0 (pacemaker-2.1.7):
-  - XML_NODE_IN_CLUSTER    ::= <timestamp>|0
+  - PCMK__XA_IN_CCM        ::= <timestamp>|0
   Since when node has been a cluster member. A value 0 of means the node is not
   a cluster member.
 
@@ -1479,9 +1479,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
               pcmk__s(is_peer, "<null>"), pcmk__s(join, "<null>"),
               pcmk__s(exp_state, "<null>"), do_terminate);
 
-    /* @COMPAT with boolean values of XML_NODE_IN_CLUSTER recorded for
-     * DCs < 2.1.7
-     */
+    // @COMPAT with boolean values of PCMK__XA_IN_CCM recorded for DCs < 2.1.7
     if (crm_str_to_boolean(in_cluster, &member) != 1) {
         pcmk__scan_ll(in_cluster, &when_member, 0LL);
         member = (when_member > 0) ? true : false;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1375,7 +1375,7 @@ determine_online_status_no_fencing(pe_working_set_t *data_set,
                                    pe_node_t *this_node)
 {
     gboolean online = FALSE;
-    const char *join = crm_element_value(node_state, XML_NODE_JOIN_STATE);
+    const char *join = crm_element_value(node_state, PCMK__XA_JOIN);
     const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
     const char *in_cluster = crm_element_value(node_state, PCMK__XA_IN_CCM);
     const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
@@ -1435,7 +1435,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     gboolean online = FALSE;
     gboolean do_terminate = FALSE;
     bool crmd_online = FALSE;
-    const char *join = crm_element_value(node_state, XML_NODE_JOIN_STATE);
+    const char *join = crm_element_value(node_state, PCMK__XA_JOIN);
     const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
     const char *in_cluster = crm_element_value(node_state, PCMK__XA_IN_CCM);
     const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
@@ -1445,7 +1445,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     long long when_online = 0;
 
 /*
-  - XML_NODE_JOIN_STATE    ::= member|down|pending|banned
+  - PCMK__XA_JOIN          ::= member|down|pending|banned
   - XML_NODE_EXPECTED      ::= member|down
 
   @COMPAT with entries recorded for DCs < 2.1.7

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1498,7 +1498,8 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     gboolean do_terminate = FALSE;
     const char *join = crm_element_value(node_state, PCMK__XA_JOIN);
     const char *exp_state = crm_element_value(node_state, PCMK__XA_EXPECTED);
-    const char *terminate = pe_node_attribute_raw(this_node, "terminate");
+    const char *terminate = pe_node_attribute_raw(this_node,
+                                                  PCMK_NODE_ATTR_TERMINATE);
     long long when_member = unpack_node_member(node_state, data_set);
     long long when_online = unpack_node_online(node_state);
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1568,7 +1568,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
                       "peer failed Pacemaker membership criteria", FALSE);
 
     } else if (termination_requested) {
-        if ((when_member == 0) && (when_online == 0)
+        if ((when_member <= 0) && (when_online <= 0)
             && pcmk__str_eq(join, CRMD_JOINSTATE_DOWN, pcmk__str_none)) {
             crm_info("%s was fenced as requested", pe__node_name(this_node));
             return false;
@@ -1579,7 +1579,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
                             pcmk__str_null_matches)) {
 
         if ((data_set->node_pending_timeout > 0)
-            && (when_member > 0) && (when_online == 0)
+            && (when_member > 0) && (when_online <= 0)
             && (get_effective_time(data_set) - when_member
                 >= data_set->node_pending_timeout)) {
             pe_fence_node(data_set, this_node,
@@ -1597,11 +1597,11 @@ determine_online_status_fencing(pe_working_set_t *data_set,
                       pe__node_name(this_node));
         }
 
-    } else if (when_member == 0) {
+    } else if (when_member <= 0) {
         // Consider `priority-fencing-delay` for lost nodes
         pe_fence_node(data_set, this_node, "peer is no longer part of the cluster", TRUE);
 
-    } else if (when_online == 0) {
+    } else if (when_online <= 0) {
         pe_fence_node(data_set, this_node, "peer process is no longer available", FALSE);
 
         /* Everything is running at this point, now check join state */

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1554,10 +1554,6 @@ determine_online_status_fencing(pe_working_set_t *data_set,
 
     online = (when_member > 0);
 
-    if (exp_state == NULL) {
-        exp_state = CRMD_JOINSTATE_DOWN;
-    }
-
     if (this_node->details->shutdown) {
         crm_debug("%s is shutting down", pe__node_name(this_node));
 
@@ -1567,7 +1563,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     } else if (when_member < 0) {
         pe_fence_node(data_set, this_node, "peer has not been seen by the cluster", FALSE);
 
-    } else if (pcmk__str_eq(join, CRMD_JOINSTATE_NACK, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(join, CRMD_JOINSTATE_NACK, pcmk__str_none)) {
         pe_fence_node(data_set, this_node,
                       "peer failed Pacemaker membership criteria", FALSE);
 
@@ -1580,7 +1576,8 @@ determine_online_status_fencing(pe_working_set_t *data_set,
             pe_fence_node(data_set, this_node, "fencing was requested", false);
         }
 
-    } else if (pcmk__str_eq(exp_state, CRMD_JOINSTATE_DOWN, pcmk__str_none)) {
+    } else if (pcmk__str_eq(exp_state, CRMD_JOINSTATE_DOWN,
+                            pcmk__str_null_matches)) {
 
         if ((data_set->node_pending_timeout > 0)
             && (when_member > 0) && (when_online == 0)
@@ -1610,10 +1607,11 @@ determine_online_status_fencing(pe_working_set_t *data_set,
 
         /* Everything is running at this point, now check join state */
 
-    } else if (pcmk__str_eq(join, CRMD_JOINSTATE_MEMBER, pcmk__str_casei)) {
+    } else if (pcmk__str_eq(join, CRMD_JOINSTATE_MEMBER, pcmk__str_none)) {
         crm_info("%s is active", pe__node_name(this_node));
 
-    } else if (pcmk__strcase_any_of(join, CRMD_JOINSTATE_PENDING, CRMD_JOINSTATE_DOWN, NULL)) {
+    } else if (pcmk__str_any_of(join, CRMD_JOINSTATE_PENDING,
+                                CRMD_JOINSTATE_DOWN, NULL)) {
         crm_info("%s is not ready to run resources", pe__node_name(this_node));
         this_node->details->standby = TRUE;
         this_node->details->pending = TRUE;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1378,7 +1378,7 @@ determine_online_status_no_fencing(pe_working_set_t *data_set,
     const char *join = crm_element_value(node_state, PCMK__XA_JOIN);
     const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
     const char *in_cluster = crm_element_value(node_state, PCMK__XA_IN_CCM);
-    const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
+    const char *exp_state = crm_element_value(node_state, PCMK__XA_EXPECTED);
     int member = false;
     bool crmd_online = false;
     long long when_member = 0;
@@ -1438,7 +1438,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     const char *join = crm_element_value(node_state, PCMK__XA_JOIN);
     const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
     const char *in_cluster = crm_element_value(node_state, PCMK__XA_IN_CCM);
-    const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
+    const char *exp_state = crm_element_value(node_state, PCMK__XA_EXPECTED);
     const char *terminate = pe_node_attribute_raw(this_node, "terminate");
     int member = false;
     long long when_member = 0;
@@ -1446,7 +1446,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
 
 /*
   - PCMK__XA_JOIN          ::= member|down|pending|banned
-  - XML_NODE_EXPECTED      ::= member|down
+  - PCMK__XA_EXPECTED      ::= member|down
 
   @COMPAT with entries recorded for DCs < 2.1.7
   - PCMK__XA_IN_CCM        ::= true|false
@@ -1652,7 +1652,7 @@ determine_online_status(const xmlNode *node_state, pe_node_t *this_node,
                         pe_working_set_t *data_set)
 {
     gboolean online = FALSE;
-    const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
+    const char *exp_state = crm_element_value(node_state, PCMK__XA_EXPECTED);
 
     CRM_CHECK(this_node != NULL, return);
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1376,7 +1376,7 @@ determine_online_status_no_fencing(pe_working_set_t *data_set,
 {
     gboolean online = FALSE;
     const char *join = crm_element_value(node_state, XML_NODE_JOIN_STATE);
-    const char *is_peer = crm_element_value(node_state, XML_NODE_IS_PEER);
+    const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
     const char *in_cluster = crm_element_value(node_state, XML_NODE_IN_CLUSTER);
     const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
     int member = false;
@@ -1436,7 +1436,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
     gboolean do_terminate = FALSE;
     bool crmd_online = FALSE;
     const char *join = crm_element_value(node_state, XML_NODE_JOIN_STATE);
-    const char *is_peer = crm_element_value(node_state, XML_NODE_IS_PEER);
+    const char *is_peer = crm_element_value(node_state, PCMK__XA_CRMD);
     const char *in_cluster = crm_element_value(node_state, XML_NODE_IN_CLUSTER);
     const char *exp_state = crm_element_value(node_state, XML_NODE_EXPECTED);
     const char *terminate = pe_node_attribute_raw(this_node, "terminate");
@@ -1450,14 +1450,14 @@ determine_online_status_fencing(pe_working_set_t *data_set,
 
   @COMPAT with entries recorded for DCs < 2.1.7
   - XML_NODE_IN_CLUSTER    ::= true|false
-  - XML_NODE_IS_PEER       ::= online|offline
+  - PCMK__XA_CRMD          ::= online|offline
 
   Since crm_feature_set 3.18.0 (pacemaker-2.1.7):
   - XML_NODE_IN_CLUSTER    ::= <timestamp>|0
   Since when node has been a cluster member. A value 0 of means the node is not
   a cluster member.
 
-  - XML_NODE_IS_PEER       ::= <timestamp>|0
+  - PCMK__XA_CRMD          ::= <timestamp>|0
   Since when peer has been online in CPG. A value 0 means the peer is offline
   in CPG.
 */
@@ -1489,7 +1489,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
 
     online = member;
 
-    /* @COMPAT with "online"/"offline" values of XML_NODE_IS_PEER recorded for
+    /* @COMPAT with "online"/"offline" values of PCMK__XA_CRMD recorded for
      * DCs < 2.1.7
      */
     if (pcmk__str_eq(is_peer, ONLINESTATUS, pcmk__str_casei)) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1383,8 +1383,8 @@ unpack_status(xmlNode * status, pe_working_set_t * data_set)
  * \param[in,out] data_set    Cluster working set
  *
  * \return Epoch time when node became a cluster member
- *         (or 1 for legacy entries) if a member, 0 if not a member,
- *         or -1 if no valid information available
+ *         (or working set effective time for legacy entries) if a member,
+ *         0 if not a member, or -1 if no valid information available
  */
 static long long
 unpack_node_member(const xmlNode *node_state, pe_working_set_t *data_set)


### PR DESCRIPTION
Allow node-pending-timeout to be set to 0 to disable the timeout, raise the default to 2 hours, and avoid fencing nodes due to node-pending-timeout when they are leaving the cluster rather than joining.