### PR TITLE
Fix: controller: don't fence leaving nodes for node-pending-timeout

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -345,6 +345,17 @@ peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *d
             }
         }
 
+        if (!appeared && (type == crm_status_processes)
+            && (node->when_member > 1)) {
+            /* The node left CPG but is still a cluster member. Set its
+             * membership time to 1 to record it in the cluster state as a
+             * boolean, so we don't fence it due to node-pending-timeout.
+             */
+            node->when_member = 1;
+            flags |= node_update_cluster;
+            controld_node_pending_timer(node);
+        }
+
         /* Update the CIB node state */
         update = create_node_state_update(node, flags, NULL, __func__);
         if (update == NULL) {

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -263,11 +263,12 @@ controld_node_pending_timer(const crm_node_t *node)
 {
     long long remaining_timeout = 0;
 
-    /* If the node is not an active cluster node, or is already part of CPG, or
-     * node-pending-timeout is disabled, free any node pending timer for it.
+    /* If the node is not an active cluster node, is leaving the cluster, or is
+     * already part of CPG, or node-pending-timeout is disabled, free any
+     * node pending timer for it.
      */
     if (pcmk_is_set(node->flags, crm_remote_node)
-        || (node->when_member <= 0) || (node->when_online > 0)
+        || (node->when_member <= 1) || (node->when_online > 0)
         || (controld_globals.node_pending_timeout == 0)) {
         remove_node_pending_timer(node->uuid);
         return;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1395,11 +1395,15 @@ unpack_node_member(const xmlNode *node_state, pe_working_set_t *data_set)
     if (member_time == NULL) {
         return -1LL;
 
-    // @COMPAT Entries recorded for DCs < 2.1.7 are boolean
     } else if (crm_str_to_boolean(member_time, &member) == 1) {
-        /* What's important when member is true is that effective time minus
-         * this value is less than the pending node timeout (we can't time out
-         * pending nodes that use boolean values)
+        /* If in_ccm=0, we'll return 0 here. If in_ccm=1, either the entry was
+         * recorded as a boolean for a DC < 2.1.7, or the node is pending
+         * shutdown and has left the CPG, in which case it was set to 1 to avoid
+         * fencing for node-pending-timeout.
+         *
+         * We return the effective time for in_ccm=1 because what's important to
+         * avoid fencing is that effective time minus this value is less than
+         * the pending node timeout.
          */
         return member? (long long) get_effective_time(data_set) : 0LL;
 


### PR DESCRIPTION
The node-pending-timeout is intended to apply only when the node is joining the cluster, not when it is leaving. Avoid enforcing it for leaving nodes by setting their in_ccm to 1 (rather than a timestamp) when they leave CPG. This will cause the scheduler to ignore node-pending-timeout (since it appears the same as a legacy node_state entry).

This does mean that if someone stops Pacemaker (but not the cluster layer) on a node, then starts it again (without restarting the cluster layer), that node-pending-timeout will not apply in that case, either. But since that would likely be a system administrator doing manual troubleshooting, that's acceptable.

Fixes T695