### PR TITLE
Low: libcrmcommon: Ignore text nodes when creating XML patchset

### DIFF
--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -41,6 +41,14 @@ add_xml_changes_to_patchset(xmlNode *xml, xmlNode *patchset)
     xml_node_private_t *nodepriv = xml->_private;
     const char *value = NULL;
 
+    if (nodepriv == NULL) {
+        /* Elements that shouldn't occur in a CIB don't have _private set. They
+         * should be stripped out, ignored, or have an error thrown by any code
+         * that processes their parent, so we ignore any changes to them.
+         */
+        return;
+    }
+
     // If this XML node is new, just report that
     if (patchset && pcmk_is_set(nodepriv->flags, pcmk__xf_created)) {
         GString *xpath = pcmk__element_xpath(xml->parent);

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -854,25 +854,6 @@ cib_upgrade_err(void *ctx, const char *fmt, ...)
     va_end(ap);
 }
 
-
-/* Denotes temporary emergency fix for "xmldiff'ing not text-node-ready";
-   proper fix is most likely to teach __xml_diff_object and friends to
-   deal with XML_TEXT_NODE (and more?), i.e., those nodes currently
-   missing "_private" field (implicitly as NULL) which clashes with
-   unchecked accesses (e.g. in __xml_offset) -- the outcome may be that
-   those unexpected XML nodes will simply be ignored for the purpose of
-   diff'ing, or it may be made more robust, or per the user's preference
-   (which then may be exposed as crm_diff switch).
-
-   Said XML_TEXT_NODE may appear unexpectedly due to how upgrade-2.10.xsl
-   is arranged.
-
-   The emergency fix is simple: reparse XSLT output with blank-ignoring
-   parser. */
-#ifndef PCMK_SCHEMAS_EMERGENCY_XSLT
-#define PCMK_SCHEMAS_EMERGENCY_XSLT 1
-#endif
-
 static xmlNode *
 apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
 {
@@ -880,11 +861,6 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
     xmlNode *out = NULL;
     xmlDocPtr res = NULL;
     xsltStylesheet *xslt = NULL;
-#if PCMK_SCHEMAS_EMERGENCY_XSLT != 0
-    xmlChar *emergency_result;
-    int emergency_txt_len;
-    int emergency_res;
-#endif
 
     xform = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_legacy_xslt,
                                     transform);
@@ -907,17 +883,7 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
 
     xsltSetGenericErrorFunc(NULL, NULL);  /* restore default one */
 
-
-#if PCMK_SCHEMAS_EMERGENCY_XSLT != 0
-    emergency_res = xsltSaveResultToString(&emergency_result,
-                                           &emergency_txt_len, res, xslt);
-    xmlFreeDoc(res);
-    CRM_CHECK(emergency_res == 0, goto cleanup);
-    out = string2xml((const char *) emergency_result);
-    free(emergency_result);
-#else
     out = xmlDocGetRootElement(res);
-#endif
 
   cleanup:
     if (xslt) {


### PR DESCRIPTION
Node types other than document, element, attribute, and comment shouldn't occur in a CIB, and they don't get a `_private` member created by `xml.c:new_private_data()`. Pacemaker strips out text nodes from a CIB and should ignore or throw errors on other unexpected node types.

This allows us to remove some hack code from `schemas.c:apply_transformation()`. It's unclear why that "emergency" code was needed in the first place; no reproducer notes were given.

Even immediately before it was added, regression tests ran fine (including `xml/regression.sh`). We've been unable to reproduce a crash with current code with either the `cts-cli` upgrade test (which includes a transformation using `upgrade-2.10.xsl`) or the `xml/regression.sh` test. As far as we can tell, Pacemaker always strips out text nodes (if they might exist) before an XML node reaches `pcmk__xml_create_patchset()`.

Closes T151