### PR TITLE
Refactor: based: Use new XML logger functions

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -471,9 +471,7 @@ process_ping_reply(xmlNode *reply)
             if(remote_cib && remote_cib->children) {
                 // Additional debug
                 xml_calculate_changes(the_cib, remote_cib);
-
-                pcmk__output_set_log_level(logger_out, LOG_INFO);
-                pcmk__xml_show_changes(logger_out, remote_cib);
+                pcmk__log_xml_changes(LOG_INFO, remote_cib);
                 crm_trace("End of differences");
             }
 
@@ -1473,8 +1471,7 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
                         *cib_diff);
     }
 
-    pcmk__output_set_log_level(logger_out, LOG_TRACE);
-    logger_out->message(logger_out, "xml-patchset", *cib_diff);
+    pcmk__log_xml_patchset(LOG_TRACE, *cib_diff);
 
   done:
     if (!pcmk_is_set(call_options, cib_discard_reply) || cib_legacy_mode()) {
@@ -1661,12 +1658,6 @@ terminate_cib(const char *caller, int fast)
     }
 
     uninitializeCib();
-
-    if (logger_out != NULL) {
-        logger_out->finish(logger_out, CRM_EX_OK, true, NULL);
-        pcmk__output_free(logger_out);
-        logger_out = NULL;
-    }
 
     if (fast > 0) {
         /* Quit fast on error */

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -334,8 +334,7 @@ cib_server_process_diff(const char *op, int options, const char *section, xmlNod
         crm_warn("Requesting full CIB refresh because update failed: %s"
                  CRM_XS " rc=%d", pcmk_strerror(rc), rc);
 
-        pcmk__output_set_log_level(logger_out, LOG_INFO);
-        logger_out->message(logger_out, "xml-patchset", input);
+        pcmk__log_xml_patchset(LOG_INFO, input);
         free_xml(*result_cib);
         *result_cib = NULL;
         send_sync_request(NULL);

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -51,8 +51,6 @@ int remote_tls_fd = 0;
 GHashTable *config_hash = NULL;
 GHashTable *local_notify_queue = NULL;
 
-pcmk__output_t *logger_out = NULL;
-
 static void cib_init(void);
 void cib_shutdown(int nsig);
 static bool startCib(const char *filename);
@@ -198,15 +196,6 @@ main(int argc, char **argv)
         out->version(out, false);
         goto done;
     }
-
-    rc = pcmk__log_output_new(&logger_out);
-    if (rc != pcmk_rc_ok) {
-        exit_code = CRM_EX_ERROR;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                    "Error creating output format log: %s", pcmk_rc_str(rc));
-        goto done;
-    }
-    pcmk__output_set_log_level(logger_out, LOG_TRACE);
 
     mainloop_add_signal(SIGTERM, cib_shutdown);
     mainloop_add_signal(SIGPIPE, cib_enable_writes);

--- a/daemons/based/pacemaker-based.h
+++ b/daemons/based/pacemaker-based.h
@@ -63,7 +63,6 @@ extern gboolean stand_alone;
 extern gboolean cib_shutdown_flag;
 extern gchar *cib_root;
 extern int cib_status;
-extern pcmk__output_t *logger_out;
 
 extern struct qb_ipcs_service_handlers ipc_ro_callbacks;
 extern struct qb_ipcs_service_handlers ipc_rw_callbacks;


### PR DESCRIPTION
Drop unused `logger_out`

I missed this in #3222