### PR TITLE
Build: python: Fix python tests when there's a separate build directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,6 +129,9 @@ PACKAGE         ?= pacemaker
 .PHONY: clean-local
 clean-local:
 	-rm -f $(builddir)/$(PACKAGE)-*.tar.gz
+	-if [ "x$(top_srcdir)" != "x$(top_builddir)" ]; then \
+		rm -rf $(top_builddir)/python; \
+	fi
 
 .PHONY: distclean-local
 distclean-local:

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -16,7 +16,10 @@ SUBDIRS	= pacemaker \
 
 .PHONY: check-local
 check-local:
-	PYTHONPATH=$(top_srcdir)/python:$(top_builddir)/python $(PYTHON) -m unittest discover -v -s $(top_srcdir)/python/tests $(top_builddir)/python/tests
+	if [ "x$(top_srcdir)" != "x$(top_builddir)" ]; then \
+		cp -r $(top_srcdir)/python/* $(abs_top_builddir)/python/; \
+	fi
+	PYTHONPATH=$(top_builddir)/python $(PYTHON) -m unittest discover -v -s $(top_builddir)/python/tests
 
 .PHONY: pylint
 pylint:


### PR DESCRIPTION
See the substantial comments in the Makefile.am for the reason.

With this done, we can get rid of the additional path added to PYTHONPATH as well as get rid of trying to run tests out of separate directories.  Passing both on the command line was always a bug anyway, and that bug was disguising the underlying problem, resulting in no python tests actually being run.