### PR TITLE
New cib_api_operations_t:set_user() method

### DIFF
--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -425,11 +425,12 @@ controld_delete_resource_history(const char *rsc_id, const char *node,
     char *desc = NULL;
     char *xpath = NULL;
     int rc = pcmk_rc_ok;
+    cib_t *cib = controld_globals.cib_conn;
 
     CRM_CHECK((rsc_id != NULL) && (node != NULL), return EINVAL);
 
     desc = crm_strdup_printf("resource history for %s on %s", rsc_id, node);
-    if (controld_globals.cib_conn == NULL) {
+    if (cib == NULL) {
         crm_err("Unable to clear %s: no CIB connection", desc);
         free(desc);
         return ENOTCONN;
@@ -437,9 +438,10 @@ controld_delete_resource_history(const char *rsc_id, const char *node,
 
     // Ask CIB to delete the entry
     xpath = crm_strdup_printf(XPATH_RESOURCE_HISTORY, node, rsc_id);
-    rc = cib_internal_op(controld_globals.cib_conn, PCMK__CIB_REQUEST_DELETE,
-                         NULL, xpath, NULL, NULL, call_options|cib_xpath,
-                         user_name);
+
+    cib->cmds->set_user(cib, user_name);
+    rc = cib->cmds->remove(cib, xpath, NULL, call_options|cib_xpath);
+    cib->cmds->set_user(cib, NULL);
 
     if (rc < 0) {
         rc = pcmk_legacy2rc(rc);
@@ -832,14 +834,13 @@ int
 controld_update_cib(const char *section, xmlNode *data, int options,
                     void (*callback)(xmlNode *, int, int, xmlNode *, void *))
 {
+    cib_t *cib = controld_globals.cib_conn;
     int cib_rc = -ENOTCONN;
 
     CRM_ASSERT(data != NULL);
 
-    if (controld_globals.cib_conn != NULL) {
-        cib_rc = cib_internal_op(controld_globals.cib_conn,
-                                 PCMK__CIB_REQUEST_MODIFY, NULL, section,
-                                 data, NULL, options, NULL);
+    if (cib != NULL) {
+        cib_rc = cib->cmds->modify(cib, section, data, options);
         if (cib_rc >= 0) {
             crm_debug("Submitted CIB update %d for %s section",
                       cib_rc, section);

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -328,6 +328,8 @@ struct cib_s {
     cib_api_operations_t *cmds;
 
     xmlNode *transaction;
+
+    char *user;
 };
 
 #ifdef __cplusplus

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -307,6 +307,18 @@ typedef struct cib_api_operations_s {
      * \return Legacy Pacemaker return code
      */
     int (*end_transaction)(cib_t *cib, bool commit, int call_options);
+
+    /*!
+     * \brief Set the user as whom all CIB requests via methods will be executed
+     *
+     * By default, the value of the \c CIB_user environment variable is used if
+     * set. Otherwise, \c root is used.
+     *
+     * \param[in,out] cib   CIB connection
+     * \param[in]     user  Name of user whose permissions to use when
+     *                      processing requests
+     */
+    void (*set_user)(cib_t *cib, const char *user);
 } cib_api_operations_t;
 
 struct cib_s {

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -253,14 +253,15 @@ cib_client_noop(cib_t * cib, int call_options)
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_NOOP, NULL, NULL, NULL, NULL,
-                           call_options, NULL);
+                           call_options, cib->user);
 }
 
 static int
 cib_client_ping(cib_t * cib, xmlNode ** output_data, int call_options)
 {
     op_common(cib);
-    return cib_internal_op(cib, CRM_OP_PING, NULL, NULL, NULL, output_data, call_options, NULL);
+    return cib_internal_op(cib, CRM_OP_PING, NULL, NULL, NULL, output_data,
+                           call_options, cib->user);
 }
 
 static int
@@ -275,7 +276,7 @@ cib_client_query_from(cib_t * cib, const char *host, const char *section,
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_QUERY, host, section, NULL,
-                           output_data, call_options, NULL);
+                           output_data, call_options, cib->user);
 }
 
 static int
@@ -283,7 +284,7 @@ is_primary(cib_t *cib)
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_IS_PRIMARY, NULL, NULL, NULL,
-                           NULL, cib_scope_local|cib_sync_call, NULL);
+                           NULL, cib_scope_local|cib_sync_call, cib->user);
 }
 
 static int
@@ -291,7 +292,7 @@ set_secondary(cib_t *cib, int call_options)
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_SECONDARY, NULL, NULL, NULL,
-                           NULL, call_options, NULL);
+                           NULL, call_options, cib->user);
 }
 
 static int
