### PR TITLE
Minor cleanup of some action code

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -642,9 +642,7 @@ void pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
                                 gboolean overwrite, pe_working_set_t *data_set);
 
 bool pe__resource_is_disabled(const pe_resource_t *rsc);
-pe_action_t *pe__clear_resource_history(pe_resource_t *rsc,
-                                        const pe_node_t *node,
-                                        pe_working_set_t *data_set);
+void pe__clear_resource_history(pe_resource_t *rsc, const pe_node_t *node);
 
 GList *pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name);
 GList *pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -407,11 +407,6 @@ pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
 		rsc, delete_key(rsc), PCMK_ACTION_DELETE, node, \
 		optional, TRUE, rsc->cluster);
 
-#  define stopped_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_STOPPED, 0)
-#  define stopped_action(rsc, node, optional) custom_action(		\
-		rsc, stopped_key(rsc), PCMK_ACTION_STOPPED, node,	\
-		optional, TRUE, rsc->cluster);
-
 #  define stop_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_STOP, 0)
 #  define stop_action(rsc, node, optional) custom_action(			\
 		rsc, stop_key(rsc), PCMK_ACTION_STOP, node,		\
@@ -423,29 +418,14 @@ pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
 		rsc, start_key(rsc), PCMK_ACTION_START, node,           \
 		optional, TRUE, rsc->cluster)
 
-#  define started_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_RUNNING, 0)
-#  define started_action(rsc, node, optional) custom_action(		\
-		rsc, started_key(rsc), PCMK_ACTION_RUNNING, node,	\
-		optional, TRUE, rsc->cluster)
-
 #  define promote_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_PROMOTE, 0)
 #  define promote_action(rsc, node, optional) custom_action(		\
 		rsc, promote_key(rsc), PCMK_ACTION_PROMOTE, node,	\
 		optional, TRUE, rsc->cluster)
 
-#  define promoted_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_PROMOTED, 0)
-#  define promoted_action(rsc, node, optional) custom_action(		\
-		rsc, promoted_key(rsc), PCMK_ACTION_PROMOTED, node,	\
-		optional, TRUE, rsc->cluster)
-
 #  define demote_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DEMOTE, 0)
 #  define demote_action(rsc, node, optional) custom_action(		\
 		rsc, demote_key(rsc), PCMK_ACTION_DEMOTE, node, \
-		optional, TRUE, rsc->cluster)
-
-#  define demoted_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DEMOTED, 0)
-#  define demoted_action(rsc, node, optional) custom_action(		\
-		rsc, demoted_key(rsc), PCMK_ACTION_DEMOTED, node,	\
 		optional, TRUE, rsc->cluster)
 
 extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1610,7 +1610,7 @@ pcmk__primitive_shutdown_lock(pe_resource_t *rsc)
             pe_rsc_info(rsc,
                         "Cancelling shutdown lock because %s is already active",
                         rsc->id);
-            pe__clear_resource_history(rsc, rsc->lock_node, rsc->cluster);
+            pe__clear_resource_history(rsc, rsc->lock_node);
             rsc->lock_node = NULL;
             rsc->lock_time = 0;
         }

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1564,20 +1564,14 @@ void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrit
  *
  * \param[in,out] rsc       Resource to clear
  * \param[in]     node      Node to clear history on
- * \param[in,out] data_set  Cluster working set
- *
- * \return New action to clear resource history
  */
-pe_action_t *
-pe__clear_resource_history(pe_resource_t *rsc, const pe_node_t *node,
-                           pe_working_set_t *data_set)
+void
+pe__clear_resource_history(pe_resource_t *rsc, const pe_node_t *node)
 {
-    char *key = NULL;
+    CRM_ASSERT((rsc != NULL) && (node != NULL));
 
-    CRM_ASSERT(rsc && node);
-    key = pcmk__op_key(rsc->id, PCMK_ACTION_LRM_DELETE, 0);
-    return custom_action(rsc, key, PCMK_ACTION_LRM_DELETE, node, FALSE, TRUE,
-                         data_set);
+    custom_action(rsc, pcmk__op_key(rsc->id, PCMK_ACTION_LRM_DELETE, 0),
+                  PCMK_ACTION_LRM_DELETE, node, FALSE, TRUE, rsc->cluster);
 }
 
 #define sort_return(an_int, why) do {					\

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1024,7 +1024,8 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
  * \param[in]     save_action  Whether action should be recorded in transition graph
  * \param[in,out] data_set     Cluster working set
  *
- * \return Action object corresponding to arguments
+ * \return Action object corresponding to arguments (guaranteed not to be
+ *         \c NULL)
  * \note This function takes ownership of (and might free) \p key. If
  *       \p save_action is true, \p data_set will own the returned action,
  *       otherwise it is the caller's responsibility to free the return value

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2495,7 +2495,7 @@ unpack_shutdown_lock(const xmlNode *rsc_entry, pe_resource_t *rsc,
                 > (lock_time + data_set->shutdown_lock))) {
             pe_rsc_info(rsc, "Shutdown lock for %s on %s expired",
                         rsc->id, pe__node_name(node));
-            pe__clear_resource_history(rsc, node, data_set);
+            pe__clear_resource_history(rsc, node);
         } else {
             /* @COMPAT I don't like breaking const signatures, but
              * rsc->lock_node should really be const -- we just can't change it


### PR DESCRIPTION
`pcmk__create_migration_actions()` could benefit from further reorganization IMO. However, the changes I wanted to make involved creating the `migrate_from` action before the `migrate_to` action. That changed test outputs (the action numbers and the order in which actions appeared in the summary).

The function is clear enough as-is, so it's not worth sorting through all that to figure out whether the changes are meaningful.