@@ -306,7 +307,7 @@ set_primary(cib_t *cib, int call_options)
     op_common(cib);
     crm_trace("Adding cib_scope_local to options");
     return cib_internal_op(cib, PCMK__CIB_REQUEST_PRIMARY, NULL, NULL, NULL,
-                           NULL, call_options|cib_scope_local, NULL);
+                           NULL, call_options|cib_scope_local, cib->user);
 }
 
 static int
@@ -314,7 +315,7 @@ cib_client_bump_epoch(cib_t * cib, int call_options)
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_BUMP, NULL, NULL, NULL, NULL,
-                           call_options, NULL);
+                           call_options, cib->user);
 }
 
 static int
@@ -322,7 +323,7 @@ cib_client_upgrade(cib_t * cib, int call_options)
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_UPGRADE, NULL, NULL, NULL,
-                           NULL, call_options, NULL);
+                           NULL, call_options, cib->user);
 }
 
 static int
@@ -336,7 +337,7 @@ cib_client_sync_from(cib_t * cib, const char *host, const char *section, int cal
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_SYNC_TO_ALL, host, section,
-                           NULL, NULL, call_options, NULL);
+                           NULL, NULL, call_options, cib->user);
 }
 
 static int
@@ -344,7 +345,7 @@ cib_client_create(cib_t * cib, const char *section, xmlNode * data, int call_opt
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_CREATE, NULL, section, data,
-                           NULL, call_options, NULL);
+                           NULL, call_options, cib->user);
 }
 
 static int
@@ -352,7 +353,7 @@ cib_client_modify(cib_t * cib, const char *section, xmlNode * data, int call_opt
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_MODIFY, NULL, section, data,
-                           NULL, call_options, NULL);
+                           NULL, call_options, cib->user);
 }
 
 static int
@@ -360,7 +361,7 @@ cib_client_replace(cib_t * cib, const char *section, xmlNode * data, int call_op
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_REPLACE, NULL, section, data,
-                           NULL, call_options, NULL);
+                           NULL, call_options, cib->user);
 }
 
 static int
@@ -368,7 +369,7 @@ cib_client_delete(cib_t * cib, const char *section, xmlNode * data, int call_opt
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_DELETE, NULL, section, data,
-                           NULL, call_options, NULL);
+                           NULL, call_options, cib->user);
 }
 
 static int
@@ -376,7 +377,7 @@ cib_client_delete_absolute(cib_t * cib, const char *section, xmlNode * data, int
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_ABS_DELETE, NULL, section,
-                           data, NULL, call_options, NULL);
+                           data, NULL, call_options, cib->user);
 }
 
 static int
@@ -384,7 +385,7 @@ cib_client_erase(cib_t * cib, xmlNode ** output_data, int call_options)
 {
     op_common(cib);
     return cib_internal_op(cib, PCMK__CIB_REQUEST_ERASE, NULL, NULL, NULL,
-                           output_data, call_options, NULL);
+                           output_data, call_options, cib->user);
 }
 
 static int
@@ -435,7 +436,7 @@ cib_client_end_transaction(cib_t *cib, bool commit, int call_options)
             return pcmk_rc2legacy(rc);
         }
         rc = cib_internal_op(cib, PCMK__CIB_REQUEST_COMMIT_TRANSACT, NULL, NULL,
-                             cib->transaction, NULL, call_options, NULL);
+                             cib->transaction, NULL, call_options, cib->user);
 
     } else {
         // Discard always succeeds
@@ -448,6 +449,12 @@ cib_client_end_transaction(cib_t *cib, bool commit, int call_options)
     free_xml(cib->transaction);
     cib->transaction = NULL;
     return rc;
+}
+
+static void
+cib_client_set_user(cib_t *cib, const char *user)
+{
+    pcmk__str_update(&(cib->user), user);
 }
 
 static void
@@ -726,6 +733,8 @@ cib_new_variant(void)
 
     new_cib->cmds->init_transaction = cib_client_init_transaction;
     new_cib->cmds->end_transaction = cib_client_end_transaction;
+
+    new_cib->cmds->set_user = cib_client_set_user;
 
     return new_cib;
 }

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -585,6 +585,7 @@ cib_file_free(cib_t *cib)
         free(private->filename);
         free(private);
         free(cib->cmds);
+        free(cib->user);
         free(cib);
 
     } else {

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -388,6 +388,7 @@ cib_native_free(cib_t *cib)
         free(native->token);
         free(cib->variant_opaque);
         free(cib->cmds);
+        free(cib->user);
         free(cib);
     }
 

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -518,6 +518,7 @@ cib_remote_free(cib_t *cib)
             free(private->user);
             free(private->passwd);
             free(cib->cmds);
+            free(cib->user);
             free(private);
             free(cib);
         }


### PR DESCRIPTION
We avoid dropping `cib_internal_op()` from `attrd` until after #3229 is merged. We cannot drop it from `cibadmin.c` (the only other non-library caller) because we need the granularity for other reasons than setting the user.