### PR TITLE
Move core scheduler typedefs to libcrmcommon

### DIFF
--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -443,7 +443,7 @@ static int
 generate_params(void)
 {
     int rc = pcmk_rc_ok;
-    pe_working_set_t *data_set = NULL;
+    pcmk_scheduler_t *data_set = NULL;
     xmlNode *cib_xml_copy = NULL;
     pcmk_resource_t *rsc = NULL;
     GHashTable *params = NULL;

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -445,7 +445,7 @@ generate_params(void)
     int rc = pcmk_rc_ok;
     pe_working_set_t *data_set = NULL;
     xmlNode *cib_xml_copy = NULL;
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     GHashTable *params = NULL;
     GHashTable *meta = NULL;
     GHashTableIter iter;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -56,7 +56,7 @@ static gboolean stonith_shutdown_flag = FALSE;
 
 static qb_ipcs_service_t *ipcs = NULL;
 static xmlNode *local_cib = NULL;
-static pe_working_set_t *fenced_data_set = NULL;
+static pcmk_scheduler_t *fenced_data_set = NULL;
 static const unsigned long long data_set_flags = pcmk_sched_location_only
                                                  |pcmk_sched_no_compat
                                                  |pcmk_sched_no_counts;
@@ -692,7 +692,7 @@ update_stonith_watchdog_timeout_ms(xmlNode *cib)
  * \param[in,out] data_set  Cluster working set with device information
  */
 static void
-cib_device_update(pcmk_resource_t *rsc, pe_working_set_t *data_set)
+cib_device_update(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     pcmk_node_t *node = NULL;
     const char *value = NULL;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -604,11 +604,11 @@ fencing_topology_init(void)
  *
  * \return Pointer to node object if found, NULL otherwise
  */
-static pe_node_t *
+static pcmk_node_t *
 our_node_allowed_for(const pe_resource_t *rsc)
 {
     GHashTableIter iter;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
 
     if (rsc && stonith_our_uname) {
         g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -694,10 +694,10 @@ update_stonith_watchdog_timeout_ms(xmlNode *cib)
 static void
 cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
 {
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
     const char *value = NULL;
     const char *rclass = NULL;
-    pe_node_t *parent = NULL;
+    pcmk_node_t *parent = NULL;
 
     /* If this is a complex resource, check children rather than this resource itself. */
     if(rsc->children) {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -605,7 +605,7 @@ fencing_topology_init(void)
  * \return Pointer to node object if found, NULL otherwise
  */
 static pcmk_node_t *
-our_node_allowed_for(const pe_resource_t *rsc)
+our_node_allowed_for(const pcmk_resource_t *rsc)
 {
     GHashTableIter iter;
     pcmk_node_t *node = NULL;
@@ -692,7 +692,7 @@ update_stonith_watchdog_timeout_ms(xmlNode *cib)
  * \param[in,out] data_set  Cluster working set with device information
  */
 static void
-cib_device_update(pe_resource_t *rsc, pe_working_set_t *data_set)
+cib_device_update(pcmk_resource_t *rsc, pe_working_set_t *data_set)
 {
     pcmk_node_t *node = NULL;
     const char *value = NULL;

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -22,10 +22,10 @@
 
 static GHashTable *schedulerd_handlers = NULL;
 
-static pe_working_set_t *
+static pcmk_scheduler_t *
 init_working_set(void)
 {
-    pe_working_set_t *data_set = pe_new_working_set();
+    pcmk_scheduler_t *data_set = pe_new_working_set();
 
     CRM_ASSERT(data_set != NULL);
 
@@ -72,7 +72,7 @@ handle_pecalc_request(pcmk__request_t *request)
     xmlNode *reply = NULL;
     bool is_repoke = false;
     bool process = true;
-    pe_working_set_t *data_set = init_working_set();
+    pcmk_scheduler_t *data_set = init_working_set();
 
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
                        "ack", NULL, CRM_EX_INDETERMINATE);

--- a/doc/sphinx/Pacemaker_Development/c.rst
+++ b/doc/sphinx/Pacemaker_Development/c.rst
@@ -225,7 +225,7 @@ a ``GHashTable *`` member, the argument should be marked as ``[in,out]`` if the
 function inserts data into the table, even if the struct members themselves are
 not changed. However, an argument is not ``[in,out]`` if something reachable
 via the argument is modified via a separate argument. For example, both
-``pe_resource_t`` and ``pe_node_t`` contain pointers to their
+``pe_resource_t`` and ``pcmk_node_t`` contain pointers to their
 ``pe_working_set_t`` and thus indirectly to each other, but if the function
 modifies the resource via the resource argument, the node argument does not
 have to be ``[in,out]``.

--- a/doc/sphinx/Pacemaker_Development/c.rst
+++ b/doc/sphinx/Pacemaker_Development/c.rst
@@ -225,7 +225,7 @@ a ``GHashTable *`` member, the argument should be marked as ``[in,out]`` if the
 function inserts data into the table, even if the struct members themselves are
 not changed. However, an argument is not ``[in,out]`` if something reachable
 via the argument is modified via a separate argument. For example, both
-``pe_resource_t`` and ``pcmk_node_t`` contain pointers to their
+``pcmk_resource_t`` and ``pcmk_node_t`` contain pointers to their
 ``pe_working_set_t`` and thus indirectly to each other, but if the function
 modifies the resource via the resource argument, the node argument does not
 have to be ``[in,out]``.

--- a/doc/sphinx/Pacemaker_Development/c.rst
+++ b/doc/sphinx/Pacemaker_Development/c.rst
@@ -226,7 +226,7 @@ function inserts data into the table, even if the struct members themselves are
 not changed. However, an argument is not ``[in,out]`` if something reachable
 via the argument is modified via a separate argument. For example, both
 ``pcmk_resource_t`` and ``pcmk_node_t`` contain pointers to their
-``pe_working_set_t`` and thus indirectly to each other, but if the function
+``pcmk_scheduler_t`` and thus indirectly to each other, but if the function
 modifies the resource via the resource argument, the node argument does not
 have to be ``[in,out]``.
 

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -335,7 +335,7 @@ Working with the scheduler is difficult. Challenges include:
 * It produces an insane amount of log messages at debug and trace levels.
   You can put resource ID(s) in the ``PCMK_trace_tags`` environment variable to
   enable trace-level messages only when related to specific resources.
-* Different parts of the main ``pe_working_set_t`` structure are finalized at
+* Different parts of the main ``pcmk_scheduler_t`` structure are finalized at
   different points in the scheduling process, so you have to keep in mind
   whether information you're using at one point of the code can possibly change
   later. For example, data unpacked from the CIB can safely be used anytime
@@ -347,12 +347,12 @@ Working with the scheduler is difficult. Challenges include:
 
 
 .. index::
-   single: pe_working_set_t
+   single: pcmk_scheduler_t
 
 Cluster Working Set
 ___________________
 
-The main data object for the scheduler is ``pe_working_set_t``, which contains
+The main data object for the scheduler is ``pcmk_scheduler_t``, which contains
 all information needed about nodes, resources, constraints, etc., both as the
 raw CIB XML and parsed into more usable data structures, plus the resulting
 transition graph XML. The variable name is usually ``data_set``.
@@ -389,7 +389,7 @@ Assignment of resources to nodes is done by choosing the node with the highest
 score for a given resource. The scheduler does a bunch of processing to
 generate the scores, then the actual assignment is straightforward.
 
-Node lists are frequently used. For example, ``pe_working_set_t`` has a
+Node lists are frequently used. For example, ``pcmk_scheduler_t`` has a
 ``nodes`` member which is a list of all nodes in the cluster, and
 ``pcmk_resource_t`` has a ``running_on`` member which is a list of all nodes on
 which the resource is (or might be) active. These are lists of ``pcmk_node_t``

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -406,13 +406,13 @@ In this way, the other members of ``pcmk_node_t`` (such as ``weight``, which is
 the node score) may vary by node list, while the common details are shared.
 
 .. index::
-   single: pe_action_t
+   single: pcmk_action_t
    single: pe_action_flags
 
 Actions
 _______
 
-``pe_action_t`` is the data object representing actions that might need to be
+``pcmk_action_t`` is the data object representing actions that might need to be
 taken. These could be resource actions, cluster-wide actions such as fencing a
 node, or "pseudo-actions" which are abstractions used as convenient points for
 ordering other actions against.

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -358,13 +358,13 @@ raw CIB XML and parsed into more usable data structures, plus the resulting
 transition graph XML. The variable name is usually ``data_set``.
 
 .. index::
-   single: pe_resource_t
+   single: pcmk_resource_t
 
 Resources
 _________
 
-``pe_resource_t`` is the data object representing cluster resources. A resource
-has a variant: primitive (a.k.a. native), group, clone, or bundle.
+``pcmk_resource_t`` is the data object representing cluster resources. A
+resource has a variant: primitive (a.k.a. native), group, clone, or bundle.
 
 The resource object has members for two sets of methods,
 ``resource_object_functions_t`` from the ``libpe_status`` public API, and
@@ -391,7 +391,7 @@ generate the scores, then the actual assignment is straightforward.
 
 Node lists are frequently used. For example, ``pe_working_set_t`` has a
 ``nodes`` member which is a list of all nodes in the cluster, and
-``pe_resource_t`` has a ``running_on`` member which is a list of all nodes on
+``pcmk_resource_t`` has a ``running_on`` member which is a list of all nodes on
 which the resource is (or might be) active. These are lists of ``pcmk_node_t``
 objects.
 

--- a/doc/sphinx/Pacemaker_Development/components.rst
+++ b/doc/sphinx/Pacemaker_Development/components.rst
@@ -380,7 +380,7 @@ such as processing location and ordering constraints. For example,
 ``internal_constraints()`` method for each top-level resource in the cluster.
 
 .. index::
-   single: pe_node_t
+   single: pcmk_node_t
 
 Nodes
 _____
@@ -392,18 +392,18 @@ generate the scores, then the actual assignment is straightforward.
 Node lists are frequently used. For example, ``pe_working_set_t`` has a
 ``nodes`` member which is a list of all nodes in the cluster, and
 ``pe_resource_t`` has a ``running_on`` member which is a list of all nodes on
-which the resource is (or might be) active. These are lists of ``pe_node_t``
+which the resource is (or might be) active. These are lists of ``pcmk_node_t``
 objects.
 
-The ``pe_node_t`` object contains a ``struct pe_node_shared_s *details`` member
-with all node information that is independent of resource assignment (the node
-name, etc.).
+The ``pcmk_node_t`` object contains a ``struct pe_node_shared_s *details``
+member with all node information that is independent of resource assignment
+(the node name, etc.).
 
 The working set's ``nodes`` member contains the original of this information.
-All other node lists contain copies of ``pe_node_t`` where only the ``details``
-member points to the originals in the working set's ``nodes`` list. In this
-way, the other members of ``pe_node_t`` (such as ``weight``, which is the node
-score) may vary by node list, while the common details are shared.
+All other node lists contain copies of ``pcmk_node_t`` where only the
+``details`` member points to the originals in the working set's ``nodes`` list.
+In this way, the other members of ``pcmk_node_t`` (such as ``weight``, which is
+the node score) may vary by node list, while the common details are shared.
 
 .. index::
    single: pe_action_t

--- a/include/crm/common/Makefile.am
+++ b/include/crm/common/Makefile.am
@@ -33,6 +33,7 @@ header_HEADERS = acl.h 			\
 		 results_compat.h 	\
 		 roles.h		\
 		 scheduler.h		\
+		 scheduler_types.h	\
 		 util.h 		\
 		 util_compat.h 		\
 		 xml.h 			\

--- a/include/crm/common/health_internal.h
+++ b/include/crm/common/health_internal.h
@@ -18,7 +18,7 @@ extern "C" {
  * \internal
  * \brief Possible node health strategies
  *
- * \note It would be nice to use this in pe_working_set_t but that will have to
+ * \note It would be nice to use this in pcmk_scheduler_t but that will have to
  *       wait for an API backward compatibility break.
  */
 enum pcmk__health_strategy {

--- a/include/crm/common/scheduler.h
+++ b/include/crm/common/scheduler.h
@@ -14,6 +14,7 @@
 #include <crm/common/nodes.h>
 #include <crm/common/resources.h>
 #include <crm/common/roles.h>
+#include <crm/common/scheduler_types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/scheduler_types.h
+++ b/include/crm/common/scheduler_types.h
@@ -23,6 +23,9 @@ extern "C" {
 //! Node object (including information that may vary depending on resource)
 typedef struct pe_node_s pcmk_node_t;
 
+//! Resource object
+typedef struct pe_resource_s pcmk_resource_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/scheduler_types.h
+++ b/include/crm/common/scheduler_types.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CRM_COMMON_SCHEDULER_TYPES__H
+#  define PCMK__CRM_COMMON_SCHEDULER_TYPES__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \file
+ * \brief Type aliases needed to define scheduler objects
+ * \ingroup core
+ */
+
+//! Node object (including information that may vary depending on resource)
+typedef struct pe_node_s pcmk_node_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__CRM_COMMON_SCHEDULER_TYPES__H

--- a/include/crm/common/scheduler_types.h
+++ b/include/crm/common/scheduler_types.h
@@ -29,6 +29,9 @@ typedef struct pe_resource_s pcmk_resource_t;
 //! Action object
 typedef struct pe_action_s pcmk_action_t;
 
+//! Scheduler object
+typedef struct pe_working_set_s pcmk_scheduler_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/scheduler_types.h
+++ b/include/crm/common/scheduler_types.h
@@ -26,6 +26,9 @@ typedef struct pe_node_s pcmk_node_t;
 //! Resource object
 typedef struct pe_resource_s pcmk_resource_t;
 
+//! Action object
+typedef struct pe_action_s pcmk_action_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/pengine/complex.h
+++ b/include/crm/pengine/complex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -12,7 +12,7 @@
 
 #include <glib.h>                   // gboolean, GHashTable
 #include <libxml/tree.h>            // xmlNode
-#include <crm/pengine/pe_types.h>   // pe_node_t, pe_resource_t, etc.
+#include <crm/pengine/pe_types.h>   // pcmk_node_t, pe_resource_t, etc.
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,12 +20,12 @@ extern "C" {
 
 extern resource_object_functions_t resource_class_functions[];
 
-GHashTable *pe_rsc_params(pe_resource_t *rsc, const pe_node_t *node,
+GHashTable *pe_rsc_params(pe_resource_t *rsc, const pcmk_node_t *node,
                           pe_working_set_t *data_set);
 void get_meta_attributes(GHashTable * meta_hash, pe_resource_t *rsc,
-                         pe_node_t *node, pe_working_set_t *data_set);
+                         pcmk_node_t *node, pe_working_set_t *data_set);
 void get_rsc_attributes(GHashTable *meta_hash, const pe_resource_t *rsc,
-                        const pe_node_t *node, pe_working_set_t *data_set);
+                        const pcmk_node_t *node, pe_working_set_t *data_set);
 
 gboolean is_parent(pe_resource_t *child, pe_resource_t *rsc);
 pe_resource_t *uber_parent(pe_resource_t *rsc);

--- a/include/crm/pengine/complex.h
+++ b/include/crm/pengine/complex.h
@@ -21,11 +21,11 @@ extern "C" {
 extern resource_object_functions_t resource_class_functions[];
 
 GHashTable *pe_rsc_params(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                          pe_working_set_t *data_set);
+                          pcmk_scheduler_t *data_set);
 void get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t *rsc,
-                         pcmk_node_t *node, pe_working_set_t *data_set);
+                         pcmk_node_t *node, pcmk_scheduler_t *data_set);
 void get_rsc_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
-                        const pcmk_node_t *node, pe_working_set_t *data_set);
+                        const pcmk_node_t *node, pcmk_scheduler_t *data_set);
 
 gboolean is_parent(pcmk_resource_t *child, pcmk_resource_t *rsc);
 pcmk_resource_t *uber_parent(pcmk_resource_t *rsc);

--- a/include/crm/pengine/complex.h
+++ b/include/crm/pengine/complex.h
@@ -12,7 +12,7 @@
 
 #include <glib.h>                   // gboolean, GHashTable
 #include <libxml/tree.h>            // xmlNode
-#include <crm/pengine/pe_types.h>   // pcmk_node_t, pe_resource_t, etc.
+#include <crm/pengine/pe_types.h>   // pcmk_node_t, pcmk_resource_t, etc.
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,15 +20,15 @@ extern "C" {
 
 extern resource_object_functions_t resource_class_functions[];
 
-GHashTable *pe_rsc_params(pe_resource_t *rsc, const pcmk_node_t *node,
+GHashTable *pe_rsc_params(pcmk_resource_t *rsc, const pcmk_node_t *node,
                           pe_working_set_t *data_set);
-void get_meta_attributes(GHashTable * meta_hash, pe_resource_t *rsc,
+void get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t *rsc,
                          pcmk_node_t *node, pe_working_set_t *data_set);
-void get_rsc_attributes(GHashTable *meta_hash, const pe_resource_t *rsc,
+void get_rsc_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
                         const pcmk_node_t *node, pe_working_set_t *data_set);
 
-gboolean is_parent(pe_resource_t *child, pe_resource_t *rsc);
-pe_resource_t *uber_parent(pe_resource_t *rsc);
+gboolean is_parent(pcmk_resource_t *child, pcmk_resource_t *rsc);
+pcmk_resource_t *uber_parent(pcmk_resource_t *rsc);
 
 #ifdef __cplusplus
 }

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -169,12 +169,12 @@ typedef struct pe__order_constraint_s {
 
     void *lh_opaque;
     pcmk_resource_t *lh_rsc;
-    pe_action_t *lh_action;
+    pcmk_action_t *lh_action;
     char *lh_action_task;
 
     void *rh_opaque;
     pcmk_resource_t *rh_rsc;
-    pe_action_t *rh_action;
+    pcmk_action_t *rh_action;
     char *rh_action_task;
 } pe__ordering_t;
 
@@ -188,12 +188,13 @@ int pe__clone_promoted_node_max(const pcmk_resource_t *clone);
 void pe__create_clone_notifications(pcmk_resource_t *clone);
 void pe__free_clone_notification_data(pcmk_resource_t *clone);
 void pe__create_clone_notif_pseudo_ops(pcmk_resource_t *clone,
-                                       pe_action_t *start, pe_action_t *started,
-                                       pe_action_t *stop, pe_action_t *stopped);
+                                       pcmk_action_t *start,
+                                       pcmk_action_t *started,
+                                       pcmk_action_t *stop,
+                                       pcmk_action_t *stopped);
 
-
-pe_action_t *pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task,
-                                       bool optional, bool runnable);
+pcmk_action_t *pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task,
+                                         bool optional, bool runnable);
 
 void pe__create_promotable_pseudo_ops(pcmk_resource_t *clone,
                                       bool any_promoting, bool any_demoting);
@@ -252,9 +253,9 @@ char *pe__node_display_name(pcmk_node_t *node, bool print_detail);
 
 
 // Clone notifications (pe_notif.c)
-void pe__order_notifs_after_fencing(const pe_action_t *action,
+void pe__order_notifs_after_fencing(const pcmk_action_t *action,
                                     pcmk_resource_t *rsc,
-                                    pe_action_t *stonith_op);
+                                    pcmk_action_t *stonith_op);
 
 
 static inline const char *
@@ -305,9 +306,9 @@ int pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
                      time_t *last_failure, uint32_t flags,
                      const xmlNode *xml_op);
 
-pe_action_t *pe__clear_failcount(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                                 const char *reason,
-                                 pe_working_set_t *data_set);
+pcmk_action_t *pe__clear_failcount(pcmk_resource_t *rsc,
+                                   const pcmk_node_t *node, const char *reason,
+                                   pe_working_set_t *data_set);
 
 /* Functions for finding/counting a resource's active nodes */
 
@@ -328,8 +329,8 @@ pe__current_node(const pcmk_resource_t *rsc)
 /* Binary like operators for lists of nodes */
 GHashTable *pe__node_list2table(const GList *list);
 
-extern pe_action_t *get_pseudo_op(const char *name, pe_working_set_t * data_set);
-gboolean order_actions(pe_action_t *lh_action, pe_action_t *rh_action,
+pcmk_action_t *get_pseudo_op(const char *name, pe_working_set_t *data_set);
+gboolean order_actions(pcmk_action_t *lh_action, pcmk_action_t *rh_action,
                        uint32_t flags);
 
 void pe__show_node_scores_as(const char *file, const char *function,
@@ -348,9 +349,9 @@ GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
                                      const char *action_name, guint interval_ms,
                                      const xmlNode *action_config);
 
-pe_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
-                           const pcmk_node_t *on_node, gboolean optional,
-                           gboolean foo, pe_working_set_t *data_set);
+pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
+                             const pcmk_node_t *on_node, gboolean optional,
+                             gboolean foo, pe_working_set_t *data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DELETE, 0)
 #  define delete_action(rsc, node, optional) custom_action(		\
@@ -381,8 +382,8 @@ pe_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
 extern int pe_get_configured_timeout(pcmk_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
-pe_action_t *find_first_action(const GList *input, const char *uuid,
-                               const char *task, const pcmk_node_t *on_node);
+pcmk_action_t *find_first_action(const GList *input, const char *uuid,
+                                 const char *task, const pcmk_node_t *on_node);
 
 enum action_tasks get_complex_task(const pcmk_resource_t *rsc,
                                    const char *name);
@@ -393,7 +394,7 @@ GList *find_actions_exact(GList *input, const char *key,
 GList *pe__resource_actions(const pcmk_resource_t *rsc, const pcmk_node_t *node,
                             const char *task, bool require_node);
 
-extern void pe_free_action(pe_action_t * action);
+extern void pe_free_action(pcmk_action_t *action);
 
 void resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
                        const char *tag, pe_working_set_t *data_set);
@@ -458,16 +459,17 @@ op_digest_cache_t *rsc_action_digest_cmp(pcmk_resource_t *rsc,
                                          pcmk_node_t *node,
                                          pe_working_set_t *data_set);
 
-pe_action_t *pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
-                         const char *reason, bool priority_delay,
-                         pe_working_set_t *data_set);
+pcmk_action_t *pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
+                           const char *reason, bool priority_delay,
+                           pe_working_set_t *data_set);
 void trigger_unfencing(pcmk_resource_t *rsc, pcmk_node_t *node,
-                       const char *reason, pe_action_t *dependency,
+                       const char *reason, pcmk_action_t *dependency,
                        pe_working_set_t *data_set);
 
-char *pe__action2reason(const pe_action_t *action, enum pe_action_flags flag);
-void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrite);
-void pe__add_action_expected_result(pe_action_t *action, int expected_result);
+char *pe__action2reason(const pcmk_action_t *action, enum pe_action_flags flag);
+void pe_action_set_reason(pcmk_action_t *action, const char *reason,
+                          bool overwrite);
+void pe__add_action_expected_result(pcmk_action_t *action, int expected_result);
 
 void pe__set_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags);
 void pe__clear_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -159,7 +159,7 @@ typedef struct pe__location_constraint_s {
     pe_resource_t *rsc_lh;              // Resource being located
     enum rsc_role_e role_filter;        // Role to locate
     enum pe_discover_e discover_mode;   // Resource discovery
-    GList *node_list_rh;              // List of pe_node_t*
+    GList *node_list_rh;                // List of pcmk_node_t*
 } pe__location_t;
 
 typedef struct pe__order_constraint_s {
@@ -197,26 +197,28 @@ pe_action_t *pe__new_rsc_pseudo_action(pe_resource_t *rsc, const char *task,
 void pe__create_promotable_pseudo_ops(pe_resource_t *clone, bool any_promoting,
                                       bool any_demoting);
 
-bool pe_can_fence(const pe_working_set_t *data_set, const pe_node_t *node);
+bool pe_can_fence(const pe_working_set_t *data_set, const pcmk_node_t *node);
 
 void add_hash_param(GHashTable * hash, const char *name, const char *value);
 
-char *native_parameter(pe_resource_t * rsc, pe_node_t * node, gboolean create, const char *name,
-                       pe_working_set_t * data_set);
-pe_node_t *native_location(const pe_resource_t *rsc, GList **list, int current);
+char *native_parameter(pe_resource_t *rsc, pcmk_node_t *node, gboolean create,
+                       const char *name, pe_working_set_t *data_set);
+pcmk_node_t *native_location(const pe_resource_t *rsc, GList **list,
+                             int current);
 
 void pe_metadata(pcmk__output_t *out);
 void verify_pe_options(GHashTable * options);
 
-void native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * data_set, gboolean failed);
+void native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
+                        pe_working_set_t *data_set, gboolean failed);
 
 gboolean native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
 gboolean pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set);
 
-pe_resource_t *native_find_rsc(pe_resource_t *rsc, const char *id, const pe_node_t *node,
-                               int flags);
+pe_resource_t *native_find_rsc(pe_resource_t *rsc, const char *id,
+                               const pcmk_node_t *node, int flags);
 
 gboolean native_active(pe_resource_t * rsc, gboolean all);
 gboolean group_active(pe_resource_t * rsc, gboolean all);
@@ -240,12 +242,12 @@ void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
                       void *print_data);
 
 gchar *pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
-                                  const pe_node_t *node, uint32_t show_opts,
+                                  const pcmk_node_t *node, uint32_t show_opts,
                                   const char *target_role, bool show_nodes);
 
 int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
                          , size_t pairs_count, ...);
-char *pe__node_display_name(pe_node_t *node, bool print_detail);
+char *pe__node_display_name(pcmk_node_t *node, bool print_detail);
 
 
 // Clone notifications (pe_notif.c)
@@ -290,29 +292,29 @@ void pe__count_bundle(pe_resource_t *rsc);
 
 void common_free(pe_resource_t * rsc);
 
-pe_node_t *pe__copy_node(const pe_node_t *this_node);
+pcmk_node_t *pe__copy_node(const pcmk_node_t *this_node);
 extern time_t get_effective_time(pe_working_set_t * data_set);
 
 /* Failure handling utilities (from failcounts.c) */
 
-int pe_get_failcount(const pe_node_t *node, pe_resource_t *rsc,
+int pe_get_failcount(const pcmk_node_t *node, pe_resource_t *rsc,
                      time_t *last_failure, uint32_t flags,
                      const xmlNode *xml_op);
 
-pe_action_t *pe__clear_failcount(pe_resource_t *rsc, const pe_node_t *node,
+pe_action_t *pe__clear_failcount(pe_resource_t *rsc, const pcmk_node_t *node,
                                  const char *reason,
                                  pe_working_set_t *data_set);
 
 /* Functions for finding/counting a resource's active nodes */
 
-bool pe__count_active_node(const pe_resource_t *rsc, pe_node_t *node,
-                           pe_node_t **active, unsigned int *count_all,
+bool pe__count_active_node(const pe_resource_t *rsc, pcmk_node_t *node,
+                           pcmk_node_t **active, unsigned int *count_all,
                            unsigned int *count_clean);
 
-pe_node_t *pe__find_active_requires(const pe_resource_t *rsc,
+pcmk_node_t *pe__find_active_requires(const pe_resource_t *rsc,
                                     unsigned int *count);
 
-static inline pe_node_t *
+static inline pcmk_node_t *
 pe__current_node(const pe_resource_t *rsc)
 {
     return (rsc == NULL)? NULL : rsc->fns->active_node(rsc, NULL, NULL);
@@ -337,12 +339,13 @@ void pe__show_node_scores_as(const char *file, const char *function,
 
 xmlNode *find_rsc_op_entry(const pe_resource_t *rsc, const char *key);
 
-GHashTable *pcmk__unpack_action_meta(pe_resource_t *rsc, const pe_node_t *node,
+GHashTable *pcmk__unpack_action_meta(pe_resource_t *rsc,
+                                     const pcmk_node_t *node,
                                      const char *action_name, guint interval_ms,
                                      const xmlNode *action_config);
 
 pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
-                           const pe_node_t *on_node, gboolean optional,
+                           const pcmk_node_t *on_node, gboolean optional,
                            gboolean foo, pe_working_set_t *data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DELETE, 0)
@@ -375,19 +378,19 @@ extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
 pe_action_t *find_first_action(const GList *input, const char *uuid,
-                               const char *task, const pe_node_t *on_node);
+                               const char *task, const pcmk_node_t *on_node);
 
 enum action_tasks get_complex_task(const pe_resource_t *rsc, const char *name);
 
-extern GList *find_actions(GList *input, const char *key, const pe_node_t *on_node);
+GList *find_actions(GList *input, const char *key, const pcmk_node_t *on_node);
 GList *find_actions_exact(GList *input, const char *key,
-                          const pe_node_t *on_node);
-GList *pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
+                          const pcmk_node_t *on_node);
+GList *pe__resource_actions(const pe_resource_t *rsc, const pcmk_node_t *node,
                             const char *task, bool require_node);
 
 extern void pe_free_action(pe_action_t * action);
 
-void resource_location(pe_resource_t *rsc, const pe_node_t *node, int score,
+void resource_location(pe_resource_t *rsc, const pcmk_node_t *node, int score,
                        const char *tag, pe_working_set_t *data_set);
 
 extern int pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b,
@@ -437,7 +440,7 @@ typedef struct op_digest_cache_s {
 
 op_digest_cache_t *pe__calculate_digests(pe_resource_t *rsc, const char *task,
                                          guint *interval_ms,
-                                         const pe_node_t *node,
+                                         const pcmk_node_t *node,
                                          const xmlNode *xml_op,
                                          GHashTable *overrides,
                                          bool calc_secure,
@@ -447,13 +450,13 @@ void pe__free_digests(gpointer ptr);
 
 op_digest_cache_t *rsc_action_digest_cmp(pe_resource_t *rsc,
                                          const xmlNode *xml_op,
-                                         pe_node_t *node,
+                                         pcmk_node_t *node,
                                          pe_working_set_t *data_set);
 
-pe_action_t *pe_fence_op(pe_node_t *node, const char *op, bool optional,
+pe_action_t *pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
                          const char *reason, bool priority_delay,
                          pe_working_set_t *data_set);
-void trigger_unfencing(pe_resource_t *rsc, pe_node_t *node,
+void trigger_unfencing(pe_resource_t *rsc, pcmk_node_t *node,
                        const char *reason, pe_action_t *dependency,
                        pe_working_set_t *data_set);
 
@@ -471,26 +474,27 @@ gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj
 void print_rscs_brief(GList *rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
 int pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, unsigned int options);
-void pe_fence_node(pe_working_set_t * data_set, pe_node_t * node, const char *reason, bool priority_delay);
+void pe_fence_node(pe_working_set_t *data_set, pcmk_node_t *node,
+                   const char *reason, bool priority_delay);
 
-pe_node_t *pe_create_node(const char *id, const char *uname, const char *type,
-                          const char *score, pe_working_set_t * data_set);
+pcmk_node_t *pe_create_node(const char *id, const char *uname, const char *type,
+                            const char *score, pe_working_set_t *data_set);
 
 //! \deprecated This function will be removed in a future release
 void common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
-                  const pe_node_t *node, long options, void *print_data);
+                  const pcmk_node_t *node, long options, void *print_data);
 int pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
-                           const char *name, const pe_node_t *node,
+                           const char *name, const pcmk_node_t *node,
                            unsigned int options);
 int pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
-                           const char *name, const pe_node_t *node,
+                           const char *name, const pcmk_node_t *node,
                            unsigned int options);
 
 //! A single instance of a bundle
 typedef struct {
     int offset;                 //!< 0-origin index of this instance in bundle
     char *ipaddr;               //!< IP address associated with this instance
-    pe_node_t *node;            //!< Node created for this instance
+    pcmk_node_t *node;          //!< Node created for this instance
     pe_resource_t *ip;          //!< IP address resource for ipaddr
     pe_resource_t *child;       //!< Instance of bundled resource
     pe_resource_t *container;   //!< Container associated with this instance
@@ -501,7 +505,7 @@ GList *pe__bundle_containers(const pe_resource_t *bundle);
 
 int pe__bundle_max(const pe_resource_t *rsc);
 bool pe__node_is_bundle_instance(const pe_resource_t *bundle,
-                                 const pe_node_t *node);
+                                 const pcmk_node_t *node);
 pe_resource_t *pe__bundled_resource(const pe_resource_t *rsc);
 const pe_resource_t *pe__get_rsc_in_container(const pe_resource_t *instance);
 pe_resource_t *pe__first_container(const pe_resource_t *bundle);
@@ -513,30 +517,30 @@ void pe__foreach_const_bundle_replica(const pe_resource_t *bundle,
                                                  void *),
                                       void *user_data);
 pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
-                                       const pe_node_t *node);
+                                       const pcmk_node_t *node);
 bool pe__bundle_needs_remote_name(pe_resource_t *rsc);
 const char *pe__add_bundle_remote_name(pe_resource_t *rsc,
                                        pe_working_set_t *data_set,
                                        xmlNode *xml, const char *field);
 
-const char *pe__node_attribute_calculated(const pe_node_t *node,
+const char *pe__node_attribute_calculated(const pcmk_node_t *node,
                                           const char *name,
                                           const pe_resource_t *rsc,
                                           enum pcmk__rsc_node node_type,
                                           bool force_host);
-const char *pe_node_attribute_raw(const pe_node_t *node, const char *name);
+const char *pe_node_attribute_raw(const pcmk_node_t *node, const char *name);
 bool pe__is_universal_clone(const pe_resource_t *rsc,
                             const pe_working_set_t *data_set);
 void pe__add_param_check(const xmlNode *rsc_op, pe_resource_t *rsc,
-                         pe_node_t *node, enum pcmk__check_parameters,
+                         pcmk_node_t *node, enum pcmk__check_parameters,
                          pe_working_set_t *data_set);
 void pe__foreach_param_check(pe_working_set_t *data_set,
-                             void (*cb)(pe_resource_t*, pe_node_t*,
+                             void (*cb)(pe_resource_t*, pcmk_node_t*,
                                         const xmlNode*,
                                         enum pcmk__check_parameters));
 void pe__free_param_checks(pe_working_set_t *data_set);
 
-bool pe__shutdown_requested(const pe_node_t *node);
+bool pe__shutdown_requested(const pcmk_node_t *node);
 void pe__update_recheck_time(time_t recheck, pe_working_set_t *data_set);
 
 /*!
@@ -553,14 +557,14 @@ void pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
                                 gboolean overwrite, pe_working_set_t *data_set);
 
 bool pe__resource_is_disabled(const pe_resource_t *rsc);
-void pe__clear_resource_history(pe_resource_t *rsc, const pe_node_t *node);
+void pe__clear_resource_history(pe_resource_t *rsc, const pcmk_node_t *node);
 
 GList *pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name);
 GList *pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name);
 bool pe__rsc_has_tag(pe_working_set_t *data_set, const char *rsc, const char *tag);
 bool pe__uname_has_tag(pe_working_set_t *data_set, const char *node, const char *tag);
 
-bool pe__rsc_running_on_only(const pe_resource_t *rsc, const pe_node_t *node);
+bool pe__rsc_running_on_only(const pe_resource_t *rsc, const pcmk_node_t *node);
 bool pe__rsc_running_on_any(pe_resource_t *rsc, GList *node_list);
 GList *pe__filter_rsc_list(GList *rscs, GList *filter);
 GList * pe__build_node_name_list(pe_working_set_t *data_set, const char *s);
@@ -581,8 +585,8 @@ xmlNode *pe__failed_probe_for_rsc(const pe_resource_t *rsc, const char *name);
 
 const char *pe__clone_child_id(const pe_resource_t *rsc);
 
-int pe__sum_node_health_scores(const pe_node_t *node, int base_health);
-int pe__node_health(pe_node_t *node);
+int pe__sum_node_health_scores(const pcmk_node_t *node, int base_health);
+int pe__node_health(pcmk_node_t *node);
 
 static inline enum pcmk__health_strategy
 pe__health_strategy(pe_working_set_t *data_set)
@@ -608,7 +612,7 @@ pe__health_score(const char *option, pe_working_set_t *data_set)
  *         if node has neither a name nor ID.
  */
 static inline const char *
-pe__node_name(const pe_node_t *node)
+pe__node_name(const pcmk_node_t *node)
 {
     if (node == NULL) {
         return "unspecified node";
@@ -634,7 +638,7 @@ pe__node_name(const pe_node_t *node)
  * \return true if \p node1 and \p node2 refer to the same node
  */
 static inline bool
-pe__same_node(const pe_node_t *node1, const pe_node_t *node2)
+pe__same_node(const pcmk_node_t *node1, const pcmk_node_t *node2)
 {
     return (node1 != NULL) && (node2 != NULL)
            && (node1->details == node2->details);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -21,14 +21,15 @@
 #  include <crm/common/output_internal.h>
 #  include <crm/common/scheduler_internal.h>
 
-const char *pe__resource_description(const pe_resource_t *rsc, uint32_t show_opts);
+const char *pe__resource_description(const pcmk_resource_t *rsc,
+                                     uint32_t show_opts);
 
-bool pe__clone_is_ordered(const pe_resource_t *clone);
-int pe__set_clone_flag(pe_resource_t *clone, enum pcmk__clone_flags flag);
-bool pe__clone_flag_is_set(const pe_resource_t *clone, uint32_t flags);
+bool pe__clone_is_ordered(const pcmk_resource_t *clone);
+int pe__set_clone_flag(pcmk_resource_t *clone, enum pcmk__clone_flags flag);
+bool pe__clone_flag_is_set(const pcmk_resource_t *clone, uint32_t flags);
 
-bool pe__group_flag_is_set(const pe_resource_t *group, uint32_t flags);
-pe_resource_t *pe__last_group_member(const pe_resource_t *group);
+bool pe__group_flag_is_set(const pcmk_resource_t *group, uint32_t flags);
+pcmk_resource_t *pe__last_group_member(const pcmk_resource_t *group);
 
 
 #  define pe_rsc_info(rsc, fmt, args...)  crm_log_tag(LOG_INFO,  rsc ? rsc->id : "<NULL>", fmt, ##args)
@@ -156,7 +157,7 @@ pe_resource_t *pe__last_group_member(const pe_resource_t *group);
 
 typedef struct pe__location_constraint_s {
     char *id;                           // Constraint XML ID
-    pe_resource_t *rsc_lh;              // Resource being located
+    pcmk_resource_t *rsc_lh;            // Resource being located
     enum rsc_role_e role_filter;        // Role to locate
     enum pe_discover_e discover_mode;   // Resource discovery
     GList *node_list_rh;                // List of pcmk_node_t*
@@ -167,81 +168,81 @@ typedef struct pe__order_constraint_s {
     uint32_t flags; // Group of enum pcmk__action_relation_flags
 
     void *lh_opaque;
-    pe_resource_t *lh_rsc;
+    pcmk_resource_t *lh_rsc;
     pe_action_t *lh_action;
     char *lh_action_task;
 
     void *rh_opaque;
-    pe_resource_t *rh_rsc;
+    pcmk_resource_t *rh_rsc;
     pe_action_t *rh_action;
     char *rh_action_task;
 } pe__ordering_t;
 
-const pe_resource_t *pe__const_top_resource(const pe_resource_t *rsc,
-                                            bool include_bundle);
+const pcmk_resource_t *pe__const_top_resource(const pcmk_resource_t *rsc,
+                                              bool include_bundle);
 
-int pe__clone_max(const pe_resource_t *clone);
-int pe__clone_node_max(const pe_resource_t *clone);
-int pe__clone_promoted_max(const pe_resource_t *clone);
-int pe__clone_promoted_node_max(const pe_resource_t *clone);
-void pe__create_clone_notifications(pe_resource_t *clone);
-void pe__free_clone_notification_data(pe_resource_t *clone);
-void pe__create_clone_notif_pseudo_ops(pe_resource_t *clone,
+int pe__clone_max(const pcmk_resource_t *clone);
+int pe__clone_node_max(const pcmk_resource_t *clone);
+int pe__clone_promoted_max(const pcmk_resource_t *clone);
+int pe__clone_promoted_node_max(const pcmk_resource_t *clone);
+void pe__create_clone_notifications(pcmk_resource_t *clone);
+void pe__free_clone_notification_data(pcmk_resource_t *clone);
+void pe__create_clone_notif_pseudo_ops(pcmk_resource_t *clone,
                                        pe_action_t *start, pe_action_t *started,
                                        pe_action_t *stop, pe_action_t *stopped);
 
 
-pe_action_t *pe__new_rsc_pseudo_action(pe_resource_t *rsc, const char *task,
+pe_action_t *pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task,
                                        bool optional, bool runnable);
 
-void pe__create_promotable_pseudo_ops(pe_resource_t *clone, bool any_promoting,
-                                      bool any_demoting);
+void pe__create_promotable_pseudo_ops(pcmk_resource_t *clone,
+                                      bool any_promoting, bool any_demoting);
 
 bool pe_can_fence(const pe_working_set_t *data_set, const pcmk_node_t *node);
 
 void add_hash_param(GHashTable * hash, const char *name, const char *value);
 
-char *native_parameter(pe_resource_t *rsc, pcmk_node_t *node, gboolean create,
+char *native_parameter(pcmk_resource_t *rsc, pcmk_node_t *node, gboolean create,
                        const char *name, pe_working_set_t *data_set);
-pcmk_node_t *native_location(const pe_resource_t *rsc, GList **list,
+pcmk_node_t *native_location(const pcmk_resource_t *rsc, GList **list,
                              int current);
 
 void pe_metadata(pcmk__output_t *out);
 void verify_pe_options(GHashTable * options);
 
-void native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
+void native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
                         pe_working_set_t *data_set, gboolean failed);
 
-gboolean native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
-gboolean group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
-gboolean clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set);
-gboolean pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set);
+gboolean native_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set);
+gboolean group_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set);
+gboolean clone_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set);
+gboolean pe__unpack_bundle(pcmk_resource_t *rsc, pe_working_set_t *data_set);
 
-pe_resource_t *native_find_rsc(pe_resource_t *rsc, const char *id,
-                               const pcmk_node_t *node, int flags);
+pcmk_resource_t *native_find_rsc(pcmk_resource_t *rsc, const char *id,
+                                 const pcmk_node_t *node, int flags);
 
-gboolean native_active(pe_resource_t * rsc, gboolean all);
-gboolean group_active(pe_resource_t * rsc, gboolean all);
-gboolean clone_active(pe_resource_t * rsc, gboolean all);
-gboolean pe__bundle_active(pe_resource_t *rsc, gboolean all);
+gboolean native_active(pcmk_resource_t *rsc, gboolean all);
+gboolean group_active(pcmk_resource_t *rsc, gboolean all);
+gboolean clone_active(pcmk_resource_t *rsc, gboolean all);
+gboolean pe__bundle_active(pcmk_resource_t *rsc, gboolean all);
 
 //! \deprecated This function will be removed in a future release
-void native_print(pe_resource_t *rsc, const char *pre_text, long options,
+void native_print(pcmk_resource_t *rsc, const char *pre_text, long options,
                   void *print_data);
 
 //! \deprecated This function will be removed in a future release
-void group_print(pe_resource_t *rsc, const char *pre_text, long options,
+void group_print(pcmk_resource_t *rsc, const char *pre_text, long options,
                  void *print_data);
 
 //! \deprecated This function will be removed in a future release
-void clone_print(pe_resource_t *rsc, const char *pre_text, long options,
+void clone_print(pcmk_resource_t *rsc, const char *pre_text, long options,
                  void *print_data);
 
 //! \deprecated This function will be removed in a future release
-void pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
+void pe__print_bundle(pcmk_resource_t *rsc, const char *pre_text, long options,
                       void *print_data);
 
-gchar *pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
+gchar *pcmk__native_output_string(const pcmk_resource_t *rsc, const char *name,
                                   const pcmk_node_t *node, uint32_t show_opts,
                                   const char *target_role, bool show_nodes);
 
@@ -252,12 +253,12 @@ char *pe__node_display_name(pcmk_node_t *node, bool print_detail);
 
 // Clone notifications (pe_notif.c)
 void pe__order_notifs_after_fencing(const pe_action_t *action,
-                                    pe_resource_t *rsc,
+                                    pcmk_resource_t *rsc,
                                     pe_action_t *stonith_op);
 
 
 static inline const char *
-pe__rsc_bool_str(const pe_resource_t *rsc, uint64_t rsc_flag)
+pe__rsc_bool_str(const pcmk_resource_t *rsc, uint64_t rsc_flag)
 {
     return pcmk__btoa(pcmk_is_set(rsc->flags, rsc_flag));
 }
@@ -276,46 +277,49 @@ int pe__resource_xml(pcmk__output_t *out, va_list args);
 int pe__resource_html(pcmk__output_t *out, va_list args);
 int pe__resource_text(pcmk__output_t *out, va_list args);
 
-void native_free(pe_resource_t * rsc);
-void group_free(pe_resource_t * rsc);
-void clone_free(pe_resource_t * rsc);
-void pe__free_bundle(pe_resource_t *rsc);
+void native_free(pcmk_resource_t *rsc);
+void group_free(pcmk_resource_t *rsc);
+void clone_free(pcmk_resource_t *rsc);
+void pe__free_bundle(pcmk_resource_t *rsc);
 
-enum rsc_role_e native_resource_state(const pe_resource_t * rsc, gboolean current);
-enum rsc_role_e group_resource_state(const pe_resource_t * rsc, gboolean current);
-enum rsc_role_e clone_resource_state(const pe_resource_t * rsc, gboolean current);
-enum rsc_role_e pe__bundle_resource_state(const pe_resource_t *rsc,
+enum rsc_role_e native_resource_state(const pcmk_resource_t *rsc,
+                                      gboolean current);
+enum rsc_role_e group_resource_state(const pcmk_resource_t *rsc,
+                                     gboolean current);
+enum rsc_role_e clone_resource_state(const pcmk_resource_t *rsc,
+                                     gboolean current);
+enum rsc_role_e pe__bundle_resource_state(const pcmk_resource_t *rsc,
                                           gboolean current);
 
-void pe__count_common(pe_resource_t *rsc);
-void pe__count_bundle(pe_resource_t *rsc);
+void pe__count_common(pcmk_resource_t *rsc);
+void pe__count_bundle(pcmk_resource_t *rsc);
 
-void common_free(pe_resource_t * rsc);
+void common_free(pcmk_resource_t *rsc);
 
 pcmk_node_t *pe__copy_node(const pcmk_node_t *this_node);
 extern time_t get_effective_time(pe_working_set_t * data_set);
 
 /* Failure handling utilities (from failcounts.c) */
 
-int pe_get_failcount(const pcmk_node_t *node, pe_resource_t *rsc,
+int pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
                      time_t *last_failure, uint32_t flags,
                      const xmlNode *xml_op);
 
-pe_action_t *pe__clear_failcount(pe_resource_t *rsc, const pcmk_node_t *node,
+pe_action_t *pe__clear_failcount(pcmk_resource_t *rsc, const pcmk_node_t *node,
                                  const char *reason,
                                  pe_working_set_t *data_set);
 
 /* Functions for finding/counting a resource's active nodes */
 
-bool pe__count_active_node(const pe_resource_t *rsc, pcmk_node_t *node,
+bool pe__count_active_node(const pcmk_resource_t *rsc, pcmk_node_t *node,
                            pcmk_node_t **active, unsigned int *count_all,
                            unsigned int *count_clean);
 
-pcmk_node_t *pe__find_active_requires(const pe_resource_t *rsc,
+pcmk_node_t *pe__find_active_requires(const pcmk_resource_t *rsc,
                                     unsigned int *count);
 
 static inline pcmk_node_t *
-pe__current_node(const pe_resource_t *rsc)
+pe__current_node(const pcmk_resource_t *rsc)
 {
     return (rsc == NULL)? NULL : rsc->fns->active_node(rsc, NULL, NULL);
 }
@@ -329,7 +333,7 @@ gboolean order_actions(pe_action_t *lh_action, pe_action_t *rh_action,
                        uint32_t flags);
 
 void pe__show_node_scores_as(const char *file, const char *function,
-                             int line, bool to_log, const pe_resource_t *rsc,
+                             int line, bool to_log, const pcmk_resource_t *rsc,
                              const char *comment, GHashTable *nodes,
                              pe_working_set_t *data_set);
 
@@ -337,14 +341,14 @@ void pe__show_node_scores_as(const char *file, const char *function,
         pe__show_node_scores_as(__FILE__, __func__, __LINE__,      \
                                 (level), (rsc), (text), (nodes), (data_set))
 
-xmlNode *find_rsc_op_entry(const pe_resource_t *rsc, const char *key);
+xmlNode *find_rsc_op_entry(const pcmk_resource_t *rsc, const char *key);
 
-GHashTable *pcmk__unpack_action_meta(pe_resource_t *rsc,
+GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
                                      const pcmk_node_t *node,
                                      const char *action_name, guint interval_ms,
                                      const xmlNode *action_config);
 
-pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
+pe_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                            const pcmk_node_t *on_node, gboolean optional,
                            gboolean foo, pe_working_set_t *data_set);
 
@@ -374,34 +378,35 @@ pe_action_t *custom_action(pe_resource_t *rsc, char *key, const char *task,
 		rsc, demote_key(rsc), PCMK_ACTION_DEMOTE, node, \
 		optional, TRUE, rsc->cluster)
 
-extern int pe_get_configured_timeout(pe_resource_t *rsc, const char *action,
+extern int pe_get_configured_timeout(pcmk_resource_t *rsc, const char *action,
                                      pe_working_set_t *data_set);
 
 pe_action_t *find_first_action(const GList *input, const char *uuid,
                                const char *task, const pcmk_node_t *on_node);
 
-enum action_tasks get_complex_task(const pe_resource_t *rsc, const char *name);
+enum action_tasks get_complex_task(const pcmk_resource_t *rsc,
+                                   const char *name);
 
 GList *find_actions(GList *input, const char *key, const pcmk_node_t *on_node);
 GList *find_actions_exact(GList *input, const char *key,
                           const pcmk_node_t *on_node);
-GList *pe__resource_actions(const pe_resource_t *rsc, const pcmk_node_t *node,
+GList *pe__resource_actions(const pcmk_resource_t *rsc, const pcmk_node_t *node,
                             const char *task, bool require_node);
 
 extern void pe_free_action(pe_action_t * action);
 
-void resource_location(pe_resource_t *rsc, const pcmk_node_t *node, int score,
+void resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
                        const char *tag, pe_working_set_t *data_set);
 
 extern int pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b,
                            bool same_node_default);
 extern gint sort_op_by_callid(gconstpointer a, gconstpointer b);
-gboolean get_target_role(const pe_resource_t *rsc, enum rsc_role_e *role);
-void pe__set_next_role(pe_resource_t *rsc, enum rsc_role_e role,
+gboolean get_target_role(const pcmk_resource_t *rsc, enum rsc_role_e *role);
+void pe__set_next_role(pcmk_resource_t *rsc, enum rsc_role_e role,
                        const char *why);
 
-pe_resource_t *find_clone_instance(const pe_resource_t *rsc,
-                                   const char *sub_id);
+pcmk_resource_t *find_clone_instance(const pcmk_resource_t *rsc,
+                                     const char *sub_id);
 
 extern void destroy_ticket(gpointer data);
 extern pe_ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
@@ -412,7 +417,7 @@ char *clone_strip(const char *last_rsc_id);
 char *clone_zero(const char *last_rsc_id);
 
 static inline bool
-pe_base_name_eq(const pe_resource_t *rsc, const char *id)
+pe_base_name_eq(const pcmk_resource_t *rsc, const char *id)
 {
     if (id && rsc && rsc->id) {
         // Number of characters in rsc->id before any clone suffix
@@ -426,7 +431,7 @@ pe_base_name_eq(const pe_resource_t *rsc, const char *id)
 int pe__target_rc_from_xml(const xmlNode *xml_op);
 
 gint pe__cmp_node_name(gconstpointer a, gconstpointer b);
-bool is_set_recursive(const pe_resource_t *rsc, long long flag, bool any);
+bool is_set_recursive(const pcmk_resource_t *rsc, long long flag, bool any);
 
 typedef struct op_digest_cache_s {
     enum pcmk__digest_result rc;
@@ -438,7 +443,7 @@ typedef struct op_digest_cache_s {
     char *digest_restart_calc;
 } op_digest_cache_t;
 
-op_digest_cache_t *pe__calculate_digests(pe_resource_t *rsc, const char *task,
+op_digest_cache_t *pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
                                          guint *interval_ms,
                                          const pcmk_node_t *node,
                                          const xmlNode *xml_op,
@@ -448,7 +453,7 @@ op_digest_cache_t *pe__calculate_digests(pe_resource_t *rsc, const char *task,
 
 void pe__free_digests(gpointer ptr);
 
-op_digest_cache_t *rsc_action_digest_cmp(pe_resource_t *rsc,
+op_digest_cache_t *rsc_action_digest_cmp(pcmk_resource_t *rsc,
                                          const xmlNode *xml_op,
                                          pcmk_node_t *node,
                                          pe_working_set_t *data_set);
@@ -456,7 +461,7 @@ op_digest_cache_t *rsc_action_digest_cmp(pe_resource_t *rsc,
 pe_action_t *pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
                          const char *reason, bool priority_delay,
                          pe_working_set_t *data_set);
-void trigger_unfencing(pe_resource_t *rsc, pcmk_node_t *node,
+void trigger_unfencing(pcmk_resource_t *rsc, pcmk_node_t *node,
                        const char *reason, pe_action_t *dependency,
                        pe_working_set_t *data_set);
 
@@ -464,8 +469,8 @@ char *pe__action2reason(const pe_action_t *action, enum pe_action_flags flag);
 void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrite);
 void pe__add_action_expected_result(pe_action_t *action, int expected_result);
 
-void pe__set_resource_flags_recursive(pe_resource_t *rsc, uint64_t flags);
-void pe__clear_resource_flags_recursive(pe_resource_t *rsc, uint64_t flags);
+void pe__set_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags);
+void pe__clear_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags);
 void pe__clear_resource_flags_on_all(pe_working_set_t *data_set, uint64_t flag);
 
 gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref);
@@ -481,12 +486,12 @@ pcmk_node_t *pe_create_node(const char *id, const char *uname, const char *type,
                             const char *score, pe_working_set_t *data_set);
 
 //! \deprecated This function will be removed in a future release
-void common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
+void common_print(pcmk_resource_t *rsc, const char *pre_text, const char *name,
                   const pcmk_node_t *node, long options, void *print_data);
-int pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
+int pe__common_output_text(pcmk__output_t *out, const pcmk_resource_t *rsc,
                            const char *name, const pcmk_node_t *node,
                            unsigned int options);
-int pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
+int pe__common_output_html(pcmk__output_t *out, const pcmk_resource_t *rsc,
                            const char *name, const pcmk_node_t *node,
                            unsigned int options);
 
@@ -495,47 +500,47 @@ typedef struct {
     int offset;                 //!< 0-origin index of this instance in bundle
     char *ipaddr;               //!< IP address associated with this instance
     pcmk_node_t *node;          //!< Node created for this instance
-    pe_resource_t *ip;          //!< IP address resource for ipaddr
-    pe_resource_t *child;       //!< Instance of bundled resource
-    pe_resource_t *container;   //!< Container associated with this instance
-    pe_resource_t *remote;      //!< Pacemaker Remote connection into container
+    pcmk_resource_t *ip;        //!< IP address resource for ipaddr
+    pcmk_resource_t *child;     //!< Instance of bundled resource
+    pcmk_resource_t *container; //!< Container associated with this instance
+    pcmk_resource_t *remote;    //!< Pacemaker Remote connection into container
 } pe__bundle_replica_t;
 
-GList *pe__bundle_containers(const pe_resource_t *bundle);
+GList *pe__bundle_containers(const pcmk_resource_t *bundle);
 
-int pe__bundle_max(const pe_resource_t *rsc);
-bool pe__node_is_bundle_instance(const pe_resource_t *bundle,
+int pe__bundle_max(const pcmk_resource_t *rsc);
+bool pe__node_is_bundle_instance(const pcmk_resource_t *bundle,
                                  const pcmk_node_t *node);
-pe_resource_t *pe__bundled_resource(const pe_resource_t *rsc);
-const pe_resource_t *pe__get_rsc_in_container(const pe_resource_t *instance);
-pe_resource_t *pe__first_container(const pe_resource_t *bundle);
-void pe__foreach_bundle_replica(pe_resource_t *bundle,
+pcmk_resource_t *pe__bundled_resource(const pcmk_resource_t *rsc);
+const pcmk_resource_t *pe__get_rsc_in_container(const pcmk_resource_t *instance);
+pcmk_resource_t *pe__first_container(const pcmk_resource_t *bundle);
+void pe__foreach_bundle_replica(pcmk_resource_t *bundle,
                                 bool (*fn)(pe__bundle_replica_t *, void *),
                                 void *user_data);
-void pe__foreach_const_bundle_replica(const pe_resource_t *bundle,
+void pe__foreach_const_bundle_replica(const pcmk_resource_t *bundle,
                                       bool (*fn)(const pe__bundle_replica_t *,
                                                  void *),
                                       void *user_data);
-pe_resource_t *pe__find_bundle_replica(const pe_resource_t *bundle,
-                                       const pcmk_node_t *node);
-bool pe__bundle_needs_remote_name(pe_resource_t *rsc);
-const char *pe__add_bundle_remote_name(pe_resource_t *rsc,
+pcmk_resource_t *pe__find_bundle_replica(const pcmk_resource_t *bundle,
+                                         const pcmk_node_t *node);
+bool pe__bundle_needs_remote_name(pcmk_resource_t *rsc);
+const char *pe__add_bundle_remote_name(pcmk_resource_t *rsc,
                                        pe_working_set_t *data_set,
                                        xmlNode *xml, const char *field);
 
 const char *pe__node_attribute_calculated(const pcmk_node_t *node,
                                           const char *name,
-                                          const pe_resource_t *rsc,
+                                          const pcmk_resource_t *rsc,
                                           enum pcmk__rsc_node node_type,
                                           bool force_host);
 const char *pe_node_attribute_raw(const pcmk_node_t *node, const char *name);
-bool pe__is_universal_clone(const pe_resource_t *rsc,
+bool pe__is_universal_clone(const pcmk_resource_t *rsc,
                             const pe_working_set_t *data_set);
-void pe__add_param_check(const xmlNode *rsc_op, pe_resource_t *rsc,
+void pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
                          pcmk_node_t *node, enum pcmk__check_parameters,
                          pe_working_set_t *data_set);
 void pe__foreach_param_check(pe_working_set_t *data_set,
-                             void (*cb)(pe_resource_t*, pcmk_node_t*,
+                             void (*cb)(pcmk_resource_t*, pcmk_node_t*,
                                         const xmlNode*,
                                         enum pcmk__check_parameters));
 void pe__free_param_checks(pe_working_set_t *data_set);
@@ -556,34 +561,35 @@ void pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
                                 GHashTable *hash, const char *always_first,
                                 gboolean overwrite, pe_working_set_t *data_set);
 
-bool pe__resource_is_disabled(const pe_resource_t *rsc);
-void pe__clear_resource_history(pe_resource_t *rsc, const pcmk_node_t *node);
+bool pe__resource_is_disabled(const pcmk_resource_t *rsc);
+void pe__clear_resource_history(pcmk_resource_t *rsc, const pcmk_node_t *node);
 
 GList *pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name);
 GList *pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name);
 bool pe__rsc_has_tag(pe_working_set_t *data_set, const char *rsc, const char *tag);
 bool pe__uname_has_tag(pe_working_set_t *data_set, const char *node, const char *tag);
 
-bool pe__rsc_running_on_only(const pe_resource_t *rsc, const pcmk_node_t *node);
-bool pe__rsc_running_on_any(pe_resource_t *rsc, GList *node_list);
+bool pe__rsc_running_on_only(const pcmk_resource_t *rsc,
+                             const pcmk_node_t *node);
+bool pe__rsc_running_on_any(pcmk_resource_t *rsc, GList *node_list);
 GList *pe__filter_rsc_list(GList *rscs, GList *filter);
 GList * pe__build_node_name_list(pe_working_set_t *data_set, const char *s);
 GList * pe__build_rsc_list(pe_working_set_t *data_set, const char *s);
 
-bool pcmk__rsc_filtered_by_node(pe_resource_t *rsc, GList *only_node);
+bool pcmk__rsc_filtered_by_node(pcmk_resource_t *rsc, GList *only_node);
 
-gboolean pe__bundle_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+gboolean pe__bundle_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                                 gboolean check_parent);
-gboolean pe__clone_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+gboolean pe__clone_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                                gboolean check_parent);
-gboolean pe__group_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+gboolean pe__group_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                                gboolean check_parent);
-gboolean pe__native_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+gboolean pe__native_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                                 gboolean check_parent);
 
-xmlNode *pe__failed_probe_for_rsc(const pe_resource_t *rsc, const char *name);
+xmlNode *pe__failed_probe_for_rsc(const pcmk_resource_t *rsc, const char *name);
 
-const char *pe__clone_child_id(const pe_resource_t *rsc);
+const char *pe__clone_child_id(const pcmk_resource_t *rsc);
 
 int pe__sum_node_health_scores(const pcmk_node_t *node, int base_health);
 int pe__node_health(pcmk_node_t *node);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -199,12 +199,12 @@ pcmk_action_t *pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task,
 void pe__create_promotable_pseudo_ops(pcmk_resource_t *clone,
                                       bool any_promoting, bool any_demoting);
 
-bool pe_can_fence(const pe_working_set_t *data_set, const pcmk_node_t *node);
+bool pe_can_fence(const pcmk_scheduler_t *data_set, const pcmk_node_t *node);
 
 void add_hash_param(GHashTable * hash, const char *name, const char *value);
 
 char *native_parameter(pcmk_resource_t *rsc, pcmk_node_t *node, gboolean create,
-                       const char *name, pe_working_set_t *data_set);
+                       const char *name, pcmk_scheduler_t *data_set);
 pcmk_node_t *native_location(const pcmk_resource_t *rsc, GList **list,
                              int current);
 
@@ -212,12 +212,12 @@ void pe_metadata(pcmk__output_t *out);
 void verify_pe_options(GHashTable * options);
 
 void native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
-                        pe_working_set_t *data_set, gboolean failed);
+                        pcmk_scheduler_t *data_set, gboolean failed);
 
-gboolean native_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set);
-gboolean group_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set);
-gboolean clone_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set);
-gboolean pe__unpack_bundle(pcmk_resource_t *rsc, pe_working_set_t *data_set);
+gboolean native_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set);
+gboolean group_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set);
+gboolean clone_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set);
+gboolean pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set);
 
 pcmk_resource_t *native_find_rsc(pcmk_resource_t *rsc, const char *id,
                                  const pcmk_node_t *node, int flags);
@@ -298,7 +298,7 @@ void pe__count_bundle(pcmk_resource_t *rsc);
 void common_free(pcmk_resource_t *rsc);
 
 pcmk_node_t *pe__copy_node(const pcmk_node_t *this_node);
-extern time_t get_effective_time(pe_working_set_t * data_set);
+time_t get_effective_time(pcmk_scheduler_t *data_set);
 
 /* Failure handling utilities (from failcounts.c) */
 
@@ -308,7 +308,7 @@ int pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
 
 pcmk_action_t *pe__clear_failcount(pcmk_resource_t *rsc,
                                    const pcmk_node_t *node, const char *reason,
-                                   pe_working_set_t *data_set);
+                                   pcmk_scheduler_t *data_set);
 
 /* Functions for finding/counting a resource's active nodes */
 
@@ -329,14 +329,14 @@ pe__current_node(const pcmk_resource_t *rsc)
 /* Binary like operators for lists of nodes */
 GHashTable *pe__node_list2table(const GList *list);
 
-pcmk_action_t *get_pseudo_op(const char *name, pe_working_set_t *data_set);
+pcmk_action_t *get_pseudo_op(const char *name, pcmk_scheduler_t *data_set);
 gboolean order_actions(pcmk_action_t *lh_action, pcmk_action_t *rh_action,
                        uint32_t flags);
 
 void pe__show_node_scores_as(const char *file, const char *function,
                              int line, bool to_log, const pcmk_resource_t *rsc,
                              const char *comment, GHashTable *nodes,
-                             pe_working_set_t *data_set);
+                             pcmk_scheduler_t *data_set);
 
 #define pe__show_node_scores(level, rsc, text, nodes, data_set)    \
         pe__show_node_scores_as(__FILE__, __func__, __LINE__,      \
@@ -351,7 +351,7 @@ GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
 
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,
-                             gboolean foo, pe_working_set_t *data_set);
+                             gboolean foo, pcmk_scheduler_t *data_set);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DELETE, 0)
 #  define delete_action(rsc, node, optional) custom_action(		\
@@ -380,7 +380,7 @@ pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
 		optional, TRUE, rsc->cluster)
 
 extern int pe_get_configured_timeout(pcmk_resource_t *rsc, const char *action,
-                                     pe_working_set_t *data_set);
+                                     pcmk_scheduler_t *data_set);
 
 pcmk_action_t *find_first_action(const GList *input, const char *uuid,
                                  const char *task, const pcmk_node_t *on_node);
@@ -397,7 +397,7 @@ GList *pe__resource_actions(const pcmk_resource_t *rsc, const pcmk_node_t *node,
 extern void pe_free_action(pcmk_action_t *action);
 
 void resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
-                       const char *tag, pe_working_set_t *data_set);
+                       const char *tag, pcmk_scheduler_t *data_set);
 
 extern int pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b,
                            bool same_node_default);
@@ -410,7 +410,7 @@ pcmk_resource_t *find_clone_instance(const pcmk_resource_t *rsc,
                                      const char *sub_id);
 
 extern void destroy_ticket(gpointer data);
-extern pe_ticket_t *ticket_new(const char *ticket_id, pe_working_set_t * data_set);
+extern pe_ticket_t *ticket_new(const char *ticket_id, pcmk_scheduler_t * data_set);
 
 // Resources for manipulating resource names
 const char *pe_base_name_end(const char *id);
@@ -450,21 +450,21 @@ op_digest_cache_t *pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
                                          const xmlNode *xml_op,
                                          GHashTable *overrides,
                                          bool calc_secure,
-                                         pe_working_set_t *data_set);
+                                         pcmk_scheduler_t *data_set);
 
 void pe__free_digests(gpointer ptr);
 
 op_digest_cache_t *rsc_action_digest_cmp(pcmk_resource_t *rsc,
                                          const xmlNode *xml_op,
                                          pcmk_node_t *node,
-                                         pe_working_set_t *data_set);
+                                         pcmk_scheduler_t *data_set);
 
 pcmk_action_t *pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
                            const char *reason, bool priority_delay,
-                           pe_working_set_t *data_set);
+                           pcmk_scheduler_t *data_set);
 void trigger_unfencing(pcmk_resource_t *rsc, pcmk_node_t *node,
                        const char *reason, pcmk_action_t *dependency,
-                       pe_working_set_t *data_set);
+                       pcmk_scheduler_t *data_set);
 
 char *pe__action2reason(const pcmk_action_t *action, enum pe_action_flags flag);
 void pe_action_set_reason(pcmk_action_t *action, const char *reason,
@@ -473,7 +473,7 @@ void pe__add_action_expected_result(pcmk_action_t *action, int expected_result);
 
 void pe__set_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags);
 void pe__clear_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags);
-void pe__clear_resource_flags_on_all(pe_working_set_t *data_set, uint64_t flag);
+void pe__clear_resource_flags_on_all(pcmk_scheduler_t *data_set, uint64_t flag);
 
 gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj_ref);
 
@@ -481,11 +481,11 @@ gboolean add_tag_ref(GHashTable * tags, const char * tag_name,  const char * obj
 void print_rscs_brief(GList *rsc_list, const char * pre_text, long options,
                       void * print_data, gboolean print_all);
 int pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, unsigned int options);
-void pe_fence_node(pe_working_set_t *data_set, pcmk_node_t *node,
+void pe_fence_node(pcmk_scheduler_t *data_set, pcmk_node_t *node,
                    const char *reason, bool priority_delay);
 
 pcmk_node_t *pe_create_node(const char *id, const char *uname, const char *type,
-                            const char *score, pe_working_set_t *data_set);
+                            const char *score, pcmk_scheduler_t *data_set);
 
 //! \deprecated This function will be removed in a future release
 void common_print(pcmk_resource_t *rsc, const char *pre_text, const char *name,
@@ -527,7 +527,7 @@ pcmk_resource_t *pe__find_bundle_replica(const pcmk_resource_t *bundle,
                                          const pcmk_node_t *node);
 bool pe__bundle_needs_remote_name(pcmk_resource_t *rsc);
 const char *pe__add_bundle_remote_name(pcmk_resource_t *rsc,
-                                       pe_working_set_t *data_set,
+                                       pcmk_scheduler_t *data_set,
                                        xmlNode *xml, const char *field);
 
 const char *pe__node_attribute_calculated(const pcmk_node_t *node,
@@ -537,18 +537,18 @@ const char *pe__node_attribute_calculated(const pcmk_node_t *node,
                                           bool force_host);
 const char *pe_node_attribute_raw(const pcmk_node_t *node, const char *name);
 bool pe__is_universal_clone(const pcmk_resource_t *rsc,
-                            const pe_working_set_t *data_set);
+                            const pcmk_scheduler_t *data_set);
 void pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
                          pcmk_node_t *node, enum pcmk__check_parameters,
-                         pe_working_set_t *data_set);
-void pe__foreach_param_check(pe_working_set_t *data_set,
+                         pcmk_scheduler_t *data_set);
+void pe__foreach_param_check(pcmk_scheduler_t *data_set,
                              void (*cb)(pcmk_resource_t*, pcmk_node_t*,
                                         const xmlNode*,
                                         enum pcmk__check_parameters));
-void pe__free_param_checks(pe_working_set_t *data_set);
+void pe__free_param_checks(pcmk_scheduler_t *data_set);
 
 bool pe__shutdown_requested(const pcmk_node_t *node);
-void pe__update_recheck_time(time_t recheck, pe_working_set_t *data_set);
+void pe__update_recheck_time(time_t recheck, pcmk_scheduler_t *data_set);
 
 /*!
  * \internal
@@ -561,22 +561,24 @@ void pe__register_messages(pcmk__output_t *out);
 void pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
                                 const pe_rule_eval_data_t *rule_data,
                                 GHashTable *hash, const char *always_first,
-                                gboolean overwrite, pe_working_set_t *data_set);
+                                gboolean overwrite, pcmk_scheduler_t *data_set);
 
 bool pe__resource_is_disabled(const pcmk_resource_t *rsc);
 void pe__clear_resource_history(pcmk_resource_t *rsc, const pcmk_node_t *node);
 
-GList *pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name);
-GList *pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name);
-bool pe__rsc_has_tag(pe_working_set_t *data_set, const char *rsc, const char *tag);
-bool pe__uname_has_tag(pe_working_set_t *data_set, const char *node, const char *tag);
+GList *pe__rscs_with_tag(pcmk_scheduler_t *data_set, const char *tag_name);
+GList *pe__unames_with_tag(pcmk_scheduler_t *data_set, const char *tag_name);
+bool pe__rsc_has_tag(pcmk_scheduler_t *data_set, const char *rsc,
+                     const char *tag);
+bool pe__uname_has_tag(pcmk_scheduler_t *data_set, const char *node,
+                       const char *tag);
 
 bool pe__rsc_running_on_only(const pcmk_resource_t *rsc,
                              const pcmk_node_t *node);
 bool pe__rsc_running_on_any(pcmk_resource_t *rsc, GList *node_list);
 GList *pe__filter_rsc_list(GList *rscs, GList *filter);
-GList * pe__build_node_name_list(pe_working_set_t *data_set, const char *s);
-GList * pe__build_rsc_list(pe_working_set_t *data_set, const char *s);
+GList * pe__build_node_name_list(pcmk_scheduler_t *data_set, const char *s);
+GList * pe__build_rsc_list(pcmk_scheduler_t *data_set, const char *s);
 
 bool pcmk__rsc_filtered_by_node(pcmk_resource_t *rsc, GList *only_node);
 
@@ -597,14 +599,14 @@ int pe__sum_node_health_scores(const pcmk_node_t *node, int base_health);
 int pe__node_health(pcmk_node_t *node);
 
 static inline enum pcmk__health_strategy
-pe__health_strategy(pe_working_set_t *data_set)
+pe__health_strategy(pcmk_scheduler_t *data_set)
 {
     return pcmk__parse_health_strategy(pe_pref(data_set->config_hash,
                                                PCMK__OPT_NODE_HEALTH_STRATEGY));
 }
 
 static inline int
-pe__health_score(const char *option, pe_working_set_t *data_set)
+pe__health_score(const char *option, pcmk_scheduler_t *data_set)
 {
     return char2score(pe_pref(data_set->config_hash, option));
 }

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -29,7 +29,6 @@ extern "C" {
  * \ingroup pengine
  */
 
-typedef struct pe_node_s pe_node_t;
 typedef struct pe_action_s pe_action_t;
 typedef struct pe_resource_s pe_resource_t;
 typedef struct pe_working_set_s pe_working_set_t;

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -35,12 +35,12 @@ typedef struct pe_resource_s pe_resource_t;
 typedef struct pe_working_set_s pe_working_set_t;
 
 typedef struct resource_object_functions_s {
-    gboolean (*unpack)(pcmk_resource_t*, pe_working_set_t*);
+    gboolean (*unpack)(pcmk_resource_t*, pcmk_scheduler_t*);
     pcmk_resource_t *(*find_rsc)(pcmk_resource_t *parent, const char *search,
                                  const pcmk_node_t *node, int flags);
     /* parameter result must be free'd */
     char *(*parameter)(pcmk_resource_t*, pcmk_node_t*, gboolean, const char*,
-                       pe_working_set_t*);
+                       pcmk_scheduler_t*);
     //! \deprecated will be removed in a future release
     void (*print)(pcmk_resource_t*, const char*, long, void*);
     gboolean (*active)(pcmk_resource_t*, gboolean);
@@ -169,7 +169,7 @@ struct pe_node_shared_s {
     GHashTable *utilization;
     GHashTable *digest_cache;   //!< cache of calculated resource digests
     int priority; // calculated based on the priority of resources running on the node
-    pe_working_set_t *data_set; //!< Cluster that this node is part of
+    pcmk_scheduler_t *data_set; //!< Cluster that this node is part of
 };
 
 struct pe_node_s {
@@ -187,7 +187,7 @@ struct pe_resource_s {
     xmlNode *orig_xml;
     xmlNode *ops_xml;
 
-    pe_working_set_t *cluster;
+    pcmk_scheduler_t *cluster;
     pcmk_resource_t *parent;
 
     enum pe_obj_types variant;

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -225,7 +225,7 @@ struct pe_resource_s {
     GList *rsc_cons_lhs;      // List of pcmk__colocation_t*
     GList *rsc_cons;          // List of pcmk__colocation_t*
     GList *rsc_location;      // List of pe__location_t*
-    GList *actions;           // List of pe_action_t*
+    GList *actions;           // List of pcmk_action_t*
     GList *rsc_tickets;       // List of rsc_ticket*
     //!@}
 
@@ -378,7 +378,7 @@ enum pe_ordering {
 typedef struct pe_action_wrapper_s {
     enum pe_ordering type;
     enum pe_link_state state;
-    pe_action_t *action;
+    pcmk_action_t *action;
 } pe_action_wrapper_t;
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -30,7 +30,6 @@ extern "C" {
  */
 
 typedef struct pe_action_s pe_action_t;
-typedef struct pe_resource_s pe_resource_t;
 typedef struct pe_working_set_s pe_working_set_t;
 
 typedef struct resource_object_functions_s {

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -29,8 +29,6 @@ extern "C" {
  * \ingroup pengine
  */
 
-typedef struct pe_working_set_s pe_working_set_t;
-
 typedef struct resource_object_functions_s {
     gboolean (*unpack)(pcmk_resource_t*, pcmk_scheduler_t*);
     pcmk_resource_t *(*find_rsc)(pcmk_resource_t *parent, const char *search,

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -37,15 +37,15 @@ typedef struct pe_working_set_s pe_working_set_t;
 typedef struct resource_object_functions_s {
     gboolean (*unpack) (pe_resource_t*, pe_working_set_t*);
     pe_resource_t *(*find_rsc) (pe_resource_t *parent, const char *search,
-                                const pe_node_t *node, int flags);
+                                const pcmk_node_t *node, int flags);
     /* parameter result must be free'd */
-    char *(*parameter) (pe_resource_t*, pe_node_t*, gboolean, const char*,
-                        pe_working_set_t*);
+    char *(*parameter)(pe_resource_t*, pcmk_node_t*, gboolean, const char*,
+                       pe_working_set_t*);
     //! \deprecated will be removed in a future release
     void (*print) (pe_resource_t*, const char*, long, void*);
     gboolean (*active) (pe_resource_t*, gboolean);
     enum rsc_role_e (*state) (const pe_resource_t*, gboolean);
-    pe_node_t *(*location) (const pe_resource_t*, GList**, int);
+    pcmk_node_t *(*location)(const pe_resource_t*, GList**, int);
     void (*free) (pe_resource_t*);
     void (*count) (pe_resource_t*);
     gboolean (*is_filtered) (const pe_resource_t*, GList *, gboolean);
@@ -62,8 +62,9 @@ typedef struct resource_object_functions_s {
      *         online node if the resource's "requires" is "quorum" or
      *         "nothing", or NULL if the resource is inactive.
      */
-    pe_node_t *(*active_node)(const pe_resource_t *rsc, unsigned int *count_all,
-                              unsigned int *count_clean);
+    pcmk_node_t *(*active_node)(const pe_resource_t *rsc,
+                                unsigned int *count_all,
+                                unsigned int *count_clean);
 
     /*!
      * \brief Get maximum resource instances per node
@@ -83,7 +84,7 @@ struct pe_working_set_s {
 
     /* options extracted from the input */
     char *dc_uuid;
-    pe_node_t *dc_node;
+    pcmk_node_t *dc_node;
     const char *stonith_action;
     const char *placement_strategy;
 
@@ -228,12 +229,12 @@ struct pe_resource_s {
     GList *rsc_tickets;       // List of rsc_ticket*
     //!@}
 
-    pe_node_t *allocated_to;
-    pe_node_t *partial_migration_target;
-    pe_node_t *partial_migration_source;
-    GList *running_on;        /* pe_node_t*   */
-    GHashTable *known_on;       /* pe_node_t*   */
-    GHashTable *allowed_nodes;  /* pe_node_t*   */
+    pcmk_node_t *allocated_to;
+    pcmk_node_t *partial_migration_target;
+    pcmk_node_t *partial_migration_source;
+    GList *running_on;          // pcmk_node_t*
+    GHashTable *known_on;       // pcmk_node_t*
+    GHashTable *allowed_nodes;  // pcmk_node_t*
 
     enum rsc_role_e role;
     enum rsc_role_e next_role;
@@ -243,14 +244,14 @@ struct pe_resource_s {
     GHashTable *utilization;
 
     GList *children;          /* pe_resource_t*   */
-    GList *dangling_migrations;       /* pe_node_t*       */
+    GList *dangling_migrations; // pcmk_node_t*
 
     pe_resource_t *container;
     GList *fillers;
 
     // @COMPAT These should be made const at next API compatibility break
-    pe_node_t *pending_node;    // Node on which pending_task is happening
-    pe_node_t *lock_node;       // Resource is shutdown-locked to this node
+    pcmk_node_t *pending_node;  // Node on which pending_task is happening
+    pcmk_node_t *lock_node;     // Resource is shutdown-locked to this node
 
     time_t lock_time;           // When shutdown lock started
 
@@ -267,7 +268,7 @@ struct pe_action_s {
     int priority;
 
     pe_resource_t *rsc;
-    pe_node_t *node;
+    pcmk_node_t *node;
     xmlNode *op_entry;
 
     char *task;

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -29,7 +29,6 @@ extern "C" {
  * \ingroup pengine
  */
 
-typedef struct pe_action_s pe_action_t;
 typedef struct pe_working_set_s pe_working_set_t;
 
 typedef struct resource_object_functions_s {

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -35,20 +35,20 @@ typedef struct pe_resource_s pe_resource_t;
 typedef struct pe_working_set_s pe_working_set_t;
 
 typedef struct resource_object_functions_s {
-    gboolean (*unpack) (pe_resource_t*, pe_working_set_t*);
-    pe_resource_t *(*find_rsc) (pe_resource_t *parent, const char *search,
-                                const pcmk_node_t *node, int flags);
+    gboolean (*unpack)(pcmk_resource_t*, pe_working_set_t*);
+    pcmk_resource_t *(*find_rsc)(pcmk_resource_t *parent, const char *search,
+                                 const pcmk_node_t *node, int flags);
     /* parameter result must be free'd */
-    char *(*parameter)(pe_resource_t*, pcmk_node_t*, gboolean, const char*,
+    char *(*parameter)(pcmk_resource_t*, pcmk_node_t*, gboolean, const char*,
                        pe_working_set_t*);
     //! \deprecated will be removed in a future release
-    void (*print) (pe_resource_t*, const char*, long, void*);
-    gboolean (*active) (pe_resource_t*, gboolean);
-    enum rsc_role_e (*state) (const pe_resource_t*, gboolean);
-    pcmk_node_t *(*location)(const pe_resource_t*, GList**, int);
-    void (*free) (pe_resource_t*);
-    void (*count) (pe_resource_t*);
-    gboolean (*is_filtered) (const pe_resource_t*, GList *, gboolean);
+    void (*print)(pcmk_resource_t*, const char*, long, void*);
+    gboolean (*active)(pcmk_resource_t*, gboolean);
+    enum rsc_role_e (*state)(const pcmk_resource_t*, gboolean);
+    pcmk_node_t *(*location)(const pcmk_resource_t*, GList**, int);
+    void (*free)(pcmk_resource_t*);
+    void (*count)(pcmk_resource_t*);
+    gboolean (*is_filtered)(const pcmk_resource_t*, GList *, gboolean);
 
     /*!
      * \brief Find a node (and optionally count all) where resource is active
@@ -62,7 +62,7 @@ typedef struct resource_object_functions_s {
      *         online node if the resource's "requires" is "quorum" or
      *         "nothing", or NULL if the resource is inactive.
      */
-    pcmk_node_t *(*active_node)(const pe_resource_t *rsc,
+    pcmk_node_t *(*active_node)(const pcmk_resource_t *rsc,
                                 unsigned int *count_all,
                                 unsigned int *count_clean);
 
@@ -73,7 +73,7 @@ typedef struct resource_object_functions_s {
      *
      * \return Maximum number of \p rsc instances that can be active on one node
      */
-    unsigned int (*max_per_node)(const pe_resource_t *rsc);
+    unsigned int (*max_per_node)(const pcmk_resource_t *rsc);
 } resource_object_functions_t;
 
 typedef struct resource_alloc_functions_s resource_alloc_functions_t;
@@ -161,9 +161,9 @@ struct pe_node_shared_s {
     gboolean unpacked;
 
     int num_resources;
-    pe_resource_t *remote_rsc;
-    GList *running_rsc;       /* pe_resource_t* */
-    GList *allocated_rsc;     /* pe_resource_t* */
+    pcmk_resource_t *remote_rsc;
+    GList *running_rsc;         // pcmk_resource_t*
+    GList *allocated_rsc;       // pcmk_resource_t*
 
     GHashTable *attrs;          /* char* => char* */
     GHashTable *utilization;
@@ -188,7 +188,7 @@ struct pe_resource_s {
     xmlNode *ops_xml;
 
     pe_working_set_t *cluster;
-    pe_resource_t *parent;
+    pcmk_resource_t *parent;
 
     enum pe_obj_types variant;
     void *variant_opaque;
@@ -243,10 +243,10 @@ struct pe_resource_s {
     GHashTable *parameters; //! \deprecated Use pe_rsc_params() instead
     GHashTable *utilization;
 
-    GList *children;          /* pe_resource_t*   */
+    GList *children;            // pcmk_resource_t*
     GList *dangling_migrations; // pcmk_node_t*
 
-    pe_resource_t *container;
+    pcmk_resource_t *container;
     GList *fillers;
 
     // @COMPAT These should be made const at next API compatibility break
@@ -267,7 +267,7 @@ struct pe_action_s {
     int id;
     int priority;
 
-    pe_resource_t *rsc;
+    pcmk_resource_t *rsc;
     pcmk_node_t *node;
     xmlNode *op_entry;
 

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -241,6 +241,9 @@ typedef struct pe_tag_s tag_t;
 //!< \deprecated Use pe_ticket_t instead
 typedef struct pe_ticket_s ticket_t;
 
+//!< \deprecated Use pcmk_scheduler_t instead
+typedef struct pe_working_set_s pe_working_set_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -220,6 +220,9 @@ typedef struct pe_action_wrapper_s action_wrapper_t;
 //!< \deprecated Use pcmk_node_t instead
 typedef struct pe_node_s node_t;
 
+//!< \deprecated Use pcmk_node_t instead
+typedef struct pe_node_s pe_node_t;
+
 //!< \deprecated Use enum pe_quorum_policy instead
 typedef enum pe_quorum_policy no_quorum_policy_t;
 

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -223,7 +223,7 @@ typedef struct pe_node_s node_t;
 //!< \deprecated Use enum pe_quorum_policy instead
 typedef enum pe_quorum_policy no_quorum_policy_t;
 
-//!< \deprecated use pe_resource_t instead
+//!< \deprecated use pcmk_resource_t instead
 typedef struct pe_resource_s resource_t;
 
 //!< \deprecated Use pe_tag_t instead

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -211,7 +211,7 @@ enum pe_check_parameters {
 };
 //!@}
 
-//!< \deprecated Use pe_action_t instead
+//!< \deprecated Use pcmk_action_t instead
 typedef struct pe_action_s action_t;
 
 //!< \deprecated Use pe_action_wrapper_t instead

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -217,7 +217,7 @@ typedef struct pe_action_s action_t;
 //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_action_wrapper_s action_wrapper_t;
 
-//!< \deprecated Use pe_node_t instead
+//!< \deprecated Use pcmk_node_t instead
 typedef struct pe_node_s node_t;
 
 //!< \deprecated Use enum pe_quorum_policy instead

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -229,6 +229,9 @@ typedef enum pe_quorum_policy no_quorum_policy_t;
 //!< \deprecated use pcmk_resource_t instead
 typedef struct pe_resource_s resource_t;
 
+//!< \deprecated use pcmk_resource_t instead
+typedef struct pe_resource_s pe_resource_t;
+
 //!< \deprecated Use pe_tag_t instead
 typedef struct pe_tag_s tag_t;
 

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -214,6 +214,9 @@ enum pe_check_parameters {
 //!< \deprecated Use pcmk_action_t instead
 typedef struct pe_action_s action_t;
 
+//!< \deprecated Use pcmk_action_t instead
+typedef struct pe_action_s pe_action_t;
+
 //!< \deprecated Use pe_action_wrapper_t instead
 typedef struct pe_action_wrapper_s action_wrapper_t;
 

--- a/include/crm/pengine/remote_internal.h
+++ b/include/crm/pengine/remote_internal.h
@@ -19,15 +19,17 @@ extern "C" {
 #include <crm/pengine/status.h>
 
 bool xml_contains_remote_node(xmlNode *xml);
-bool pe__is_remote_node(const pe_node_t *node);
-bool pe__is_guest_node(const pe_node_t *node);
-bool pe__is_guest_or_remote_node(const pe_node_t *node);
-bool pe__is_bundle_node(const pe_node_t *node);
+bool pe__is_remote_node(const pcmk_node_t *node);
+bool pe__is_guest_node(const pcmk_node_t *node);
+bool pe__is_guest_or_remote_node(const pcmk_node_t *node);
+bool pe__is_bundle_node(const pcmk_node_t *node);
 bool pe__resource_is_remote_conn(const pe_resource_t *rsc);
 pe_resource_t *pe__resource_contains_guest_node(const pe_working_set_t *data_set,
                                                 const pe_resource_t *rsc);
-void pe_foreach_guest_node(const pe_working_set_t *data_set, const pe_node_t *host,
-                           void (*helper)(const pe_node_t*, void*), void *user_data);
+void pe_foreach_guest_node(const pe_working_set_t *data_set,
+                           const pcmk_node_t *host,
+                           void (*helper)(const pcmk_node_t*, void*),
+                           void *user_data);
 xmlNode *pe_create_remote_xml(xmlNode *parent, const char *uname,
                               const char *container_id, const char *migrateable,
                               const char *is_managed, const char *start_timeout,

--- a/include/crm/pengine/remote_internal.h
+++ b/include/crm/pengine/remote_internal.h
@@ -23,9 +23,9 @@ bool pe__is_remote_node(const pcmk_node_t *node);
 bool pe__is_guest_node(const pcmk_node_t *node);
 bool pe__is_guest_or_remote_node(const pcmk_node_t *node);
 bool pe__is_bundle_node(const pcmk_node_t *node);
-bool pe__resource_is_remote_conn(const pe_resource_t *rsc);
-pe_resource_t *pe__resource_contains_guest_node(const pe_working_set_t *data_set,
-                                                const pe_resource_t *rsc);
+bool pe__resource_is_remote_conn(const pcmk_resource_t *rsc);
+pcmk_resource_t *pe__resource_contains_guest_node(const pe_working_set_t *data_set,
+                                                  const pcmk_resource_t *rsc);
 void pe_foreach_guest_node(const pe_working_set_t *data_set,
                            const pcmk_node_t *host,
                            void (*helper)(const pcmk_node_t*, void*),

--- a/include/crm/pengine/remote_internal.h
+++ b/include/crm/pengine/remote_internal.h
@@ -24,9 +24,9 @@ bool pe__is_guest_node(const pcmk_node_t *node);
 bool pe__is_guest_or_remote_node(const pcmk_node_t *node);
 bool pe__is_bundle_node(const pcmk_node_t *node);
 bool pe__resource_is_remote_conn(const pcmk_resource_t *rsc);
-pcmk_resource_t *pe__resource_contains_guest_node(const pe_working_set_t *data_set,
+pcmk_resource_t *pe__resource_contains_guest_node(const pcmk_scheduler_t *data_set,
                                                   const pcmk_resource_t *rsc);
-void pe_foreach_guest_node(const pe_working_set_t *data_set,
+void pe_foreach_guest_node(const pcmk_scheduler_t *data_set,
                            const pcmk_node_t *host,
                            void (*helper)(const pcmk_node_t*, void*),
                            void *user_data);

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -29,12 +29,12 @@ extern "C" {
  */
 
 const char *rsc_printable_id(const pcmk_resource_t *rsc);
-gboolean cluster_status(pe_working_set_t * data_set);
-pe_working_set_t *pe_new_working_set(void);
-void pe_free_working_set(pe_working_set_t *data_set);
-void set_working_set_defaults(pe_working_set_t * data_set);
-void cleanup_calculations(pe_working_set_t * data_set);
-void pe_reset_working_set(pe_working_set_t *data_set);
+gboolean cluster_status(pcmk_scheduler_t *data_set);
+pcmk_scheduler_t *pe_new_working_set(void);
+void pe_free_working_set(pcmk_scheduler_t *data_set);
+void set_working_set_defaults(pcmk_scheduler_t *data_set);
+void cleanup_calculations(pcmk_scheduler_t *data_set);
+void pe_reset_working_set(pcmk_scheduler_t *data_set);
 pcmk_resource_t *pe_find_resource(GList *rsc_list, const char *id_rh);
 pcmk_resource_t *pe_find_resource_with_flags(GList *rsc_list, const char *id,
                                              enum pe_find flags);
@@ -43,7 +43,7 @@ pcmk_node_t *pe_find_node_id(const GList *node_list, const char *id);
 pcmk_node_t *pe_find_node_any(const GList *node_list, const char *id,
                             const char *node_name);
 GList *find_operations(const char *rsc, const char *node, gboolean active_filter,
-                         pe_working_set_t * data_set);
+                         pcmk_scheduler_t *data_set);
 void calculate_active_ops(const GList *sorted_op_list, int *start_index,
                           int *stop_index);
 int pe_bundle_replicas(const pcmk_resource_t *rsc);

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -15,7 +15,7 @@
 #  include <crm/common/util.h>      // pcmk_is_set()
 #  include <crm/common/iso8601.h>
 #  include <crm/pengine/common.h>
-#  include <crm/pengine/pe_types.h> // pe_node_t, pe_resource_t, etc.
+#  include <crm/pengine/pe_types.h> // pcmk_node_t, pe_resource_t, etc.
 #  include <crm/pengine/complex.h>
 
 #ifdef __cplusplus
@@ -37,9 +37,9 @@ void cleanup_calculations(pe_working_set_t * data_set);
 void pe_reset_working_set(pe_working_set_t *data_set);
 pe_resource_t *pe_find_resource(GList *rsc_list, const char *id_rh);
 pe_resource_t *pe_find_resource_with_flags(GList *rsc_list, const char *id, enum pe_find flags);
-pe_node_t *pe_find_node(const GList *node_list, const char *node_name);
-pe_node_t *pe_find_node_id(const GList *node_list, const char *id);
-pe_node_t *pe_find_node_any(const GList *node_list, const char *id,
+pcmk_node_t *pe_find_node(const GList *node_list, const char *node_name);
+pcmk_node_t *pe_find_node_id(const GList *node_list, const char *id);
+pcmk_node_t *pe_find_node_any(const GList *node_list, const char *id,
                             const char *node_name);
 GList *find_operations(const char *rsc, const char *node, gboolean active_filter,
                          pe_working_set_t * data_set);

--- a/include/crm/pengine/status.h
+++ b/include/crm/pengine/status.h
@@ -15,7 +15,7 @@
 #  include <crm/common/util.h>      // pcmk_is_set()
 #  include <crm/common/iso8601.h>
 #  include <crm/pengine/common.h>
-#  include <crm/pengine/pe_types.h> // pcmk_node_t, pe_resource_t, etc.
+#  include <crm/pengine/pe_types.h> // pcmk_node_t, pcmk_resource_t, etc.
 #  include <crm/pengine/complex.h>
 
 #ifdef __cplusplus
@@ -28,15 +28,16 @@ extern "C" {
  * \ingroup pengine
  */
 
-const char *rsc_printable_id(const pe_resource_t *rsc);
+const char *rsc_printable_id(const pcmk_resource_t *rsc);
 gboolean cluster_status(pe_working_set_t * data_set);
 pe_working_set_t *pe_new_working_set(void);
 void pe_free_working_set(pe_working_set_t *data_set);
 void set_working_set_defaults(pe_working_set_t * data_set);
 void cleanup_calculations(pe_working_set_t * data_set);
 void pe_reset_working_set(pe_working_set_t *data_set);
-pe_resource_t *pe_find_resource(GList *rsc_list, const char *id_rh);
-pe_resource_t *pe_find_resource_with_flags(GList *rsc_list, const char *id, enum pe_find flags);
+pcmk_resource_t *pe_find_resource(GList *rsc_list, const char *id_rh);
+pcmk_resource_t *pe_find_resource_with_flags(GList *rsc_list, const char *id,
+                                             enum pe_find flags);
 pcmk_node_t *pe_find_node(const GList *node_list, const char *node_name);
 pcmk_node_t *pe_find_node_id(const GList *node_list, const char *id);
 pcmk_node_t *pe_find_node_any(const GList *node_list, const char *id,
@@ -45,7 +46,7 @@ GList *find_operations(const char *rsc, const char *node, gboolean active_filter
                          pe_working_set_t * data_set);
 void calculate_active_ops(const GList *sorted_op_list, int *start_index,
                           int *stop_index);
-int pe_bundle_replicas(const pe_resource_t *rsc);
+int pe_bundle_replicas(const pcmk_resource_t *rsc);
 
 /*!
  * \brief Check whether a resource is any clone type
@@ -55,7 +56,7 @@ int pe_bundle_replicas(const pe_resource_t *rsc);
  * \return true if resource is clone, false otherwise
  */
 static inline bool
-pe_rsc_is_clone(const pe_resource_t *rsc)
+pe_rsc_is_clone(const pcmk_resource_t *rsc)
 {
     return (rsc != NULL) && (rsc->variant == pcmk_rsc_variant_clone);
 }
@@ -68,7 +69,7 @@ pe_rsc_is_clone(const pe_resource_t *rsc)
  * \return true if resource is unique clone, false otherwise
  */
 static inline bool
-pe_rsc_is_unique_clone(const pe_resource_t *rsc)
+pe_rsc_is_unique_clone(const pcmk_resource_t *rsc)
 {
     return pe_rsc_is_clone(rsc) && pcmk_is_set(rsc->flags, pcmk_rsc_unique);
 }
@@ -81,7 +82,7 @@ pe_rsc_is_unique_clone(const pe_resource_t *rsc)
  * \return true if resource is anonymous clone, false otherwise
  */
 static inline bool
-pe_rsc_is_anon_clone(const pe_resource_t *rsc)
+pe_rsc_is_anon_clone(const pcmk_resource_t *rsc)
 {
     return pe_rsc_is_clone(rsc) && !pcmk_is_set(rsc->flags, pcmk_rsc_unique);
 }
@@ -94,7 +95,7 @@ pe_rsc_is_anon_clone(const pe_resource_t *rsc)
  * \return true if resource is part of a bundle, false otherwise
  */
 static inline bool
-pe_rsc_is_bundled(const pe_resource_t *rsc)
+pe_rsc_is_bundled(const pcmk_resource_t *rsc)
 {
     if (rsc == NULL) {
         return false;

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -206,7 +206,7 @@ int pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_resource_digests(xmlNodePtr *xml, pe_resource_t *rsc,
+int pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
                           const pcmk_node_t *node, GHashTable *overrides,
                           pe_working_set_t *data_set);
 

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -207,7 +207,7 @@ int pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
  * \return Standard Pacemaker return code
  */
 int pcmk_resource_digests(xmlNodePtr *xml, pe_resource_t *rsc,
-                          const pe_node_t *node, GHashTable *overrides,
+                          const pcmk_node_t *node, GHashTable *overrides,
                           pe_working_set_t *data_set);
 
 /*!

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -208,7 +208,7 @@ int pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
  */
 int pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
                           const pcmk_node_t *node, GHashTable *overrides,
-                          pe_working_set_t *data_set);
+                          pcmk_scheduler_t *data_set);
 
 /*!
  * \brief Simulate a cluster's response to events
@@ -238,7 +238,7 @@ int pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_simulate(xmlNodePtr *xml, pe_working_set_t *data_set,
+int pcmk_simulate(xmlNodePtr *xml, pcmk_scheduler_t *data_set,
                   const pcmk_injections_t *injections, unsigned int flags,
                   unsigned int section_opts, const char *use_date,
                   const char *input_file, const char *graph_file,

--- a/include/pcmki/pcmki_resource.h
+++ b/include/pcmki/pcmki_resource.h
@@ -14,7 +14,7 @@
 #include <crm/common/output_internal.h>
 #include <crm/pengine/pe_types.h>
 
-int pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
+int pcmk__resource_digests(pcmk__output_t *out, pcmk_resource_t *rsc,
                            const pcmk_node_t *node, GHashTable *overrides);
 
 #endif /* PCMK__PCMKI_PCMKI_RESOURCE__H */

--- a/include/pcmki/pcmki_resource.h
+++ b/include/pcmki/pcmki_resource.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the Pacemaker project contributors
+ * Copyright 2021-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -15,6 +15,6 @@
 #include <crm/pengine/pe_types.h>
 
 int pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
-                           const pe_node_t *node, GHashTable *overrides);
+                           const pcmk_node_t *node, GHashTable *overrides);
 
 #endif /* PCMK__PCMKI_PCMKI_RESOURCE__H */

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -15,13 +15,13 @@
 #include <libxml/tree.h>        // xmlNode
 
 #include <crm/lrmd_events.h>    // lrmd_event_data_t
-#include <crm/pengine/status.h> // pe_resource_t, pe_working_set_t
+#include <crm/pengine/status.h> // pcmk_resource_t, pe_working_set_t
 
 typedef struct {
     const char *id;
     const char *node_attribute;
-    pe_resource_t *dependent;   // The resource being colocated
-    pe_resource_t *primary;     // The resource the dependent is colocated with
+    pcmk_resource_t *dependent; // The resource being colocated
+    pcmk_resource_t *primary;   // The resource the dependent is colocated with
 
     int dependent_role; // Colocation applies only if dependent has this role
     int primary_role;   // Colocation applies only if primary has this role

--- a/include/pcmki/pcmki_scheduler.h
+++ b/include/pcmki/pcmki_scheduler.h
@@ -15,7 +15,7 @@
 #include <libxml/tree.h>        // xmlNode
 
 #include <crm/lrmd_events.h>    // lrmd_event_data_t
-#include <crm/pengine/status.h> // pcmk_resource_t, pe_working_set_t
+#include <crm/pengine/status.h> // pcmk_resource_t, pcmk_scheduler_t
 
 typedef struct {
     const char *id;
@@ -30,10 +30,10 @@ typedef struct {
     uint32_t flags;     // Group of enum pcmk__coloc_flags
 } pcmk__colocation_t;
 
-void pcmk__unpack_constraints(pe_working_set_t *data_set);
+void pcmk__unpack_constraints(pcmk_scheduler_t *data_set);
 
 void pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
-                            pe_working_set_t *data_set);
+                            pcmk_scheduler_t *data_set);
 
 GList *pcmk__copy_node_list(const GList *list, bool reset);
 

--- a/include/pcmki/pcmki_simulate.h
+++ b/include/pcmki/pcmki_simulate.h
@@ -32,7 +32,7 @@
  * \param[in,out] data_set Working set for the cluster
  * \param[in]     use_date The date to set the cluster's time to (may be NULL)
  */
-void pcmk__profile_dir(const char *dir, long long repeat, pe_working_set_t *data_set,
+void pcmk__profile_dir(const char *dir, long long repeat, pcmk_scheduler_t *data_set,
                        const char *use_date);
 
 /*!
@@ -45,7 +45,7 @@ void pcmk__profile_dir(const char *dir, long long repeat, pe_working_set_t *data
  *
  * \return Transition status after simulated execution
  */
-enum pcmk__graph_status pcmk__simulate_transition(pe_working_set_t *data_set,
+enum pcmk__graph_status pcmk__simulate_transition(pcmk_scheduler_t *data_set,
                                                   cib_t *cib,
                                                   const GList *op_fail_list);
 
@@ -80,7 +80,7 @@ enum pcmk__graph_status pcmk__simulate_transition(pe_working_set_t *data_set,
  *
  * \return Standard Pacemaker return code
  */
-int pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
+int pcmk__simulate(pcmk_scheduler_t *data_set, pcmk__output_t *out,
                    const pcmk_injections_t *injections, unsigned int flags,
                    uint32_t section_opts, const char *use_date,
                    const char *input_file, const char *graph_file,

--- a/include/pcmki/pcmki_status.h
+++ b/include/pcmki/pcmki_status.h
@@ -39,7 +39,7 @@ extern "C" {
  *       callers should be added.
  */
 int pcmk__output_simple_status(pcmk__output_t *out,
-                               const pe_working_set_t *data_set);
+                               const pcmk_scheduler_t *data_set);
 
 int pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith,
                                 cib_t *cib, xmlNode *current_cib,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -87,7 +87,7 @@ struct resource_alloc_functions_s {
      *       same effect as calling pcmk__unassign_resource(); there are no side
      *       effects on roles or actions.
      */
-    pcmk_node_t *(*assign)(pe_resource_t *rsc, const pcmk_node_t *prefer,
+    pcmk_node_t *(*assign)(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
                            bool stop_if_fail);
 
     /*!
@@ -96,7 +96,7 @@ struct resource_alloc_functions_s {
      *
      * \param[in,out] rsc  Resource to create actions for
      */
-    void (*create_actions)(pe_resource_t *rsc);
+    void (*create_actions)(pcmk_resource_t *rsc);
 
     /*!
      * \internal
@@ -107,7 +107,7 @@ struct resource_alloc_functions_s {
      *
      * \return true if any probe was created, otherwise false
      */
-    bool (*create_probe)(pe_resource_t *rsc, pcmk_node_t *node);
+    bool (*create_probe)(pcmk_resource_t *rsc, pcmk_node_t *node);
 
     /*!
      * \internal
@@ -115,7 +115,7 @@ struct resource_alloc_functions_s {
      *
      * \param[in,out] rsc  Resource to create implicit constraints for
      */
-    void (*internal_constraints)(pe_resource_t *rsc);
+    void (*internal_constraints)(pcmk_resource_t *rsc);
 
     /*!
      * \internal
@@ -130,8 +130,8 @@ struct resource_alloc_functions_s {
      * \param[in]     colocation     Colocation constraint to apply
      * \param[in]     for_dependent  true if called on behalf of dependent
      */
-    void (*apply_coloc_score)(pe_resource_t *dependent,
-                              const pe_resource_t *primary,
+    void (*apply_coloc_score)(pcmk_resource_t *dependent,
+                              const pcmk_resource_t *primary,
                               const pcmk__colocation_t *colocation,
                               bool for_dependent);
 
@@ -152,8 +152,8 @@ struct resource_alloc_functions_s {
      *       \p colocated_rscs and \p orig_rsc, and the desired resource as
      *       \p rsc. The recursive calls will use other values.
      */
-    GList *(*colocated_resources)(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc,
+    GList *(*colocated_resources)(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
                                   GList *colocated_rscs);
 
     /*!
@@ -173,8 +173,9 @@ struct resource_alloc_functions_s {
      * \note The pcmk__with_this_colocations() wrapper should usually be used
      *       instead of using this method directly.
      */
-    void (*with_this_colocations)(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc, GList **list);
+    void (*with_this_colocations)(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
+                                  GList **list);
 
     /*!
      * \internal
@@ -194,8 +195,9 @@ struct resource_alloc_functions_s {
      * \note The pcmk__this_with_colocations() wrapper should usually be used
      *       instead of using this method directly.
      */
-    void (*this_with_colocations)(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc, GList **list);
+    void (*this_with_colocations)(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
+                                  GList **list);
 
     /*!
      * \internal
@@ -226,8 +228,8 @@ struct resource_alloc_functions_s {
      *       only by \c cmp_resources()).
      * \note The caller remains responsible for freeing \p *nodes.
      */
-    void (*add_colocated_node_scores)(pe_resource_t *source_rsc,
-                                      const pe_resource_t *target_rsc,
+    void (*add_colocated_node_scores)(pcmk_resource_t *source_rsc,
+                                      const pcmk_resource_t *target_rsc,
                                       const char *log_id, GHashTable **nodes,
                                       const pcmk__colocation_t *colocation,
                                       float factor, uint32_t flags);
@@ -239,7 +241,7 @@ struct resource_alloc_functions_s {
      * \param[in,out] rsc       Resource to apply constraint to
      * \param[in,out] location  Location constraint to apply
      */
-    void (*apply_location)(pe_resource_t *rsc, pe__location_t *location);
+    void (*apply_location)(pcmk_resource_t *rsc, pe__location_t *location);
 
     /*!
      * \internal
@@ -289,7 +291,7 @@ struct resource_alloc_functions_s {
      *
      * \param[in,out] rsc  Resource to output actions for
      */
-    void (*output_actions)(pe_resource_t *rsc);
+    void (*output_actions)(pcmk_resource_t *rsc);
 
     /*!
      * \internal
@@ -297,7 +299,7 @@ struct resource_alloc_functions_s {
      *
      * \param[in,out] rsc  Resource whose actions should be added
      */
-    void (*add_actions_to_graph)(pe_resource_t *rsc);
+    void (*add_actions_to_graph)(pcmk_resource_t *rsc);
 
     /*!
      * \internal
@@ -309,7 +311,7 @@ struct resource_alloc_functions_s {
      * \param[in]     rsc  Resource whose meta-attributes should be added
      * \param[in,out] xml  Transition graph action attributes XML to add to
      */
-    void (*add_graph_meta)(const pe_resource_t *rsc, xmlNode *xml);
+    void (*add_graph_meta)(const pcmk_resource_t *rsc, xmlNode *xml);
 
     /*!
      * \internal
@@ -326,8 +328,8 @@ struct resource_alloc_functions_s {
      * \param[in]     all_rscs     List of all resources that will be summed
      * \param[in,out] utilization  Table of utilization values to add to
      */
-    void (*add_utilization)(const pe_resource_t *rsc,
-                            const pe_resource_t *orig_rsc, GList *all_rscs,
+    void (*add_utilization)(const pcmk_resource_t *rsc,
+                            const pcmk_resource_t *orig_rsc, GList *all_rscs,
                             GHashTable *utilization);
 
     /*!
@@ -336,7 +338,7 @@ struct resource_alloc_functions_s {
      *
      * \param[in,out] rsc       Resource to check for shutdown lock
      */
-    void (*shutdown_lock)(pe_resource_t *rsc);
+    void (*shutdown_lock)(pcmk_resource_t *rsc);
 };
 
 // Actions (pcmk_sched_actions.c)
@@ -356,7 +358,7 @@ void pcmk__log_action(const char *pre_text, const pe_action_t *action,
                       bool details);
 
 G_GNUC_INTERNAL
-pe_action_t *pcmk__new_cancel_action(pe_resource_t *rsc, const char *name,
+pe_action_t *pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *name,
                                      guint interval_ms,
                                      const pcmk_node_t *node);
 
@@ -373,7 +375,7 @@ G_GNUC_INTERNAL
 void pcmk__output_actions(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__check_action_config(pe_resource_t *rsc, pcmk_node_t *node,
+bool pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
                                const xmlNode *xml_op);
 
 G_GNUC_INTERNAL
@@ -383,15 +385,15 @@ void pcmk__handle_rsc_config_changes(pe_working_set_t *data_set);
 // Recurring actions (pcmk_sched_recurring.c)
 
 G_GNUC_INTERNAL
-void pcmk__create_recurring_actions(pe_resource_t *rsc);
+void pcmk__create_recurring_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__schedule_cancel(pe_resource_t *rsc, const char *call_id,
+void pcmk__schedule_cancel(pcmk_resource_t *rsc, const char *call_id,
                            const char *task, guint interval_ms,
                            const pcmk_node_t *node, const char *reason);
 
 G_GNUC_INTERNAL
-void pcmk__reschedule_recurring(pe_resource_t *rsc, const char *task,
+void pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
                                 guint interval_ms, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
@@ -406,7 +408,7 @@ bool pcmk__graph_has_loop(const pe_action_t *init_action,
                           pe_action_wrapper_t *input);
 
 G_GNUC_INTERNAL
-void pcmk__add_rsc_actions_to_graph(pe_resource_t *rsc);
+void pcmk__add_rsc_actions_to_graph(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__create_graph(pe_working_set_t *data_set);
@@ -418,7 +420,7 @@ G_GNUC_INTERNAL
 void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__order_vs_unfence(const pe_resource_t *rsc, pcmk_node_t *node,
+void pcmk__order_vs_unfence(const pcmk_resource_t *rsc, pcmk_node_t *node,
                             pe_action_t *action,
                             enum pcmk__action_relation_flags order);
 
@@ -441,7 +443,8 @@ void pcmk__inject_scheduler_input(pe_working_set_t *data_set, cib_t *cib,
 // Constraints of any type (pcmk_sched_constraints.c)
 
 G_GNUC_INTERNAL
-pe_resource_t *pcmk__find_constraint_resource(GList *rsc_list, const char *id);
+pcmk_resource_t *pcmk__find_constraint_resource(GList *rsc_list,
+                                                const char *id);
 
 G_GNUC_INTERNAL
 xmlNode *pcmk__expand_tags_in_sets(xmlNode *xml_obj,
@@ -449,7 +452,7 @@ xmlNode *pcmk__expand_tags_in_sets(xmlNode *xml_obj,
 
 G_GNUC_INTERNAL
 bool pcmk__valid_resource_or_tag(const pe_working_set_t *data_set,
-                                 const char *id, pe_resource_t **rsc,
+                                 const char *id, pcmk_resource_t **rsc,
                                  pe_tag_t **tag);
 
 G_GNUC_INTERNAL
@@ -466,7 +469,7 @@ G_GNUC_INTERNAL
 void pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-pe__location_t *pcmk__new_location(const char *id, pe_resource_t *rsc,
+pe__location_t *pcmk__new_location(const char *id, pcmk_resource_t *rsc,
                                    int node_score, const char *discover_mode,
                                    pcmk_node_t *foo_node);
 
@@ -474,7 +477,7 @@ G_GNUC_INTERNAL
 void pcmk__apply_locations(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__apply_location(pe_resource_t *rsc, pe__location_t *constraint);
+void pcmk__apply_location(pcmk_resource_t *rsc, pe__location_t *constraint);
 
 
 // Colocation constraints (pcmk_sched_colocation.c)
@@ -503,9 +506,9 @@ enum pcmk__coloc_affects {
  */
 static inline const char *
 pcmk__colocation_node_attr(const pcmk_node_t *node, const char *attr,
-                           const pe_resource_t *rsc)
+                           const pcmk_resource_t *rsc)
 {
-    const pe_resource_t *top = pe__const_top_resource(rsc, false);
+    const pcmk_resource_t *top = pe__const_top_resource(rsc, false);
     const bool force_host = pe__is_bundle_node(node)
                             && pe_rsc_is_bundled(rsc)
                             && (top == pe__bundled_resource(rsc));
@@ -515,26 +518,27 @@ pcmk__colocation_node_attr(const pcmk_node_t *node, const char *attr,
 }
 
 G_GNUC_INTERNAL
-enum pcmk__coloc_affects pcmk__colocation_affects(const pe_resource_t
+enum pcmk__coloc_affects pcmk__colocation_affects(const pcmk_resource_t
                                                     *dependent,
-                                                  const pe_resource_t *primary,
+                                                  const pcmk_resource_t
+                                                    *primary,
                                                   const pcmk__colocation_t
                                                     *colocation,
                                                   bool preview);
 
 G_GNUC_INTERNAL
-void pcmk__apply_coloc_to_scores(pe_resource_t *dependent,
-                                 const pe_resource_t *primary,
+void pcmk__apply_coloc_to_scores(pcmk_resource_t *dependent,
+                                 const pcmk_resource_t *primary,
                                  const pcmk__colocation_t *colocation);
 
 G_GNUC_INTERNAL
-void pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
-                                   const pe_resource_t *primary,
+void pcmk__apply_coloc_to_priority(pcmk_resource_t *dependent,
+                                   const pcmk_resource_t *primary,
                                    const pcmk__colocation_t *colocation);
 
 G_GNUC_INTERNAL
-void pcmk__add_colocated_node_scores(pe_resource_t *source_rsc,
-                                     const pe_resource_t *target_rsc,
+void pcmk__add_colocated_node_scores(pcmk_resource_t *source_rsc,
+                                     const pcmk_resource_t *target_rsc,
                                      const char *log_id, GHashTable **nodes,
                                      const pcmk__colocation_t *colocation,
                                      float factor, uint32_t flags);
@@ -543,8 +547,8 @@ G_GNUC_INTERNAL
 void pcmk__add_dependent_scores(gpointer data, gpointer user_data);
 
 G_GNUC_INTERNAL
-void pcmk__colocation_intersect_nodes(pe_resource_t *dependent,
-                                      const pe_resource_t *primary,
+void pcmk__colocation_intersect_nodes(pcmk_resource_t *dependent,
+                                      const pcmk_resource_t *primary,
                                       const pcmk__colocation_t *colocation,
                                       const GList *primary_nodes,
                                       bool merge_scores);
@@ -554,29 +558,29 @@ void pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__add_this_with(GList **list, const pcmk__colocation_t *colocation,
-                         const pe_resource_t *rsc);
+                         const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__add_this_with_list(GList **list, GList *addition,
-                              const pe_resource_t *rsc);
+                              const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__add_with_this(GList **list, const pcmk__colocation_t *colocation,
-                         const pe_resource_t *rsc);
+                         const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__add_with_this_list(GList **list, GList *addition,
-                              const pe_resource_t *rsc);
+                              const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-GList *pcmk__with_this_colocations(const pe_resource_t *rsc);
+GList *pcmk__with_this_colocations(const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-GList *pcmk__this_with_colocations(const pe_resource_t *rsc);
+GList *pcmk__this_with_colocations(const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__new_colocation(const char *id, const char *node_attr, int score,
-                          pe_resource_t *dependent, pe_resource_t *primary,
+                          pcmk_resource_t *dependent, pcmk_resource_t *primary,
                           const char *dependent_role, const char *primary_role,
                           uint32_t flags);
 
@@ -597,7 +601,7 @@ void pcmk__block_colocation_dependents(pe_action_t *action);
  */
 static inline bool
 pcmk__colocation_has_influence(const pcmk__colocation_t *colocation,
-                               const pe_resource_t *rsc)
+                               const pcmk_resource_t *rsc)
 {
     if (rsc == NULL) {
         rsc = colocation->primary;
@@ -633,8 +637,8 @@ pcmk__colocation_has_influence(const pcmk__colocation_t *colocation,
 // Ordering constraints (pcmk_sched_ordering.c)
 
 G_GNUC_INTERNAL
-void pcmk__new_ordering(pe_resource_t *first_rsc, char *first_task,
-                        pe_action_t *first_action, pe_resource_t *then_rsc,
+void pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_task,
+                        pe_action_t *first_action, pcmk_resource_t *then_rsc,
                         char *then_task, pe_action_t *then_action,
                         uint32_t flags, pe_working_set_t *sched);
 
@@ -692,32 +696,32 @@ void pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set);
 // Promotable clone resources (pcmk_sched_promotable.c)
 
 G_GNUC_INTERNAL
-void pcmk__add_promotion_scores(pe_resource_t *rsc);
+void pcmk__add_promotion_scores(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__require_promotion_tickets(pe_resource_t *rsc);
+void pcmk__require_promotion_tickets(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__set_instance_roles(pe_resource_t *rsc);
+void pcmk__set_instance_roles(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__create_promotable_actions(pe_resource_t *clone);
+void pcmk__create_promotable_actions(pcmk_resource_t *clone);
 
 G_GNUC_INTERNAL
-void pcmk__promotable_restart_ordering(pe_resource_t *rsc);
+void pcmk__promotable_restart_ordering(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__order_promotable_instances(pe_resource_t *clone);
+void pcmk__order_promotable_instances(pcmk_resource_t *clone);
 
 G_GNUC_INTERNAL
-void pcmk__update_dependent_with_promotable(const pe_resource_t *primary,
-                                            pe_resource_t *dependent,
+void pcmk__update_dependent_with_promotable(const pcmk_resource_t *primary,
+                                            pcmk_resource_t *dependent,
                                             const pcmk__colocation_t
                                                 *colocation);
 
 G_GNUC_INTERNAL
-void pcmk__update_promotable_dependent_priority(const pe_resource_t *primary,
-                                                pe_resource_t *dependent,
+void pcmk__update_promotable_dependent_priority(const pcmk_resource_t *primary,
+                                                pcmk_resource_t *dependent,
                                                 const pcmk__colocation_t
                                                     *colocation);
 
@@ -731,14 +735,14 @@ G_GNUC_INTERNAL
 void pcmk__order_remote_connection_actions(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__rsc_corresponds_to_guest(const pe_resource_t *rsc,
+bool pcmk__rsc_corresponds_to_guest(const pcmk_resource_t *rsc,
                                     const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 pcmk_node_t *pcmk__connection_host_for_action(const pe_action_t *action);
 
 G_GNUC_INTERNAL
-void pcmk__substitute_remote_addr(pe_resource_t *rsc, GHashTable *params);
+void pcmk__substitute_remote_addr(pcmk_resource_t *rsc, GHashTable *params);
 
 G_GNUC_INTERNAL
 void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action);
@@ -747,88 +751,90 @@ void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action);
 // Primitives (pcmk_sched_primitive.c)
 
 G_GNUC_INTERNAL
-pcmk_node_t *pcmk__primitive_assign(pe_resource_t *rsc,
+pcmk_node_t *pcmk__primitive_assign(pcmk_resource_t *rsc,
                                     const pcmk_node_t *prefer,
                                     bool stop_if_fail);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_create_actions(pe_resource_t *rsc);
+void pcmk__primitive_create_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_internal_constraints(pe_resource_t *rsc);
+void pcmk__primitive_internal_constraints(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__primitive_action_flags(pe_action_t *action,
                                       const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
-                                       const pe_resource_t *primary,
+void pcmk__primitive_apply_coloc_score(pcmk_resource_t *dependent,
+                                       const pcmk_resource_t *primary,
                                        const pcmk__colocation_t *colocation,
                                        bool for_dependent);
 
 G_GNUC_INTERNAL
-void pcmk__with_primitive_colocations(const pe_resource_t *rsc,
-                                      const pe_resource_t *orig_rsc,
+void pcmk__with_primitive_colocations(const pcmk_resource_t *rsc,
+                                      const pcmk_resource_t *orig_rsc,
                                       GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_with_colocations(const pe_resource_t *rsc,
-                                      const pe_resource_t *orig_rsc,
+void pcmk__primitive_with_colocations(const pcmk_resource_t *rsc,
+                                      const pcmk_resource_t *orig_rsc,
                                       GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__schedule_cleanup(pe_resource_t *rsc, const pcmk_node_t *node,
+void pcmk__schedule_cleanup(pcmk_resource_t *rsc, const pcmk_node_t *node,
                             bool optional);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_add_graph_meta(const pe_resource_t *rsc, xmlNode *xml);
+void pcmk__primitive_add_graph_meta(const pcmk_resource_t *rsc, xmlNode *xml);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_add_utilization(const pe_resource_t *rsc,
-                                     const pe_resource_t *orig_rsc,
+void pcmk__primitive_add_utilization(const pcmk_resource_t *rsc,
+                                     const pcmk_resource_t *orig_rsc,
                                      GList *all_rscs, GHashTable *utilization);
 
 G_GNUC_INTERNAL
-void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
+void pcmk__primitive_shutdown_lock(pcmk_resource_t *rsc);
 
 
 // Groups (pcmk_sched_group.c)
 
 G_GNUC_INTERNAL
-pcmk_node_t *pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+pcmk_node_t *pcmk__group_assign(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
                                 bool stop_if_fail);
 
 G_GNUC_INTERNAL
-void pcmk__group_create_actions(pe_resource_t *rsc);
+void pcmk__group_create_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__group_internal_constraints(pe_resource_t *rsc);
+void pcmk__group_internal_constraints(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__group_apply_coloc_score(pe_resource_t *dependent,
-                                   const pe_resource_t *primary,
+void pcmk__group_apply_coloc_score(pcmk_resource_t *dependent,
+                                   const pcmk_resource_t *primary,
                                    const pcmk__colocation_t *colocation,
                                    bool for_dependent);
 
 G_GNUC_INTERNAL
-void pcmk__with_group_colocations(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc, GList **list);
+void pcmk__with_group_colocations(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
+                                  GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__group_with_colocations(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc, GList **list);
+void pcmk__group_with_colocations(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
+                                  GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__group_add_colocated_node_scores(pe_resource_t *source_rsc,
-                                           const pe_resource_t *target_rsc,
+void pcmk__group_add_colocated_node_scores(pcmk_resource_t *source_rsc,
+                                           const pcmk_resource_t *target_rsc,
                                            const char *log_id,
                                            GHashTable **nodes,
                                            const pcmk__colocation_t *colocation,
                                            float factor, uint32_t flags);
 
 G_GNUC_INTERNAL
-void pcmk__group_apply_location(pe_resource_t *rsc, pe__location_t *location);
+void pcmk__group_apply_location(pcmk_resource_t *rsc, pe__location_t *location);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node);
@@ -842,99 +848,104 @@ uint32_t pcmk__group_update_ordered_actions(pe_action_t *first,
                                             pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-GList *pcmk__group_colocated_resources(const pe_resource_t *rsc,
-                                       const pe_resource_t *orig_rsc,
+GList *pcmk__group_colocated_resources(const pcmk_resource_t *rsc,
+                                       const pcmk_resource_t *orig_rsc,
                                        GList *colocated_rscs);
 
 G_GNUC_INTERNAL
-void pcmk__group_add_utilization(const pe_resource_t *rsc,
-                                 const pe_resource_t *orig_rsc, GList *all_rscs,
-                                 GHashTable *utilization);
+void pcmk__group_add_utilization(const pcmk_resource_t *rsc,
+                                 const pcmk_resource_t *orig_rsc,
+                                 GList *all_rscs, GHashTable *utilization);
 
 G_GNUC_INTERNAL
-void pcmk__group_shutdown_lock(pe_resource_t *rsc);
+void pcmk__group_shutdown_lock(pcmk_resource_t *rsc);
 
 
 // Clones (pcmk_sched_clone.c)
 
 G_GNUC_INTERNAL
-pcmk_node_t *pcmk__clone_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+pcmk_node_t *pcmk__clone_assign(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
                                 bool stop_if_fail);
 
 G_GNUC_INTERNAL
-void pcmk__clone_create_actions(pe_resource_t *rsc);
+void pcmk__clone_create_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__clone_create_probe(pe_resource_t *rsc, pcmk_node_t *node);
+bool pcmk__clone_create_probe(pcmk_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__clone_internal_constraints(pe_resource_t *rsc);
+void pcmk__clone_internal_constraints(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__clone_apply_coloc_score(pe_resource_t *dependent,
-                                   const pe_resource_t *primary,
+void pcmk__clone_apply_coloc_score(pcmk_resource_t *dependent,
+                                   const pcmk_resource_t *primary,
                                    const pcmk__colocation_t *colocation,
                                    bool for_dependent);
 
 G_GNUC_INTERNAL
-void pcmk__with_clone_colocations(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc, GList **list);
+void pcmk__with_clone_colocations(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
+                                  GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__clone_with_colocations(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc, GList **list);
+void pcmk__clone_with_colocations(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
+                                  GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__clone_apply_location(pe_resource_t *rsc, pe__location_t *constraint);
+void pcmk__clone_apply_location(pcmk_resource_t *rsc,
+                                pe__location_t *constraint);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__clone_action_flags(pe_action_t *action, const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__clone_add_actions_to_graph(pe_resource_t *rsc);
+void pcmk__clone_add_actions_to_graph(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__clone_add_graph_meta(const pe_resource_t *rsc, xmlNode *xml);
+void pcmk__clone_add_graph_meta(const pcmk_resource_t *rsc, xmlNode *xml);
 
 G_GNUC_INTERNAL
-void pcmk__clone_add_utilization(const pe_resource_t *rsc,
-                                 const pe_resource_t *orig_rsc,
+void pcmk__clone_add_utilization(const pcmk_resource_t *rsc,
+                                 const pcmk_resource_t *orig_rsc,
                                  GList *all_rscs, GHashTable *utilization);
 
 G_GNUC_INTERNAL
-void pcmk__clone_shutdown_lock(pe_resource_t *rsc);
+void pcmk__clone_shutdown_lock(pcmk_resource_t *rsc);
 
 // Bundles (pcmk_sched_bundle.c)
 
 G_GNUC_INTERNAL
-pcmk_node_t *pcmk__bundle_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
-                                 bool stop_if_fail);
+pcmk_node_t *pcmk__bundle_assign(pcmk_resource_t *rsc,
+                                 const pcmk_node_t *prefer, bool stop_if_fail);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_create_actions(pe_resource_t *rsc);
+void pcmk__bundle_create_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__bundle_create_probe(pe_resource_t *rsc, pcmk_node_t *node);
+bool pcmk__bundle_create_probe(pcmk_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_internal_constraints(pe_resource_t *rsc);
+void pcmk__bundle_internal_constraints(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
-                                    const pe_resource_t *primary,
+void pcmk__bundle_apply_coloc_score(pcmk_resource_t *dependent,
+                                    const pcmk_resource_t *primary,
                                     const pcmk__colocation_t *colocation,
                                     bool for_dependent);
 
 G_GNUC_INTERNAL
-void pcmk__with_bundle_colocations(const pe_resource_t *rsc,
-                                   const pe_resource_t *orig_rsc, GList **list);
+void pcmk__with_bundle_colocations(const pcmk_resource_t *rsc,
+                                   const pcmk_resource_t *orig_rsc,
+                                   GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_with_colocations(const pe_resource_t *rsc,
-                                   const pe_resource_t *orig_rsc, GList **list);
+void pcmk__bundle_with_colocations(const pcmk_resource_t *rsc,
+                                   const pcmk_resource_t *orig_rsc,
+                                   GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_apply_location(pe_resource_t *rsc,
+void pcmk__bundle_apply_location(pcmk_resource_t *rsc,
                                  pe__location_t *constraint);
 
 G_GNUC_INTERNAL
@@ -942,39 +953,39 @@ uint32_t pcmk__bundle_action_flags(pe_action_t *action,
                                    const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__output_bundle_actions(pe_resource_t *rsc);
+void pcmk__output_bundle_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_add_actions_to_graph(pe_resource_t *rsc);
+void pcmk__bundle_add_actions_to_graph(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_add_utilization(const pe_resource_t *rsc,
-                                  const pe_resource_t *orig_rsc,
+void pcmk__bundle_add_utilization(const pcmk_resource_t *rsc,
+                                  const pcmk_resource_t *orig_rsc,
                                   GList *all_rscs, GHashTable *utilization);
 
 G_GNUC_INTERNAL
-void pcmk__bundle_shutdown_lock(pe_resource_t *rsc);
+void pcmk__bundle_shutdown_lock(pcmk_resource_t *rsc);
 
 
 // Clone instances or bundle replica containers (pcmk_sched_instances.c)
 
 G_GNUC_INTERNAL
-void pcmk__assign_instances(pe_resource_t *collective, GList *instances,
+void pcmk__assign_instances(pcmk_resource_t *collective, GList *instances,
                             int max_total, int max_per_node);
 
 G_GNUC_INTERNAL
-void pcmk__create_instance_actions(pe_resource_t *rsc, GList *instances);
+void pcmk__create_instance_actions(pcmk_resource_t *rsc, GList *instances);
 
 G_GNUC_INTERNAL
-bool pcmk__instance_matches(const pe_resource_t *instance,
+bool pcmk__instance_matches(const pcmk_resource_t *instance,
                             const pcmk_node_t *node, enum rsc_role_e role,
                             bool current);
 
 G_GNUC_INTERNAL
-pe_resource_t *pcmk__find_compatible_instance(const pe_resource_t *match_rsc,
-                                              const pe_resource_t *rsc,
-                                              enum rsc_role_e role,
-                                              bool current);
+pcmk_resource_t *pcmk__find_compatible_instance(const pcmk_resource_t *match_rsc,
+                                                const pcmk_resource_t *rsc,
+                                                enum rsc_role_e role,
+                                                bool current);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__instance_update_ordered_actions(pe_action_t *first,
@@ -1030,10 +1041,10 @@ G_GNUC_INTERNAL
 GHashTable *pcmk__copy_node_table(GHashTable *nodes);
 
 G_GNUC_INTERNAL
-void pcmk__copy_node_tables(const pe_resource_t *rsc, GHashTable **copy);
+void pcmk__copy_node_tables(const pcmk_resource_t *rsc, GHashTable **copy);
 
 G_GNUC_INTERNAL
-void pcmk__restore_node_tables(pe_resource_t *rsc, GHashTable *backup);
+void pcmk__restore_node_tables(pcmk_resource_t *rsc, GHashTable *backup);
 
 G_GNUC_INTERNAL
 GList *pcmk__sort_nodes(GList *nodes, pcmk_node_t *active_node);
@@ -1042,7 +1053,7 @@ G_GNUC_INTERNAL
 void pcmk__apply_node_health(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-pcmk_node_t *pcmk__top_allowed_node(const pe_resource_t *rsc,
+pcmk_node_t *pcmk__top_allowed_node(const pcmk_resource_t *rsc,
                                     const pcmk_node_t *node);
 
 
@@ -1052,33 +1063,33 @@ G_GNUC_INTERNAL
 void pcmk__set_assignment_methods(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__rsc_agent_changed(pe_resource_t *rsc, pcmk_node_t *node,
+bool pcmk__rsc_agent_changed(pcmk_resource_t *rsc, pcmk_node_t *node,
                              const xmlNode *rsc_entry, bool active_on_node);
 
 G_GNUC_INTERNAL
 GList *pcmk__rscs_matching_id(const char *id, const pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-GList *pcmk__colocated_resources(const pe_resource_t *rsc,
-                                 const pe_resource_t *orig_rsc,
+GList *pcmk__colocated_resources(const pcmk_resource_t *rsc,
+                                 const pcmk_resource_t *orig_rsc,
                                  GList *colocated_rscs);
 
 G_GNUC_INTERNAL
-void pcmk__noop_add_graph_meta(const pe_resource_t *rsc, xmlNode *xml);
+void pcmk__noop_add_graph_meta(const pcmk_resource_t *rsc, xmlNode *xml);
 
 G_GNUC_INTERNAL
-void pcmk__output_resource_actions(pe_resource_t *rsc);
+void pcmk__output_resource_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__assign_resource(pe_resource_t *rsc, pcmk_node_t *node, bool force,
+bool pcmk__assign_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool force,
                            bool stop_if_fail);
 
 G_GNUC_INTERNAL
-void pcmk__unassign_resource(pe_resource_t *rsc);
+void pcmk__unassign_resource(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__threshold_reached(pe_resource_t *rsc, const pcmk_node_t *node,
-                             pe_resource_t **failed);
+bool pcmk__threshold_reached(pcmk_resource_t *rsc, const pcmk_node_t *node,
+                             pcmk_resource_t **failed);
 
 G_GNUC_INTERNAL
 void pcmk__sort_resources(pe_working_set_t *data_set);
@@ -1093,7 +1104,7 @@ gint pcmk__cmp_instance_number(gconstpointer a, gconstpointer b);
 // Functions related to probes (pcmk_sched_probes.c)
 
 G_GNUC_INTERNAL
-bool pcmk__probe_rsc_on_node(pe_resource_t *rsc, pcmk_node_t *node);
+bool pcmk__probe_rsc_on_node(pcmk_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__order_probes(pe_working_set_t *data_set);
@@ -1107,12 +1118,12 @@ void pcmk__schedule_probes(pe_working_set_t *data_set);
 
 // Functions related to live migration (pcmk_sched_migration.c)
 
-void pcmk__create_migration_actions(pe_resource_t *rsc,
+void pcmk__create_migration_actions(pcmk_resource_t *rsc,
                                     const pcmk_node_t *current);
 
 void pcmk__abort_dangling_migration(void *data, void *user_data);
 
-bool pcmk__rsc_can_migrate(const pe_resource_t *rsc,
+bool pcmk__rsc_can_migrate(const pcmk_resource_t *rsc,
                            const pcmk_node_t *current);
 
 void pcmk__order_migration_equivalents(pe__ordering_t *order);
@@ -1126,17 +1137,17 @@ int pcmk__compare_node_capacities(const pcmk_node_t *node1,
 
 G_GNUC_INTERNAL
 void pcmk__consume_node_capacity(GHashTable *current_utilization,
-                                 const pe_resource_t *rsc);
+                                 const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__release_node_capacity(GHashTable *current_utilization,
-                                 const pe_resource_t *rsc);
+                                 const pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-const pcmk_node_t *pcmk__ban_insufficient_capacity(pe_resource_t *rsc);
+const pcmk_node_t *pcmk__ban_insufficient_capacity(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__create_utilization_constraints(pe_resource_t *rsc,
+void pcmk__create_utilization_constraints(pcmk_resource_t *rsc,
                                           const GList *allowed_nodes);
 
 G_GNUC_INTERNAL

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -15,7 +15,7 @@
  */
 
 #include <crm/lrmd_events.h>      // lrmd_event_data_t
-#include <crm/pengine/pe_types.h> // pe_action_t, pe_node_t, pe_working_set_t
+#include <crm/pengine/pe_types.h> // pe_action_t, pcmk_node_t, pe_working_set_t
 #include <crm/pengine/internal.h> // pe__location_t
 
 // Colocation flags
@@ -87,8 +87,8 @@ struct resource_alloc_functions_s {
      *       same effect as calling pcmk__unassign_resource(); there are no side
      *       effects on roles or actions.
      */
-    pe_node_t *(*assign)(pe_resource_t *rsc, const pe_node_t *prefer,
-                         bool stop_if_fail);
+    pcmk_node_t *(*assign)(pe_resource_t *rsc, const pcmk_node_t *prefer,
+                           bool stop_if_fail);
 
     /*!
      * \internal
@@ -107,7 +107,7 @@ struct resource_alloc_functions_s {
      *
      * \return true if any probe was created, otherwise false
      */
-    bool (*create_probe)(pe_resource_t *rsc, pe_node_t *node);
+    bool (*create_probe)(pe_resource_t *rsc, pcmk_node_t *node);
 
     /*!
      * \internal
@@ -253,7 +253,7 @@ struct resource_alloc_functions_s {
      *       of node. For collective resources, the flags can differ due to
      *       multiple instances possibly being involved.
      */
-    uint32_t (*action_flags)(pe_action_t *action, const pe_node_t *node);
+    uint32_t (*action_flags)(pe_action_t *action, const pcmk_node_t *node);
 
     /*!
      * \internal
@@ -279,7 +279,7 @@ struct resource_alloc_functions_s {
      * \return Group of enum pcmk__updated flags indicating what was updated
      */
     uint32_t (*update_ordered_actions)(pe_action_t *first, pe_action_t *then,
-                                       const pe_node_t *node, uint32_t flags,
+                                       const pcmk_node_t *node, uint32_t flags,
                                        uint32_t filter, uint32_t type,
                                        pe_working_set_t *data_set);
 
@@ -347,7 +347,7 @@ void pcmk__update_action_for_orderings(pe_action_t *action,
 
 G_GNUC_INTERNAL
 uint32_t pcmk__update_ordered_actions(pe_action_t *first, pe_action_t *then,
-                                      const pe_node_t *node, uint32_t flags,
+                                      const pcmk_node_t *node, uint32_t flags,
                                       uint32_t filter, uint32_t type,
                                       pe_working_set_t *data_set);
 
@@ -357,10 +357,11 @@ void pcmk__log_action(const char *pre_text, const pe_action_t *action,
 
 G_GNUC_INTERNAL
 pe_action_t *pcmk__new_cancel_action(pe_resource_t *rsc, const char *name,
-                                     guint interval_ms, const pe_node_t *node);
+                                     guint interval_ms,
+                                     const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-pe_action_t *pcmk__new_shutdown_action(pe_node_t *node);
+pe_action_t *pcmk__new_shutdown_action(pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 bool pcmk__action_locks_rsc_to_node(const pe_action_t *action);
@@ -372,7 +373,7 @@ G_GNUC_INTERNAL
 void pcmk__output_actions(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__check_action_config(pe_resource_t *rsc, pe_node_t *node,
+bool pcmk__check_action_config(pe_resource_t *rsc, pcmk_node_t *node,
                                const xmlNode *xml_op);
 
 G_GNUC_INTERNAL
@@ -387,11 +388,11 @@ void pcmk__create_recurring_actions(pe_resource_t *rsc);
 G_GNUC_INTERNAL
 void pcmk__schedule_cancel(pe_resource_t *rsc, const char *call_id,
                            const char *task, guint interval_ms,
-                           const pe_node_t *node, const char *reason);
+                           const pcmk_node_t *node, const char *reason);
 
 G_GNUC_INTERNAL
 void pcmk__reschedule_recurring(pe_resource_t *rsc, const char *task,
-                                guint interval_ms, pe_node_t *node);
+                                guint interval_ms, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 bool pcmk__action_is_recurring(const pe_action_t *action);
@@ -417,15 +418,15 @@ G_GNUC_INTERNAL
 void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__order_vs_unfence(const pe_resource_t *rsc, pe_node_t *node,
+void pcmk__order_vs_unfence(const pe_resource_t *rsc, pcmk_node_t *node,
                             pe_action_t *action,
                             enum pcmk__action_relation_flags order);
 
 G_GNUC_INTERNAL
-void pcmk__fence_guest(pe_node_t *node);
+void pcmk__fence_guest(pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-bool pcmk__node_unfenced(const pe_node_t *node);
+bool pcmk__node_unfenced(const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data);
@@ -467,7 +468,7 @@ void pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set);
 G_GNUC_INTERNAL
 pe__location_t *pcmk__new_location(const char *id, pe_resource_t *rsc,
                                    int node_score, const char *discover_mode,
-                                   pe_node_t *foo_node);
+                                   pcmk_node_t *foo_node);
 
 G_GNUC_INTERNAL
 void pcmk__apply_locations(pe_working_set_t *data_set);
@@ -501,7 +502,7 @@ enum pcmk__coloc_affects {
  * \return Value of \p attr on \p node or on the host of \p node, as appropriate
  */
 static inline const char *
-pcmk__colocation_node_attr(const pe_node_t *node, const char *attr,
+pcmk__colocation_node_attr(const pcmk_node_t *node, const char *attr,
                            const pe_resource_t *rsc)
 {
     const pe_resource_t *top = pe__const_top_resource(rsc, false);
@@ -644,7 +645,7 @@ G_GNUC_INTERNAL
 void pcmk__disable_invalid_orderings(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__order_stops_before_shutdown(pe_node_t *node,
+void pcmk__order_stops_before_shutdown(pcmk_node_t *node,
                                        pe_action_t *shutdown_op);
 
 G_GNUC_INTERNAL
@@ -724,17 +725,17 @@ void pcmk__update_promotable_dependent_priority(const pe_resource_t *primary,
 // Pacemaker Remote nodes (pcmk_sched_remote.c)
 
 G_GNUC_INTERNAL
-bool pcmk__is_failed_remote_node(const pe_node_t *node);
+bool pcmk__is_failed_remote_node(const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__order_remote_connection_actions(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 bool pcmk__rsc_corresponds_to_guest(const pe_resource_t *rsc,
-                                    const pe_node_t *node);
+                                    const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__connection_host_for_action(const pe_action_t *action);
+pcmk_node_t *pcmk__connection_host_for_action(const pe_action_t *action);
 
 G_GNUC_INTERNAL
 void pcmk__substitute_remote_addr(pe_resource_t *rsc, GHashTable *params);
@@ -746,8 +747,9 @@ void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action);
 // Primitives (pcmk_sched_primitive.c)
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__primitive_assign(pe_resource_t *rsc, const pe_node_t *prefer,
-                                  bool stop_if_fail);
+pcmk_node_t *pcmk__primitive_assign(pe_resource_t *rsc,
+                                    const pcmk_node_t *prefer,
+                                    bool stop_if_fail);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_create_actions(pe_resource_t *rsc);
@@ -757,7 +759,7 @@ void pcmk__primitive_internal_constraints(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__primitive_action_flags(pe_action_t *action,
-                                      const pe_node_t *node);
+                                      const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__primitive_apply_coloc_score(pe_resource_t *dependent,
@@ -776,7 +778,7 @@ void pcmk__primitive_with_colocations(const pe_resource_t *rsc,
                                       GList **list);
 
 G_GNUC_INTERNAL
-void pcmk__schedule_cleanup(pe_resource_t *rsc, const pe_node_t *node,
+void pcmk__schedule_cleanup(pe_resource_t *rsc, const pcmk_node_t *node,
                             bool optional);
 
 G_GNUC_INTERNAL
@@ -794,8 +796,8 @@ void pcmk__primitive_shutdown_lock(pe_resource_t *rsc);
 // Groups (pcmk_sched_group.c)
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__group_assign(pe_resource_t *rsc, const pe_node_t *prefer,
-                              bool stop_if_fail);
+pcmk_node_t *pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+                                bool stop_if_fail);
 
 G_GNUC_INTERNAL
 void pcmk__group_create_actions(pe_resource_t *rsc);
@@ -829,12 +831,12 @@ G_GNUC_INTERNAL
 void pcmk__group_apply_location(pe_resource_t *rsc, pe__location_t *location);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__group_action_flags(pe_action_t *action, const pe_node_t *node);
+uint32_t pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__group_update_ordered_actions(pe_action_t *first,
                                             pe_action_t *then,
-                                            const pe_node_t *node,
+                                            const pcmk_node_t *node,
                                             uint32_t flags, uint32_t filter,
                                             uint32_t type,
                                             pe_working_set_t *data_set);
@@ -856,14 +858,14 @@ void pcmk__group_shutdown_lock(pe_resource_t *rsc);
 // Clones (pcmk_sched_clone.c)
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__clone_assign(pe_resource_t *rsc, const pe_node_t *prefer,
-                              bool stop_if_fail);
+pcmk_node_t *pcmk__clone_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+                                bool stop_if_fail);
 
 G_GNUC_INTERNAL
 void pcmk__clone_create_actions(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__clone_create_probe(pe_resource_t *rsc, pe_node_t *node);
+bool pcmk__clone_create_probe(pe_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__clone_internal_constraints(pe_resource_t *rsc);
@@ -886,7 +888,7 @@ G_GNUC_INTERNAL
 void pcmk__clone_apply_location(pe_resource_t *rsc, pe__location_t *constraint);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__clone_action_flags(pe_action_t *action, const pe_node_t *node);
+uint32_t pcmk__clone_action_flags(pe_action_t *action, const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__clone_add_actions_to_graph(pe_resource_t *rsc);
@@ -905,14 +907,14 @@ void pcmk__clone_shutdown_lock(pe_resource_t *rsc);
 // Bundles (pcmk_sched_bundle.c)
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__bundle_assign(pe_resource_t *rsc, const pe_node_t *prefer,
-                               bool stop_if_fail);
+pcmk_node_t *pcmk__bundle_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+                                 bool stop_if_fail);
 
 G_GNUC_INTERNAL
 void pcmk__bundle_create_actions(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node);
+bool pcmk__bundle_create_probe(pe_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__bundle_internal_constraints(pe_resource_t *rsc);
@@ -936,7 +938,8 @@ void pcmk__bundle_apply_location(pe_resource_t *rsc,
                                  pe__location_t *constraint);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node);
+uint32_t pcmk__bundle_action_flags(pe_action_t *action,
+                                   const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__output_bundle_actions(pe_resource_t *rsc);
@@ -964,7 +967,7 @@ void pcmk__create_instance_actions(pe_resource_t *rsc, GList *instances);
 
 G_GNUC_INTERNAL
 bool pcmk__instance_matches(const pe_resource_t *instance,
-                            const pe_node_t *node, enum rsc_role_e role,
+                            const pcmk_node_t *node, enum rsc_role_e role,
                             bool current);
 
 G_GNUC_INTERNAL
@@ -976,7 +979,7 @@ pe_resource_t *pcmk__find_compatible_instance(const pe_resource_t *match_rsc,
 G_GNUC_INTERNAL
 uint32_t pcmk__instance_update_ordered_actions(pe_action_t *first,
                                                pe_action_t *then,
-                                               const pe_node_t *node,
+                                               const pcmk_node_t *node,
                                                uint32_t flags, uint32_t filter,
                                                uint32_t type,
                                                pe_working_set_t *data_set);
@@ -984,7 +987,7 @@ uint32_t pcmk__instance_update_ordered_actions(pe_action_t *first,
 G_GNUC_INTERNAL
 uint32_t pcmk__collective_action_flags(pe_action_t *action,
                                        const GList *instances,
-                                       const pe_node_t *node);
+                                       const pcmk_node_t *node);
 
 
 // Injections (pcmk_injections.c)
@@ -1017,7 +1020,7 @@ xmlNode *pcmk__inject_action_result(xmlNode *cib_resource,
 // Nodes (pcmk_sched_nodes.c)
 
 G_GNUC_INTERNAL
-bool pcmk__node_available(const pe_node_t *node, bool consider_score,
+bool pcmk__node_available(const pcmk_node_t *node, bool consider_score,
                           bool consider_guest);
 
 G_GNUC_INTERNAL
@@ -1033,14 +1036,14 @@ G_GNUC_INTERNAL
 void pcmk__restore_node_tables(pe_resource_t *rsc, GHashTable *backup);
 
 G_GNUC_INTERNAL
-GList *pcmk__sort_nodes(GList *nodes, pe_node_t *active_node);
+GList *pcmk__sort_nodes(GList *nodes, pcmk_node_t *active_node);
 
 G_GNUC_INTERNAL
 void pcmk__apply_node_health(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-pe_node_t *pcmk__top_allowed_node(const pe_resource_t *rsc,
-                                  const pe_node_t *node);
+pcmk_node_t *pcmk__top_allowed_node(const pe_resource_t *rsc,
+                                    const pcmk_node_t *node);
 
 
 // Functions applying to more than one variant (pcmk_sched_resource.c)
@@ -1049,7 +1052,7 @@ G_GNUC_INTERNAL
 void pcmk__set_assignment_methods(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__rsc_agent_changed(pe_resource_t *rsc, pe_node_t *node,
+bool pcmk__rsc_agent_changed(pe_resource_t *rsc, pcmk_node_t *node,
                              const xmlNode *rsc_entry, bool active_on_node);
 
 G_GNUC_INTERNAL
@@ -1067,14 +1070,14 @@ G_GNUC_INTERNAL
 void pcmk__output_resource_actions(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__assign_resource(pe_resource_t *rsc, pe_node_t *node, bool force,
+bool pcmk__assign_resource(pe_resource_t *rsc, pcmk_node_t *node, bool force,
                            bool stop_if_fail);
 
 G_GNUC_INTERNAL
 void pcmk__unassign_resource(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-bool pcmk__threshold_reached(pe_resource_t *rsc, const pe_node_t *node,
+bool pcmk__threshold_reached(pe_resource_t *rsc, const pcmk_node_t *node,
                              pe_resource_t **failed);
 
 G_GNUC_INTERNAL
@@ -1090,13 +1093,13 @@ gint pcmk__cmp_instance_number(gconstpointer a, gconstpointer b);
 // Functions related to probes (pcmk_sched_probes.c)
 
 G_GNUC_INTERNAL
-bool pcmk__probe_rsc_on_node(pe_resource_t *rsc, pe_node_t *node);
+bool pcmk__probe_rsc_on_node(pe_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__order_probes(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__probe_resource_list(GList *rscs, pe_node_t *node);
+bool pcmk__probe_resource_list(GList *rscs, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__schedule_probes(pe_working_set_t *data_set);
@@ -1105,11 +1108,12 @@ void pcmk__schedule_probes(pe_working_set_t *data_set);
 // Functions related to live migration (pcmk_sched_migration.c)
 
 void pcmk__create_migration_actions(pe_resource_t *rsc,
-                                    const pe_node_t *current);
+                                    const pcmk_node_t *current);
 
 void pcmk__abort_dangling_migration(void *data, void *user_data);
 
-bool pcmk__rsc_can_migrate(const pe_resource_t *rsc, const pe_node_t *current);
+bool pcmk__rsc_can_migrate(const pe_resource_t *rsc,
+                           const pcmk_node_t *current);
 
 void pcmk__order_migration_equivalents(pe__ordering_t *order);
 
@@ -1117,8 +1121,8 @@ void pcmk__order_migration_equivalents(pe__ordering_t *order);
 // Functions related to node utilization (pcmk_sched_utilization.c)
 
 G_GNUC_INTERNAL
-int pcmk__compare_node_capacities(const pe_node_t *node1,
-                                  const pe_node_t *node2);
+int pcmk__compare_node_capacities(const pcmk_node_t *node1,
+                                  const pcmk_node_t *node2);
 
 G_GNUC_INTERNAL
 void pcmk__consume_node_capacity(GHashTable *current_utilization,
@@ -1129,7 +1133,7 @@ void pcmk__release_node_capacity(GHashTable *current_utilization,
                                  const pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
-const pe_node_t *pcmk__ban_insufficient_capacity(pe_resource_t *rsc);
+const pcmk_node_t *pcmk__ban_insufficient_capacity(pe_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__create_utilization_constraints(pe_resource_t *rsc,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -15,7 +15,7 @@
  */
 
 #include <crm/lrmd_events.h>      // lrmd_event_data_t
-#include <crm/pengine/pe_types.h> // pe_action_t, pcmk_node_t, pe_working_set_t
+#include <crm/pengine/pe_types.h> // pcmk_action_t, pcmk_node_t, etc.
 #include <crm/pengine/internal.h> // pe__location_t
 
 // Colocation flags
@@ -255,7 +255,7 @@ struct resource_alloc_functions_s {
      *       of node. For collective resources, the flags can differ due to
      *       multiple instances possibly being involved.
      */
-    uint32_t (*action_flags)(pe_action_t *action, const pcmk_node_t *node);
+    uint32_t (*action_flags)(pcmk_action_t *action, const pcmk_node_t *node);
 
     /*!
      * \internal
@@ -280,7 +280,8 @@ struct resource_alloc_functions_s {
      *
      * \return Group of enum pcmk__updated flags indicating what was updated
      */
-    uint32_t (*update_ordered_actions)(pe_action_t *first, pe_action_t *then,
+    uint32_t (*update_ordered_actions)(pcmk_action_t *first,
+                                       pcmk_action_t *then,
                                        const pcmk_node_t *node, uint32_t flags,
                                        uint32_t filter, uint32_t type,
                                        pe_working_set_t *data_set);
@@ -344,32 +345,32 @@ struct resource_alloc_functions_s {
 // Actions (pcmk_sched_actions.c)
 
 G_GNUC_INTERNAL
-void pcmk__update_action_for_orderings(pe_action_t *action,
+void pcmk__update_action_for_orderings(pcmk_action_t *action,
                                        pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__update_ordered_actions(pe_action_t *first, pe_action_t *then,
+uint32_t pcmk__update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                                       const pcmk_node_t *node, uint32_t flags,
                                       uint32_t filter, uint32_t type,
                                       pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__log_action(const char *pre_text, const pe_action_t *action,
+void pcmk__log_action(const char *pre_text, const pcmk_action_t *action,
                       bool details);
 
 G_GNUC_INTERNAL
-pe_action_t *pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *name,
-                                     guint interval_ms,
-                                     const pcmk_node_t *node);
+pcmk_action_t *pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *name,
+                                       guint interval_ms,
+                                       const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-pe_action_t *pcmk__new_shutdown_action(pcmk_node_t *node);
+pcmk_action_t *pcmk__new_shutdown_action(pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-bool pcmk__action_locks_rsc_to_node(const pe_action_t *action);
+bool pcmk__action_locks_rsc_to_node(const pcmk_action_t *action);
 
 G_GNUC_INTERNAL
-void pcmk__deduplicate_action_inputs(pe_action_t *action);
+void pcmk__deduplicate_action_inputs(pcmk_action_t *action);
 
 G_GNUC_INTERNAL
 void pcmk__output_actions(pe_working_set_t *data_set);
@@ -397,14 +398,14 @@ void pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
                                 guint interval_ms, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-bool pcmk__action_is_recurring(const pe_action_t *action);
+bool pcmk__action_is_recurring(const pcmk_action_t *action);
 
 
 // Producing transition graphs (pcmk_graph_producer.c)
 
 G_GNUC_INTERNAL
-bool pcmk__graph_has_loop(const pe_action_t *init_action,
-                          const pe_action_t *action,
+bool pcmk__graph_has_loop(const pcmk_action_t *init_action,
+                          const pcmk_action_t *action,
                           pe_action_wrapper_t *input);
 
 G_GNUC_INTERNAL
@@ -417,11 +418,12 @@ void pcmk__create_graph(pe_working_set_t *data_set);
 // Fencing (pcmk_sched_fencing.c)
 
 G_GNUC_INTERNAL
-void pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set);
+void pcmk__order_vs_fence(pcmk_action_t *stonith_op,
+                          pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__order_vs_unfence(const pcmk_resource_t *rsc, pcmk_node_t *node,
-                            pe_action_t *action,
+                            pcmk_action_t *action,
                             enum pcmk__action_relation_flags order);
 
 G_GNUC_INTERNAL
@@ -585,7 +587,7 @@ void pcmk__new_colocation(const char *id, const char *node_attr, int score,
                           uint32_t flags);
 
 G_GNUC_INTERNAL
-void pcmk__block_colocation_dependents(pe_action_t *action);
+void pcmk__block_colocation_dependents(pcmk_action_t *action);
 
 /*!
  * \internal
@@ -638,8 +640,8 @@ pcmk__colocation_has_influence(const pcmk__colocation_t *colocation,
 
 G_GNUC_INTERNAL
 void pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_task,
-                        pe_action_t *first_action, pcmk_resource_t *then_rsc,
-                        char *then_task, pe_action_t *then_action,
+                        pcmk_action_t *first_action, pcmk_resource_t *then_rsc,
+                        char *then_task, pcmk_action_t *then_action,
                         uint32_t flags, pe_working_set_t *sched);
 
 G_GNUC_INTERNAL
@@ -650,13 +652,13 @@ void pcmk__disable_invalid_orderings(pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__order_stops_before_shutdown(pcmk_node_t *node,
-                                       pe_action_t *shutdown_op);
+                                       pcmk_action_t *shutdown_op);
 
 G_GNUC_INTERNAL
 void pcmk__apply_orderings(pe_working_set_t *sched);
 
 G_GNUC_INTERNAL
-void pcmk__order_after_each(pe_action_t *after, GList *list);
+void pcmk__order_after_each(pcmk_action_t *after, GList *list);
 
 
 /*!
@@ -739,13 +741,14 @@ bool pcmk__rsc_corresponds_to_guest(const pcmk_resource_t *rsc,
                                     const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-pcmk_node_t *pcmk__connection_host_for_action(const pe_action_t *action);
+pcmk_node_t *pcmk__connection_host_for_action(const pcmk_action_t *action);
 
 G_GNUC_INTERNAL
 void pcmk__substitute_remote_addr(pcmk_resource_t *rsc, GHashTable *params);
 
 G_GNUC_INTERNAL
-void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action);
+void pcmk__add_bundle_meta_to_xml(xmlNode *args_xml,
+                                  const pcmk_action_t *action);
 
 
 // Primitives (pcmk_sched_primitive.c)
@@ -762,7 +765,7 @@ G_GNUC_INTERNAL
 void pcmk__primitive_internal_constraints(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__primitive_action_flags(pe_action_t *action,
+uint32_t pcmk__primitive_action_flags(pcmk_action_t *action,
                                       const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
@@ -837,11 +840,12 @@ G_GNUC_INTERNAL
 void pcmk__group_apply_location(pcmk_resource_t *rsc, pe__location_t *location);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node);
+uint32_t pcmk__group_action_flags(pcmk_action_t *action,
+                                  const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__group_update_ordered_actions(pe_action_t *first,
-                                            pe_action_t *then,
+uint32_t pcmk__group_update_ordered_actions(pcmk_action_t *first,
+                                            pcmk_action_t *then,
                                             const pcmk_node_t *node,
                                             uint32_t flags, uint32_t filter,
                                             uint32_t type,
@@ -897,7 +901,8 @@ void pcmk__clone_apply_location(pcmk_resource_t *rsc,
                                 pe__location_t *constraint);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__clone_action_flags(pe_action_t *action, const pcmk_node_t *node);
+uint32_t pcmk__clone_action_flags(pcmk_action_t *action,
+                                  const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 void pcmk__clone_add_actions_to_graph(pcmk_resource_t *rsc);
@@ -949,7 +954,7 @@ void pcmk__bundle_apply_location(pcmk_resource_t *rsc,
                                  pe__location_t *constraint);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__bundle_action_flags(pe_action_t *action,
+uint32_t pcmk__bundle_action_flags(pcmk_action_t *action,
                                    const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
@@ -988,15 +993,15 @@ pcmk_resource_t *pcmk__find_compatible_instance(const pcmk_resource_t *match_rsc
                                                 bool current);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__instance_update_ordered_actions(pe_action_t *first,
-                                               pe_action_t *then,
+uint32_t pcmk__instance_update_ordered_actions(pcmk_action_t *first,
+                                               pcmk_action_t *then,
                                                const pcmk_node_t *node,
                                                uint32_t flags, uint32_t filter,
                                                uint32_t type,
                                                pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-uint32_t pcmk__collective_action_flags(pe_action_t *action,
+uint32_t pcmk__collective_action_flags(pcmk_action_t *action,
                                        const GList *instances,
                                        const pcmk_node_t *node);
 

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -284,7 +284,7 @@ struct resource_alloc_functions_s {
                                        pcmk_action_t *then,
                                        const pcmk_node_t *node, uint32_t flags,
                                        uint32_t filter, uint32_t type,
-                                       pe_working_set_t *data_set);
+                                       pcmk_scheduler_t *data_set);
 
     /*!
      * \internal
@@ -346,13 +346,13 @@ struct resource_alloc_functions_s {
 
 G_GNUC_INTERNAL
 void pcmk__update_action_for_orderings(pcmk_action_t *action,
-                                       pe_working_set_t *data_set);
+                                       pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                                       const pcmk_node_t *node, uint32_t flags,
                                       uint32_t filter, uint32_t type,
-                                      pe_working_set_t *data_set);
+                                      pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__log_action(const char *pre_text, const pcmk_action_t *action,
@@ -373,14 +373,14 @@ G_GNUC_INTERNAL
 void pcmk__deduplicate_action_inputs(pcmk_action_t *action);
 
 G_GNUC_INTERNAL
-void pcmk__output_actions(pe_working_set_t *data_set);
+void pcmk__output_actions(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 bool pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
                                const xmlNode *xml_op);
 
 G_GNUC_INTERNAL
-void pcmk__handle_rsc_config_changes(pe_working_set_t *data_set);
+void pcmk__handle_rsc_config_changes(pcmk_scheduler_t *data_set);
 
 
 // Recurring actions (pcmk_sched_recurring.c)
@@ -412,14 +412,14 @@ G_GNUC_INTERNAL
 void pcmk__add_rsc_actions_to_graph(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
-void pcmk__create_graph(pe_working_set_t *data_set);
+void pcmk__create_graph(pcmk_scheduler_t *data_set);
 
 
 // Fencing (pcmk_sched_fencing.c)
 
 G_GNUC_INTERNAL
 void pcmk__order_vs_fence(pcmk_action_t *stonith_op,
-                          pe_working_set_t *data_set);
+                          pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__order_vs_unfence(const pcmk_resource_t *rsc, pcmk_node_t *node,
@@ -438,7 +438,7 @@ void pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data);
 
 // Injected scheduler inputs (pcmk_sched_injections.c)
 
-void pcmk__inject_scheduler_input(pe_working_set_t *data_set, cib_t *cib,
+void pcmk__inject_scheduler_input(pcmk_scheduler_t *data_set, cib_t *cib,
                                   const pcmk_injections_t *injections);
 
 
@@ -450,25 +450,25 @@ pcmk_resource_t *pcmk__find_constraint_resource(GList *rsc_list,
 
 G_GNUC_INTERNAL
 xmlNode *pcmk__expand_tags_in_sets(xmlNode *xml_obj,
-                                   const pe_working_set_t *data_set);
+                                   const pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-bool pcmk__valid_resource_or_tag(const pe_working_set_t *data_set,
+bool pcmk__valid_resource_or_tag(const pcmk_scheduler_t *data_set,
                                  const char *id, pcmk_resource_t **rsc,
                                  pe_tag_t **tag);
 
 G_GNUC_INTERNAL
 bool pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
-                      bool convert_rsc, const pe_working_set_t *data_set);
+                      bool convert_rsc, const pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__create_internal_constraints(pe_working_set_t *data_set);
+void pcmk__create_internal_constraints(pcmk_scheduler_t *data_set);
 
 
 // Location constraints
 
 G_GNUC_INTERNAL
-void pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set);
+void pcmk__unpack_location(xmlNode *xml_obj, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 pe__location_t *pcmk__new_location(const char *id, pcmk_resource_t *rsc,
@@ -476,7 +476,7 @@ pe__location_t *pcmk__new_location(const char *id, pcmk_resource_t *rsc,
                                    pcmk_node_t *foo_node);
 
 G_GNUC_INTERNAL
-void pcmk__apply_locations(pe_working_set_t *data_set);
+void pcmk__apply_locations(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__apply_location(pcmk_resource_t *rsc, pe__location_t *constraint);
@@ -556,7 +556,7 @@ void pcmk__colocation_intersect_nodes(pcmk_resource_t *dependent,
                                       bool merge_scores);
 
 G_GNUC_INTERNAL
-void pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set);
+void pcmk__unpack_colocation(xmlNode *xml_obj, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__add_this_with(GList **list, const pcmk__colocation_t *colocation,
@@ -642,20 +642,20 @@ G_GNUC_INTERNAL
 void pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_task,
                         pcmk_action_t *first_action, pcmk_resource_t *then_rsc,
                         char *then_task, pcmk_action_t *then_action,
-                        uint32_t flags, pe_working_set_t *sched);
+                        uint32_t flags, pcmk_scheduler_t *sched);
 
 G_GNUC_INTERNAL
-void pcmk__unpack_ordering(xmlNode *xml_obj, pe_working_set_t *data_set);
+void pcmk__unpack_ordering(xmlNode *xml_obj, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-void pcmk__disable_invalid_orderings(pe_working_set_t *data_set);
+void pcmk__disable_invalid_orderings(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 void pcmk__order_stops_before_shutdown(pcmk_node_t *node,
                                        pcmk_action_t *shutdown_op);
 
 G_GNUC_INTERNAL
-void pcmk__apply_orderings(pe_working_set_t *sched);
+void pcmk__apply_orderings(pcmk_scheduler_t *sched);
 
 G_GNUC_INTERNAL
 void pcmk__order_after_each(pcmk_action_t *after, GList *list);
@@ -692,7 +692,7 @@ void pcmk__order_after_each(pcmk_action_t *after, GList *list);
 // Ticket constraints (pcmk_sched_tickets.c)
 
 G_GNUC_INTERNAL
-void pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set);
+void pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pcmk_scheduler_t *data_set);
 
 
 // Promotable clone resources (pcmk_sched_promotable.c)
@@ -734,7 +734,7 @@ G_GNUC_INTERNAL
 bool pcmk__is_failed_remote_node(const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__order_remote_connection_actions(pe_working_set_t *data_set);
+void pcmk__order_remote_connection_actions(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 bool pcmk__rsc_corresponds_to_guest(const pcmk_resource_t *rsc,
@@ -849,7 +849,7 @@ uint32_t pcmk__group_update_ordered_actions(pcmk_action_t *first,
                                             const pcmk_node_t *node,
                                             uint32_t flags, uint32_t filter,
                                             uint32_t type,
-                                            pe_working_set_t *data_set);
+                                            pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 GList *pcmk__group_colocated_resources(const pcmk_resource_t *rsc,
@@ -998,7 +998,7 @@ uint32_t pcmk__instance_update_ordered_actions(pcmk_action_t *first,
                                                const pcmk_node_t *node,
                                                uint32_t flags, uint32_t filter,
                                                uint32_t type,
-                                               pe_working_set_t *data_set);
+                                               pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 uint32_t pcmk__collective_action_flags(pcmk_action_t *action,
@@ -1055,7 +1055,7 @@ G_GNUC_INTERNAL
 GList *pcmk__sort_nodes(GList *nodes, pcmk_node_t *active_node);
 
 G_GNUC_INTERNAL
-void pcmk__apply_node_health(pe_working_set_t *data_set);
+void pcmk__apply_node_health(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 pcmk_node_t *pcmk__top_allowed_node(const pcmk_resource_t *rsc,
@@ -1065,14 +1065,14 @@ pcmk_node_t *pcmk__top_allowed_node(const pcmk_resource_t *rsc,
 // Functions applying to more than one variant (pcmk_sched_resource.c)
 
 G_GNUC_INTERNAL
-void pcmk__set_assignment_methods(pe_working_set_t *data_set);
+void pcmk__set_assignment_methods(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 bool pcmk__rsc_agent_changed(pcmk_resource_t *rsc, pcmk_node_t *node,
                              const xmlNode *rsc_entry, bool active_on_node);
 
 G_GNUC_INTERNAL
-GList *pcmk__rscs_matching_id(const char *id, const pe_working_set_t *data_set);
+GList *pcmk__rscs_matching_id(const char *id, const pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 GList *pcmk__colocated_resources(const pcmk_resource_t *rsc,
@@ -1097,7 +1097,7 @@ bool pcmk__threshold_reached(pcmk_resource_t *rsc, const pcmk_node_t *node,
                              pcmk_resource_t **failed);
 
 G_GNUC_INTERNAL
-void pcmk__sort_resources(pe_working_set_t *data_set);
+void pcmk__sort_resources(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 gint pcmk__cmp_instance(gconstpointer a, gconstpointer b);
@@ -1112,13 +1112,13 @@ G_GNUC_INTERNAL
 bool pcmk__probe_rsc_on_node(pcmk_resource_t *rsc, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__order_probes(pe_working_set_t *data_set);
+void pcmk__order_probes(pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 bool pcmk__probe_resource_list(GList *rscs, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__schedule_probes(pe_working_set_t *data_set);
+void pcmk__schedule_probes(pcmk_scheduler_t *data_set);
 
 
 // Functions related to live migration (pcmk_sched_migration.c)
@@ -1156,6 +1156,6 @@ void pcmk__create_utilization_constraints(pcmk_resource_t *rsc,
                                           const GList *allowed_nodes);
 
 G_GNUC_INTERNAL
-void pcmk__show_node_capacities(const char *desc, pe_working_set_t *data_set);
+void pcmk__show_node_capacities(const char *desc, pcmk_scheduler_t *data_set);
 
 #endif // PCMK__LIBPACEMAKER_PRIVATE__H

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -61,7 +61,7 @@ add_node_to_xml_by_id(const char *id, xmlNode *xml)
  * \param[in,out] xml   XML to add node to
  */
 static void
-add_node_to_xml(const pe_node_t *node, void *xml)
+add_node_to_xml(const pcmk_node_t *node, void *xml)
 {
     add_node_to_xml_by_id(node->details->id, (xmlNode *) xml);
 }
@@ -86,7 +86,7 @@ add_maintenance_nodes(xmlNode *xml, const pe_working_set_t *data_set)
         maintenance = create_xml_node(xml, XML_GRAPH_TAG_MAINTENANCE);
     }
     for (const GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-        const pe_node_t *node = iter->data;
+        const pcmk_node_t *node = iter->data;
 
         if (pe__is_guest_or_remote_node(node) &&
             (node->details->maintenance != node->details->remote_maintenance)) {
@@ -224,7 +224,7 @@ clone_op_key(const pe_action_t *action, guint interval_ms)
 static void
 add_node_details(const pe_action_t *action, xmlNode *xml)
 {
-    pe_node_t *router_node = pcmk__connection_host_for_action(action);
+    pcmk_node_t *router_node = pcmk__connection_host_for_action(action);
 
     crm_xml_add(xml, XML_LRM_ATTR_TARGET, action->node->details->uname);
     crm_xml_add(xml, XML_LRM_ATTR_TARGET_UUID, action->node->details->id);
@@ -663,13 +663,13 @@ should_add_input_to_graph(const pe_action_t *action, pe_action_wrapper_t *input)
         return false;
 
     } else if ((uint32_t) input->type == pcmk__ar_if_on_same_node_or_target) {
-        pe_node_t *input_node = input->action->node;
+        pcmk_node_t *input_node = input->action->node;
 
         if ((action->rsc != NULL)
             && pcmk__str_eq(action->task, PCMK_ACTION_MIGRATE_TO,
                             pcmk__str_none)) {
 
-            pe_node_t *assigned = action->rsc->allocated_to;
+            pcmk_node_t *assigned = action->rsc->allocated_to;
 
             /* For load_stopped -> migrate_to orderings, we care about where
              * the resource has been assigned, not where migrate_to will be

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -77,7 +77,7 @@ add_node_to_xml(const pcmk_node_t *node, void *xml)
  * \note Only Pacemaker Remote nodes are considered currently
  */
 static int
-add_maintenance_nodes(xmlNode *xml, const pe_working_set_t *data_set)
+add_maintenance_nodes(xmlNode *xml, const pcmk_scheduler_t *data_set)
 {
     xmlNode *maintenance = NULL;
     int count = 0;
@@ -112,7 +112,7 @@ add_maintenance_nodes(xmlNode *xml, const pe_working_set_t *data_set)
  * \param[in,out] data_set  Working set for cluster
  */
 static void
-add_maintenance_update(pe_working_set_t *data_set)
+add_maintenance_update(pcmk_scheduler_t *data_set)
 {
     pcmk_action_t *action = NULL;
 
@@ -392,7 +392,7 @@ add_action_attributes(pcmk_action_t *action, xmlNode *action_xml)
  */
 static void
 create_graph_action(xmlNode *parent, pcmk_action_t *action, bool skip_details,
-                    const pe_working_set_t *data_set)
+                    const pcmk_scheduler_t *data_set)
 {
     bool needs_node_info = true;
     bool needs_maintenance_info = false;
@@ -847,7 +847,7 @@ pcmk__graph_has_loop(const pcmk_action_t *init_action,
  * \return Newly added XML element for new graph synapse
  */
 static xmlNode *
-create_graph_synapse(const pcmk_action_t *action, pe_working_set_t *data_set)
+create_graph_synapse(const pcmk_action_t *action, pcmk_scheduler_t *data_set)
 {
     int synapse_priority = 0;
     xmlNode *syn = create_xml_node(data_set->graph, "synapse");
@@ -887,7 +887,7 @@ static void
 add_action_to_graph(gpointer data, gpointer user_data)
 {
     pcmk_action_t *action = (pcmk_action_t *) data;
-    pe_working_set_t *data_set = (pe_working_set_t *) user_data;
+    pcmk_scheduler_t *data_set = (pcmk_scheduler_t *) user_data;
 
     xmlNode *syn = NULL;
     xmlNode *set = NULL;
@@ -998,7 +998,7 @@ pcmk__add_rsc_actions_to_graph(pcmk_resource_t *rsc)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__create_graph(pe_working_set_t *data_set)
+pcmk__create_graph(pcmk_scheduler_t *data_set)
 {
     GList *iter = NULL;
     const char *value = NULL;

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -114,7 +114,7 @@ add_maintenance_nodes(xmlNode *xml, const pe_working_set_t *data_set)
 static void
 add_maintenance_update(pe_working_set_t *data_set)
 {
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
 
     if (add_maintenance_nodes(NULL, data_set) != 0) {
         action = get_pseudo_op(PCMK_ACTION_MAINTENANCE_NODES, data_set);
@@ -134,7 +134,7 @@ add_maintenance_update(pe_working_set_t *data_set)
  * \param[in]     action    Action to check for downed nodes
  */
 static void
-add_downed_nodes(xmlNode *xml, const pe_action_t *action)
+add_downed_nodes(xmlNode *xml, const pcmk_action_t *action)
 {
     CRM_CHECK((xml != NULL) && (action != NULL) && (action->node != NULL),
               return);
@@ -166,7 +166,7 @@ add_downed_nodes(xmlNode *xml, const pe_action_t *action)
          * unless it's part of a migration
          */
         GList *iter;
-        pe_action_t *input;
+        pcmk_action_t *input;
         bool migrating = false;
 
         for (iter = action->actions_before; iter != NULL; iter = iter->next) {
@@ -196,7 +196,7 @@ add_downed_nodes(xmlNode *xml, const pe_action_t *action)
  * \return Newly allocated string with transition graph operation key
  */
 static char *
-clone_op_key(const pe_action_t *action, guint interval_ms)
+clone_op_key(const pcmk_action_t *action, guint interval_ms)
 {
     if (pcmk__str_eq(action->task, PCMK_ACTION_NOTIFY, pcmk__str_none)) {
         const char *n_type = g_hash_table_lookup(action->meta, "notify_type");
@@ -222,7 +222,7 @@ clone_op_key(const pe_action_t *action, guint interval_ms)
  * \param[in,out] xml     Transition graph action XML for \p action
  */
 static void
-add_node_details(const pe_action_t *action, xmlNode *xml)
+add_node_details(const pcmk_action_t *action, xmlNode *xml)
 {
     pcmk_node_t *router_node = pcmk__connection_host_for_action(action);
 
@@ -241,7 +241,7 @@ add_node_details(const pe_action_t *action, xmlNode *xml)
  * \param[in,out] action_xml  Transition graph action XML for \p action
  */
 static void
-add_resource_details(const pe_action_t *action, xmlNode *action_xml)
+add_resource_details(const pcmk_action_t *action, xmlNode *action_xml)
 {
     xmlNode *rsc_xml = NULL;
     const char *attr_list[] = {
@@ -324,7 +324,7 @@ add_resource_details(const pe_action_t *action, xmlNode *action_xml)
  * \param[in,out] action_xml  Transition graph action XML for \p action
  */
 static void
-add_action_attributes(pe_action_t *action, xmlNode *action_xml)
+add_action_attributes(pcmk_action_t *action, xmlNode *action_xml)
 {
     xmlNode *args_xml = NULL;
 
@@ -391,7 +391,7 @@ add_action_attributes(pe_action_t *action, xmlNode *action_xml)
  * \param[in]     data_set      Cluster working set
  */
 static void
-create_graph_action(xmlNode *parent, pe_action_t *action, bool skip_details,
+create_graph_action(xmlNode *parent, pcmk_action_t *action, bool skip_details,
                     const pe_working_set_t *data_set)
 {
     bool needs_node_info = true;
@@ -496,7 +496,7 @@ create_graph_action(xmlNode *parent, pe_action_t *action, bool skip_details,
  * \return true if action should be added to graph, otherwise false
  */
 static bool
-should_add_action_to_graph(const pe_action_t *action)
+should_add_action_to_graph(const pcmk_action_t *action)
 {
     if (!pcmk_is_set(action->flags, pcmk_action_runnable)) {
         crm_trace("Ignoring action %s (%d): unrunnable",
@@ -608,7 +608,8 @@ ordering_can_change_actions(const pe_action_wrapper_t *ordering)
  *       circumstances (load or anti-colocation orderings that are not needed).
  */
 static bool
-should_add_input_to_graph(const pe_action_t *action, pe_action_wrapper_t *input)
+should_add_input_to_graph(const pcmk_action_t *action,
+                          pe_action_wrapper_t *input)
 {
     if (input->state == pe_link_dumped) {
         return true;
@@ -770,8 +771,8 @@ should_add_input_to_graph(const pe_action_t *action, pe_action_wrapper_t *input)
  * \return true if the ordering creates a loop, otherwise false
  */
 bool
-pcmk__graph_has_loop(const pe_action_t *init_action, const pe_action_t *action,
-                     pe_action_wrapper_t *input)
+pcmk__graph_has_loop(const pcmk_action_t *init_action,
+                     const pcmk_action_t *action, pe_action_wrapper_t *input)
 {
     bool has_loop = false;
 
@@ -846,7 +847,7 @@ pcmk__graph_has_loop(const pe_action_t *init_action, const pe_action_t *action,
  * \return Newly added XML element for new graph synapse
  */
 static xmlNode *
-create_graph_synapse(const pe_action_t *action, pe_working_set_t *data_set)
+create_graph_synapse(const pcmk_action_t *action, pe_working_set_t *data_set)
 {
     int synapse_priority = 0;
     xmlNode *syn = create_xml_node(data_set->graph, "synapse");
@@ -885,7 +886,7 @@ create_graph_synapse(const pe_action_t *action, pe_working_set_t *data_set)
 static void
 add_action_to_graph(gpointer data, gpointer user_data)
 {
-    pe_action_t *action = (pe_action_t *) data;
+    pcmk_action_t *action = (pcmk_action_t *) data;
     pe_working_set_t *data_set = (pe_working_set_t *) user_data;
 
     xmlNode *syn = NULL;
@@ -1059,7 +1060,7 @@ pcmk__create_graph(pe_working_set_t *data_set)
 
     // Add non-resource (node) actions
     for (iter = data_set->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *action = (pe_action_t *) iter->data;
+        pcmk_action_t *action = (pcmk_action_t *) iter->data;
 
         if ((action->rsc != NULL)
             && (action->node != NULL)

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -356,7 +356,7 @@ add_action_attributes(pe_action_t *action, xmlNode *action_xml)
 
     g_hash_table_foreach(action->meta, hash2metafield, args_xml);
     if (action->rsc != NULL) {
-        pe_resource_t *parent = action->rsc;
+        pcmk_resource_t *parent = action->rsc;
 
         while (parent != NULL) {
             parent->cmds->add_graph_meta(parent, args_xml);
@@ -972,7 +972,7 @@ pcmk__log_transition_summary(const char *filename)
  * \param[in,out] rsc  Resource whose actions should be added
  */
 void
-pcmk__add_rsc_actions_to_graph(pe_resource_t *rsc)
+pcmk__add_rsc_actions_to_graph(pcmk_resource_t *rsc)
 {
     GList *iter = NULL;
 
@@ -984,7 +984,7 @@ pcmk__add_rsc_actions_to_graph(pe_resource_t *rsc)
 
     // Then recursively add its children's actions (appropriate to variant)
     for (iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) iter->data;
 
         child_rsc->cmds->add_actions_to_graph(child_rsc);
     }
@@ -1048,7 +1048,7 @@ pcmk__create_graph(pe_working_set_t *data_set)
 
     // Add resource actions to graph
     for (iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         pe_rsc_trace(rsc, "Processing actions for %s", rsc->id);
         rsc->cmds->add_actions_to_graph(rsc);

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -556,7 +556,7 @@ set_ticket_state_attr(pcmk__output_t *out, const char *ticket_id,
  */
 static void
 inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
-              const pe_working_set_t *data_set)
+              const pcmk_scheduler_t *data_set)
 {
     int rc;
     int outcome = PCMK_OCF_OK;
@@ -636,7 +636,7 @@ done:
  * \param[in]     injections  Injections to apply
  */
 void
-pcmk__inject_scheduler_input(pe_working_set_t *data_set, cib_t *cib,
+pcmk__inject_scheduler_input(pcmk_scheduler_t *data_set, cib_t *cib,
                              const pcmk_injections_t *injections)
 {
     int rc = pcmk_ok;

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -574,7 +574,7 @@ inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
     xmlNode *cib_op = NULL;
     xmlNode *cib_node = NULL;
     xmlNode *cib_resource = NULL;
-    const pe_resource_t *rsc = NULL;
+    const pcmk_resource_t *rsc = NULL;
     lrmd_event_data_t *op = NULL;
 
     out->message(out, "inject-spec", spec);

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 static char *
-colocations_header(pe_resource_t *rsc, pcmk__colocation_t *cons,
+colocations_header(pcmk_resource_t *rsc, pcmk__colocation_t *cons,
                    bool dependents) {
     char *retval = NULL;
 
@@ -39,7 +39,7 @@ colocations_header(pe_resource_t *rsc, pcmk__colocation_t *cons,
 }
 
 static void
-colocations_xml_node(pcmk__output_t *out, pe_resource_t *rsc,
+colocations_xml_node(pcmk__output_t *out, pcmk_resource_t *rsc,
                      pcmk__colocation_t *cons) {
     xmlNodePtr node = NULL;
 
@@ -68,7 +68,8 @@ colocations_xml_node(pcmk__output_t *out, pe_resource_t *rsc,
 }
 
 static int
-do_locations_list_xml(pcmk__output_t *out, pe_resource_t *rsc, bool add_header)
+do_locations_list_xml(pcmk__output_t *out, pcmk_resource_t *rsc,
+                      bool add_header)
 {
     GList *lpc = NULL;
     GList *list = rsc->rsc_location;
@@ -103,14 +104,14 @@ do_locations_list_xml(pcmk__output_t *out, pe_resource_t *rsc, bool add_header)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pcmk_resource_t *",
                   "pcmk_node_t *", "pcmk_node_t *", "pe_action_t *",
                   "pe_action_t *")
 static int
 rsc_action_item(pcmk__output_t *out, va_list args)
 {
     const char *change = va_arg(args, const char *);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *origin = va_arg(args, pcmk_node_t *);
     pcmk_node_t *destination = va_arg(args, pcmk_node_t *);
     pe_action_t *action = va_arg(args, pe_action_t *);
@@ -230,14 +231,14 @@ rsc_action_item(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pcmk_resource_t *",
                   "pcmk_node_t *", "pcmk_node_t *", "pe_action_t *",
                   "pe_action_t *")
 static int
 rsc_action_item_xml(pcmk__output_t *out, va_list args)
 {
     const char *change = va_arg(args, const char *);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *origin = va_arg(args, pcmk_node_t *);
     pcmk_node_t *destination = va_arg(args, pcmk_node_t *);
     pe_action_t *action = va_arg(args, pe_action_t *);
@@ -362,10 +363,10 @@ rsc_action_item_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("rsc-is-colocated-with-list", "pe_resource_t *", "bool")
+PCMK__OUTPUT_ARGS("rsc-is-colocated-with-list", "pcmk_resource_t *", "bool")
 static int
 rsc_is_colocated_with_list(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     bool recursive = va_arg(args, int);
 
     int rc = pcmk_rc_no_output;
@@ -411,10 +412,10 @@ rsc_is_colocated_with_list(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("rsc-is-colocated-with-list", "pe_resource_t *", "bool")
+PCMK__OUTPUT_ARGS("rsc-is-colocated-with-list", "pcmk_resource_t *", "bool")
 static int
 rsc_is_colocated_with_list_xml(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     bool recursive = va_arg(args, int);
 
     int rc = pcmk_rc_no_output;
@@ -447,10 +448,10 @@ rsc_is_colocated_with_list_xml(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("rscs-colocated-with-list", "pe_resource_t *", "bool")
+PCMK__OUTPUT_ARGS("rscs-colocated-with-list", "pcmk_resource_t *", "bool")
 static int
 rscs_colocated_with_list(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     bool recursive = va_arg(args, int);
 
     int rc = pcmk_rc_no_output;
@@ -497,10 +498,10 @@ rscs_colocated_with_list(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("rscs-colocated-with-list", "pe_resource_t *", "bool")
+PCMK__OUTPUT_ARGS("rscs-colocated-with-list", "pcmk_resource_t *", "bool")
 static int
 rscs_colocated_with_list_xml(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     bool recursive = va_arg(args, int);
 
     int rc = pcmk_rc_no_output;
@@ -534,10 +535,10 @@ rscs_colocated_with_list_xml(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("locations-list", "pe_resource_t *")
+PCMK__OUTPUT_ARGS("locations-list", "pcmk_resource_t *")
 static int
 locations_list(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
 
     GList *lpc = NULL;
     GList *list = rsc->rsc_location;
@@ -563,19 +564,19 @@ locations_list(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("locations-list", "pe_resource_t *")
+PCMK__OUTPUT_ARGS("locations-list", "pcmk_resource_t *")
 static int
 locations_list_xml(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     return do_locations_list_xml(out, rsc, true);
 }
 
-PCMK__OUTPUT_ARGS("locations-and-colocations", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("locations-and-colocations", "pcmk_resource_t *",
                   "bool", "bool")
 static int
 locations_and_colocations(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     bool recursive = va_arg(args, int);
     bool force = va_arg(args, int);
 
@@ -596,12 +597,12 @@ locations_and_colocations(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("locations-and-colocations", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("locations-and-colocations", "pcmk_resource_t *",
                   "bool", "bool")
 static int
 locations_and_colocations_xml(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     bool recursive = va_arg(args, int);
     bool force = va_arg(args, int);
 
@@ -954,12 +955,12 @@ crmadmin_node_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("digests", "const pe_resource_t *", "const pcmk_node_t *",
+PCMK__OUTPUT_ARGS("digests", "const pcmk_resource_t *", "const pcmk_node_t *",
                   "const char *", "guint", "const op_digest_cache_t *")
 static int
 digests_text(pcmk__output_t *out, va_list args)
 {
-    const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
+    const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     const pcmk_node_t *node = va_arg(args, const pcmk_node_t *);
     const char *task = va_arg(args, const char *);
     guint interval_ms = va_arg(args, guint);
@@ -1024,12 +1025,12 @@ add_digest_xml(xmlNode *parent, const char *type, const char *digest,
     }
 }
 
-PCMK__OUTPUT_ARGS("digests", "const pe_resource_t *", "const pcmk_node_t *",
+PCMK__OUTPUT_ARGS("digests", "const pcmk_resource_t *", "const pcmk_node_t *",
                   "const char *", "guint", "const op_digest_cache_t *")
 static int
 digests_xml(pcmk__output_t *out, va_list args)
 {
-    const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
+    const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     const pcmk_node_t *node = va_arg(args, const pcmk_node_t *);
     const char *task = va_arg(args, const char *);
     guint interval_ms = va_arg(args, guint);
@@ -1071,12 +1072,12 @@ digests_xml(pcmk__output_t *out, va_list args)
         }                                                               \
     } while (0)
 
-PCMK__OUTPUT_ARGS("rsc-action", "pe_resource_t *", "pcmk_node_t *",
+PCMK__OUTPUT_ARGS("rsc-action", "pcmk_resource_t *", "pcmk_node_t *",
                   "pcmk_node_t *")
 static int
 rsc_action_default(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *current = va_arg(args, pcmk_node_t *);
     pcmk_node_t *next = va_arg(args, pcmk_node_t *);
 

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -80,7 +80,7 @@ do_locations_list_xml(pcmk__output_t *out, pe_resource_t *rsc, bool add_header)
         GList *lpc2 = NULL;
 
         for (lpc2 = cons->node_list_rh; lpc2 != NULL; lpc2 = lpc2->next) {
-            pe_node_t *node = (pe_node_t *) lpc2->data;
+            pcmk_node_t *node = (pcmk_node_t *) lpc2->data;
 
             if (add_header) {
                 PCMK__OUTPUT_LIST_HEADER(out, false, rc, "locations");
@@ -104,15 +104,15 @@ do_locations_list_xml(pcmk__output_t *out, pe_resource_t *rsc, bool add_header)
 }
 
 PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pe_resource_t *",
-                  "pe_node_t *", "pe_node_t *", "pe_action_t *",
+                  "pcmk_node_t *", "pcmk_node_t *", "pe_action_t *",
                   "pe_action_t *")
 static int
 rsc_action_item(pcmk__output_t *out, va_list args)
 {
     const char *change = va_arg(args, const char *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *origin = va_arg(args, pe_node_t *);
-    pe_node_t *destination = va_arg(args, pe_node_t *);
+    pcmk_node_t *origin = va_arg(args, pcmk_node_t *);
+    pcmk_node_t *destination = va_arg(args, pcmk_node_t *);
     pe_action_t *action = va_arg(args, pe_action_t *);
     pe_action_t *source = va_arg(args, pe_action_t *);
 
@@ -231,15 +231,15 @@ rsc_action_item(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pe_resource_t *",
-                  "pe_node_t *", "pe_node_t *", "pe_action_t *",
+                  "pcmk_node_t *", "pcmk_node_t *", "pe_action_t *",
                   "pe_action_t *")
 static int
 rsc_action_item_xml(pcmk__output_t *out, va_list args)
 {
     const char *change = va_arg(args, const char *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *origin = va_arg(args, pe_node_t *);
-    pe_node_t *destination = va_arg(args, pe_node_t *);
+    pcmk_node_t *origin = va_arg(args, pcmk_node_t *);
+    pcmk_node_t *destination = va_arg(args, pcmk_node_t *);
     pe_action_t *action = va_arg(args, pe_action_t *);
     pe_action_t *source = va_arg(args, pe_action_t *);
 
@@ -549,7 +549,7 @@ locations_list(pcmk__output_t *out, va_list args) {
         GList *lpc2 = NULL;
 
         for (lpc2 = cons->node_list_rh; lpc2 != NULL; lpc2 = lpc2->next) {
-            pe_node_t *node = (pe_node_t *) lpc2->data;
+            pcmk_node_t *node = (pcmk_node_t *) lpc2->data;
 
             PCMK__OUTPUT_LIST_HEADER(out, false, rc, "Locations");
             out->list_item(out, NULL, "Node %s (score=%s, id=%s, rsc=%s)",
@@ -954,13 +954,13 @@ crmadmin_node_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("digests", "const pe_resource_t *", "const pe_node_t *",
+PCMK__OUTPUT_ARGS("digests", "const pe_resource_t *", "const pcmk_node_t *",
                   "const char *", "guint", "const op_digest_cache_t *")
 static int
 digests_text(pcmk__output_t *out, va_list args)
 {
     const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
-    const pe_node_t *node = va_arg(args, const pe_node_t *);
+    const pcmk_node_t *node = va_arg(args, const pcmk_node_t *);
     const char *task = va_arg(args, const char *);
     guint interval_ms = va_arg(args, guint);
     const op_digest_cache_t *digests = va_arg(args, const op_digest_cache_t *);
@@ -1024,13 +1024,13 @@ add_digest_xml(xmlNode *parent, const char *type, const char *digest,
     }
 }
 
-PCMK__OUTPUT_ARGS("digests", "const pe_resource_t *", "const pe_node_t *",
+PCMK__OUTPUT_ARGS("digests", "const pe_resource_t *", "const pcmk_node_t *",
                   "const char *", "guint", "const op_digest_cache_t *")
 static int
 digests_xml(pcmk__output_t *out, va_list args)
 {
     const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
-    const pe_node_t *node = va_arg(args, const pe_node_t *);
+    const pcmk_node_t *node = va_arg(args, const pcmk_node_t *);
     const char *task = va_arg(args, const char *);
     guint interval_ms = va_arg(args, guint);
     const op_digest_cache_t *digests = va_arg(args, const op_digest_cache_t *);
@@ -1071,20 +1071,21 @@ digests_xml(pcmk__output_t *out, va_list args)
         }                                                               \
     } while (0)
 
-PCMK__OUTPUT_ARGS("rsc-action", "pe_resource_t *", "pe_node_t *", "pe_node_t *")
+PCMK__OUTPUT_ARGS("rsc-action", "pe_resource_t *", "pcmk_node_t *",
+                  "pcmk_node_t *")
 static int
 rsc_action_default(pcmk__output_t *out, va_list args)
 {
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *current = va_arg(args, pe_node_t *);
-    pe_node_t *next = va_arg(args, pe_node_t *);
+    pcmk_node_t *current = va_arg(args, pcmk_node_t *);
+    pcmk_node_t *next = va_arg(args, pcmk_node_t *);
 
     GList *possible_matches = NULL;
     char *key = NULL;
     int rc = pcmk_rc_no_output;
     bool moving = false;
 
-    pe_node_t *start_node = NULL;
+    pcmk_node_t *start_node = NULL;
     pe_action_t *start = NULL;
     pe_action_t *stop = NULL;
     pe_action_t *promote = NULL;
@@ -1226,7 +1227,7 @@ rsc_action_default(pcmk__output_t *out, va_list args)
 
         key = stop_key(rsc);
         for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
-            pe_node_t *node = iter->data;
+            pcmk_node_t *node = iter->data;
             pe_action_t *stop_op = NULL;
 
             reason_op = start;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -105,8 +105,8 @@ do_locations_list_xml(pcmk__output_t *out, pcmk_resource_t *rsc,
 }
 
 PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pcmk_resource_t *",
-                  "pcmk_node_t *", "pcmk_node_t *", "pe_action_t *",
-                  "pe_action_t *")
+                  "pcmk_node_t *", "pcmk_node_t *", "pcmk_action_t *",
+                  "pcmk_action_t *")
 static int
 rsc_action_item(pcmk__output_t *out, va_list args)
 {
@@ -114,8 +114,8 @@ rsc_action_item(pcmk__output_t *out, va_list args)
     pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *origin = va_arg(args, pcmk_node_t *);
     pcmk_node_t *destination = va_arg(args, pcmk_node_t *);
-    pe_action_t *action = va_arg(args, pe_action_t *);
-    pe_action_t *source = va_arg(args, pe_action_t *);
+    pcmk_action_t *action = va_arg(args, pcmk_action_t *);
+    pcmk_action_t *source = va_arg(args, pcmk_action_t *);
 
     int len = 0;
     char *reason = NULL;
@@ -232,8 +232,8 @@ rsc_action_item(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("rsc-action-item", "const char *", "pcmk_resource_t *",
-                  "pcmk_node_t *", "pcmk_node_t *", "pe_action_t *",
-                  "pe_action_t *")
+                  "pcmk_node_t *", "pcmk_node_t *", "pcmk_action_t *",
+                  "pcmk_action_t *")
 static int
 rsc_action_item_xml(pcmk__output_t *out, va_list args)
 {
@@ -241,8 +241,8 @@ rsc_action_item_xml(pcmk__output_t *out, va_list args)
     pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *origin = va_arg(args, pcmk_node_t *);
     pcmk_node_t *destination = va_arg(args, pcmk_node_t *);
-    pe_action_t *action = va_arg(args, pe_action_t *);
-    pe_action_t *source = va_arg(args, pe_action_t *);
+    pcmk_action_t *action = va_arg(args, pcmk_action_t *);
+    pcmk_action_t *source = va_arg(args, pcmk_action_t *);
 
     char *change_str = NULL;
 
@@ -1087,11 +1087,11 @@ rsc_action_default(pcmk__output_t *out, va_list args)
     bool moving = false;
 
     pcmk_node_t *start_node = NULL;
-    pe_action_t *start = NULL;
-    pe_action_t *stop = NULL;
-    pe_action_t *promote = NULL;
-    pe_action_t *demote = NULL;
-    pe_action_t *reason_op = NULL;
+    pcmk_action_t *start = NULL;
+    pcmk_action_t *stop = NULL;
+    pcmk_action_t *promote = NULL;
+    pcmk_action_t *demote = NULL;
+    pcmk_action_t *reason_op = NULL;
 
     if (!pcmk_is_set(rsc->flags, pcmk_rsc_managed)
         || (current == NULL && next == NULL)) {
@@ -1152,7 +1152,7 @@ rsc_action_default(pcmk__output_t *out, va_list args)
     }
 
     if (rsc->role == rsc->next_role) {
-        pe_action_t *migrate_op = NULL;
+        pcmk_action_t *migrate_op = NULL;
 
         CRM_CHECK(next != NULL, return rc);
 
@@ -1229,7 +1229,7 @@ rsc_action_default(pcmk__output_t *out, va_list args)
         key = stop_key(rsc);
         for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
             pcmk_node_t *node = iter->data;
-            pe_action_t *stop_op = NULL;
+            pcmk_action_t *stop_op = NULL;
 
             reason_op = start;
             possible_matches = find_actions(rsc->actions, key, node);

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1779,14 +1779,14 @@ inject_rsc_action_xml(pcmk__output_t *out, va_list args)
         retcode = pcmk_rc_ok;       \
     }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("cluster-status", "pcmk_scheduler_t *",
                   "enum pcmk_pacemakerd_state", "crm_exit_t",
                   "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
                   "uint32_t", "const char *", "GList *", "GList *")
 int
 pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
 {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     enum pcmk_pacemakerd_state pcmkd_state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     crm_exit_t history_rc = va_arg(args, crm_exit_t);
@@ -1916,14 +1916,14 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("cluster-status", "pcmk_scheduler_t *",
                   "enum pcmk_pacemakerd_state", "crm_exit_t",
                   "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
                   "uint32_t", "const char *", "GList *", "GList *")
 static int
 cluster_status_xml(pcmk__output_t *out, va_list args)
 {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     enum pcmk_pacemakerd_state pcmkd_state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     crm_exit_t history_rc = va_arg(args, crm_exit_t);
@@ -1997,14 +1997,14 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("cluster-status", "pcmk_scheduler_t *",
                   "enum pcmk_pacemakerd_state", "crm_exit_t",
                   "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
                   "uint32_t", "const char *", "GList *", "GList *")
 static int
 cluster_status_html(pcmk__output_t *out, va_list args)
 {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     enum pcmk_pacemakerd_state pcmkd_state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     crm_exit_t history_rc = va_arg(args, crm_exit_t);

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -28,7 +28,7 @@
                          "/" XML_LRM_TAG_RESOURCE "[@" XML_ATTR_ID "='%s']"
 
 static xmlNode *
-best_op(const pe_resource_t *rsc, const pcmk_node_t *node)
+best_op(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     char *xpath = NULL;
     xmlNode *history = NULL;
@@ -115,7 +115,7 @@ is_best:
  * \return Standard Pacemaker return code
  */
 int
-pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
+pcmk__resource_digests(pcmk__output_t *out, pcmk_resource_t *rsc,
                        const pcmk_node_t *node, GHashTable *overrides)
 {
     const char *task = NULL;
@@ -155,7 +155,7 @@ pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
 }
 
 int
-pcmk_resource_digests(xmlNodePtr *xml, pe_resource_t *rsc,
+pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
                       const pcmk_node_t *node, GHashTable *overrides,
                       pe_working_set_t *data_set)
 {

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -28,7 +28,7 @@
                          "/" XML_LRM_TAG_RESOURCE "[@" XML_ATTR_ID "='%s']"
 
 static xmlNode *
-best_op(const pe_resource_t *rsc, const pe_node_t *node)
+best_op(const pe_resource_t *rsc, const pcmk_node_t *node)
 {
     char *xpath = NULL;
     xmlNode *history = NULL;
@@ -116,7 +116,7 @@ is_best:
  */
 int
 pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
-                       const pe_node_t *node, GHashTable *overrides)
+                       const pcmk_node_t *node, GHashTable *overrides)
 {
     const char *task = NULL;
     xmlNode *xml_op = NULL;
@@ -156,7 +156,7 @@ pcmk__resource_digests(pcmk__output_t *out, pe_resource_t *rsc,
 
 int
 pcmk_resource_digests(xmlNodePtr *xml, pe_resource_t *rsc,
-                      const pe_node_t *node, GHashTable *overrides,
+                      const pcmk_node_t *node, GHashTable *overrides,
                       pe_working_set_t *data_set)
 {
     pcmk__output_t *out = NULL;

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -157,7 +157,7 @@ pcmk__resource_digests(pcmk__output_t *out, pcmk_resource_t *rsc,
 int
 pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
                       const pcmk_node_t *node, GHashTable *overrides,
-                      pe_working_set_t *data_set)
+                      pcmk_scheduler_t *data_set)
 {
     pcmk__output_t *out = NULL;
     int rc = pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_rule.c
+++ b/lib/pacemaker/pcmk_rule.c
@@ -59,10 +59,10 @@ eval_date_expression(const xmlNode *expr, crm_time_t *now)
  */
 static int
 init_rule_check(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
-                pe_working_set_t **data_set)
+                pcmk_scheduler_t **data_set)
 {
     // Allows for cleaner syntax than dereferencing the data_set argument
-    pe_working_set_t *new_data_set = NULL;
+    pcmk_scheduler_t *new_data_set = NULL;
 
     new_data_set = pe_new_working_set();
     if (new_data_set == NULL) {
@@ -119,7 +119,7 @@ init_rule_check(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
  * \return Standard Pacemaker return code
  */
 static int
-eval_rule(pe_working_set_t *data_set, const char *rule_id, const char **error)
+eval_rule(pcmk_scheduler_t *data_set, const char *rule_id, const char **error)
 {
     xmlNodePtr cib_constraints = NULL;
     xmlNodePtr match = NULL;
@@ -245,7 +245,7 @@ int
 pcmk__check_rules(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
                   const char **rule_ids)
 {
-    pe_working_set_t *data_set = NULL;
+    pcmk_scheduler_t *data_set = NULL;
     int rc = pcmk_rc_ok;
 
     CRM_ASSERT(out != NULL);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -29,7 +29,7 @@
  * \return Action flags that should be used for orderings
  */
 static uint32_t
-action_flags_for_ordering(pe_action_t *action, const pe_node_t *node)
+action_flags_for_ordering(pe_action_t *action, const pcmk_node_t *node)
 {
     bool runnable = false;
     uint32_t flags;
@@ -219,7 +219,7 @@ action_for_ordering(pe_action_t *action)
  */
 static inline uint32_t
 update(pe_resource_t *rsc, pe_action_t *first, pe_action_t *then,
-       const pe_node_t *node, uint32_t flags, uint32_t filter, uint32_t type,
+       const pcmk_node_t *node, uint32_t flags, uint32_t filter, uint32_t type,
        pe_working_set_t *data_set)
 {
     return rsc->cmds->update_ordered_actions(first, then, node, flags, filter,
@@ -252,7 +252,7 @@ update_action_for_ordering_flags(pe_action_t *first, pe_action_t *then,
      * whole 'then' clone should restart if 'first' is restarted, so then->node
      * is needed.
      */
-    pe_node_t *node = then->node;
+    pcmk_node_t *node = then->node;
 
     if (pcmk_is_set(order->type, pcmk__ar_first_implies_same_node_then)) {
         /* For unfencing, only instances of 'then' on the same node as 'first'
@@ -537,8 +537,8 @@ pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
         pe_action_wrapper_t *other = (pe_action_wrapper_t *) lpc->data;
         pe_action_t *first = other->action;
 
-        pe_node_t *then_node = then->node;
-        pe_node_t *first_node = first->node;
+        pcmk_node_t *then_node = then->node;
+        pcmk_node_t *first_node = first->node;
 
         if ((first->rsc != NULL)
             && (first->rsc->variant == pcmk_rsc_variant_group)
@@ -834,7 +834,7 @@ handle_restart_ordering(pe_action_t *first, pe_action_t *then, uint32_t filter)
  */
 uint32_t
 pcmk__update_ordered_actions(pe_action_t *first, pe_action_t *then,
-                             const pe_node_t *node, uint32_t flags,
+                             const pcmk_node_t *node, uint32_t flags,
                              uint32_t filter, uint32_t type,
                              pe_working_set_t *data_set)
 {
@@ -1047,7 +1047,7 @@ pcmk__log_action(const char *pre_text, const pe_action_t *action, bool details)
  * \return Newly created shutdown action for \p node
  */
 pe_action_t *
-pcmk__new_shutdown_action(pe_node_t *node)
+pcmk__new_shutdown_action(pcmk_node_t *node)
 {
     char *shutdown_id = NULL;
     pe_action_t *shutdown_op = NULL;
@@ -1531,7 +1531,7 @@ only_sanitized_changed(const xmlNode *xml_op,
  */
 static void
 force_restart(pe_resource_t *rsc, const char *task, guint interval_ms,
-              pe_node_t *node)
+              pcmk_node_t *node)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
     pe_action_t *required = custom_action(rsc, key, task, NULL, FALSE, TRUE,
@@ -1553,7 +1553,7 @@ static void
 schedule_reload(gpointer data, gpointer user_data)
 {
     pe_resource_t *rsc = data;
-    const pe_node_t *node = user_data;
+    const pcmk_node_t *node = user_data;
     pe_action_t *reload = NULL;
 
     // For collective resources, just call recursively for children
@@ -1615,7 +1615,7 @@ schedule_reload(gpointer data, gpointer user_data)
  * \return true if action configuration changed, otherwise false
  */
 bool
-pcmk__check_action_config(pe_resource_t *rsc, pe_node_t *node,
+pcmk__check_action_config(pe_resource_t *rsc, pcmk_node_t *node,
                           const xmlNode *xml_op)
 {
     guint interval_ms = 0;
@@ -1752,7 +1752,7 @@ rsc_history_as_list(const xmlNode *rsc_entry, int *start_index, int *stop_index)
  */
 static void
 process_rsc_history(const xmlNode *rsc_entry, pe_resource_t *rsc,
-                    pe_node_t *node)
+                    pcmk_node_t *node)
 {
     int offset = -1;
     int stop_index = 0;
@@ -1864,7 +1864,7 @@ process_rsc_history(const xmlNode *rsc_entry, pe_resource_t *rsc,
  * \param[in]     lrm_rscs  Node's <lrm_resources> from CIB status XML
  */
 static void
-process_node_history(pe_node_t *node, const xmlNode *lrm_rscs)
+process_node_history(pcmk_node_t *node, const xmlNode *lrm_rscs)
 {
     crm_trace("Processing node history for %s", pe__node_name(node));
     for (const xmlNode *rsc_entry = first_named_child(lrm_rscs,
@@ -1914,7 +1914,7 @@ pcmk__handle_rsc_config_changes(pe_working_set_t *data_set)
      * orphaned nodes and lets us eliminate some cases before searching the XML.
      */
     for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk_node_t *node = (pcmk_node_t *) iter->data;
 
         /* Don't bother checking actions for a node that can't run actions ...
          * unless it's in maintenance mode, in which case we still need to

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -89,7 +89,8 @@ action_flags_for_ordering(pe_action_t *action, const pcmk_node_t *node)
  * \note It is the caller's responsibility to free the return value.
  */
 static char *
-action_uuid_for_ordering(const char *first_uuid, const pe_resource_t *first_rsc)
+action_uuid_for_ordering(const char *first_uuid,
+                         const pcmk_resource_t *first_rsc)
 {
     guint interval_ms = 0;
     char *uuid = NULL;
@@ -181,7 +182,7 @@ static pe_action_t *
 action_for_ordering(pe_action_t *action)
 {
     pe_action_t *result = action;
-    pe_resource_t *rsc = action->rsc;
+    pcmk_resource_t *rsc = action->rsc;
 
     if ((rsc != NULL) && (rsc->variant >= pcmk_rsc_variant_group)
         && (action->uuid != NULL)) {
@@ -218,7 +219,7 @@ action_for_ordering(pe_action_t *action)
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 static inline uint32_t
-update(pe_resource_t *rsc, pe_action_t *first, pe_action_t *then,
+update(pcmk_resource_t *rsc, pe_action_t *first, pe_action_t *then,
        const pcmk_node_t *node, uint32_t flags, uint32_t filter, uint32_t type,
        pe_working_set_t *data_set)
 {
@@ -1418,7 +1419,7 @@ pcmk__output_actions(pe_working_set_t *data_set)
         }
 
         if (pe__is_guest_node(action->node)) {
-            const pe_resource_t *remote = action->node->details->remote_rsc;
+            const pcmk_resource_t *remote = action->node->details->remote_rsc;
 
             node_name = crm_strdup_printf("%s (resource: %s)",
                                           pe__node_name(action->node),
@@ -1435,7 +1436,7 @@ pcmk__output_actions(pe_working_set_t *data_set)
 
     // Output resource actions
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         rsc->cmds->output_actions(rsc);
     }
@@ -1452,7 +1453,8 @@ pcmk__output_actions(pe_working_set_t *data_set)
  * \return true if action is still in resource configuration, otherwise false
  */
 static bool
-action_in_config(const pe_resource_t *rsc, const char *task, guint interval_ms)
+action_in_config(const pcmk_resource_t *rsc, const char *task,
+                 guint interval_ms)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
     bool config = (find_rsc_op_entry(rsc, key) != NULL);
@@ -1530,7 +1532,7 @@ only_sanitized_changed(const xmlNode *xml_op,
  * \param[in,out] node         Node where resource should be restarted
  */
 static void
-force_restart(pe_resource_t *rsc, const char *task, guint interval_ms,
+force_restart(pcmk_resource_t *rsc, const char *task, guint interval_ms,
               pcmk_node_t *node)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
@@ -1552,7 +1554,7 @@ force_restart(pe_resource_t *rsc, const char *task, guint interval_ms,
 static void
 schedule_reload(gpointer data, gpointer user_data)
 {
-    pe_resource_t *rsc = data;
+    pcmk_resource_t *rsc = data;
     const pcmk_node_t *node = user_data;
     pe_action_t *reload = NULL;
 
@@ -1615,7 +1617,7 @@ schedule_reload(gpointer data, gpointer user_data)
  * \return true if action configuration changed, otherwise false
  */
 bool
-pcmk__check_action_config(pe_resource_t *rsc, pcmk_node_t *node,
+pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
                           const xmlNode *xml_op)
 {
     guint interval_ms = 0;
@@ -1751,7 +1753,7 @@ rsc_history_as_list(const xmlNode *rsc_entry, int *start_index, int *stop_index)
  * \param[in,out] node       Node whose history is being processed
  */
 static void
-process_rsc_history(const xmlNode *rsc_entry, pe_resource_t *rsc,
+process_rsc_history(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
                     pcmk_node_t *node)
 {
     int offset = -1;
@@ -1876,7 +1878,7 @@ process_node_history(pcmk_node_t *node, const xmlNode *lrm_rscs)
                                                    node->details->data_set);
 
             for (GList *iter = result; iter != NULL; iter = iter->next) {
-                pe_resource_t *rsc = (pe_resource_t *) iter->data;
+                pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
                 if (rsc->variant == pcmk_rsc_variant_primitive) {
                     process_rsc_history(rsc_entry, rsc, node);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -29,7 +29,7 @@
  * \return Action flags that should be used for orderings
  */
 static uint32_t
-action_flags_for_ordering(pe_action_t *action, const pcmk_node_t *node)
+action_flags_for_ordering(pcmk_action_t *action, const pcmk_node_t *node)
 {
     bool runnable = false;
     uint32_t flags;
@@ -178,10 +178,10 @@ done:
  *
  * \return Actual action that should be used for the ordering
  */
-static pe_action_t *
-action_for_ordering(pe_action_t *action)
+static pcmk_action_t *
+action_for_ordering(pcmk_action_t *action)
 {
-    pe_action_t *result = action;
+    pcmk_action_t *result = action;
     pcmk_resource_t *rsc = action->rsc;
 
     if ((rsc != NULL) && (rsc->variant >= pcmk_rsc_variant_group)
@@ -219,7 +219,7 @@ action_for_ordering(pe_action_t *action)
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 static inline uint32_t
-update(pcmk_resource_t *rsc, pe_action_t *first, pe_action_t *then,
+update(pcmk_resource_t *rsc, pcmk_action_t *first, pcmk_action_t *then,
        const pcmk_node_t *node, uint32_t flags, uint32_t filter, uint32_t type,
        pe_working_set_t *data_set)
 {
@@ -241,7 +241,7 @@ update(pcmk_resource_t *rsc, pe_action_t *first, pe_action_t *then,
  * \return Group of enum pcmk__updated flags
  */
 static uint32_t
-update_action_for_ordering_flags(pe_action_t *first, pe_action_t *then,
+update_action_for_ordering_flags(pcmk_action_t *first, pcmk_action_t *then,
                                  uint32_t first_flags, uint32_t then_flags,
                                  pe_action_wrapper_t *order,
                                  pe_working_set_t *data_set)
@@ -501,7 +501,8 @@ update_action_for_ordering_flags(pe_action_t *first, pe_action_t *then,
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
+pcmk__update_action_for_orderings(pcmk_action_t *then,
+                                  pe_working_set_t *data_set)
 {
     GList *lpc = NULL;
     uint32_t changed = pcmk__updated_none;
@@ -536,7 +537,7 @@ pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
 
     for (lpc = then->actions_before; lpc != NULL; lpc = lpc->next) {
         pe_action_wrapper_t *other = (pe_action_wrapper_t *) lpc->data;
-        pe_action_t *first = other->action;
+        pcmk_action_t *first = other->action;
 
         pcmk_node_t *then_node = then->node;
         pcmk_node_t *first_node = first->node;
@@ -674,7 +675,7 @@ pcmk__update_action_for_orderings(pe_action_t *then, pe_working_set_t *data_set)
 }
 
 static inline bool
-is_primitive_action(const pe_action_t *action)
+is_primitive_action(const pcmk_action_t *action)
 {
     return (action != NULL) && (action->rsc != NULL)
            && (action->rsc->variant == pcmk_rsc_variant_primitive);
@@ -710,7 +711,7 @@ is_primitive_action(const pe_action_t *action)
  * \param[in,out] then   'Then' action in an asymmetric ordering
  */
 static void
-handle_asymmetric_ordering(const pe_action_t *first, pe_action_t *then)
+handle_asymmetric_ordering(const pcmk_action_t *first, pcmk_action_t *then)
 {
     /* Only resource actions after an unrunnable 'first' action need updates for
      * asymmetric ordering.
@@ -757,7 +758,8 @@ handle_asymmetric_ordering(const pe_action_t *first, pe_action_t *then)
  *       "stop later group member before stopping earlier group member"
  */
 static void
-handle_restart_ordering(pe_action_t *first, pe_action_t *then, uint32_t filter)
+handle_restart_ordering(pcmk_action_t *first, pcmk_action_t *then,
+                        uint32_t filter)
 {
     const char *reason = NULL;
 
@@ -834,7 +836,7 @@ handle_restart_ordering(pe_action_t *first, pe_action_t *then, uint32_t filter)
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 uint32_t
-pcmk__update_ordered_actions(pe_action_t *first, pe_action_t *then,
+pcmk__update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                              const pcmk_node_t *node, uint32_t flags,
                              uint32_t filter, uint32_t type,
                              pe_working_set_t *data_set)
@@ -958,7 +960,8 @@ pcmk__update_ordered_actions(pe_action_t *first, pe_action_t *then,
  * \param[in] details   If true, recursively log dependent actions
  */
 void
-pcmk__log_action(const char *pre_text, const pe_action_t *action, bool details)
+pcmk__log_action(const char *pre_text, const pcmk_action_t *action,
+                 bool details)
 {
     const char *node_uname = NULL;
     const char *node_uuid = NULL;
@@ -1047,11 +1050,11 @@ pcmk__log_action(const char *pre_text, const pe_action_t *action, bool details)
  *
  * \return Newly created shutdown action for \p node
  */
-pe_action_t *
+pcmk_action_t *
 pcmk__new_shutdown_action(pcmk_node_t *node)
 {
     char *shutdown_id = NULL;
-    pe_action_t *shutdown_op = NULL;
+    pcmk_action_t *shutdown_op = NULL;
 
     CRM_ASSERT(node != NULL);
 
@@ -1294,7 +1297,7 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
  *         otherwise false
  */
 bool
-pcmk__action_locks_rsc_to_node(const pe_action_t *action)
+pcmk__action_locks_rsc_to_node(const pcmk_action_t *action)
 {
     // Only resource actions taking place on resource's lock node are locked
     if ((action == NULL) || (action->rsc == NULL)
@@ -1342,7 +1345,7 @@ sort_action_id(gconstpointer a, gconstpointer b)
  * \param[in,out] action  Action whose inputs should be checked
  */
 void
-pcmk__deduplicate_action_inputs(pe_action_t *action)
+pcmk__deduplicate_action_inputs(pcmk_action_t *action)
 {
     GList *item = NULL;
     GList *next = NULL;
@@ -1394,7 +1397,7 @@ pcmk__output_actions(pe_working_set_t *data_set)
     for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
         char *node_name = NULL;
         char *task = NULL;
-        pe_action_t *action = (pe_action_t *) iter->data;
+        pcmk_action_t *action = (pcmk_action_t *) iter->data;
 
         if (action->rsc != NULL) {
             continue; // Resource actions will be output later
@@ -1536,8 +1539,8 @@ force_restart(pcmk_resource_t *rsc, const char *task, guint interval_ms,
               pcmk_node_t *node)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
-    pe_action_t *required = custom_action(rsc, key, task, NULL, FALSE, TRUE,
-                                          rsc->cluster);
+    pcmk_action_t *required = custom_action(rsc, key, task, NULL, FALSE, TRUE,
+                                            rsc->cluster);
 
     pe_action_set_reason(required, "resource definition change", true);
     trigger_unfencing(rsc, node, "Device parameters changed", NULL,
@@ -1556,7 +1559,7 @@ schedule_reload(gpointer data, gpointer user_data)
 {
     pcmk_resource_t *rsc = data;
     const pcmk_node_t *node = user_data;
-    pe_action_t *reload = NULL;
+    pcmk_action_t *reload = NULL;
 
     // For collective resources, just call recursively for children
     if (rsc->variant > pcmk_rsc_variant_primitive) {

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -221,7 +221,7 @@ action_for_ordering(pcmk_action_t *action)
 static inline uint32_t
 update(pcmk_resource_t *rsc, pcmk_action_t *first, pcmk_action_t *then,
        const pcmk_node_t *node, uint32_t flags, uint32_t filter, uint32_t type,
-       pe_working_set_t *data_set)
+       pcmk_scheduler_t *data_set)
 {
     return rsc->cmds->update_ordered_actions(first, then, node, flags, filter,
                                              type, data_set);
@@ -244,7 +244,7 @@ static uint32_t
 update_action_for_ordering_flags(pcmk_action_t *first, pcmk_action_t *then,
                                  uint32_t first_flags, uint32_t then_flags,
                                  pe_action_wrapper_t *order,
-                                 pe_working_set_t *data_set)
+                                 pcmk_scheduler_t *data_set)
 {
     uint32_t changed = pcmk__updated_none;
 
@@ -502,7 +502,7 @@ update_action_for_ordering_flags(pcmk_action_t *first, pcmk_action_t *then,
  */
 void
 pcmk__update_action_for_orderings(pcmk_action_t *then,
-                                  pe_working_set_t *data_set)
+                                  pcmk_scheduler_t *data_set)
 {
     GList *lpc = NULL;
     uint32_t changed = pcmk__updated_none;
@@ -839,7 +839,7 @@ uint32_t
 pcmk__update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                              const pcmk_node_t *node, uint32_t flags,
                              uint32_t filter, uint32_t type,
-                             pe_working_set_t *data_set)
+                             pcmk_scheduler_t *data_set)
 {
     uint32_t changed = pcmk__updated_none;
     uint32_t then_flags = 0U;
@@ -1389,7 +1389,7 @@ pcmk__deduplicate_action_inputs(pcmk_action_t *action)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__output_actions(pe_working_set_t *data_set)
+pcmk__output_actions(pcmk_scheduler_t *data_set)
 {
     pcmk__output_t *out = data_set->priv;
 
@@ -1509,7 +1509,7 @@ task_for_digest(const char *task, guint interval_ms)
 static bool
 only_sanitized_changed(const xmlNode *xml_op,
                        const op_digest_cache_t *digest_data,
-                       const pe_working_set_t *data_set)
+                       const pcmk_scheduler_t *data_set)
 {
     const char *digest_secure = NULL;
 
@@ -1910,7 +1910,7 @@ process_node_history(pcmk_node_t *node, const xmlNode *lrm_rscs)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__handle_rsc_config_changes(pe_working_set_t *data_set)
+pcmk__handle_rsc_config_changes(pcmk_scheduler_t *data_set)
 {
     crm_trace("Check resource and action configuration for changes");
 

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -39,8 +39,8 @@ assign_replica(pe__bundle_replica_t *replica, void *user_data)
     const pcmk_node_t *prefer = assign_data->prefer;
     bool stop_if_fail = assign_data->stop_if_fail;
 
-    const pe_resource_t *bundle = pe__const_top_resource(replica->container,
-                                                         true);
+    const pcmk_resource_t *bundle = pe__const_top_resource(replica->container,
+                                                           true);
 
     if (replica->ip != NULL) {
         pe_rsc_trace(bundle, "Assigning bundle %s IP %s",
@@ -108,11 +108,11 @@ assign_replica(pe__bundle_replica_t *replica, void *user_data)
  *       roles or actions.
  */
 pcmk_node_t *
-pcmk__bundle_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+pcmk__bundle_assign(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
                     bool stop_if_fail)
 {
     GList *containers = NULL;
-    pe_resource_t *bundled_resource = NULL;
+    pcmk_resource_t *bundled_resource = NULL;
     struct assign_data assign_data = { prefer, stop_if_fail };
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
@@ -185,11 +185,11 @@ create_replica_actions(pe__bundle_replica_t *replica, void *user_data)
  * \param[in,out] rsc  Bundle resource to create actions for
  */
 void
-pcmk__bundle_create_actions(pe_resource_t *rsc)
+pcmk__bundle_create_actions(pcmk_resource_t *rsc)
 {
     pe_action_t *action = NULL;
     GList *containers = NULL;
-    pe_resource_t *bundled_resource = NULL;
+    pcmk_resource_t *bundled_resource = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
@@ -229,7 +229,7 @@ pcmk__bundle_create_actions(pe_resource_t *rsc)
 static bool
 replica_internal_constraints(pe__bundle_replica_t *replica, void *user_data)
 {
-    pe_resource_t *bundle = user_data;
+    pcmk_resource_t *bundle = user_data;
 
     replica->container->cmds->internal_constraints(replica->container);
 
@@ -294,9 +294,9 @@ replica_internal_constraints(pe__bundle_replica_t *replica, void *user_data)
  * \param[in,out] rsc  Bundle resource to create implicit constraints for
  */
 void
-pcmk__bundle_internal_constraints(pe_resource_t *rsc)
+pcmk__bundle_internal_constraints(pcmk_resource_t *rsc)
 {
-    pe_resource_t *bundled_resource = NULL;
+    pcmk_resource_t *bundled_resource = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
@@ -356,8 +356,8 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 }
 
 struct match_data {
-    const pcmk_node_t *node;   // Node to compare against replica
-    pe_resource_t *container;  // Replica container corresponding to node
+    const pcmk_node_t *node;    // Node to compare against replica
+    pcmk_resource_t *container; // Replica container corresponding to node
 };
 
 /*!
@@ -396,7 +396,7 @@ static const pcmk_node_t *
 get_bundle_node_host(const pcmk_node_t *node)
 {
     if (pe__is_bundle_node(node)) {
-        const pe_resource_t *container = node->details->remote_rsc->container;
+        const pcmk_resource_t *container = node->details->remote_rsc->container;
 
         return container->fns->location(container, NULL, 0);
     }
@@ -414,9 +414,9 @@ get_bundle_node_host(const pcmk_node_t *node)
  *         if assigned, otherwise assigned to any of dependent's allowed nodes,
  *         otherwise NULL.
  */
-static pe_resource_t *
-compatible_container(const pe_resource_t *dependent,
-                     const pe_resource_t *bundle)
+static pcmk_resource_t *
+compatible_container(const pcmk_resource_t *dependent,
+                     const pcmk_resource_t *bundle)
 {
     GList *scratch = NULL;
     struct match_data match_data = { NULL, NULL };
@@ -452,7 +452,7 @@ compatible_container(const pe_resource_t *dependent,
 
 struct coloc_data {
     const pcmk__colocation_t *colocation;
-    pe_resource_t *dependent;
+    pcmk_resource_t *dependent;
     GList *container_hosts;
 };
 
@@ -514,8 +514,8 @@ replica_apply_coloc_score(const pe__bundle_replica_t *replica, void *user_data)
  * \param[in]     for_dependent  true if called on behalf of dependent
  */
 void
-pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
-                               const pe_resource_t *primary,
+pcmk__bundle_apply_coloc_score(pcmk_resource_t *dependent,
+                               const pcmk_resource_t *primary,
                                const pcmk__colocation_t *colocation,
                                bool for_dependent)
 {
@@ -546,9 +546,9 @@ pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
      * of its instances. Look for a compatible instance of this bundle.
      */
     if (colocation->dependent->variant > pcmk_rsc_variant_group) {
-        const pe_resource_t *primary_container = compatible_container(dependent,
-                                                                      primary);
+        const pcmk_resource_t *primary_container = NULL;
 
+        primary_container = compatible_container(dependent, primary);
         if (primary_container != NULL) { // Success, we found one
             pe_rsc_debug(primary, "Pairing %s with %s",
                          dependent->id, primary_container->id);
@@ -581,10 +581,10 @@ pcmk__bundle_apply_coloc_score(pe_resource_t *dependent,
 
 // Bundle implementation of resource_alloc_functions_t:with_this_colocations()
 void
-pcmk__with_bundle_colocations(const pe_resource_t *rsc,
-                              const pe_resource_t *orig_rsc, GList **list)
+pcmk__with_bundle_colocations(const pcmk_resource_t *rsc,
+                              const pcmk_resource_t *orig_rsc, GList **list)
 {
-    const pe_resource_t *bundled_rsc = NULL;
+    const pcmk_resource_t *bundled_rsc = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle)
                && (orig_rsc != NULL) && (list != NULL));
@@ -626,10 +626,10 @@ pcmk__with_bundle_colocations(const pe_resource_t *rsc,
 
 // Bundle implementation of resource_alloc_functions_t:this_with_colocations()
 void
-pcmk__bundle_with_colocations(const pe_resource_t *rsc,
-                              const pe_resource_t *orig_rsc, GList **list)
+pcmk__bundle_with_colocations(const pcmk_resource_t *rsc,
+                              const pcmk_resource_t *orig_rsc, GList **list)
 {
-    const pe_resource_t *bundled_rsc = NULL;
+    const pcmk_resource_t *bundled_rsc = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle)
                && (orig_rsc != NULL) && (list != NULL));
@@ -683,7 +683,7 @@ pcmk__bundle_action_flags(pe_action_t *action, const pcmk_node_t *node)
 {
     GList *containers = NULL;
     uint32_t flags = 0;
-    pe_resource_t *bundled_resource = NULL;
+    pcmk_resource_t *bundled_resource = NULL;
 
     CRM_ASSERT((action != NULL) && (action->rsc != NULL)
                && (action->rsc->variant == pcmk_rsc_variant_bundle));
@@ -744,9 +744,9 @@ apply_location_to_replica(pe__bundle_replica_t *replica, void *user_data)
  * \param[in,out] location  Location constraint to apply
  */
 void
-pcmk__bundle_apply_location(pe_resource_t *rsc, pe__location_t *location)
+pcmk__bundle_apply_location(pcmk_resource_t *rsc, pe__location_t *location)
 {
-    pe_resource_t *bundled_resource = NULL;
+    pcmk_resource_t *bundled_resource = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle)
                && (location != NULL));
@@ -809,7 +809,7 @@ add_replica_actions_to_graph(pe__bundle_replica_t *replica, void *user_data)
                                  strdup(XML_RSC_ATTR_REMOTE_RA_ADDR),
                                  strdup(calculated_addr));
         } else {
-            pe_resource_t *bundle = user_data;
+            pcmk_resource_t *bundle = user_data;
 
             /* The only way to get here is if the remote connection is
              * neither currently running nor scheduled to run. That means we
@@ -842,9 +842,9 @@ add_replica_actions_to_graph(pe__bundle_replica_t *replica, void *user_data)
  * \param[in,out] rsc  Bundle resource whose actions should be added
  */
 void
-pcmk__bundle_add_actions_to_graph(pe_resource_t *rsc)
+pcmk__bundle_add_actions_to_graph(pcmk_resource_t *rsc)
 {
-    pe_resource_t *bundled_resource = NULL;
+    pcmk_resource_t *bundled_resource = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
@@ -856,9 +856,9 @@ pcmk__bundle_add_actions_to_graph(pe_resource_t *rsc)
 }
 
 struct probe_data {
-    pe_resource_t *bundle;  // Bundle being probed
-    pcmk_node_t *node;      // Node to create probes on
-    bool any_created;       // Whether any probes have been created
+    pcmk_resource_t *bundle;    // Bundle being probed
+    pcmk_node_t *node;          // Node to create probes on
+    bool any_created;           // Whether any probes have been created
 };
 
 /*!
@@ -975,7 +975,7 @@ create_replica_probes(pe__bundle_replica_t *replica, void *user_data)
  * \return true if any probe was created, otherwise false
  */
 bool
-pcmk__bundle_create_probe(pe_resource_t *rsc, pcmk_node_t *node)
+pcmk__bundle_create_probe(pcmk_resource_t *rsc, pcmk_node_t *node)
 {
     struct probe_data probe_data = { rsc, node, false };
 
@@ -1018,7 +1018,7 @@ output_replica_actions(pe__bundle_replica_t *replica, void *user_data)
  * \param[in,out] rsc  Bundle resource to output actions for
  */
 void
-pcmk__output_bundle_actions(pe_resource_t *rsc)
+pcmk__output_bundle_actions(pcmk_resource_t *rsc)
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
     pe__foreach_bundle_replica(rsc, output_replica_actions, NULL);
@@ -1026,11 +1026,11 @@ pcmk__output_bundle_actions(pe_resource_t *rsc)
 
 // Bundle implementation of resource_alloc_functions_t:add_utilization()
 void
-pcmk__bundle_add_utilization(const pe_resource_t *rsc,
-                             const pe_resource_t *orig_rsc, GList *all_rscs,
+pcmk__bundle_add_utilization(const pcmk_resource_t *rsc,
+                             const pcmk_resource_t *orig_rsc, GList *all_rscs,
                              GHashTable *utilization)
 {
-    pe_resource_t *container = NULL;
+    pcmk_resource_t *container = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
 
@@ -1051,7 +1051,7 @@ pcmk__bundle_add_utilization(const pe_resource_t *rsc,
 
 // Bundle implementation of resource_alloc_functions_t:shutdown_lock()
 void
-pcmk__bundle_shutdown_lock(pe_resource_t *rsc)
+pcmk__bundle_shutdown_lock(pcmk_resource_t *rsc)
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_bundle));
     // Bundles currently don't support shutdown locks

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -187,7 +187,7 @@ create_replica_actions(pe__bundle_replica_t *replica, void *user_data)
 void
 pcmk__bundle_create_actions(pcmk_resource_t *rsc)
 {
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
     GList *containers = NULL;
     pcmk_resource_t *bundled_resource = NULL;
 
@@ -679,7 +679,7 @@ pcmk__bundle_with_colocations(const pcmk_resource_t *rsc,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__bundle_action_flags(pe_action_t *action, const pcmk_node_t *node)
+pcmk__bundle_action_flags(pcmk_action_t *action, const pcmk_node_t *node)
 {
     GList *containers = NULL;
     uint32_t flags = 0;
@@ -944,9 +944,9 @@ create_replica_probes(pe__bundle_replica_t *replica, void *user_data)
          */
         char *probe_uuid = pcmk__op_key(replica->remote->id,
                                         PCMK_ACTION_MONITOR, 0);
-        pe_action_t *probe = find_first_action(replica->remote->actions,
-                                               probe_uuid, NULL,
-                                               probe_data->node);
+        pcmk_action_t *probe = find_first_action(replica->remote->actions,
+                                                 probe_uuid, NULL,
+                                                 probe_data->node);
 
         free(probe_uuid);
         if (probe != NULL) {

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -17,7 +17,7 @@
 #include "libpacemaker_private.h"
 
 struct assign_data {
-    const pe_node_t *prefer;
+    const pcmk_node_t *prefer;
     bool stop_if_fail;
 };
 
@@ -33,10 +33,10 @@ struct assign_data {
 static bool
 assign_replica(pe__bundle_replica_t *replica, void *user_data)
 {
-    pe_node_t *container_host = NULL;
+    pcmk_node_t *container_host = NULL;
 
     struct assign_data *assign_data = user_data;
-    const pe_node_t *prefer = assign_data->prefer;
+    const pcmk_node_t *prefer = assign_data->prefer;
     bool stop_if_fail = assign_data->stop_if_fail;
 
     const pe_resource_t *bundle = pe__const_top_resource(replica->container,
@@ -66,7 +66,7 @@ assign_replica(pe__bundle_replica_t *replica, void *user_data)
     }
 
     if (replica->child != NULL) {
-        pe_node_t *node = NULL;
+        pcmk_node_t *node = NULL;
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, replica->child->allowed_nodes);
@@ -107,8 +107,8 @@ assign_replica(pe__bundle_replica_t *replica, void *user_data)
  *       as calling pcmk__unassign_resource(); there are no side effects on
  *       roles or actions.
  */
-pe_node_t *
-pcmk__bundle_assign(pe_resource_t *rsc, const pe_node_t *prefer,
+pcmk_node_t *
+pcmk__bundle_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
                     bool stop_if_fail)
 {
     GList *containers = NULL;
@@ -136,7 +136,7 @@ pcmk__bundle_assign(pe_resource_t *rsc, const pe_node_t *prefer,
     // Finally, assign the bundled resources to each bundle node
     bundled_resource = pe__bundled_resource(rsc);
     if (bundled_resource != NULL) {
-        pe_node_t *node = NULL;
+        pcmk_node_t *node = NULL;
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, bundled_resource->allowed_nodes);
@@ -356,7 +356,7 @@ pcmk__bundle_internal_constraints(pe_resource_t *rsc)
 }
 
 struct match_data {
-    const pe_node_t *node;     // Node to compare against replica
+    const pcmk_node_t *node;   // Node to compare against replica
     pe_resource_t *container;  // Replica container corresponding to node
 };
 
@@ -392,8 +392,8 @@ match_replica_container(const pe__bundle_replica_t *replica, void *user_data)
  * \return Node to which the container for \p node is assigned if \p node is a
  *         bundle node, otherwise \p node itself
  */
-static const pe_node_t *
-get_bundle_node_host(const pe_node_t *node)
+static const pcmk_node_t *
+get_bundle_node_host(const pcmk_node_t *node)
 {
     if (pe__is_bundle_node(node)) {
         const pe_resource_t *container = node->details->remote_rsc->container;
@@ -469,7 +469,7 @@ static bool
 replica_apply_coloc_score(const pe__bundle_replica_t *replica, void *user_data)
 {
     struct coloc_data *coloc_data = user_data;
-    pe_node_t *chosen = NULL;
+    pcmk_node_t *chosen = NULL;
 
     if (coloc_data->colocation->score < INFINITY) {
         replica->container->cmds->apply_coloc_score(coloc_data->dependent,
@@ -679,7 +679,7 @@ pcmk__bundle_with_colocations(const pe_resource_t *rsc,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__bundle_action_flags(pe_action_t *action, const pe_node_t *node)
+pcmk__bundle_action_flags(pe_action_t *action, const pcmk_node_t *node)
 {
     GList *containers = NULL;
     uint32_t flags = 0;
@@ -857,7 +857,7 @@ pcmk__bundle_add_actions_to_graph(pe_resource_t *rsc)
 
 struct probe_data {
     pe_resource_t *bundle;  // Bundle being probed
-    pe_node_t *node;        // Node to create probes on
+    pcmk_node_t *node;      // Node to create probes on
     bool any_created;       // Whether any probes have been created
 };
 
@@ -975,7 +975,7 @@ create_replica_probes(pe__bundle_replica_t *replica, void *user_data)
  * \return true if any probe was created, otherwise false
  */
 bool
-pcmk__bundle_create_probe(pe_resource_t *rsc, pe_node_t *node)
+pcmk__bundle_create_probe(pe_resource_t *rsc, pcmk_node_t *node)
 {
     struct probe_data probe_data = { rsc, node, false };
 

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -33,8 +33,8 @@
  *       as calling pcmk__unassign_resource(); there are no side effects on
  *       roles or actions.
  */
-pe_node_t *
-pcmk__clone_assign(pe_resource_t *rsc, const pe_node_t *prefer,
+pcmk_node_t *
+pcmk__clone_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
                    bool stop_if_fail)
 {
     GList *colocations = NULL;
@@ -325,7 +325,7 @@ pcmk__clone_apply_coloc_score(pe_resource_t *dependent,
         // Dependent can run only where primary will have unblocked instances
         for (iter = primary->children; iter != NULL; iter = iter->next) {
             const pe_resource_t *instance = iter->data;
-            pe_node_t *chosen = instance->fns->location(instance, NULL, 0);
+            pcmk_node_t *chosen = instance->fns->location(instance, NULL, 0);
 
             if ((chosen != NULL)
                 && !is_set_recursive(instance, pcmk_rsc_blocked, TRUE)) {
@@ -388,7 +388,7 @@ pcmk__clone_with_colocations(const pe_resource_t *rsc,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__clone_action_flags(pe_action_t *action, const pe_node_t *node)
+pcmk__clone_action_flags(pe_action_t *action, const pcmk_node_t *node)
 {
     CRM_ASSERT((action != NULL) && pe_rsc_is_clone(action->rsc));
 
@@ -460,7 +460,7 @@ pcmk__clone_add_actions_to_graph(pe_resource_t *rsc)
  *         children, otherwise false
  */
 static bool
-rsc_probed_on(const pe_resource_t *rsc, const pe_node_t *node)
+rsc_probed_on(const pe_resource_t *rsc, const pcmk_node_t *node)
 {
     if (rsc->children != NULL) {
         for (GList *child_iter = rsc->children; child_iter != NULL;
@@ -477,7 +477,7 @@ rsc_probed_on(const pe_resource_t *rsc, const pe_node_t *node)
 
     if (rsc->known_on != NULL) {
         GHashTableIter iter;
-        pe_node_t *known_node = NULL;
+        pcmk_node_t *known_node = NULL;
 
         g_hash_table_iter_init(&iter, rsc->known_on);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &known_node)) {
@@ -500,7 +500,7 @@ rsc_probed_on(const pe_resource_t *rsc, const pe_node_t *node)
  *         otherwise NULL
  */
 static pe_resource_t *
-find_probed_instance_on(const pe_resource_t *clone, const pe_node_t *node)
+find_probed_instance_on(const pe_resource_t *clone, const pcmk_node_t *node)
 {
     for (GList *iter = clone->children; iter != NULL; iter = iter->next) {
         pe_resource_t *instance = (pe_resource_t *) iter->data;
@@ -520,7 +520,7 @@ find_probed_instance_on(const pe_resource_t *clone, const pe_node_t *node)
  * \param[in,out] node   Node to probe \p clone on
  */
 static bool
-probe_anonymous_clone(pe_resource_t *clone, pe_node_t *node)
+probe_anonymous_clone(pe_resource_t *clone, pcmk_node_t *node)
 {
     // Check whether we already probed an instance on this node
     pe_resource_t *child = find_probed_instance_on(clone, node);
@@ -529,7 +529,7 @@ probe_anonymous_clone(pe_resource_t *clone, pe_node_t *node)
     for (GList *iter = clone->children; (iter != NULL) && (child == NULL);
          iter = iter->next) {
         pe_resource_t *instance = (pe_resource_t *) iter->data;
-        const pe_node_t *instance_node = NULL;
+        const pcmk_node_t *instance_node = NULL;
 
         instance_node = instance->fns->location(instance, NULL, 0);
         if (pe__same_node(instance_node, node)) {
@@ -556,7 +556,7 @@ probe_anonymous_clone(pe_resource_t *clone, pe_node_t *node)
  * \return true if any probe was created, otherwise false
  */
 bool
-pcmk__clone_create_probe(pe_resource_t *rsc, pe_node_t *node)
+pcmk__clone_create_probe(pe_resource_t *rsc, pcmk_node_t *node)
 {
     CRM_ASSERT((node != NULL) && pe_rsc_is_clone(rsc));
 
@@ -570,8 +570,8 @@ pcmk__clone_create_probe(pe_resource_t *rsc, pe_node_t *node)
          * instances), and affects the CRM_meta_notify_available_uname variable
          * passed with notify actions.
          */
-        pe_node_t *allowed = g_hash_table_lookup(rsc->allowed_nodes,
-                                                 node->details->id);
+        pcmk_node_t *allowed = g_hash_table_lookup(rsc->allowed_nodes,
+                                                   node->details->id);
 
         if ((allowed == NULL)
             || (allowed->rsc_discover_mode != pcmk_probe_exclusive)) {

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -388,7 +388,7 @@ pcmk__clone_with_colocations(const pcmk_resource_t *rsc,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__clone_action_flags(pe_action_t *action, const pcmk_node_t *node)
+pcmk__clone_action_flags(pcmk_action_t *action, const pcmk_node_t *node)
 {
     CRM_ASSERT((action != NULL) && pe_rsc_is_clone(action->rsc));
 
@@ -422,7 +422,7 @@ call_action_flags(gpointer data, gpointer user_data)
 {
     pcmk_resource_t *rsc = user_data;
 
-    rsc->cmds->action_flags((pe_action_t *) data, NULL);
+    rsc->cmds->action_flags((pcmk_action_t *) data, NULL);
 }
 
 /*!

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -1017,7 +1017,7 @@ mark_action_blocked(pcmk_resource_t *rsc, const char *task,
     char *reason_text = crm_strdup_printf("colocation with %s", reason->id);
 
     for (iter = rsc->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *action = iter->data;
+        pcmk_action_t *action = iter->data;
 
         if (pcmk_is_set(action->flags, pcmk_action_runnable)
             && pcmk__str_eq(action->task, task, pcmk__str_none)) {
@@ -1047,7 +1047,7 @@ mark_action_blocked(pcmk_resource_t *rsc, const char *task,
  * \param[in,out] action  Action to check
  */
 void
-pcmk__block_colocation_dependents(pe_action_t *action)
+pcmk__block_colocation_dependents(pcmk_action_t *action)
 {
     GList *iter = NULL;
     GList *colocations = NULL;
@@ -1078,8 +1078,8 @@ pcmk__block_colocation_dependents(pe_action_t *action)
     // Colocation fails only if entire primary can't reach desired role
     for (iter = rsc->children; iter != NULL; iter = iter->next) {
         pcmk_resource_t *child = iter->data;
-        pe_action_t *child_action = find_first_action(child->actions, NULL,
-                                                      action->task, NULL);
+        pcmk_action_t *child_action = find_first_action(child->actions, NULL,
+                                                        action->task, NULL);
 
         if ((child_action == NULL)
             || pcmk_is_set(child_action->flags, pcmk_action_runnable)) {

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -52,8 +52,8 @@ static gint
 cmp_colocation_priority(const pcmk__colocation_t *colocation1,
                         const pcmk__colocation_t *colocation2, bool dependent)
 {
-    const pe_resource_t *rsc1 = NULL;
-    const pe_resource_t *rsc2 = NULL;
+    const pcmk_resource_t *rsc1 = NULL;
+    const pcmk_resource_t *rsc2 = NULL;
 
     if (colocation1 == NULL) {
         return 1;
@@ -171,7 +171,7 @@ cmp_primary_priority(gconstpointer a, gconstpointer b)
  */
 void
 pcmk__add_this_with(GList **list, const pcmk__colocation_t *colocation,
-                    const pe_resource_t *rsc)
+                    const pcmk_resource_t *rsc)
 {
     CRM_ASSERT((list != NULL) && (colocation != NULL) && (rsc != NULL));
 
@@ -198,7 +198,7 @@ pcmk__add_this_with(GList **list, const pcmk__colocation_t *colocation,
  */
 void
 pcmk__add_this_with_list(GList **list, GList *addition,
-                         const pe_resource_t *rsc)
+                         const pcmk_resource_t *rsc)
 {
     CRM_ASSERT((list != NULL) && (rsc != NULL));
 
@@ -231,7 +231,7 @@ pcmk__add_this_with_list(GList **list, GList *addition,
  */
 void
 pcmk__add_with_this(GList **list, const pcmk__colocation_t *colocation,
-                    const pe_resource_t *rsc)
+                    const pcmk_resource_t *rsc)
 {
     CRM_ASSERT((list != NULL) && (colocation != NULL) && (rsc != NULL));
 
@@ -258,7 +258,7 @@ pcmk__add_with_this(GList **list, const pcmk__colocation_t *colocation,
  */
 void
 pcmk__add_with_this_list(GList **list, GList *addition,
-                         const pe_resource_t *rsc)
+                         const pcmk_resource_t *rsc)
 {
     CRM_ASSERT((list != NULL) && (rsc != NULL));
 
@@ -288,8 +288,8 @@ pcmk__add_with_this_list(GList **list, GList *addition,
  * \param[in]     then_role   Anti-colocation role of \p then_rsc
  */
 static void
-anti_colocation_order(pe_resource_t *first_rsc, int first_role,
-                      pe_resource_t *then_rsc, int then_role)
+anti_colocation_order(pcmk_resource_t *first_rsc, int first_role,
+                      pcmk_resource_t *then_rsc, int then_role)
 {
     const char *first_tasks[] = { NULL, NULL };
     const char *then_tasks[] = { NULL, NULL };
@@ -346,7 +346,7 @@ anti_colocation_order(pe_resource_t *first_rsc, int first_role,
  */
 void
 pcmk__new_colocation(const char *id, const char *node_attr, int score,
-                     pe_resource_t *dependent, pe_resource_t *primary,
+                     pcmk_resource_t *dependent, pcmk_resource_t *primary,
                      const char *dependent_role, const char *primary_role,
                      uint32_t flags)
 {
@@ -416,7 +416,7 @@ pcmk__new_colocation(const char *id, const char *node_attr, int score,
  *         pcmk__coloc_none
  */
 static uint32_t
-unpack_influence(const char *coloc_id, const pe_resource_t *rsc,
+unpack_influence(const char *coloc_id, const pcmk_resource_t *rsc,
                  const char *influence_s)
 {
     if (influence_s != NULL) {
@@ -441,8 +441,8 @@ unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
                       const char *influence_s, pe_working_set_t *data_set)
 {
     xmlNode *xml_rsc = NULL;
-    pe_resource_t *other = NULL;
-    pe_resource_t *resource = NULL;
+    pcmk_resource_t *other = NULL;
+    pcmk_resource_t *resource = NULL;
     const char *set_id = ID(set);
     const char *role = crm_element_value(set, "role");
     bool with_previous = false;
@@ -567,8 +567,8 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
                   pe_working_set_t *data_set)
 {
     xmlNode *xml_rsc = NULL;
-    pe_resource_t *rsc_1 = NULL;
-    pe_resource_t *rsc_2 = NULL;
+    pcmk_resource_t *rsc_1 = NULL;
+    pcmk_resource_t *rsc_2 = NULL;
 
     const char *xml_rsc_id = NULL;
     const char *role_1 = crm_element_value(set1, "role");
@@ -724,8 +724,8 @@ unpack_simple_colocation(xmlNode *xml_obj, const char *id,
 
     const char *primary_instance = NULL;
     const char *dependent_instance = NULL;
-    pe_resource_t *primary = NULL;
-    pe_resource_t *dependent = NULL;
+    pcmk_resource_t *primary = NULL;
+    pcmk_resource_t *dependent = NULL;
 
     primary = pcmk__find_constraint_resource(data_set->resources, primary_id);
     dependent = pcmk__find_constraint_resource(data_set->resources,
@@ -816,8 +816,8 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     const char *dependent_role = NULL;
     const char *primary_role = NULL;
 
-    pe_resource_t *dependent = NULL;
-    pe_resource_t *primary = NULL;
+    pcmk_resource_t *dependent = NULL;
+    pcmk_resource_t *primary = NULL;
 
     pe_tag_t *dependent_tag = NULL;
     pe_tag_t *primary_tag = NULL;
@@ -1010,8 +1010,8 @@ pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set)
  * \param[in]     reason  Unrunnable start action causing the block
  */
 static void
-mark_action_blocked(pe_resource_t *rsc, const char *task,
-                    const pe_resource_t *reason)
+mark_action_blocked(pcmk_resource_t *rsc, const char *task,
+                    const pcmk_resource_t *reason)
 {
     GList *iter = NULL;
     char *reason_text = crm_strdup_printf("colocation with %s", reason->id);
@@ -1031,7 +1031,7 @@ mark_action_blocked(pe_resource_t *rsc, const char *task,
 
     // If parent resource can't perform an action, neither can any children
     for (iter = rsc->children; iter != NULL; iter = iter->next) {
-        mark_action_blocked((pe_resource_t *) (iter->data), task, reason);
+        mark_action_blocked((pcmk_resource_t *) (iter->data), task, reason);
     }
     free(reason_text);
 }
@@ -1051,7 +1051,7 @@ pcmk__block_colocation_dependents(pe_action_t *action)
 {
     GList *iter = NULL;
     GList *colocations = NULL;
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     bool is_start = false;
 
     if (pcmk_is_set(action->flags, pcmk_action_runnable)) {
@@ -1077,7 +1077,7 @@ pcmk__block_colocation_dependents(pe_action_t *action)
 
     // Colocation fails only if entire primary can't reach desired role
     for (iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *child = iter->data;
+        pcmk_resource_t *child = iter->data;
         pe_action_t *child_action = find_first_action(child->actions, NULL,
                                                       action->task, NULL);
 
@@ -1142,11 +1142,11 @@ pcmk__block_colocation_dependents(pe_action_t *action)
  *
  * \return Resource to use for role comparisons
  */
-static const pe_resource_t *
-get_resource_for_role(const pe_resource_t *rsc)
+static const pcmk_resource_t *
+get_resource_for_role(const pcmk_resource_t *rsc)
 {
     if (pcmk_is_set(rsc->flags, pcmk_rsc_replica_container)) {
-        const pe_resource_t *child = pe__get_rsc_in_container(rsc);
+        const pcmk_resource_t *child = pe__get_rsc_in_container(rsc);
 
         if (child != NULL) {
             return child;
@@ -1174,12 +1174,12 @@ get_resource_for_role(const pe_resource_t *rsc)
  * \return How colocation constraint should be applied at this point
  */
 enum pcmk__coloc_affects
-pcmk__colocation_affects(const pe_resource_t *dependent,
-                         const pe_resource_t *primary,
+pcmk__colocation_affects(const pcmk_resource_t *dependent,
+                         const pcmk_resource_t *primary,
                          const pcmk__colocation_t *colocation, bool preview)
 {
-    const pe_resource_t *dependent_role_rsc = NULL;
-    const pe_resource_t *primary_role_rsc = NULL;
+    const pcmk_resource_t *dependent_role_rsc = NULL;
+    const pcmk_resource_t *primary_role_rsc = NULL;
 
     CRM_ASSERT((dependent != NULL) && (primary != NULL)
                && (colocation != NULL));
@@ -1276,8 +1276,8 @@ pcmk__colocation_affects(const pe_resource_t *dependent,
  * \param[in]     colocation  Colocation constraint
  */
 void
-pcmk__apply_coloc_to_scores(pe_resource_t *dependent,
-                            const pe_resource_t *primary,
+pcmk__apply_coloc_to_scores(pcmk_resource_t *dependent,
+                            const pcmk_resource_t *primary,
                             const pcmk__colocation_t *colocation)
 {
     const char *attr = colocation->node_attribute;
@@ -1377,8 +1377,8 @@ pcmk__apply_coloc_to_scores(pe_resource_t *dependent,
  * \param[in]     colocation  Colocation constraint
  */
 void
-pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
-                              const pe_resource_t *primary,
+pcmk__apply_coloc_to_priority(pcmk_resource_t *dependent,
+                              const pcmk_resource_t *primary,
                               const pcmk__colocation_t *colocation)
 {
     const char *dependent_value = NULL;
@@ -1386,7 +1386,7 @@ pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
     const char *attr = colocation->node_attribute;
     int score_multiplier = 1;
 
-    const pe_resource_t *primary_role_rsc = NULL;
+    const pcmk_resource_t *primary_role_rsc = NULL;
 
     CRM_ASSERT((dependent != NULL) && (primary != NULL) &&
                (colocation != NULL));
@@ -1438,7 +1438,7 @@ pcmk__apply_coloc_to_priority(pe_resource_t *dependent,
  * \param[in] value  Colocation attribute value to require
  */
 static int
-best_node_score_matching_attr(const pe_resource_t *rsc, const char *attr,
+best_node_score_matching_attr(const pcmk_resource_t *rsc, const char *attr,
                               const char *value)
 {
     GHashTableIter iter;
@@ -1482,7 +1482,7 @@ best_node_score_matching_attr(const pe_resource_t *rsc, const char *attr,
  * \return \c true if \p rsc is allowed only on one node, otherwise \c false
  */
 static bool
-allowed_on_one(const pe_resource_t *rsc)
+allowed_on_one(const pcmk_resource_t *rsc)
 {
     GHashTableIter iter;
     pcmk_node_t *allowed_node = NULL;
@@ -1520,8 +1520,8 @@ allowed_on_one(const pe_resource_t *rsc)
  */
 static void
 add_node_scores_matching_attr(GHashTable *nodes,
-                              const pe_resource_t *source_rsc,
-                              const pe_resource_t *target_rsc,
+                              const pcmk_resource_t *source_rsc,
+                              const pcmk_resource_t *target_rsc,
                               const pcmk__colocation_t *colocation,
                               float factor, bool only_positive)
 {
@@ -1662,8 +1662,8 @@ add_node_scores_matching_attr(GHashTable *nodes,
  *       \c resource_alloc_functions_t:add_colocated_node_scores().
  */
 void
-pcmk__add_colocated_node_scores(pe_resource_t *source_rsc,
-                                const pe_resource_t *target_rsc,
+pcmk__add_colocated_node_scores(pcmk_resource_t *source_rsc,
+                                const pcmk_resource_t *target_rsc,
                                 const char *log_id,
                                 GHashTable **nodes,
                                 const pcmk__colocation_t *colocation,
@@ -1726,7 +1726,7 @@ pcmk__add_colocated_node_scores(pe_resource_t *source_rsc,
         for (GList *iter = colocations; iter != NULL; iter = iter->next) {
             pcmk__colocation_t *constraint = iter->data;
 
-            pe_resource_t *other = NULL;
+            pcmk_resource_t *other = NULL;
             float other_factor = factor * constraint->score / (float) INFINITY;
 
             if (pcmk_is_set(flags, pcmk__coloc_select_this_with)) {
@@ -1789,9 +1789,9 @@ void
 pcmk__add_dependent_scores(gpointer data, gpointer user_data)
 {
     pcmk__colocation_t *colocation = data;
-    pe_resource_t *target_rsc = user_data;
+    pcmk_resource_t *target_rsc = user_data;
 
-    pe_resource_t *source_rsc = colocation->dependent;
+    pcmk_resource_t *source_rsc = colocation->dependent;
     const float factor = colocation->score / (float) INFINITY;
     uint32_t flags = pcmk__coloc_select_active;
 
@@ -1829,8 +1829,8 @@ pcmk__add_dependent_scores(gpointer data, gpointer user_data)
  *                               the node's score in \p table
  */
 void
-pcmk__colocation_intersect_nodes(pe_resource_t *dependent,
-                                 const pe_resource_t *primary,
+pcmk__colocation_intersect_nodes(pcmk_resource_t *dependent,
+                                 const pcmk_resource_t *primary,
                                  const pcmk__colocation_t *colocation,
                                  const GList *primary_nodes, bool merge_scores)
 {
@@ -1878,7 +1878,7 @@ pcmk__colocation_intersect_nodes(pe_resource_t *dependent,
  * \note This is a convenience wrapper for the with_this_colocations() method.
  */
 GList *
-pcmk__with_this_colocations(const pe_resource_t *rsc)
+pcmk__with_this_colocations(const pcmk_resource_t *rsc)
 {
     GList *list = NULL;
 
@@ -1897,7 +1897,7 @@ pcmk__with_this_colocations(const pe_resource_t *rsc)
  * \note This is a convenience wrapper for the this_with_colocations() method.
  */
 GList *
-pcmk__this_with_colocations(const pe_resource_t *rsc)
+pcmk__this_with_colocations(const pcmk_resource_t *rsc)
 {
     GList *list = NULL;
 

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -438,7 +438,7 @@ unpack_influence(const char *coloc_id, const pcmk_resource_t *rsc,
 
 static void
 unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
-                      const char *influence_s, pe_working_set_t *data_set)
+                      const char *influence_s, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_rsc = NULL;
     pcmk_resource_t *other = NULL;
@@ -564,7 +564,7 @@ unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
 static void
 colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
                   int score, const char *influence_s,
-                  pe_working_set_t *data_set)
+                  pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_rsc = NULL;
     pcmk_resource_t *rsc_1 = NULL;
@@ -707,7 +707,7 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
 
 static void
 unpack_simple_colocation(xmlNode *xml_obj, const char *id,
-                         const char *influence_s, pe_working_set_t *data_set)
+                         const char *influence_s, pcmk_scheduler_t *data_set)
 {
     int score_i = 0;
     uint32_t flags = pcmk__coloc_none;
@@ -808,7 +808,7 @@ unpack_simple_colocation(xmlNode *xml_obj, const char *id,
 // \return Standard Pacemaker return code
 static int
 unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
-                       pe_working_set_t *data_set)
+                       pcmk_scheduler_t *data_set)
 {
     const char *id = NULL;
     const char *dependent_id = NULL;
@@ -933,7 +933,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
  * \param[in,out] data_set  Cluster working set to add constraint to
  */
 void
-pcmk__unpack_colocation(xmlNode *xml_obj, pe_working_set_t *data_set)
+pcmk__unpack_colocation(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     int score_i = 0;
     xmlNode *set = NULL;

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -1210,7 +1210,7 @@ pcmk__colocation_affects(const pe_resource_t *dependent,
          * colocation constraint has been violated.
          */
 
-        const pe_node_t *primary_node = primary->allocated_to;
+        const pcmk_node_t *primary_node = primary->allocated_to;
 
         if (dependent->allocated_to == NULL) {
             crm_trace("Skipping colocation '%s': %s will not run anywhere",
@@ -1284,7 +1284,7 @@ pcmk__apply_coloc_to_scores(pe_resource_t *dependent,
     const char *value = NULL;
     GHashTable *work = NULL;
     GHashTableIter iter;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
 
     if (primary->allocated_to != NULL) {
         value = pcmk__colocation_node_attr(primary->allocated_to, attr,
@@ -1442,7 +1442,7 @@ best_node_score_matching_attr(const pe_resource_t *rsc, const char *attr,
                               const char *value)
 {
     GHashTableIter iter;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
     int best_score = -INFINITY;
     const char *best_node = NULL;
 
@@ -1485,7 +1485,7 @@ static bool
 allowed_on_one(const pe_resource_t *rsc)
 {
     GHashTableIter iter;
-    pe_node_t *allowed_node = NULL;
+    pcmk_node_t *allowed_node = NULL;
     int allowed_nodes = 0;
 
     g_hash_table_iter_init(&iter, rsc->allowed_nodes);
@@ -1526,7 +1526,7 @@ add_node_scores_matching_attr(GHashTable *nodes,
                               float factor, bool only_positive)
 {
     GHashTableIter iter;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
     const char *attr = colocation->node_attribute;
 
     // Iterate through each node
@@ -1759,7 +1759,7 @@ pcmk__add_colocated_node_scores(pe_resource_t *source_rsc,
 
 
     if (pcmk_is_set(flags, pcmk__coloc_select_nonnegative)) {
-        pe_node_t *node = NULL;
+        pcmk_node_t *node = NULL;
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, work);
@@ -1835,14 +1835,14 @@ pcmk__colocation_intersect_nodes(pe_resource_t *dependent,
                                  const GList *primary_nodes, bool merge_scores)
 {
     GHashTableIter iter;
-    pe_node_t *dependent_node = NULL;
+    pcmk_node_t *dependent_node = NULL;
 
     CRM_ASSERT((dependent != NULL) && (primary != NULL)
                && (colocation != NULL));
 
     g_hash_table_iter_init(&iter, dependent->allowed_nodes);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &dependent_node)) {
-        const pe_node_t *primary_node = NULL;
+        const pcmk_node_t *primary_node = NULL;
 
         primary_node = pe_find_node_id(primary_nodes,
                                        dependent_node->details->id);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -28,7 +28,7 @@
 #include "libpacemaker_private.h"
 
 static bool
-evaluate_lifetime(xmlNode *lifetime, pe_working_set_t *data_set)
+evaluate_lifetime(xmlNode *lifetime, pcmk_scheduler_t *data_set)
 {
     bool result = FALSE;
     crm_time_t *next_change = crm_time_new_undefined();
@@ -53,7 +53,7 @@ evaluate_lifetime(xmlNode *lifetime, pe_working_set_t *data_set)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__unpack_constraints(pe_working_set_t *data_set)
+pcmk__unpack_constraints(pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_constraints = pcmk_find_cib_element(data_set->input,
                                                      XML_CIB_TAG_CONSTRAINTS);
@@ -139,7 +139,7 @@ pcmk__find_constraint_resource(GList *rsc_list, const char *id)
  *         otherwise false
  */
 static bool
-find_constraint_tag(const pe_working_set_t *data_set, const char *id,
+find_constraint_tag(const pcmk_scheduler_t *data_set, const char *id,
                     pe_tag_t **tag)
 {
     *tag = NULL;
@@ -182,7 +182,7 @@ find_constraint_tag(const pe_working_set_t *data_set, const char *id,
  * \return true if id refers to a resource (possibly indirectly via a tag)
  */
 bool
-pcmk__valid_resource_or_tag(const pe_working_set_t *data_set, const char *id,
+pcmk__valid_resource_or_tag(const pcmk_scheduler_t *data_set, const char *id,
                             pcmk_resource_t **rsc, pe_tag_t **tag)
 {
     if (rsc != NULL) {
@@ -214,7 +214,7 @@ pcmk__valid_resource_or_tag(const pe_working_set_t *data_set, const char *id,
  * \note It is the caller's responsibility to free the result with free_xml().
  */
 xmlNode *
-pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pe_working_set_t *data_set)
+pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pcmk_scheduler_t *data_set)
 {
     xmlNode *new_xml = NULL;
     bool any_refs = false;
@@ -333,7 +333,7 @@ pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pe_working_set_t *data_set)
  */
 bool
 pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
-                 bool convert_rsc, const pe_working_set_t *data_set)
+                 bool convert_rsc, const pcmk_scheduler_t *data_set)
 {
     const char *cons_id = NULL;
     const char *id = NULL;
@@ -413,7 +413,7 @@ pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__create_internal_constraints(pe_working_set_t *data_set)
+pcmk__create_internal_constraints(pcmk_scheduler_t *data_set)
 {
     crm_trace("Create internal constraints");
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -103,16 +103,16 @@ pcmk__unpack_constraints(pe_working_set_t *data_set)
     }
 }
 
-pe_resource_t *
+pcmk_resource_t *
 pcmk__find_constraint_resource(GList *rsc_list, const char *id)
 {
     if (id == NULL) {
         return NULL;
     }
     for (GList *iter = rsc_list; iter != NULL; iter = iter->next) {
-        pe_resource_t *parent = iter->data;
-        pe_resource_t *match = parent->fns->find_rsc(parent, id, NULL,
-                                                     pcmk_rsc_match_history);
+        pcmk_resource_t *parent = iter->data;
+        pcmk_resource_t *match = parent->fns->find_rsc(parent, id, NULL,
+                                                       pcmk_rsc_match_history);
 
         if (match != NULL) {
             if (!pcmk__str_eq(match->id, id, pcmk__str_none)) {
@@ -183,7 +183,7 @@ find_constraint_tag(const pe_working_set_t *data_set, const char *id,
  */
 bool
 pcmk__valid_resource_or_tag(const pe_working_set_t *data_set, const char *id,
-                            pe_resource_t **rsc, pe_tag_t **tag)
+                            pcmk_resource_t **rsc, pe_tag_t **tag)
 {
     if (rsc != NULL) {
         *rsc = pcmk__find_constraint_resource(data_set->resources, id);
@@ -235,7 +235,7 @@ pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pe_working_set_t *data_set)
         for (xmlNode *xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
              xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
 
-            pe_resource_t *rsc = NULL;
+            pcmk_resource_t *rsc = NULL;
             pe_tag_t *tag = NULL;
 
             if (!pcmk__valid_resource_or_tag(data_set, ID(xml_rsc), &rsc,
@@ -338,7 +338,7 @@ pcmk__tag_to_set(xmlNode *xml_obj, xmlNode **rsc_set, const char *attr,
     const char *cons_id = NULL;
     const char *id = NULL;
 
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     pe_tag_t *tag = NULL;
 
     *rsc_set = NULL;
@@ -417,7 +417,7 @@ pcmk__create_internal_constraints(pe_working_set_t *data_set)
 {
     crm_trace("Create internal constraints");
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         rsc->cmds->internal_constraints(rsc);
     }

--- a/lib/pacemaker/pcmk_sched_fencing.c
+++ b/lib/pacemaker/pcmk_sched_fencing.c
@@ -285,7 +285,7 @@ rsc_stonith_ordering(pcmk_resource_t *rsc, pcmk_action_t *stonith_op)
  * \param[in,out] data_set    Working set of cluster
  */
 void
-pcmk__order_vs_fence(pcmk_action_t *stonith_op, pe_working_set_t *data_set)
+pcmk__order_vs_fence(pcmk_action_t *stonith_op, pcmk_scheduler_t *data_set)
 {
     CRM_CHECK(stonith_op && data_set, return);
     for (GList *r = data_set->resources; r != NULL; r = r->next) {

--- a/lib/pacemaker/pcmk_sched_fencing.c
+++ b/lib/pacemaker/pcmk_sched_fencing.c
@@ -26,7 +26,7 @@
  * \return TRUE if resource (or parent if an anonymous clone) is known
  */
 static bool
-rsc_is_known_on(const pe_resource_t *rsc, const pcmk_node_t *node)
+rsc_is_known_on(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
    if (g_hash_table_lookup(rsc->known_on, node->details->id) != NULL) {
        return TRUE;
@@ -52,7 +52,7 @@ rsc_is_known_on(const pe_resource_t *rsc, const pcmk_node_t *node)
  * \param[in,out] stonith_op  Fence action
  */
 static void
-order_start_vs_fencing(pe_resource_t *rsc, pe_action_t *stonith_op)
+order_start_vs_fencing(pcmk_resource_t *rsc, pe_action_t *stonith_op)
 {
     pcmk_node_t *target;
 
@@ -106,13 +106,13 @@ order_start_vs_fencing(pe_resource_t *rsc, pe_action_t *stonith_op)
  * \param[in,out] stonith_op  Fence action
  */
 static void
-order_stop_vs_fencing(pe_resource_t *rsc, pe_action_t *stonith_op)
+order_stop_vs_fencing(pcmk_resource_t *rsc, pe_action_t *stonith_op)
 {
     GList *iter = NULL;
     GList *action_list = NULL;
     bool order_implicit = false;
 
-    pe_resource_t *top = uber_parent(rsc);
+    pcmk_resource_t *top = uber_parent(rsc);
     pe_action_t *parent_stop = NULL;
     pcmk_node_t *target;
 
@@ -253,11 +253,11 @@ order_stop_vs_fencing(pe_resource_t *rsc, pe_action_t *stonith_op)
  * \param[in,out] stonith_op  Fencing operation to be ordered against
  */
 static void
-rsc_stonith_ordering(pe_resource_t *rsc, pe_action_t *stonith_op)
+rsc_stonith_ordering(pcmk_resource_t *rsc, pe_action_t *stonith_op)
 {
     if (rsc->children) {
         for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-            pe_resource_t *child_rsc = iter->data;
+            pcmk_resource_t *child_rsc = iter->data;
 
             rsc_stonith_ordering(child_rsc, stonith_op);
         }
@@ -289,7 +289,7 @@ pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set)
 {
     CRM_CHECK(stonith_op && data_set, return);
     for (GList *r = data_set->resources; r != NULL; r = r->next) {
-        rsc_stonith_ordering((pe_resource_t *) r->data, stonith_op);
+        rsc_stonith_ordering((pcmk_resource_t *) r->data, stonith_op);
     }
 }
 
@@ -303,7 +303,7 @@ pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set)
  * \param[in]     order     Ordering flags
  */
 void
-pcmk__order_vs_unfence(const pe_resource_t *rsc, pcmk_node_t *node,
+pcmk__order_vs_unfence(const pcmk_resource_t *rsc, pcmk_node_t *node,
                        pe_action_t *action,
                        enum pcmk__action_relation_flags order)
 {
@@ -348,7 +348,7 @@ pcmk__order_vs_unfence(const pe_resource_t *rsc, pcmk_node_t *node,
 void
 pcmk__fence_guest(pcmk_node_t *node)
 {
-    pe_resource_t *container = NULL;
+    pcmk_resource_t *container = NULL;
     pe_action_t *stop = NULL;
     pe_action_t *stonith_op = NULL;
 
@@ -464,7 +464,7 @@ void
 pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data)
 {
     pcmk_node_t *node = (pcmk_node_t *) data;
-    pe_resource_t *rsc = (pe_resource_t *) user_data;
+    pcmk_resource_t *rsc = (pcmk_resource_t *) user_data;
 
     pe_action_t *unfence = pe_fence_op(node, PCMK_ACTION_ON, true, NULL, false,
                                        rsc->cluster);

--- a/lib/pacemaker/pcmk_sched_fencing.c
+++ b/lib/pacemaker/pcmk_sched_fencing.c
@@ -26,7 +26,7 @@
  * \return TRUE if resource (or parent if an anonymous clone) is known
  */
 static bool
-rsc_is_known_on(const pe_resource_t *rsc, const pe_node_t *node)
+rsc_is_known_on(const pe_resource_t *rsc, const pcmk_node_t *node)
 {
    if (g_hash_table_lookup(rsc->known_on, node->details->id) != NULL) {
        return TRUE;
@@ -54,7 +54,7 @@ rsc_is_known_on(const pe_resource_t *rsc, const pe_node_t *node)
 static void
 order_start_vs_fencing(pe_resource_t *rsc, pe_action_t *stonith_op)
 {
-    pe_node_t *target;
+    pcmk_node_t *target;
 
     CRM_CHECK(stonith_op && stonith_op->node, return);
     target = stonith_op->node;
@@ -114,7 +114,7 @@ order_stop_vs_fencing(pe_resource_t *rsc, pe_action_t *stonith_op)
 
     pe_resource_t *top = uber_parent(rsc);
     pe_action_t *parent_stop = NULL;
-    pe_node_t *target;
+    pcmk_node_t *target;
 
     CRM_CHECK(stonith_op && stonith_op->node, return);
     target = stonith_op->node;
@@ -303,7 +303,7 @@ pcmk__order_vs_fence(pe_action_t *stonith_op, pe_working_set_t *data_set)
  * \param[in]     order     Ordering flags
  */
 void
-pcmk__order_vs_unfence(const pe_resource_t *rsc, pe_node_t *node,
+pcmk__order_vs_unfence(const pe_resource_t *rsc, pcmk_node_t *node,
                        pe_action_t *action,
                        enum pcmk__action_relation_flags order)
 {
@@ -346,7 +346,7 @@ pcmk__order_vs_unfence(const pe_resource_t *rsc, pe_node_t *node,
  * \param[in,out] node  Guest node to fence
  */
 void
-pcmk__fence_guest(pe_node_t *node)
+pcmk__fence_guest(pcmk_node_t *node)
 {
     pe_resource_t *container = NULL;
     pe_action_t *stop = NULL;
@@ -446,7 +446,7 @@ pcmk__fence_guest(pe_node_t *node)
  *         otherwise false
  */
 bool
-pcmk__node_unfenced(const pe_node_t *node)
+pcmk__node_unfenced(const pcmk_node_t *node)
 {
     const char *unfenced = pe_node_attribute_raw(node, CRM_ATTR_UNFENCED);
 
@@ -463,7 +463,7 @@ pcmk__node_unfenced(const pe_node_t *node)
 void
 pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data)
 {
-    pe_node_t *node = (pe_node_t *) data;
+    pcmk_node_t *node = (pcmk_node_t *) data;
     pe_resource_t *rsc = (pe_resource_t *) user_data;
 
     pe_action_t *unfence = pe_fence_op(node, PCMK_ACTION_ON, true, NULL, false,

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -34,11 +34,11 @@
  *       as calling pcmk__unassign_resource(); there are no side effects on
  *       roles or actions.
  */
-pe_node_t *
-pcmk__group_assign(pe_resource_t *rsc, const pe_node_t *prefer,
+pcmk_node_t *
+pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
                    bool stop_if_fail)
 {
-    pe_node_t *first_assigned_node = NULL;
+    pcmk_node_t *first_assigned_node = NULL;
     pe_resource_t *first_member = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
@@ -68,7 +68,7 @@ pcmk__group_assign(pe_resource_t *rsc, const pe_node_t *prefer,
 
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
         pe_resource_t *member = (pe_resource_t *) iter->data;
-        pe_node_t *node = NULL;
+        pcmk_node_t *node = NULL;
 
         pe_rsc_trace(rsc, "Assigning group %s member %s",
                      rsc->id, member->id);
@@ -484,7 +484,7 @@ pcmk__group_apply_coloc_score(pe_resource_t *dependent,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__group_action_flags(pe_action_t *action, const pe_node_t *node)
+pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node)
 {
     // Default flags for a group action
     uint32_t flags = pcmk_action_optional
@@ -568,7 +568,7 @@ pcmk__group_action_flags(pe_action_t *action, const pe_node_t *node)
  */
 uint32_t
 pcmk__group_update_ordered_actions(pe_action_t *first, pe_action_t *then,
-                                   const pe_node_t *node, uint32_t flags,
+                                   const pcmk_node_t *node, uint32_t flags,
                                    uint32_t filter, uint32_t type,
                                    pe_working_set_t *data_set)
 {

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -35,11 +35,11 @@
  *       roles or actions.
  */
 pcmk_node_t *
-pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
+pcmk__group_assign(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
                    bool stop_if_fail)
 {
     pcmk_node_t *first_assigned_node = NULL;
-    pe_resource_t *first_member = NULL;
+    pcmk_resource_t *first_member = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
@@ -59,7 +59,7 @@ pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
     }
 
     pe__set_resource_flags(rsc, pcmk_rsc_assigning);
-    first_member = (pe_resource_t *) rsc->children->data;
+    first_member = (pcmk_resource_t *) rsc->children->data;
     rsc->role = first_member->role;
 
     pe__show_node_scores(!pcmk_is_set(rsc->cluster->flags,
@@ -67,7 +67,7 @@ pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
                          rsc, __func__, rsc->allowed_nodes, rsc->cluster);
 
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *member = (pe_resource_t *) iter->data;
+        pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
         pcmk_node_t *node = NULL;
 
         pe_rsc_trace(rsc, "Assigning group %s member %s",
@@ -97,7 +97,7 @@ pcmk__group_assign(pe_resource_t *rsc, const pcmk_node_t *prefer,
  * \return Newly created pseudo-operation
  */
 static pe_action_t *
-create_group_pseudo_op(pe_resource_t *group, const char *action)
+create_group_pseudo_op(pcmk_resource_t *group, const char *action)
 {
     pe_action_t *op = custom_action(group, pcmk__op_key(group->id, action, 0),
                                     action, NULL, TRUE, TRUE, group->cluster);
@@ -112,7 +112,7 @@ create_group_pseudo_op(pe_resource_t *group, const char *action)
  * \param[in,out] rsc  Group resource to create actions for
  */
 void
-pcmk__group_create_actions(pe_resource_t *rsc)
+pcmk__group_create_actions(pcmk_resource_t *rsc)
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
@@ -120,7 +120,7 @@ pcmk__group_create_actions(pe_resource_t *rsc)
 
     // Create actions for individual group members
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *member = (pe_resource_t *) iter->data;
+        pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
 
         member->cmds->create_actions(member);
     }
@@ -145,8 +145,8 @@ struct member_data {
     bool colocated;
     bool promotable;
 
-    pe_resource_t *last_active;
-    pe_resource_t *previous_member;
+    pcmk_resource_t *last_active;
+    pcmk_resource_t *previous_member;
 };
 
 /*!
@@ -159,7 +159,7 @@ struct member_data {
 static void
 member_internal_constraints(gpointer data, gpointer user_data)
 {
-    pe_resource_t *member = (pe_resource_t *) data;
+    pcmk_resource_t *member = (pcmk_resource_t *) data;
     struct member_data *member_data = (struct member_data *) user_data;
 
     // For ordering demote vs demote or stop vs stop
@@ -303,10 +303,10 @@ member_internal_constraints(gpointer data, gpointer user_data)
  * \param[in,out] rsc  Group resource to create implicit constraints for
  */
 void
-pcmk__group_internal_constraints(pe_resource_t *rsc)
+pcmk__group_internal_constraints(pcmk_resource_t *rsc)
 {
     struct member_data member_data = { false, };
-    const pe_resource_t *top = NULL;
+    const pcmk_resource_t *top = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
@@ -344,10 +344,10 @@ pcmk__group_internal_constraints(pe_resource_t *rsc)
  * \param[in]     colocation     Colocation constraint to apply
  */
 static void
-colocate_group_with(pe_resource_t *dependent, const pe_resource_t *primary,
+colocate_group_with(pcmk_resource_t *dependent, const pcmk_resource_t *primary,
                     const pcmk__colocation_t *colocation)
 {
-    pe_resource_t *member = NULL;
+    pcmk_resource_t *member = NULL;
 
     if (dependent->children == NULL) {
         return;
@@ -358,7 +358,7 @@ colocate_group_with(pe_resource_t *dependent, const pe_resource_t *primary,
 
     if (pe__group_flag_is_set(dependent, pcmk__group_colocated)) {
         // Colocate first member (internal colocations will handle the rest)
-        member = (pe_resource_t *) dependent->children->data;
+        member = (pcmk_resource_t *) dependent->children->data;
         member->cmds->apply_coloc_score(member, primary, colocation, true);
         return;
     }
@@ -372,7 +372,7 @@ colocate_group_with(pe_resource_t *dependent, const pe_resource_t *primary,
 
     // Colocate each member individually
     for (GList *iter = dependent->children; iter != NULL; iter = iter->next) {
-        member = (pe_resource_t *) iter->data;
+        member = (pcmk_resource_t *) iter->data;
         member->cmds->apply_coloc_score(member, primary, colocation, true);
     }
 }
@@ -390,10 +390,10 @@ colocate_group_with(pe_resource_t *dependent, const pe_resource_t *primary,
  * \param[in]     colocation     Colocation constraint to apply
  */
 static void
-colocate_with_group(pe_resource_t *dependent, const pe_resource_t *primary,
+colocate_with_group(pcmk_resource_t *dependent, const pcmk_resource_t *primary,
                     const pcmk__colocation_t *colocation)
 {
-    const pe_resource_t *member = NULL;
+    const pcmk_resource_t *member = NULL;
 
     pe_rsc_trace(primary,
                  "Processing colocation %s (%s with group %s) for primary",
@@ -416,7 +416,7 @@ colocate_with_group(pe_resource_t *dependent, const pe_resource_t *primary,
              * up doesn't matter, so apply the colocation based on the first
              * member.
              */
-            member = (pe_resource_t *) primary->children->data;
+            member = (pcmk_resource_t *) primary->children->data;
         }
         if (member == NULL) {
             return; // Nothing to colocate with
@@ -455,8 +455,8 @@ colocate_with_group(pe_resource_t *dependent, const pe_resource_t *primary,
  * \param[in]     for_dependent  true if called on behalf of dependent
  */
 void
-pcmk__group_apply_coloc_score(pe_resource_t *dependent,
-                              const pe_resource_t *primary,
+pcmk__group_apply_coloc_score(pcmk_resource_t *dependent,
+                              const pcmk_resource_t *primary,
                               const pcmk__colocation_t *colocation,
                               bool for_dependent)
 {
@@ -495,7 +495,7 @@ pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node)
 
     // Update flags considering each member's own flags for same action
     for (GList *iter = action->rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *member = (pe_resource_t *) iter->data;
+        pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
 
         // Check whether member has the same action
         enum action_tasks task = get_complex_task(member, action->task);
@@ -584,7 +584,7 @@ pcmk__group_update_ordered_actions(pe_action_t *first, pe_action_t *then,
 
     // Update the actions for each group member
     for (GList *iter = then->rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *member = (pe_resource_t *) iter->data;
+        pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
 
         pe_action_t *member_action = find_first_action(member->actions, NULL,
                                                        then->task, node);
@@ -607,7 +607,7 @@ pcmk__group_update_ordered_actions(pe_action_t *first, pe_action_t *then,
  * \param[in,out] location  Location constraint to apply
  */
 void
-pcmk__group_apply_location(pe_resource_t *rsc, pe__location_t *location)
+pcmk__group_apply_location(pcmk_resource_t *rsc, pe__location_t *location)
 {
     GList *node_list_orig = NULL;
     GList *node_list_copy = NULL;
@@ -625,7 +625,7 @@ pcmk__group_apply_location(pe_resource_t *rsc, pe__location_t *location)
 
     // Apply the constraint for each member
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *member = (pe_resource_t *) iter->data;
+        pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
 
         member->cmds->apply_location(member, location);
 
@@ -645,11 +645,11 @@ pcmk__group_apply_location(pe_resource_t *rsc, pe__location_t *location)
 
 // Group implementation of resource_alloc_functions_t:colocated_resources()
 GList *
-pcmk__group_colocated_resources(const pe_resource_t *rsc,
-                                const pe_resource_t *orig_rsc,
+pcmk__group_colocated_resources(const pcmk_resource_t *rsc,
+                                const pcmk_resource_t *orig_rsc,
                                 GList *colocated_rscs)
 {
-    const pe_resource_t *member = NULL;
+    const pcmk_resource_t *member = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
@@ -667,7 +667,7 @@ pcmk__group_colocated_resources(const pe_resource_t *rsc,
         for (const GList *iter = rsc->children;
              iter != NULL; iter = iter->next) {
 
-            member = (const pe_resource_t *) iter->data;
+            member = (const pcmk_resource_t *) iter->data;
             colocated_rscs = member->cmds->colocated_resources(member, orig_rsc,
                                                                colocated_rscs);
         }
@@ -685,8 +685,8 @@ pcmk__group_colocated_resources(const pe_resource_t *rsc,
 
 // Group implementation of resource_alloc_functions_t:with_this_colocations()
 void
-pcmk__with_group_colocations(const pe_resource_t *rsc,
-                             const pe_resource_t *orig_rsc, GList **list)
+pcmk__with_group_colocations(const pcmk_resource_t *rsc,
+                             const pcmk_resource_t *orig_rsc, GList **list)
 
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
@@ -724,7 +724,7 @@ pcmk__with_group_colocations(const pe_resource_t *rsc,
 
     // Add explicit colocations with the group's (other) children
     for (const GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        const pe_resource_t *member = iter->data;
+        const pcmk_resource_t *member = iter->data;
 
         if (member != orig_rsc) {
             member->cmds->with_this_colocations(member, orig_rsc, list);
@@ -734,10 +734,10 @@ pcmk__with_group_colocations(const pe_resource_t *rsc,
 
 // Group implementation of resource_alloc_functions_t:this_with_colocations()
 void
-pcmk__group_with_colocations(const pe_resource_t *rsc,
-                             const pe_resource_t *orig_rsc, GList **list)
+pcmk__group_with_colocations(const pcmk_resource_t *rsc,
+                             const pcmk_resource_t *orig_rsc, GList **list)
 {
-    const pe_resource_t *member = NULL;
+    const pcmk_resource_t *member = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
                && (orig_rsc != NULL) && (list != NULL));
@@ -751,7 +751,7 @@ pcmk__group_with_colocations(const pe_resource_t *rsc,
      * for its first member.
      */
     if ((rsc == orig_rsc)
-        || (orig_rsc == (const pe_resource_t *) rsc->children->data)) {
+        || (orig_rsc == (const pcmk_resource_t *) rsc->children->data)) {
         pe_rsc_trace(rsc, "Adding '%s with' colocations to list for %s",
                      rsc->id, orig_rsc->id);
 
@@ -841,13 +841,13 @@ pcmk__group_with_colocations(const pe_resource_t *rsc,
  *       \c resource_alloc_functions_t:add_colocated_node_scores().
  */
 void
-pcmk__group_add_colocated_node_scores(pe_resource_t *source_rsc,
-                                      const pe_resource_t *target_rsc,
+pcmk__group_add_colocated_node_scores(pcmk_resource_t *source_rsc,
+                                      const pcmk_resource_t *target_rsc,
                                       const char *log_id, GHashTable **nodes,
                                       const pcmk__colocation_t *colocation,
                                       float factor, uint32_t flags)
 {
-    pe_resource_t *member = NULL;
+    pcmk_resource_t *member = NULL;
 
     CRM_ASSERT((source_rsc != NULL)
                && (source_rsc->variant == pcmk_rsc_variant_group)
@@ -896,11 +896,11 @@ pcmk__group_add_colocated_node_scores(pe_resource_t *source_rsc,
 
 // Group implementation of resource_alloc_functions_t:add_utilization()
 void
-pcmk__group_add_utilization(const pe_resource_t *rsc,
-                            const pe_resource_t *orig_rsc, GList *all_rscs,
+pcmk__group_add_utilization(const pcmk_resource_t *rsc,
+                            const pcmk_resource_t *orig_rsc, GList *all_rscs,
                             GHashTable *utilization)
 {
-    pe_resource_t *member = NULL;
+    pcmk_resource_t *member = NULL;
 
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group)
                && (orig_rsc != NULL) && (utilization != NULL));
@@ -915,7 +915,7 @@ pcmk__group_add_utilization(const pe_resource_t *rsc,
         || pe_rsc_is_clone(rsc->parent)) {
         // Every group member will be on same node, so sum all members
         for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-            member = (pe_resource_t *) iter->data;
+            member = (pcmk_resource_t *) iter->data;
 
             if (pcmk_is_set(member->flags, pcmk_rsc_unassigned)
                 && (g_list_find(all_rscs, member) == NULL)) {
@@ -926,7 +926,7 @@ pcmk__group_add_utilization(const pe_resource_t *rsc,
 
     } else if (rsc->children != NULL) {
         // Just add first member's utilization
-        member = (pe_resource_t *) rsc->children->data;
+        member = (pcmk_resource_t *) rsc->children->data;
         if ((member != NULL)
             && pcmk_is_set(member->flags, pcmk_rsc_unassigned)
             && (g_list_find(all_rscs, member) == NULL)) {
@@ -939,12 +939,12 @@ pcmk__group_add_utilization(const pe_resource_t *rsc,
 
 // Group implementation of resource_alloc_functions_t:shutdown_lock()
 void
-pcmk__group_shutdown_lock(pe_resource_t *rsc)
+pcmk__group_shutdown_lock(pcmk_resource_t *rsc)
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
 
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *member = (pe_resource_t *) iter->data;
+        pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
 
         member->cmds->shutdown_lock(member);
     }

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -96,11 +96,11 @@ pcmk__group_assign(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
  *
  * \return Newly created pseudo-operation
  */
-static pe_action_t *
+static pcmk_action_t *
 create_group_pseudo_op(pcmk_resource_t *group, const char *action)
 {
-    pe_action_t *op = custom_action(group, pcmk__op_key(group->id, action, 0),
-                                    action, NULL, TRUE, TRUE, group->cluster);
+    pcmk_action_t *op = custom_action(group, pcmk__op_key(group->id, action, 0),
+                                      action, NULL, TRUE, TRUE, group->cluster);
     pe__set_action_flags(op, pcmk_action_pseudo|pcmk_action_runnable);
     return op;
 }
@@ -484,7 +484,7 @@ pcmk__group_apply_coloc_score(pcmk_resource_t *dependent,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node)
+pcmk__group_action_flags(pcmk_action_t *action, const pcmk_node_t *node)
 {
     // Default flags for a group action
     uint32_t flags = pcmk_action_optional
@@ -500,8 +500,8 @@ pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node)
         // Check whether member has the same action
         enum action_tasks task = get_complex_task(member, action->task);
         const char *task_s = task2text(task);
-        pe_action_t *member_action = find_first_action(member->actions, NULL,
-                                                       task_s, node);
+        pcmk_action_t *member_action = find_first_action(member->actions, NULL,
+                                                         task_s, node);
 
         if (member_action != NULL) {
             uint32_t member_flags = member->cmds->action_flags(member_action,
@@ -567,7 +567,7 @@ pcmk__group_action_flags(pe_action_t *action, const pcmk_node_t *node)
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 uint32_t
-pcmk__group_update_ordered_actions(pe_action_t *first, pe_action_t *then,
+pcmk__group_update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                                    const pcmk_node_t *node, uint32_t flags,
                                    uint32_t filter, uint32_t type,
                                    pe_working_set_t *data_set)
@@ -586,8 +586,8 @@ pcmk__group_update_ordered_actions(pe_action_t *first, pe_action_t *then,
     for (GList *iter = then->rsc->children; iter != NULL; iter = iter->next) {
         pcmk_resource_t *member = (pcmk_resource_t *) iter->data;
 
-        pe_action_t *member_action = find_first_action(member->actions, NULL,
-                                                       then->task, node);
+        pcmk_action_t *member_action = find_first_action(member->actions, NULL,
+                                                         then->task, node);
 
         if (member_action != NULL) {
             changed |= member->cmds->update_ordered_actions(first,

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -570,7 +570,7 @@ uint32_t
 pcmk__group_update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                                    const pcmk_node_t *node, uint32_t flags,
                                    uint32_t filter, uint32_t type,
-                                   pe_working_set_t *data_set)
+                                   pcmk_scheduler_t *data_set)
 {
     uint32_t changed = pcmk__updated_none;
 

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -1568,7 +1568,7 @@ uint32_t
 pcmk__instance_update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                                       const pcmk_node_t *node, uint32_t flags,
                                       uint32_t filter, uint32_t type,
-                                      pe_working_set_t *data_set)
+                                      pcmk_scheduler_t *data_set)
 {
     CRM_ASSERT((first != NULL) && (then != NULL) && (data_set != NULL));
 

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -919,7 +919,7 @@ check_instance_state(const pcmk_resource_t *instance, uint32_t *state)
                                                |instance_stopping);
          iter = iter->next) {
 
-        const pe_action_t *action = (const pe_action_t *) iter->data;
+        const pcmk_action_t *action = (const pcmk_action_t *) iter->data;
         const bool optional = pcmk_is_set(action->flags, pcmk_action_optional);
 
         if (pcmk__str_eq(PCMK_ACTION_START, action->task, pcmk__str_none)) {
@@ -974,11 +974,11 @@ pcmk__create_instance_actions(pcmk_resource_t *collective, GList *instances)
 {
     uint32_t state = 0;
 
-    pe_action_t *stop = NULL;
-    pe_action_t *stopped = NULL;
+    pcmk_action_t *stop = NULL;
+    pcmk_action_t *stopped = NULL;
 
-    pe_action_t *start = NULL;
-    pe_action_t *started = NULL;
+    pcmk_action_t *start = NULL;
+    pcmk_action_t *started = NULL;
 
     pe_rsc_trace(collective, "Creating collective instance actions for %s",
                  collective->id);
@@ -1212,7 +1212,7 @@ pcmk__find_compatible_instance(const pcmk_resource_t *match_rsc,
  * \return true if \p then_instance was unassigned, otherwise false
  */
 static bool
-unassign_if_mandatory(const pe_action_t *first, const pe_action_t *then,
+unassign_if_mandatory(const pcmk_action_t *first, const pcmk_action_t *then,
                       pcmk_resource_t *then_instance, uint32_t type,
                       bool current)
 {
@@ -1252,13 +1252,13 @@ unassign_if_mandatory(const pe_action_t *first, const pe_action_t *then,
  *         bundle container, its containerized resource) that matches
  *         \p action_name and \p node if any, otherwise NULL
  */
-static pe_action_t *
-find_instance_action(const pe_action_t *action, const pcmk_resource_t *instance,
+static pcmk_action_t *
+find_instance_action(const pcmk_action_t *action, const pcmk_resource_t *instance,
                      const char *action_name, const pcmk_node_t *node,
                      bool for_first)
 {
     const pcmk_resource_t *rsc = NULL;
-    pe_action_t *matching_action = NULL;
+    pcmk_action_t *matching_action = NULL;
 
     /* If instance is a bundle container, sometimes we should interleave the
      * action for the container itself, and sometimes for the containerized
@@ -1324,7 +1324,7 @@ find_instance_action(const pe_action_t *action, const pcmk_resource_t *instance,
  * \return Original action name for \p action
  */
 static const char *
-orig_action_name(const pe_action_t *action)
+orig_action_name(const pcmk_action_t *action)
 {
     // Any instance will do
     const pcmk_resource_t *instance = action->rsc->children->data;
@@ -1369,7 +1369,7 @@ orig_action_name(const pe_action_t *action)
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 static uint32_t
-update_interleaved_actions(pe_action_t *first, pe_action_t *then,
+update_interleaved_actions(pcmk_action_t *first, pcmk_action_t *then,
                            const pcmk_node_t *node, uint32_t filter,
                            uint32_t type)
 {
@@ -1388,8 +1388,8 @@ update_interleaved_actions(pe_action_t *first, pe_action_t *then,
         pcmk_resource_t *first_instance = NULL;
         pcmk_resource_t *then_instance = iter->data;
 
-        pe_action_t *first_action = NULL;
-        pe_action_t *then_action = NULL;
+        pcmk_action_t *first_action = NULL;
+        pcmk_action_t *then_action = NULL;
 
         // Find a "first" instance to interleave with this "then" instance
         first_instance = pcmk__find_compatible_instance(then_instance,
@@ -1441,7 +1441,7 @@ update_interleaved_actions(pe_action_t *first, pe_action_t *then,
  * \return true if \p first and \p then can be interleaved, otherwise false
  */
 static bool
-can_interleave_actions(const pe_action_t *first, const pe_action_t *then)
+can_interleave_actions(const pcmk_action_t *first, const pcmk_action_t *then)
 {
     bool interleave = false;
     pcmk_resource_t *rsc = NULL;
@@ -1502,11 +1502,11 @@ can_interleave_actions(const pe_action_t *first, const pe_action_t *then)
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 static uint32_t
-update_noninterleaved_actions(pcmk_resource_t *instance, pe_action_t *first,
-                              const pe_action_t *then, const pcmk_node_t *node,
+update_noninterleaved_actions(pcmk_resource_t *instance, pcmk_action_t *first,
+                              const pcmk_action_t *then, const pcmk_node_t *node,
                               uint32_t flags, uint32_t filter, uint32_t type)
 {
-    pe_action_t *instance_action = NULL;
+    pcmk_action_t *instance_action = NULL;
     uint32_t instance_flags = 0;
     uint32_t changed = pcmk__updated_none;
 
@@ -1565,7 +1565,7 @@ update_noninterleaved_actions(pcmk_resource_t *instance, pe_action_t *first,
  * \return Group of enum pcmk__updated flags indicating what was updated
  */
 uint32_t
-pcmk__instance_update_ordered_actions(pe_action_t *first, pe_action_t *then,
+pcmk__instance_update_ordered_actions(pcmk_action_t *first, pcmk_action_t *then,
                                       const pcmk_node_t *node, uint32_t flags,
                                       uint32_t filter, uint32_t type,
                                       pe_working_set_t *data_set)
@@ -1615,7 +1615,7 @@ pcmk__instance_update_ordered_actions(pe_action_t *first, pe_action_t *then,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__collective_action_flags(pe_action_t *action, const GList *instances,
+pcmk__collective_action_flags(pcmk_action_t *action, const GList *instances,
                               const pcmk_node_t *node)
 {
     bool any_runnable = false;
@@ -1629,7 +1629,7 @@ pcmk__collective_action_flags(pe_action_t *action, const GList *instances,
     for (const GList *iter = instances; iter != NULL; iter = iter->next) {
         const pcmk_resource_t *instance = iter->data;
         const pcmk_node_t *instance_node = NULL;
-        pe_action_t *instance_action = NULL;
+        pcmk_action_t *instance_action = NULL;
         uint32_t instance_flags;
 
         // Node is relevant only to primitive instances

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -287,7 +287,7 @@ unpack_rsc_location(xmlNode *xml_obj, pcmk_resource_t *rsc, const char *role,
 }
 
 static void
-unpack_simple_location(xmlNode *xml_obj, pe_working_set_t *data_set)
+unpack_simple_location(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
     const char *value = crm_element_value(xml_obj, XML_LOC_ATTR_SOURCE);
@@ -364,7 +364,7 @@ unpack_simple_location(xmlNode *xml_obj, pe_working_set_t *data_set)
 // \return Standard Pacemaker return code
 static int
 unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
-                     pe_working_set_t *data_set)
+                     pcmk_scheduler_t *data_set)
 {
     const char *id = NULL;
     const char *rsc_id = NULL;
@@ -437,7 +437,7 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
 // \return Standard Pacemaker return code
 static int
-unpack_location_set(xmlNode *location, xmlNode *set, pe_working_set_t *data_set)
+unpack_location_set(xmlNode *location, xmlNode *set, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_rsc = NULL;
     pcmk_resource_t *resource = NULL;
@@ -476,7 +476,7 @@ unpack_location_set(xmlNode *location, xmlNode *set, pe_working_set_t *data_set)
 }
 
 void
-pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set)
+pcmk__unpack_location(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     xmlNode *set = NULL;
     bool any_sets = false;
@@ -595,7 +595,7 @@ pcmk__new_location(const char *id, pcmk_resource_t *rsc,
  * \param[in,out] data_set       Cluster working set
  */
 void
-pcmk__apply_locations(pe_working_set_t *data_set)
+pcmk__apply_locations(pcmk_scheduler_t *data_set)
 {
     for (GList *iter = data_set->placement_constraints;
          iter != NULL; iter = iter->next) {

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -21,7 +21,7 @@
 
 static int
 get_node_score(const char *rule, const char *score, bool raw,
-               pe_node_t *node, pe_resource_t *rsc)
+               pcmk_node_t *node, pe_resource_t *rsc)
 {
     int score_f = 0;
 
@@ -130,7 +130,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
     if (do_and) {
         nodes = pcmk__copy_node_list(rsc->cluster->nodes, true);
         for (iter = nodes; iter != NULL; iter = iter->next) {
-            pe_node_t *node = iter->data;
+            pcmk_node_t *node = iter->data;
 
             node->weight = get_node_score(rule_id, score, raw_score, node, rsc);
         }
@@ -138,7 +138,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 
     for (iter = rsc->cluster->nodes; iter != NULL; iter = iter->next) {
         int score_f = 0;
-        pe_node_t *node = iter->data;
+        pcmk_node_t *node = iter->data;
         pe_match_data_t match_data = {
             .re = re_match_data,
             .params = pe_rsc_params(rsc, node, rsc->cluster),
@@ -154,7 +154,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
         score_f = get_node_score(rule_id, score, raw_score, node, rsc);
 
         if (accept) {
-            pe_node_t *local = pe_find_node_id(nodes, node->details->id);
+            pcmk_node_t *local = pe_find_node_id(nodes, node->details->id);
 
             if ((local == NULL) && do_and) {
                 continue;
@@ -172,7 +172,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 
         } else if (do_and && !accept) {
             // Remove it
-            pe_node_t *delete = pe_find_node_id(nodes, node->details->id);
+            pcmk_node_t *delete = pe_find_node_id(nodes, node->details->id);
 
             if (delete != NULL) {
                 nodes = g_list_remove(nodes, delete);
@@ -220,7 +220,7 @@ unpack_rsc_location(xmlNode *xml_obj, pe_resource_t *rsc, const char *role,
 
     if ((node != NULL) && (score != NULL)) {
         int score_i = char2score(score);
-        pe_node_t *match = pe_find_node(rsc->cluster->nodes, node);
+        pcmk_node_t *match = pe_find_node(rsc->cluster->nodes, node);
 
         if (!match) {
             return;
@@ -534,7 +534,7 @@ pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set)
  */
 pe__location_t *
 pcmk__new_location(const char *id, pe_resource_t *rsc,
-                   int node_score, const char *discover_mode, pe_node_t *node)
+                   int node_score, const char *discover_mode, pcmk_node_t *node)
 {
     pe__location_t *new_con = NULL;
 
@@ -574,7 +574,7 @@ pcmk__new_location(const char *id, pe_resource_t *rsc,
         }
 
         if (node != NULL) {
-            pe_node_t *copy = pe__copy_node(node);
+            pcmk_node_t *copy = pe__copy_node(node);
 
             copy->weight = node_score;
             new_con->node_list_rh = g_list_prepend(NULL, copy);
@@ -645,9 +645,9 @@ pcmk__apply_location(pe_resource_t *rsc, pe__location_t *location)
     for (GList *iter = location->node_list_rh;
          iter != NULL; iter = iter->next) {
 
-        pe_node_t *node = iter->data;
-        pe_node_t *allowed_node = g_hash_table_lookup(rsc->allowed_nodes,
-                                                      node->details->id);
+        pcmk_node_t *node = iter->data;
+        pcmk_node_t *allowed_node = g_hash_table_lookup(rsc->allowed_nodes,
+                                                        node->details->id);
 
         if (allowed_node == NULL) {
             pe_rsc_trace(rsc, "* = %d on %s",

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -21,7 +21,7 @@
 
 static int
 get_node_score(const char *rule, const char *score, bool raw,
-               pcmk_node_t *node, pe_resource_t *rsc)
+               pcmk_node_t *node, pcmk_resource_t *rsc)
 {
     int score_f = 0;
 
@@ -53,7 +53,7 @@ get_node_score(const char *rule, const char *score, bool raw,
 }
 
 static pe__location_t *
-generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
+generate_location_rule(pcmk_resource_t *rsc, xmlNode *rule_xml,
                        const char *discovery, crm_time_t *next_change,
                        pe_re_match_data_t *re_match_data)
 {
@@ -198,7 +198,7 @@ generate_location_rule(pe_resource_t *rsc, xmlNode *rule_xml,
 }
 
 static void
-unpack_rsc_location(xmlNode *xml_obj, pe_resource_t *rsc, const char *role,
+unpack_rsc_location(xmlNode *xml_obj, pcmk_resource_t *rsc, const char *role,
                     const char *score, pe_re_match_data_t *re_match_data)
 {
     pe__location_t *location = NULL;
@@ -293,7 +293,7 @@ unpack_simple_location(xmlNode *xml_obj, pe_working_set_t *data_set)
     const char *value = crm_element_value(xml_obj, XML_LOC_ATTR_SOURCE);
 
     if (value) {
-        pe_resource_t *rsc;
+        pcmk_resource_t *rsc;
 
         rsc = pcmk__find_constraint_resource(data_set->resources, value);
         unpack_rsc_location(xml_obj, rsc, NULL, NULL, NULL);
@@ -320,7 +320,7 @@ unpack_simple_location(xmlNode *xml_obj, pe_working_set_t *data_set)
         for (GList *iter = data_set->resources; iter != NULL;
              iter = iter->next) {
 
-            pe_resource_t *r = iter->data;
+            pcmk_resource_t *r = iter->data;
             int nregs = 0;
             regmatch_t *pmatch = NULL;
             int status;
@@ -369,7 +369,7 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     const char *id = NULL;
     const char *rsc_id = NULL;
     const char *state = NULL;
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     pe_tag_t *tag = NULL;
     xmlNode *rsc_set = NULL;
 
@@ -440,7 +440,7 @@ static int
 unpack_location_set(xmlNode *location, xmlNode *set, pe_working_set_t *data_set)
 {
     xmlNode *xml_rsc = NULL;
-    pe_resource_t *resource = NULL;
+    pcmk_resource_t *resource = NULL;
     const char *set_id;
     const char *role;
     const char *local_score;
@@ -533,7 +533,7 @@ pcmk__unpack_location(xmlNode *xml_obj, pe_working_set_t *data_set)
  *       freed separately.
  */
 pe__location_t *
-pcmk__new_location(const char *id, pe_resource_t *rsc,
+pcmk__new_location(const char *id, pcmk_resource_t *rsc,
                    int node_score, const char *discover_mode, pcmk_node_t *node)
 {
     pe__location_t *new_con = NULL;
@@ -616,7 +616,7 @@ pcmk__apply_locations(pe_working_set_t *data_set)
  *       apply_location() method should be used instead in most cases.
  */
 void
-pcmk__apply_location(pe_resource_t *rsc, pe__location_t *location)
+pcmk__apply_location(pcmk_resource_t *rsc, pe__location_t *location)
 {
     bool need_role = false;
 

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -25,8 +25,8 @@
  * \param[in]     target  Node to add as migration target
  */
 static void
-add_migration_meta(pe_action_t *action, const pe_node_t *source,
-                   const pe_node_t *target)
+add_migration_meta(pe_action_t *action, const pcmk_node_t *source,
+                   const pcmk_node_t *target)
 {
     add_hash_param(action->meta, XML_LRM_ATTR_MIGRATE_SOURCE,
                    source->details->uname);
@@ -43,7 +43,7 @@ add_migration_meta(pe_action_t *action, const pe_node_t *source,
  * \param[in]     current  Node that resource is originally active on
  */
 void
-pcmk__create_migration_actions(pe_resource_t *rsc, const pe_node_t *current)
+pcmk__create_migration_actions(pe_resource_t *rsc, const pcmk_node_t *current)
 {
     pe_action_t *migrate_to = NULL;
     pe_action_t *migrate_from = NULL;
@@ -153,7 +153,7 @@ pcmk__create_migration_actions(pe_resource_t *rsc, const pe_node_t *current)
 void
 pcmk__abort_dangling_migration(void *data, void *user_data)
 {
-    const pe_node_t *dangling_source = (const pe_node_t *) data;
+    const pcmk_node_t *dangling_source = (const pcmk_node_t *) data;
     pe_resource_t *rsc = (pe_resource_t *) user_data;
 
     pe_action_t *stop = NULL;
@@ -181,7 +181,7 @@ pcmk__abort_dangling_migration(void *data, void *user_data)
  * \return true if \p rsc can migrate, otherwise false
  */
 bool
-pcmk__rsc_can_migrate(const pe_resource_t *rsc, const pe_node_t *current)
+pcmk__rsc_can_migrate(const pe_resource_t *rsc, const pcmk_node_t *current)
 {
     CRM_CHECK(rsc != NULL, return false);
 

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -25,7 +25,7 @@
  * \param[in]     target  Node to add as migration target
  */
 static void
-add_migration_meta(pe_action_t *action, const pcmk_node_t *source,
+add_migration_meta(pcmk_action_t *action, const pcmk_node_t *source,
                    const pcmk_node_t *target)
 {
     add_hash_param(action->meta, XML_LRM_ATTR_MIGRATE_SOURCE,
@@ -45,10 +45,10 @@ add_migration_meta(pe_action_t *action, const pcmk_node_t *source,
 void
 pcmk__create_migration_actions(pcmk_resource_t *rsc, const pcmk_node_t *current)
 {
-    pe_action_t *migrate_to = NULL;
-    pe_action_t *migrate_from = NULL;
-    pe_action_t *start = NULL;
-    pe_action_t *stop = NULL;
+    pcmk_action_t *migrate_to = NULL;
+    pcmk_action_t *migrate_from = NULL;
+    pcmk_action_t *start = NULL;
+    pcmk_action_t *stop = NULL;
 
     pe_rsc_trace(rsc, "Creating actions to %smigrate %s from %s to %s",
                  ((rsc->partial_migration_target == NULL)? "" : "partially "),
@@ -156,7 +156,7 @@ pcmk__abort_dangling_migration(void *data, void *user_data)
     const pcmk_node_t *dangling_source = (const pcmk_node_t *) data;
     pcmk_resource_t *rsc = (pcmk_resource_t *) user_data;
 
-    pe_action_t *stop = NULL;
+    pcmk_action_t *stop = NULL;
     bool cleanup = pcmk_is_set(rsc->cluster->flags,
                                pcmk_sched_remove_after_stop);
 
@@ -237,7 +237,7 @@ pcmk__rsc_can_migrate(const pcmk_resource_t *rsc, const pcmk_node_t *current)
  * \return Newly allocated copy of action name (or NULL if none available)
  */
 static char *
-task_from_action_or_key(const pe_action_t *action, const char *key)
+task_from_action_or_key(const pcmk_action_t *action, const char *key)
 {
     char *res = NULL;
 

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -43,7 +43,7 @@ add_migration_meta(pe_action_t *action, const pcmk_node_t *source,
  * \param[in]     current  Node that resource is originally active on
  */
 void
-pcmk__create_migration_actions(pe_resource_t *rsc, const pcmk_node_t *current)
+pcmk__create_migration_actions(pcmk_resource_t *rsc, const pcmk_node_t *current)
 {
     pe_action_t *migrate_to = NULL;
     pe_action_t *migrate_from = NULL;
@@ -154,7 +154,7 @@ void
 pcmk__abort_dangling_migration(void *data, void *user_data)
 {
     const pcmk_node_t *dangling_source = (const pcmk_node_t *) data;
-    pe_resource_t *rsc = (pe_resource_t *) user_data;
+    pcmk_resource_t *rsc = (pcmk_resource_t *) user_data;
 
     pe_action_t *stop = NULL;
     bool cleanup = pcmk_is_set(rsc->cluster->flags,
@@ -181,7 +181,7 @@ pcmk__abort_dangling_migration(void *data, void *user_data)
  * \return true if \p rsc can migrate, otherwise false
  */
 bool
-pcmk__rsc_can_migrate(const pe_resource_t *rsc, const pcmk_node_t *current)
+pcmk__rsc_can_migrate(const pcmk_resource_t *rsc, const pcmk_node_t *current)
 {
     CRM_CHECK(rsc != NULL, return false);
 

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -27,7 +27,7 @@
  *         or maintenance mode, otherwise false
  */
 bool
-pcmk__node_available(const pe_node_t *node, bool consider_score,
+pcmk__node_available(const pcmk_node_t *node, bool consider_score,
                      bool consider_guest)
 {
     if ((node == NULL) || (node->details == NULL) || !node->details->online
@@ -65,7 +65,7 @@ pcmk__copy_node_table(GHashTable *nodes)
 {
     GHashTable *new_table = NULL;
     GHashTableIter iter;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
 
     if (nodes == NULL) {
         return NULL;
@@ -73,7 +73,7 @@ pcmk__copy_node_table(GHashTable *nodes)
     new_table = pcmk__strkey_table(NULL, free);
     g_hash_table_iter_init(&iter, nodes);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
-        pe_node_t *new_node = pe__copy_node(node);
+        pcmk_node_t *new_node = pe__copy_node(node);
 
         g_hash_table_insert(new_table, (gpointer) new_node->details->id,
                             new_node);
@@ -172,8 +172,8 @@ pcmk__copy_node_list(const GList *list, bool reset)
     GList *result = NULL;
 
     for (const GList *iter = list; iter != NULL; iter = iter->next) {
-        pe_node_t *new_node = NULL;
-        pe_node_t *this_node = iter->data;
+        pcmk_node_t *new_node = NULL;
+        pcmk_node_t *this_node = iter->data;
 
         new_node = pe__copy_node(this_node);
         if (reset) {
@@ -201,9 +201,9 @@ pcmk__copy_node_list(const GList *list, bool reset)
 static gint
 compare_nodes(gconstpointer a, gconstpointer b, gpointer data)
 {
-    const pe_node_t *node1 = (const pe_node_t *) a;
-    const pe_node_t *node2 = (const pe_node_t *) b;
-    const pe_node_t *active = (const pe_node_t *) data;
+    const pcmk_node_t *node1 = (const pcmk_node_t *) a;
+    const pcmk_node_t *node2 = (const pcmk_node_t *) b;
+    const pcmk_node_t *active = (const pcmk_node_t *) data;
 
     int node1_score = -INFINITY;
     int node2_score = -INFINITY;
@@ -312,7 +312,7 @@ equal:
  * \return New head of sorted list
  */
 GList *
-pcmk__sort_nodes(GList *nodes, pe_node_t *active_node)
+pcmk__sort_nodes(GList *nodes, pcmk_node_t *active_node)
 {
     return g_list_sort_with_data(nodes, compare_nodes, active_node);
 }
@@ -330,7 +330,7 @@ bool
 pcmk__any_node_available(GHashTable *nodes)
 {
     GHashTableIter iter;
-    const pe_node_t *node = NULL;
+    const pcmk_node_t *node = NULL;
 
     if (nodes == NULL) {
         return false;
@@ -370,7 +370,7 @@ pcmk__apply_node_health(pe_working_set_t *data_set)
     }
 
     for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk_node_t *node = (pcmk_node_t *) iter->data;
         int health = pe__sum_node_health_scores(node, base_health);
 
         // An overall health score of 0 has no effect
@@ -413,8 +413,8 @@ pcmk__apply_node_health(pe_working_set_t *data_set)
  * \return Equivalent of \p node from \p rsc's parent's allowed nodes if any,
  *         otherwise NULL
  */
-pe_node_t *
-pcmk__top_allowed_node(const pe_resource_t *rsc, const pe_node_t *node)
+pcmk_node_t *
+pcmk__top_allowed_node(const pe_resource_t *rsc, const pcmk_node_t *node)
 {
     GHashTable *allowed_nodes = NULL;
 

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -351,7 +351,7 @@ pcmk__any_node_available(GHashTable *nodes)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__apply_node_health(pe_working_set_t *data_set)
+pcmk__apply_node_health(pcmk_scheduler_t *data_set)
 {
     int base_health = 0;
     enum pcmk__health_strategy strategy;

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -42,7 +42,7 @@ pcmk__node_available(const pcmk_node_t *node, bool consider_score,
 
     // @TODO Go through all callers to see which should set consider_guest
     if (consider_guest && pe__is_guest_node(node)) {
-        pe_resource_t *guest = node->details->remote_rsc->container;
+        pcmk_resource_t *guest = node->details->remote_rsc->container;
 
         if (guest->fns->location(guest, NULL, FALSE) == NULL) {
             return false;
@@ -111,7 +111,7 @@ destroy_node_tables(gpointer data)
  *       \c g_hash_table_destroy().
  */
 void
-pcmk__copy_node_tables(const pe_resource_t *rsc, GHashTable **copy)
+pcmk__copy_node_tables(const pcmk_resource_t *rsc, GHashTable **copy)
 {
     CRM_ASSERT((rsc != NULL) && (copy != NULL));
 
@@ -123,7 +123,7 @@ pcmk__copy_node_tables(const pe_resource_t *rsc, GHashTable **copy)
                         pcmk__copy_node_table(rsc->allowed_nodes));
 
     for (const GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pcmk__copy_node_tables((const pe_resource_t *) iter->data, copy);
+        pcmk__copy_node_tables((const pcmk_resource_t *) iter->data, copy);
     }
 }
 
@@ -142,7 +142,7 @@ pcmk__copy_node_tables(const pe_resource_t *rsc, GHashTable **copy)
  * \note This function frees the resources' current node tables.
  */
 void
-pcmk__restore_node_tables(pe_resource_t *rsc, GHashTable *backup)
+pcmk__restore_node_tables(pcmk_resource_t *rsc, GHashTable *backup)
 {
     CRM_ASSERT((rsc != NULL) && (backup != NULL));
 
@@ -153,7 +153,7 @@ pcmk__restore_node_tables(pe_resource_t *rsc, GHashTable *backup)
     rsc->allowed_nodes = pcmk__copy_node_table(rsc->allowed_nodes);
 
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pcmk__restore_node_tables((pe_resource_t *) iter->data, backup);
+        pcmk__restore_node_tables((pcmk_resource_t *) iter->data, backup);
     }
 }
 
@@ -382,7 +382,7 @@ pcmk__apply_node_health(pe_working_set_t *data_set)
 
         // Use node health as a location score for each resource on the node
         for (GList *r = data_set->resources; r != NULL; r = r->next) {
-            pe_resource_t *rsc = (pe_resource_t *) r->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) r->data;
 
             bool constrain = true;
 
@@ -414,7 +414,7 @@ pcmk__apply_node_health(pe_working_set_t *data_set)
  *         otherwise NULL
  */
 pcmk_node_t *
-pcmk__top_allowed_node(const pe_resource_t *rsc, const pcmk_node_t *node)
+pcmk__top_allowed_node(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     GHashTable *allowed_nodes = NULL;
 

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -234,7 +234,7 @@ ordering_flags_for_kind(enum pe_order_kind kind, const char *first,
 static pcmk_resource_t *
 get_ordering_resource(const xmlNode *xml, const char *resource_attr,
                       const char *instance_attr,
-                      const pe_working_set_t *data_set)
+                      const pcmk_scheduler_t *data_set)
 {
     // @COMPAT: instance_attr and instance_id variables deprecated since 2.1.5
     pcmk_resource_t *rsc = NULL;
@@ -420,7 +420,7 @@ inverse_ordering(const char *id, enum pe_order_kind kind,
 }
 
 static void
-unpack_simple_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set)
+unpack_simple_rsc_order(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     pcmk_resource_t *rsc_then = NULL;
     pcmk_resource_t *rsc_first = NULL;
@@ -525,7 +525,7 @@ void
 pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_action_task,
                    pcmk_action_t *first_action, pcmk_resource_t *then_rsc,
                    char *then_action_task, pcmk_action_t *then_action,
-                   uint32_t flags, pe_working_set_t *sched)
+                   uint32_t flags, pcmk_scheduler_t *sched)
 {
     pe__ordering_t *order = NULL;
 
@@ -591,7 +591,7 @@ pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_action_task,
  */
 static int
 unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
-                 const char *parent_symmetrical_s, pe_working_set_t *data_set)
+                 const char *parent_symmetrical_s, pcmk_scheduler_t *data_set)
 {
     GList *set_iter = NULL;
     GList *resources = NULL;
@@ -709,7 +709,7 @@ unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
  */
 static int
 order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
-               enum pe_order_kind kind, pe_working_set_t *data_set,
+               enum pe_order_kind kind, pcmk_scheduler_t *data_set,
                enum ordering_symmetry symmetry)
 {
 
@@ -892,7 +892,7 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
  */
 static int
 unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
-                  const pe_working_set_t *data_set)
+                  const pcmk_scheduler_t *data_set)
 {
     const char *id_first = NULL;
     const char *id_then = NULL;
@@ -996,7 +996,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__unpack_ordering(xmlNode *xml_obj, pe_working_set_t *data_set)
+pcmk__unpack_ordering(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     xmlNode *set = NULL;
     xmlNode *last = NULL;
@@ -1101,7 +1101,7 @@ ordering_is_invalid(pcmk_action_t *action, pe_action_wrapper_t *input)
 }
 
 void
-pcmk__disable_invalid_orderings(pe_working_set_t *data_set)
+pcmk__disable_invalid_orderings(pcmk_scheduler_t *data_set)
 {
     for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
         pcmk_action_t *action = (pcmk_action_t *) iter->data;
@@ -1375,7 +1375,7 @@ static void
 update_action_for_orderings(gpointer data, gpointer user_data)
 {
     pcmk__update_action_for_orderings((pcmk_action_t *) data,
-                                      (pe_working_set_t *) user_data);
+                                      (pcmk_scheduler_t *) user_data);
 }
 
 /*!
@@ -1385,7 +1385,7 @@ update_action_for_orderings(gpointer data, gpointer user_data)
  * \param[in,out] sched  Cluster working set
  */
 void
-pcmk__apply_orderings(pe_working_set_t *sched)
+pcmk__apply_orderings(pcmk_scheduler_t *sched)
 {
     crm_trace("Applying ordering constraints");
 

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -231,13 +231,13 @@ ordering_flags_for_kind(enum pe_order_kind kind, const char *first,
  *
  * \return Resource corresponding to \p id, or NULL if none
  */
-static pe_resource_t *
+static pcmk_resource_t *
 get_ordering_resource(const xmlNode *xml, const char *resource_attr,
                       const char *instance_attr,
                       const pe_working_set_t *data_set)
 {
     // @COMPAT: instance_attr and instance_id variables deprecated since 2.1.5
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     const char *rsc_id = crm_element_value(xml, resource_attr);
     const char *instance_id = crm_element_value(xml, instance_attr);
 
@@ -287,7 +287,7 @@ get_ordering_resource(const xmlNode *xml, const char *resource_attr,
  * \return Minimum 'first' instances required (or 0 if not applicable)
  */
 static int
-get_minimum_first_instances(const pe_resource_t *rsc, const xmlNode *xml)
+get_minimum_first_instances(const pcmk_resource_t *rsc, const xmlNode *xml)
 {
     const char *clone_min = NULL;
     bool require_all = false;
@@ -334,8 +334,8 @@ get_minimum_first_instances(const pe_resource_t *rsc, const xmlNode *xml)
  */
 static void
 clone_min_ordering(const char *id,
-                   pe_resource_t *rsc_first, const char *action_first,
-                   pe_resource_t *rsc_then, const char *action_then,
+                   pcmk_resource_t *rsc_first, const char *action_first,
+                   pcmk_resource_t *rsc_then, const char *action_then,
                    uint32_t flags, int clone_min)
 {
     // Create a pseudo-action for when the minimum instances are active
@@ -352,7 +352,7 @@ clone_min_ordering(const char *id,
 
     // Order the actions for each clone instance before the pseudo-action
     for (GList *iter = rsc_first->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *child = iter->data;
+        pcmk_resource_t *child = iter->data;
 
         pcmk__new_ordering(child, pcmk__op_key(child->id, action_first, 0),
                            NULL, NULL, NULL, clone_min_met,
@@ -401,8 +401,8 @@ clone_min_ordering(const char *id,
  */
 static void
 inverse_ordering(const char *id, enum pe_order_kind kind,
-                 pe_resource_t *rsc_first, const char *action_first,
-                 pe_resource_t *rsc_then, const char *action_then)
+                 pcmk_resource_t *rsc_first, const char *action_first,
+                 pcmk_resource_t *rsc_then, const char *action_then)
 {
     action_then = invert_action(action_then);
     action_first = invert_action(action_first);
@@ -422,8 +422,8 @@ inverse_ordering(const char *id, enum pe_order_kind kind,
 static void
 unpack_simple_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set)
 {
-    pe_resource_t *rsc_then = NULL;
-    pe_resource_t *rsc_first = NULL;
+    pcmk_resource_t *rsc_then = NULL;
+    pcmk_resource_t *rsc_first = NULL;
     int min_required_before = 0;
     enum pe_order_kind kind = pe_order_kind_mandatory;
     uint32_t flags = pcmk__ar_none;
@@ -522,8 +522,8 @@ unpack_simple_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set)
  *       then_action_task, which do not need to be freed by the caller.
  */
 void
-pcmk__new_ordering(pe_resource_t *first_rsc, char *first_action_task,
-                   pe_action_t *first_action, pe_resource_t *then_rsc,
+pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_action_task,
+                   pe_action_t *first_action, pcmk_resource_t *then_rsc,
                    char *then_action_task, pe_action_t *then_action,
                    uint32_t flags, pe_working_set_t *sched)
 {
@@ -596,8 +596,8 @@ unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
     GList *set_iter = NULL;
     GList *resources = NULL;
 
-    pe_resource_t *last = NULL;
-    pe_resource_t *resource = NULL;
+    pcmk_resource_t *last = NULL;
+    pcmk_resource_t *resource = NULL;
 
     int local_kind = parent_kind;
     bool sequential = false;
@@ -640,7 +640,7 @@ unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
 
     set_iter = resources;
     while (set_iter != NULL) {
-        resource = (pe_resource_t *) set_iter->data;
+        resource = (pcmk_resource_t *) set_iter->data;
         set_iter = set_iter->next;
 
         key = pcmk__op_key(resource->id, action, 0);
@@ -649,7 +649,7 @@ unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
             /* Serialize before everything that comes after */
 
             for (GList *iter = set_iter; iter != NULL; iter = iter->next) {
-                pe_resource_t *then_rsc = iter->data;
+                pcmk_resource_t *then_rsc = iter->data;
                 char *then_key = pcmk__op_key(then_rsc->id, action, 0);
 
                 pcmk__new_ordering(resource, strdup(key), NULL, then_rsc,
@@ -678,7 +678,7 @@ unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
 
     set_iter = resources;
     while (set_iter != NULL) {
-        resource = (pe_resource_t *) set_iter->data;
+        resource = (pcmk_resource_t *) set_iter->data;
         set_iter = set_iter->next;
 
         if (sequential) {
@@ -716,8 +716,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
     const xmlNode *xml_rsc = NULL;
     const xmlNode *xml_rsc_2 = NULL;
 
-    pe_resource_t *rsc_1 = NULL;
-    pe_resource_t *rsc_2 = NULL;
+    pcmk_resource_t *rsc_1 = NULL;
+    pcmk_resource_t *rsc_2 = NULL;
 
     const char *action_1 = crm_element_value(set1, "action");
     const char *action_2 = crm_element_value(set2, "action");
@@ -899,8 +899,8 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     const char *action_first = NULL;
     const char *action_then = NULL;
 
-    pe_resource_t *rsc_first = NULL;
-    pe_resource_t *rsc_then = NULL;
+    pcmk_resource_t *rsc_first = NULL;
+    pcmk_resource_t *rsc_then = NULL;
     pe_tag_t *tag_first = NULL;
     pe_tag_t *tag_then = NULL;
 
@@ -1190,7 +1190,7 @@ pcmk__order_stops_before_shutdown(pcmk_node_t *node, pe_action_t *shutdown_op)
  * \note It is the caller's responsibility to free the result with g_list_free()
  */
 static GList *
-find_actions_by_task(const pe_resource_t *rsc, const char *original_key)
+find_actions_by_task(const pcmk_resource_t *rsc, const char *original_key)
 {
     // Search under given task key directly
     GList *list = find_actions(rsc->actions, original_key, NULL);
@@ -1223,7 +1223,7 @@ find_actions_by_task(const pe_resource_t *rsc, const char *original_key)
  */
 static void
 order_resource_actions_after(pe_action_t *first_action,
-                             const pe_resource_t *rsc, pe__ordering_t *order)
+                             const pcmk_resource_t *rsc, pe__ordering_t *order)
 {
     GList *then_actions = NULL;
     uint32_t flags = pcmk__ar_none;
@@ -1283,11 +1283,11 @@ order_resource_actions_after(pe_action_t *first_action,
 }
 
 static void
-rsc_order_first(pe_resource_t *first_rsc, pe__ordering_t *order)
+rsc_order_first(pcmk_resource_t *first_rsc, pe__ordering_t *order)
 {
     GList *first_actions = NULL;
     pe_action_t *first_action = order->lh_action;
-    pe_resource_t *then_rsc = order->rh_rsc;
+    pcmk_resource_t *then_rsc = order->rh_rsc;
 
     CRM_ASSERT(first_rsc != NULL);
     pe_rsc_trace(first_rsc, "Applying ordering constraint %d (first: %s)",
@@ -1407,7 +1407,7 @@ pcmk__apply_orderings(pe_working_set_t *sched)
          iter != NULL; iter = iter->next) {
 
         pe__ordering_t *order = iter->data;
-        pe_resource_t *rsc = order->lh_rsc;
+        pcmk_resource_t *rsc = order->lh_rsc;
 
         if (rsc != NULL) {
             rsc_order_first(rsc, order);
@@ -1466,7 +1466,7 @@ pcmk__order_after_each(pe_action_t *after, GList *list)
  * \param[in,out] rsc  Clone or bundle to order
  */
 void
-pcmk__promotable_restart_ordering(pe_resource_t *rsc)
+pcmk__promotable_restart_ordering(pcmk_resource_t *rsc)
 {
     // Order start and promote after all instances are stopped
     pcmk__order_resource_actions(rsc, PCMK_ACTION_STOPPED,

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -340,7 +340,7 @@ clone_min_ordering(const char *id,
 {
     // Create a pseudo-action for when the minimum instances are active
     char *task = crm_strdup_printf(PCMK_ACTION_CLONE_ONE_OR_MORE ":%s", id);
-    pe_action_t *clone_min_met = get_pseudo_op(task, rsc_first->cluster);
+    pcmk_action_t *clone_min_met = get_pseudo_op(task, rsc_first->cluster);
 
     free(task);
 
@@ -523,8 +523,8 @@ unpack_simple_rsc_order(xmlNode *xml_obj, pe_working_set_t *data_set)
  */
 void
 pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_action_task,
-                   pe_action_t *first_action, pcmk_resource_t *then_rsc,
-                   char *then_action_task, pe_action_t *then_action,
+                   pcmk_action_t *first_action, pcmk_resource_t *then_rsc,
+                   char *then_action_task, pcmk_action_t *then_action,
                    uint32_t flags, pe_working_set_t *sched)
 {
     pe__ordering_t *order = NULL;
@@ -758,7 +758,7 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
      */
     if (!require_all) {
         char *task = crm_strdup_printf(PCMK_ACTION_ONE_OR_MORE ":%s", ID(set1));
-        pe_action_t *unordered_action = get_pseudo_op(task, data_set);
+        pcmk_action_t *unordered_action = get_pseudo_op(task, data_set);
 
         free(task);
         pe__set_action_flags(unordered_action, pcmk_action_min_runnable);
@@ -1069,7 +1069,7 @@ pcmk__unpack_ordering(xmlNode *xml_obj, pe_working_set_t *data_set)
 }
 
 static bool
-ordering_is_invalid(pe_action_t *action, pe_action_wrapper_t *input)
+ordering_is_invalid(pcmk_action_t *action, pe_action_wrapper_t *input)
 {
     /* Prevent user-defined ordering constraints between resources
      * running in a guest node and the resource that defines that node.
@@ -1104,7 +1104,7 @@ void
 pcmk__disable_invalid_orderings(pe_working_set_t *data_set)
 {
     for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *action = (pe_action_t *) iter->data;
+        pcmk_action_t *action = (pcmk_action_t *) iter->data;
         pe_action_wrapper_t *input = NULL;
 
         for (GList *input_iter = action->actions_before;
@@ -1126,12 +1126,12 @@ pcmk__disable_invalid_orderings(pe_working_set_t *data_set)
  * \param[in]     shutdown_op  Shutdown action for node
  */
 void
-pcmk__order_stops_before_shutdown(pcmk_node_t *node, pe_action_t *shutdown_op)
+pcmk__order_stops_before_shutdown(pcmk_node_t *node, pcmk_action_t *shutdown_op)
 {
     for (GList *iter = node->details->data_set->actions;
          iter != NULL; iter = iter->next) {
 
-        pe_action_t *action = (pe_action_t *) iter->data;
+        pcmk_action_t *action = (pcmk_action_t *) iter->data;
 
         // Only stops on the node shutting down are relevant
         if (!pe__same_node(action->node, node)
@@ -1222,7 +1222,7 @@ find_actions_by_task(const pcmk_resource_t *rsc, const char *original_key)
  * \param[in,out] order         Ordering constraint being applied
  */
 static void
-order_resource_actions_after(pe_action_t *first_action,
+order_resource_actions_after(pcmk_action_t *first_action,
                              const pcmk_resource_t *rsc, pe__ordering_t *order)
 {
     GList *then_actions = NULL;
@@ -1267,7 +1267,7 @@ order_resource_actions_after(pe_action_t *first_action,
     }
 
     for (GList *iter = then_actions; iter != NULL; iter = iter->next) {
-        pe_action_t *then_action_iter = (pe_action_t *) iter->data;
+        pcmk_action_t *then_action_iter = (pcmk_action_t *) iter->data;
 
         if (first_action != NULL) {
             order_actions(first_action, then_action_iter, flags);
@@ -1286,7 +1286,7 @@ static void
 rsc_order_first(pcmk_resource_t *first_rsc, pe__ordering_t *order)
 {
     GList *first_actions = NULL;
-    pe_action_t *first_action = order->lh_action;
+    pcmk_action_t *first_action = order->lh_action;
     pcmk_resource_t *then_rsc = order->rh_rsc;
 
     CRM_ASSERT(first_rsc != NULL);
@@ -1374,7 +1374,7 @@ block_colocation_dependents(gpointer data, gpointer user_data)
 static void
 update_action_for_orderings(gpointer data, gpointer user_data)
 {
-    pcmk__update_action_for_orderings((pe_action_t *) data,
+    pcmk__update_action_for_orderings((pcmk_action_t *) data,
                                       (pe_working_set_t *) user_data);
 }
 
@@ -1444,12 +1444,12 @@ pcmk__apply_orderings(pe_working_set_t *sched)
  * \param[in,out] list   List of "before" actions
  */
 void
-pcmk__order_after_each(pe_action_t *after, GList *list)
+pcmk__order_after_each(pcmk_action_t *after, GList *list)
 {
     const char *after_desc = (after->task == NULL)? after->uuid : after->task;
 
     for (GList *iter = list; iter != NULL; iter = iter->next) {
-        pe_action_t *before = (pe_action_t *) iter->data;
+        pcmk_action_t *before = (pcmk_action_t *) iter->data;
         const char *before_desc = before->task? before->task : before->uuid;
 
         crm_debug("Ordering %s on %s before %s on %s",

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1126,7 +1126,7 @@ pcmk__disable_invalid_orderings(pe_working_set_t *data_set)
  * \param[in]     shutdown_op  Shutdown action for node
  */
 void
-pcmk__order_stops_before_shutdown(pe_node_t *node, pe_action_t *shutdown_op)
+pcmk__order_stops_before_shutdown(pcmk_node_t *node, pe_action_t *shutdown_op)
 {
     for (GList *iter = node->details->data_set->actions;
          iter != NULL; iter = iter->next) {

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -633,7 +633,7 @@ set_default_next_role(pcmk_resource_t *rsc)
 static void
 create_pending_start(pcmk_resource_t *rsc)
 {
-    pe_action_t *start = NULL;
+    pcmk_action_t *start = NULL;
 
     pe_rsc_trace(rsc,
                  "Creating action for %s to represent already pending start",
@@ -815,7 +815,7 @@ pcmk__primitive_create_actions(pcmk_resource_t *rsc)
 
     } else if ((rsc->role > pcmk_role_started) && (current != NULL)
                && (rsc->allocated_to != NULL)) {
-        pe_action_t *start = NULL;
+        pcmk_action_t *start = NULL;
 
         pe_rsc_trace(rsc, "Creating start action for promoted resource %s",
                      rsc->id);
@@ -1186,7 +1186,7 @@ pcmk__primitive_with_colocations(const pcmk_resource_t *rsc,
  * \return Flags appropriate to \p action on \p node
  */
 uint32_t
-pcmk__primitive_action_flags(pe_action_t *action, const pcmk_node_t *node)
+pcmk__primitive_action_flags(pcmk_action_t *action, const pcmk_node_t *node)
 {
     CRM_ASSERT(action != NULL);
     return (uint32_t) action->flags;
@@ -1227,7 +1227,7 @@ stop_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
 {
     for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
         pcmk_node_t *current = (pcmk_node_t *) iter->data;
-        pe_action_t *stop = NULL;
+        pcmk_action_t *stop = NULL;
 
         if (is_expected_node(rsc, current)) {
             /* We are scheduling restart actions for a multiply active resource
@@ -1283,8 +1283,8 @@ stop_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
         }
 
         if (pcmk_is_set(rsc->flags, pcmk_rsc_needs_unfencing)) {
-            pe_action_t *unfence = pe_fence_op(current, PCMK_ACTION_ON, true,
-                                               NULL, false, rsc->cluster);
+            pcmk_action_t *unfence = pe_fence_op(current, PCMK_ACTION_ON, true,
+                                                 NULL, false, rsc->cluster);
 
             order_actions(stop, unfence, pcmk__ar_then_implies_first);
             if (!pcmk__node_unfenced(current)) {
@@ -1306,7 +1306,7 @@ stop_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
 static void
 start_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
 {
-    pe_action_t *start = NULL;
+    pcmk_action_t *start = NULL;
 
     CRM_ASSERT(node != NULL);
 
@@ -1353,7 +1353,7 @@ promote_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
     // Any start must be runnable for promotion to be runnable
     action_list = pe__resource_actions(rsc, node, PCMK_ACTION_START, true);
     for (iter = action_list; iter != NULL; iter = iter->next) {
-        pe_action_t *start = (pe_action_t *) iter->data;
+        pcmk_action_t *start = (pcmk_action_t *) iter->data;
 
         if (!pcmk_is_set(start->flags, pcmk_action_runnable)) {
             runnable = false;
@@ -1362,7 +1362,7 @@ promote_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
     g_list_free(action_list);
 
     if (runnable) {
-        pe_action_t *promote = promote_action(rsc, node, optional);
+        pcmk_action_t *promote = promote_action(rsc, node, optional);
 
         pe_rsc_trace(rsc, "Scheduling %s promotion of %s on %s",
                      (optional? "optional" : "required"), rsc->id,
@@ -1384,7 +1384,7 @@ promote_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool optional)
         action_list = pe__resource_actions(rsc, node, PCMK_ACTION_PROMOTE,
                                            true);
         for (iter = action_list; iter != NULL; iter = iter->next) {
-            pe_action_t *promote = (pe_action_t *) iter->data;
+            pcmk_action_t *promote = (pcmk_action_t *) iter->data;
 
             pe__clear_action_flags(promote, pcmk_action_runnable);
         }

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -26,10 +26,10 @@
  */
 static void
 add_expected_result(pe_action_t *probe, const pe_resource_t *rsc,
-                    const pe_node_t *node)
+                    const pcmk_node_t *node)
 {
     // Check whether resource is currently active on node
-    pe_node_t *running = pe_find_node_id(rsc->running_on, node->details->id);
+    pcmk_node_t *running = pe_find_node_id(rsc->running_on, node->details->id);
 
     // The expected result is what we think the resource's current state is
     if (running == NULL) {
@@ -50,7 +50,7 @@ add_expected_result(pe_action_t *probe, const pe_resource_t *rsc,
  * \return true if any probe was created, otherwise false
  */
 bool
-pcmk__probe_resource_list(GList *rscs, pe_node_t *node)
+pcmk__probe_resource_list(GList *rscs, pcmk_node_t *node)
 {
     bool any_created = false;
 
@@ -96,7 +96,7 @@ probe_then_start(pe_resource_t *rsc1, pe_resource_t *rsc2)
  * \return true if guest resource will likely stop, otherwise false
  */
 static bool
-guest_resource_will_stop(const pe_node_t *node)
+guest_resource_will_stop(const pcmk_node_t *node)
 {
     const pe_resource_t *guest_rsc = node->details->remote_rsc->container;
 
@@ -125,7 +125,7 @@ guest_resource_will_stop(const pe_node_t *node)
  * \return Newly created probe action
  */
 static pe_action_t *
-probe_action(pe_resource_t *rsc, pe_node_t *node)
+probe_action(pe_resource_t *rsc, pcmk_node_t *node)
 {
     pe_action_t *probe = NULL;
     char *key = pcmk__op_key(rsc->id, PCMK_ACTION_MONITOR, 0);
@@ -154,11 +154,11 @@ probe_action(pe_resource_t *rsc, pe_node_t *node)
  * \return true if any probe was created, otherwise false
  */
 bool
-pcmk__probe_rsc_on_node(pe_resource_t *rsc, pe_node_t *node)
+pcmk__probe_rsc_on_node(pe_resource_t *rsc, pcmk_node_t *node)
 {
     uint32_t flags = pcmk__ar_ordered;
     pe_action_t *probe = NULL;
-    pe_node_t *allowed = NULL;
+    pcmk_node_t *allowed = NULL;
     pe_resource_t *top = uber_parent(rsc);
     const char *reason = NULL;
 
@@ -860,7 +860,7 @@ pcmk__schedule_probes(pe_working_set_t *data_set)
 {
     // Schedule probes on each node in the cluster as needed
     for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk_node_t *node = (pcmk_node_t *) iter->data;
         const char *probed = NULL;
 
         if (!node->details->online) { // Don't probe offline nodes

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -25,7 +25,7 @@
  * \param[in]     node   Node that probe will run on
  */
 static void
-add_expected_result(pe_action_t *probe, const pe_resource_t *rsc,
+add_expected_result(pe_action_t *probe, const pcmk_resource_t *rsc,
                     const pcmk_node_t *node)
 {
     // Check whether resource is currently active on node
@@ -55,7 +55,7 @@ pcmk__probe_resource_list(GList *rscs, pcmk_node_t *node)
     bool any_created = false;
 
     for (GList *iter = rscs; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (rsc->cmds->create_probe(rsc, node)) {
             any_created = true;
@@ -72,7 +72,7 @@ pcmk__probe_resource_list(GList *rscs, pcmk_node_t *node)
  * \param[in]     rsc2  Resource that might be started
  */
 static void
-probe_then_start(pe_resource_t *rsc1, pe_resource_t *rsc2)
+probe_then_start(pcmk_resource_t *rsc1, pcmk_resource_t *rsc2)
 {
     if ((rsc1->allocated_to != NULL)
         && (g_hash_table_lookup(rsc1->known_on,
@@ -98,7 +98,7 @@ probe_then_start(pe_resource_t *rsc1, pe_resource_t *rsc2)
 static bool
 guest_resource_will_stop(const pcmk_node_t *node)
 {
-    const pe_resource_t *guest_rsc = node->details->remote_rsc->container;
+    const pcmk_resource_t *guest_rsc = node->details->remote_rsc->container;
 
     /* Ideally, we'd check whether the guest has a required stop, but that
      * information doesn't exist yet, so approximate it ...
@@ -125,7 +125,7 @@ guest_resource_will_stop(const pcmk_node_t *node)
  * \return Newly created probe action
  */
 static pe_action_t *
-probe_action(pe_resource_t *rsc, pcmk_node_t *node)
+probe_action(pcmk_resource_t *rsc, pcmk_node_t *node)
 {
     pe_action_t *probe = NULL;
     char *key = pcmk__op_key(rsc->id, PCMK_ACTION_MONITOR, 0);
@@ -154,12 +154,12 @@ probe_action(pe_resource_t *rsc, pcmk_node_t *node)
  * \return true if any probe was created, otherwise false
  */
 bool
-pcmk__probe_rsc_on_node(pe_resource_t *rsc, pcmk_node_t *node)
+pcmk__probe_rsc_on_node(pcmk_resource_t *rsc, pcmk_node_t *node)
 {
     uint32_t flags = pcmk__ar_ordered;
     pe_action_t *probe = NULL;
     pcmk_node_t *allowed = NULL;
-    pe_resource_t *top = uber_parent(rsc);
+    pcmk_resource_t *top = uber_parent(rsc);
     const char *reason = NULL;
 
     CRM_ASSERT((rsc != NULL) && (node != NULL));
@@ -233,7 +233,7 @@ pcmk__probe_rsc_on_node(pe_resource_t *rsc, pcmk_node_t *node)
     }
 
     if (pe__is_guest_node(node)) {
-        pe_resource_t *guest = node->details->remote_rsc->container;
+        pcmk_resource_t *guest = node->details->remote_rsc->container;
 
         if (guest->role == pcmk_role_stopped) {
             // The guest is stopped, so we know no resource is active there
@@ -539,7 +539,7 @@ add_restart_orderings_for_probe(pe_action_t *probe, pe_action_t *after)
 {
     GList *iter = NULL;
     bool interleave = false;
-    pe_resource_t *compatible_rsc = NULL;
+    pcmk_resource_t *compatible_rsc = NULL;
 
     // Validate that this is a resource probe followed by some action
     if ((after == NULL) || (probe == NULL) || (probe->rsc == NULL)
@@ -685,7 +685,7 @@ clear_actions_tracking_flag(pe_working_set_t *data_set)
 static void
 add_start_restart_orderings_for_rsc(gpointer data, gpointer user_data)
 {
-    pe_resource_t *rsc = data;
+    pcmk_resource_t *rsc = data;
     GList *probes = NULL;
 
     // For collective resources, order each instance recursively
@@ -758,7 +758,7 @@ order_then_probes(pe_working_set_t *data_set)
      * someone gets smarter.
      */
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         pe_action_t *start = NULL;
         GList *actions = NULL;
@@ -784,7 +784,7 @@ order_then_probes(pe_working_set_t *data_set)
             pe_action_wrapper_t *before = (pe_action_wrapper_t *) actions->data;
 
             pe_action_t *first = before->action;
-            pe_resource_t *first_rsc = first->rsc;
+            pcmk_resource_t *first_rsc = first->rsc;
 
             if (first->required_runnable_before) {
                 for (GList *clone_actions = first->actions_before;

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -338,7 +338,7 @@ probe_needed_before_action(const pcmk_action_t *probe,
  * \param[in,out] data_set  Cluster working set
  */
 static void
-add_probe_orderings_for_stops(pe_working_set_t *data_set)
+add_probe_orderings_for_stops(pcmk_scheduler_t *data_set)
 {
     for (GList *iter = data_set->ordering_constraints; iter != NULL;
          iter = iter->next) {
@@ -667,7 +667,7 @@ add_restart_orderings_for_probe(pcmk_action_t *probe, pcmk_action_t *after)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-clear_actions_tracking_flag(pe_working_set_t *data_set)
+clear_actions_tracking_flag(pcmk_scheduler_t *data_set)
 {
     for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
         pcmk_action_t *action = iter->data;
@@ -726,7 +726,7 @@ add_start_restart_orderings_for_rsc(gpointer data, gpointer user_data)
  * \note This function is currently disabled (see next comment).
  */
 static void
-order_then_probes(pe_working_set_t *data_set)
+order_then_probes(pcmk_scheduler_t *data_set)
 {
 #if 0
     /* Given an ordering "A then B", we would prefer to wait for A to be started
@@ -838,7 +838,7 @@ order_then_probes(pe_working_set_t *data_set)
 }
 
 void
-pcmk__order_probes(pe_working_set_t *data_set)
+pcmk__order_probes(pcmk_scheduler_t *data_set)
 {
     // Add orderings for "probe then X"
     g_list_foreach(data_set->resources, add_start_restart_orderings_for_rsc,
@@ -857,7 +857,7 @@ pcmk__order_probes(pe_working_set_t *data_set)
  * \note This may also schedule fencing of failed remote nodes.
  */
 void
-pcmk__schedule_probes(pe_working_set_t *data_set)
+pcmk__schedule_probes(pcmk_scheduler_t *data_set)
 {
     // Schedule probes on each node in the cluster as needed
     for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -93,7 +93,7 @@ check_for_role_change(const pcmk_resource_t *rsc, bool *demoting,
     }
 
     for (iter = rsc->actions; iter != NULL; iter = iter->next) {
-        const pe_action_t *action = (const pe_action_t *) iter->data;
+        const pcmk_action_t *action = (const pcmk_action_t *) iter->data;
 
         if (*promoting && *demoting) {
             return;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -23,8 +23,8 @@
  * \param[in,out] last   Previous instance ordered (NULL if \p child is first)
  */
 static void
-order_instance_promotion(pe_resource_t *clone, pe_resource_t *child,
-                         pe_resource_t *last)
+order_instance_promotion(pcmk_resource_t *clone, pcmk_resource_t *child,
+                         pcmk_resource_t *last)
 {
     // "Promote clone" -> promote instance -> "clone promoted"
     pcmk__order_resource_actions(clone, PCMK_ACTION_PROMOTE,
@@ -51,8 +51,8 @@ order_instance_promotion(pe_resource_t *clone, pe_resource_t *child,
  * \param[in]     last   Previous instance ordered (NULL if \p child is first)
  */
 static void
-order_instance_demotion(pe_resource_t *clone, pe_resource_t *child,
-                        pe_resource_t *last)
+order_instance_demotion(pcmk_resource_t *clone, pcmk_resource_t *child,
+                        pcmk_resource_t *last)
 {
     // "Demote clone" -> demote instance -> "clone demoted"
     pcmk__order_resource_actions(clone, PCMK_ACTION_DEMOTE, child,
@@ -78,14 +78,15 @@ order_instance_demotion(pe_resource_t *clone, pe_resource_t *child,
  * \param[out] promoting  If \p rsc will be promoted, this will be set to true
  */
 static void
-check_for_role_change(const pe_resource_t *rsc, bool *demoting, bool *promoting)
+check_for_role_change(const pcmk_resource_t *rsc, bool *demoting,
+                      bool *promoting)
 {
     const GList *iter = NULL;
 
     // If this is a cloned group, check group members recursively
     if (rsc->children != NULL) {
         for (iter = rsc->children; iter != NULL; iter = iter->next) {
-            check_for_role_change((const pe_resource_t *) iter->data,
+            check_for_role_change((const pcmk_resource_t *) iter->data,
                                   demoting, promoting);
         }
         return;
@@ -124,7 +125,7 @@ check_for_role_change(const pe_resource_t *rsc, bool *demoting, bool *promoting)
  * \param[in]     chosen                Node where \p child will be placed
  */
 static void
-apply_promoted_locations(pe_resource_t *child,
+apply_promoted_locations(pcmk_resource_t *child,
                          const GList *location_constraints,
                          const pcmk_node_t *chosen)
 {
@@ -162,15 +163,15 @@ apply_promoted_locations(pe_resource_t *child,
  * \return Node that \p rsc will be promoted on, or NULL if none
  */
 static pcmk_node_t *
-node_to_be_promoted_on(const pe_resource_t *rsc)
+node_to_be_promoted_on(const pcmk_resource_t *rsc)
 {
     pcmk_node_t *node = NULL;
     pcmk_node_t *local_node = NULL;
-    const pe_resource_t *parent = NULL;
+    const pcmk_resource_t *parent = NULL;
 
     // If this is a cloned group, bail if any group member can't be promoted
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *child = (pe_resource_t *) iter->data;
+        pcmk_resource_t *child = (pcmk_resource_t *) iter->data;
 
         if (node_to_be_promoted_on(child) == NULL) {
             pe_rsc_trace(rsc,
@@ -250,8 +251,8 @@ node_to_be_promoted_on(const pe_resource_t *rsc)
 static gint
 cmp_promotable_instance(gconstpointer a, gconstpointer b)
 {
-    const pe_resource_t *rsc1 = (const pe_resource_t *) a;
-    const pe_resource_t *rsc2 = (const pe_resource_t *) b;
+    const pcmk_resource_t *rsc1 = (const pcmk_resource_t *) a;
+    const pcmk_resource_t *rsc2 = (const pcmk_resource_t *) b;
 
     enum rsc_role_e role1 = pcmk_role_unknown;
     enum rsc_role_e role2 = pcmk_role_unknown;
@@ -308,8 +309,8 @@ cmp_promotable_instance(gconstpointer a, gconstpointer b)
 static void
 add_sort_index_to_node_score(gpointer data, gpointer user_data)
 {
-    const pe_resource_t *child = (const pe_resource_t *) data;
-    pe_resource_t *clone = (pe_resource_t *) user_data;
+    const pcmk_resource_t *child = (const pcmk_resource_t *) data;
+    pcmk_resource_t *clone = (pcmk_resource_t *) user_data;
 
     pcmk_node_t *node = NULL;
     const pcmk_node_t *chosen = NULL;
@@ -346,8 +347,8 @@ static void
 apply_coloc_to_dependent(gpointer data, gpointer user_data)
 {
     pcmk__colocation_t *colocation = data;
-    pe_resource_t *clone = user_data;
-    pe_resource_t *primary = colocation->primary;
+    pcmk_resource_t *clone = user_data;
+    pcmk_resource_t *primary = colocation->primary;
     uint32_t flags = pcmk__coloc_select_default;
     float factor = colocation->score / (float) INFINITY;
 
@@ -377,8 +378,8 @@ static void
 apply_coloc_to_primary(gpointer data, gpointer user_data)
 {
     pcmk__colocation_t *colocation = data;
-    pe_resource_t *clone = user_data;
-    pe_resource_t *dependent = colocation->dependent;
+    pcmk_resource_t *clone = user_data;
+    pcmk_resource_t *dependent = colocation->dependent;
     const float factor = colocation->score / (float) INFINITY;
     const uint32_t flags = pcmk__coloc_select_active
                            |pcmk__coloc_select_nonnegative;
@@ -407,8 +408,8 @@ apply_coloc_to_primary(gpointer data, gpointer user_data)
 static void
 set_sort_index_to_node_score(gpointer data, gpointer user_data)
 {
-    pe_resource_t *child = (pe_resource_t *) data;
-    const pe_resource_t *clone = (const pe_resource_t *) user_data;
+    pcmk_resource_t *child = (pcmk_resource_t *) data;
+    const pcmk_resource_t *clone = (const pcmk_resource_t *) user_data;
 
     pcmk_node_t *chosen = child->fns->location(child, NULL, FALSE);
 
@@ -443,7 +444,7 @@ set_sort_index_to_node_score(gpointer data, gpointer user_data)
  * \param[in,out] clone  Promotable clone to sort
  */
 static void
-sort_promotable_instances(pe_resource_t *clone)
+sort_promotable_instances(pcmk_resource_t *clone)
 {
     GList *colocations = NULL;
 
@@ -454,7 +455,7 @@ sort_promotable_instances(pe_resource_t *clone)
     pe__set_resource_flags(clone, pcmk_rsc_updating_nodes);
 
     for (GList *iter = clone->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *child = (pe_resource_t *) iter->data;
+        pcmk_resource_t *child = (pcmk_resource_t *) iter->data;
 
         pe_rsc_trace(clone,
                      "Adding scores for %s: initial sort index for %s is %d",
@@ -497,13 +498,13 @@ sort_promotable_instances(pe_resource_t *clone)
  *
  * \return
  */
-static pe_resource_t *
-find_active_anon_instance(const pe_resource_t *clone, const char *id,
+static pcmk_resource_t *
+find_active_anon_instance(const pcmk_resource_t *clone, const char *id,
                           const pcmk_node_t *node)
 {
     for (GList *iter = clone->children; iter; iter = iter->next) {
-        pe_resource_t *child = iter->data;
-        pe_resource_t *active = NULL;
+        pcmk_resource_t *child = iter->data;
+        pcmk_resource_t *active = NULL;
 
         // Use ->find_rsc() in case this is a cloned group
         active = clone->fns->find_rsc(child, id, node,
@@ -527,11 +528,11 @@ find_active_anon_instance(const pe_resource_t *clone, const char *id,
  *         otherwise false
  */
 static bool
-anonymous_known_on(const pe_resource_t *clone, const char *id,
+anonymous_known_on(const pcmk_resource_t *clone, const char *id,
                    const pcmk_node_t *node)
 {
     for (GList *iter = clone->children; iter; iter = iter->next) {
-        pe_resource_t *child = iter->data;
+        pcmk_resource_t *child = iter->data;
 
         /* Use ->find_rsc() because this might be a cloned group, and knowing
          * that other members of the group are known here implies nothing.
@@ -558,7 +559,7 @@ anonymous_known_on(const pe_resource_t *clone, const char *id,
  * \return true if \p node is allowed to run \p rsc, otherwise false
  */
 static bool
-is_allowed(const pe_resource_t *rsc, const pcmk_node_t *node)
+is_allowed(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     pcmk_node_t *allowed = g_hash_table_lookup(rsc->allowed_nodes,
                                                node->details->id);
@@ -576,11 +577,11 @@ is_allowed(const pe_resource_t *rsc, const pcmk_node_t *node)
  *         otherwise false
  */
 static bool
-promotion_score_applies(const pe_resource_t *rsc, const pcmk_node_t *node)
+promotion_score_applies(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     char *id = clone_strip(rsc->id);
-    const pe_resource_t *parent = pe__const_top_resource(rsc, false);
-    pe_resource_t *active = NULL;
+    const pcmk_resource_t *parent = pe__const_top_resource(rsc, false);
+    pcmk_resource_t *active = NULL;
     const char *reason = "allowed";
 
     // Some checks apply only to anonymous clone instances
@@ -650,7 +651,7 @@ check_allowed:
  * \return Value of promotion score node attribute for \p rsc on \p node
  */
 static const char *
-promotion_attr_value(const pe_resource_t *rsc, const pcmk_node_t *node,
+promotion_attr_value(const pcmk_resource_t *rsc, const pcmk_node_t *node,
                      const char *name)
 {
     char *attr_name = NULL;
@@ -679,7 +680,7 @@ promotion_attr_value(const pe_resource_t *rsc, const pcmk_node_t *node,
  * \return Promotion score for \p rsc on \p node (or 0 if none)
  */
 static int
-promotion_score(const pe_resource_t *rsc, const pcmk_node_t *node,
+promotion_score(const pcmk_resource_t *rsc, const pcmk_node_t *node,
                 bool *is_default)
 {
     char *name = NULL;
@@ -700,7 +701,7 @@ promotion_score(const pe_resource_t *rsc, const pcmk_node_t *node,
         for (const GList *iter = rsc->children;
              iter != NULL; iter = iter->next) {
 
-            const pe_resource_t *child = (const pe_resource_t *) iter->data;
+            const pcmk_resource_t *child = (const pcmk_resource_t *) iter->data;
             bool child_default = false;
             int child_score = promotion_score(child, node, &child_default);
 
@@ -758,7 +759,7 @@ promotion_score(const pe_resource_t *rsc, const pcmk_node_t *node,
  * \param[in,out] rsc  Promotable clone resource to update
  */
 void
-pcmk__add_promotion_scores(pe_resource_t *rsc)
+pcmk__add_promotion_scores(pcmk_resource_t *rsc)
 {
     if (pe__set_clone_flag(rsc,
                            pcmk__clone_promotion_added) == pcmk_rc_already) {
@@ -766,7 +767,7 @@ pcmk__add_promotion_scores(pe_resource_t *rsc)
     }
 
     for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) iter->data;
 
         GHashTableIter iter;
         pcmk_node_t *node = NULL;
@@ -815,7 +816,7 @@ pcmk__add_promotion_scores(pe_resource_t *rsc)
 static void
 set_current_role_unpromoted(void *data, void *user_data)
 {
-    pe_resource_t *rsc = (pe_resource_t *) data;
+    pcmk_resource_t *rsc = (pcmk_resource_t *) data;
 
     if (rsc->role == pcmk_role_started) {
         // Promotable clones should use unpromoted role instead of started
@@ -834,7 +835,7 @@ set_current_role_unpromoted(void *data, void *user_data)
 static void
 set_next_role_unpromoted(void *data, void *user_data)
 {
-    pe_resource_t *rsc = (pe_resource_t *) data;
+    pcmk_resource_t *rsc = (pcmk_resource_t *) data;
     GList *assigned = NULL;
 
     rsc->fns->location(rsc, &assigned, FALSE);
@@ -857,7 +858,7 @@ set_next_role_unpromoted(void *data, void *user_data)
 static void
 set_next_role_promoted(void *data, gpointer user_data)
 {
-    pe_resource_t *rsc = (pe_resource_t *) data;
+    pcmk_resource_t *rsc = (pcmk_resource_t *) data;
 
     if (rsc->next_role == pcmk_role_unknown) {
         pe__set_next_role(rsc, pcmk_role_promoted, "promoted instance");
@@ -872,7 +873,7 @@ set_next_role_promoted(void *data, gpointer user_data)
  * \param[in,out] instance  Promotable clone instance to show
  */
 static void
-show_promotion_score(pe_resource_t *instance)
+show_promotion_score(pcmk_resource_t *instance)
 {
     pcmk_node_t *chosen = instance->fns->location(instance, NULL, FALSE);
 
@@ -903,8 +904,8 @@ show_promotion_score(pe_resource_t *instance)
 static void
 set_instance_priority(gpointer data, gpointer user_data)
 {
-    pe_resource_t *instance = (pe_resource_t *) data;
-    const pe_resource_t *clone = (const pe_resource_t *) user_data;
+    pcmk_resource_t *instance = (pcmk_resource_t *) data;
+    const pcmk_resource_t *clone = (const pcmk_resource_t *) user_data;
     const pcmk_node_t *chosen = NULL;
     enum rsc_role_e next_role = pcmk_role_unknown;
     GList *list = NULL;
@@ -996,10 +997,10 @@ set_instance_priority(gpointer data, gpointer user_data)
 static void
 set_instance_role(gpointer data, gpointer user_data)
 {
-    pe_resource_t *instance = (pe_resource_t *) data;
+    pcmk_resource_t *instance = (pcmk_resource_t *) data;
     int *count = (int *) user_data;
 
-    const pe_resource_t *clone = pe__const_top_resource(instance, false);
+    const pcmk_resource_t *clone = pe__const_top_resource(instance, false);
     pcmk_node_t *chosen = NULL;
 
     show_promotion_score(instance);
@@ -1042,7 +1043,7 @@ set_instance_role(gpointer data, gpointer user_data)
  * \param[in,out] rsc  Promotable clone resource to update
  */
 void
-pcmk__set_instance_roles(pe_resource_t *rsc)
+pcmk__set_instance_roles(pcmk_resource_t *rsc)
 {
     int promoted = 0;
     GHashTableIter iter;
@@ -1074,11 +1075,11 @@ pcmk__set_instance_roles(pe_resource_t *rsc)
  * \param[out]    any_demoting   Will be set true if any instance is demoting
  */
 static void
-create_promotable_instance_actions(pe_resource_t *clone,
+create_promotable_instance_actions(pcmk_resource_t *clone,
                                    bool *any_promoting, bool *any_demoting)
 {
     for (GList *iter = clone->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *instance = (pe_resource_t *) iter->data;
+        pcmk_resource_t *instance = (pcmk_resource_t *) iter->data;
 
         instance->cmds->create_actions(instance);
         check_for_role_change(instance, any_demoting, any_promoting);
@@ -1096,10 +1097,10 @@ create_promotable_instance_actions(pe_resource_t *clone,
  * \param[in,out] clone  Promotable clone to reset
  */
 static void
-reset_instance_priorities(pe_resource_t *clone)
+reset_instance_priorities(pcmk_resource_t *clone)
 {
     for (GList *iter = clone->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *instance = (pe_resource_t *) iter->data;
+        pcmk_resource_t *instance = (pcmk_resource_t *) iter->data;
 
         instance->priority = clone->priority;
     }
@@ -1112,7 +1113,7 @@ reset_instance_priorities(pe_resource_t *clone)
  * \param[in,out] clone  Promotable clone to create actions for
  */
 void
-pcmk__create_promotable_actions(pe_resource_t *clone)
+pcmk__create_promotable_actions(pcmk_resource_t *clone)
 {
     bool any_promoting = false;
     bool any_demoting = false;
@@ -1134,14 +1135,14 @@ pcmk__create_promotable_actions(pe_resource_t *clone)
  * \param[in,out] clone  Promotable clone instance to order
  */
 void
-pcmk__order_promotable_instances(pe_resource_t *clone)
+pcmk__order_promotable_instances(pcmk_resource_t *clone)
 {
-    pe_resource_t *previous = NULL; // Needed for ordered clones
+    pcmk_resource_t *previous = NULL; // Needed for ordered clones
 
     pcmk__promotable_restart_ordering(clone);
 
     for (GList *iter = clone->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *instance = (pe_resource_t *) iter->data;
+        pcmk_resource_t *instance = (pcmk_resource_t *) iter->data;
 
         // Demote before promote
         pcmk__order_resource_actions(instance, PCMK_ACTION_DEMOTE,
@@ -1164,8 +1165,8 @@ pcmk__order_promotable_instances(pe_resource_t *clone)
  * \param[in]     colocation    Colocation constraint to apply
  */
 static void
-update_dependent_allowed_nodes(pe_resource_t *dependent,
-                               const pe_resource_t *primary,
+update_dependent_allowed_nodes(pcmk_resource_t *dependent,
+                               const pcmk_resource_t *primary,
                                const pcmk_node_t *primary_node,
                                const pcmk__colocation_t *colocation)
 {
@@ -1210,8 +1211,8 @@ update_dependent_allowed_nodes(pe_resource_t *dependent,
  * \param[in]     colocation  Colocation constraint to apply
  */
 void
-pcmk__update_dependent_with_promotable(const pe_resource_t *primary,
-                                       pe_resource_t *dependent,
+pcmk__update_dependent_with_promotable(const pcmk_resource_t *primary,
+                                       pcmk_resource_t *dependent,
                                        const pcmk__colocation_t *colocation)
 {
     GList *affected_nodes = NULL;
@@ -1221,7 +1222,7 @@ pcmk__update_dependent_with_promotable(const pe_resource_t *primary,
      * each one.
      */
     for (GList *iter = primary->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *instance = (pe_resource_t *) iter->data;
+        pcmk_resource_t *instance = (pcmk_resource_t *) iter->data;
         pcmk_node_t *node = instance->fns->location(instance, NULL, FALSE);
 
         if (node == NULL) {
@@ -1264,11 +1265,11 @@ pcmk__update_dependent_with_promotable(const pe_resource_t *primary,
  * \param[in]     colocation  Colocation constraint to apply
  */
 void
-pcmk__update_promotable_dependent_priority(const pe_resource_t *primary,
-                                           pe_resource_t *dependent,
+pcmk__update_promotable_dependent_priority(const pcmk_resource_t *primary,
+                                           pcmk_resource_t *dependent,
                                            const pcmk__colocation_t *colocation)
 {
-    pe_resource_t *primary_instance = NULL;
+    pcmk_resource_t *primary_instance = NULL;
 
     // Look for a primary instance where dependent will be
     primary_instance = pcmk__find_compatible_instance(dependent, primary,

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -56,7 +56,7 @@ xe_interval(const xmlNode *xml)
  *         once in the operation history of \p rsc, otherwise false
  */
 static bool
-is_op_dup(const pe_resource_t *rsc, const char *name, guint interval_ms)
+is_op_dup(const pcmk_resource_t *rsc, const char *name, guint interval_ms)
 {
     const char *id = NULL;
 
@@ -122,7 +122,7 @@ op_cannot_recur(const char *name)
  * \return true if \p xml is for a recurring action, otherwise false
  */
 static bool
-is_recurring_history(const pe_resource_t *rsc, const xmlNode *xml,
+is_recurring_history(const pcmk_resource_t *rsc, const xmlNode *xml,
                      struct op_history *op)
 {
     const char *role = NULL;
@@ -186,7 +186,7 @@ is_recurring_history(const pe_resource_t *rsc, const xmlNode *xml,
  * \return true if recurring action should be optional, otherwise false
  */
 static bool
-active_recurring_should_be_optional(const pe_resource_t *rsc,
+active_recurring_should_be_optional(const pcmk_resource_t *rsc,
                                     const pcmk_node_t *node, const char *key,
                                     pe_action_t *start)
 {
@@ -240,7 +240,7 @@ active_recurring_should_be_optional(const pe_resource_t *rsc,
  * \param[in]     op     Resource history entry
  */
 static void
-recurring_op_for_active(pe_resource_t *rsc, pe_action_t *start,
+recurring_op_for_active(pcmk_resource_t *rsc, pe_action_t *start,
                         const pcmk_node_t *node, const struct op_history *op)
 {
     pe_action_t *mon = NULL;
@@ -370,8 +370,8 @@ recurring_op_for_active(pe_resource_t *rsc, pe_action_t *start,
  * \param[in]     interval_ms  Action interval (in milliseconds)
  */
 static void
-cancel_if_running(pe_resource_t *rsc, const pcmk_node_t *node, const char *key,
-                  const char *name, guint interval_ms)
+cancel_if_running(pcmk_resource_t *rsc, const pcmk_node_t *node,
+                  const char *key, const char *name, guint interval_ms)
 {
     GList *possible_matches = find_actions_exact(rsc->actions, key, node);
     pe_action_t *cancel_op = NULL;
@@ -414,7 +414,7 @@ cancel_if_running(pe_resource_t *rsc, const pcmk_node_t *node, const char *key,
  * \param[in,out] action  Action to order after probes of \p rsc on \p node
  */
 static void
-order_after_probes(pe_resource_t *rsc, const pcmk_node_t *node,
+order_after_probes(pcmk_resource_t *rsc, const pcmk_node_t *node,
                    pe_action_t *action)
 {
     GList *probes = pe__resource_actions(rsc, node, PCMK_ACTION_MONITOR, FALSE);
@@ -435,7 +435,7 @@ order_after_probes(pe_resource_t *rsc, const pcmk_node_t *node,
  * \param[in,out] action  Action to order after stops of \p rsc on \p node
  */
 static void
-order_after_stops(pe_resource_t *rsc, const pcmk_node_t *node,
+order_after_stops(pcmk_resource_t *rsc, const pcmk_node_t *node,
                   pe_action_t *action)
 {
     GList *stop_ops = pe__resource_actions(rsc, node, PCMK_ACTION_STOP, TRUE);
@@ -477,7 +477,7 @@ order_after_stops(pe_resource_t *rsc, const pcmk_node_t *node,
  * \param[in]     op     Resource history entry
  */
 static void
-recurring_op_for_inactive(pe_resource_t *rsc, const pcmk_node_t *node,
+recurring_op_for_inactive(pcmk_resource_t *rsc, const pcmk_node_t *node,
                           const struct op_history *op)
 {
     GList *possible_matches = NULL;
@@ -558,7 +558,7 @@ recurring_op_for_inactive(pe_resource_t *rsc, const pcmk_node_t *node,
  * \param[in,out] rsc  Resource to create recurring actions for
  */
 void
-pcmk__create_recurring_actions(pe_resource_t *rsc)
+pcmk__create_recurring_actions(pcmk_resource_t *rsc)
 {
     pe_action_t *start = NULL;
 
@@ -621,8 +621,8 @@ pcmk__create_recurring_actions(pe_resource_t *rsc)
  * \return Created op
  */
 pe_action_t *
-pcmk__new_cancel_action(pe_resource_t *rsc, const char *task, guint interval_ms,
-                        const pcmk_node_t *node)
+pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *task,
+                        guint interval_ms, const pcmk_node_t *node)
 {
     pe_action_t *cancel_op = NULL;
     char *key = NULL;
@@ -659,9 +659,9 @@ pcmk__new_cancel_action(pe_resource_t *rsc, const char *task, guint interval_ms,
  * \param[in]     reason       Short description of why action is cancelled
  */
 void
-pcmk__schedule_cancel(pe_resource_t *rsc, const char *call_id, const char *task,
-                      guint interval_ms, const pcmk_node_t *node,
-                      const char *reason)
+pcmk__schedule_cancel(pcmk_resource_t *rsc, const char *call_id,
+                      const char *task, guint interval_ms,
+                      const pcmk_node_t *node, const char *reason)
 {
     pe_action_t *cancel = NULL;
 
@@ -690,7 +690,7 @@ pcmk__schedule_cancel(pe_resource_t *rsc, const char *call_id, const char *task,
  * \param[in,out] node         Node where action should be rescheduled
  */
 void
-pcmk__reschedule_recurring(pe_resource_t *rsc, const char *task,
+pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
                            guint interval_ms, pcmk_node_t *node)
 {
     pe_action_t *op = NULL;

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -187,7 +187,7 @@ is_recurring_history(const pe_resource_t *rsc, const xmlNode *xml,
  */
 static bool
 active_recurring_should_be_optional(const pe_resource_t *rsc,
-                                    const pe_node_t *node, const char *key,
+                                    const pcmk_node_t *node, const char *key,
                                     pe_action_t *start)
 {
     GList *possible_matches = NULL;
@@ -241,7 +241,7 @@ active_recurring_should_be_optional(const pe_resource_t *rsc,
  */
 static void
 recurring_op_for_active(pe_resource_t *rsc, pe_action_t *start,
-                        const pe_node_t *node, const struct op_history *op)
+                        const pcmk_node_t *node, const struct op_history *op)
 {
     pe_action_t *mon = NULL;
     bool is_optional = true;
@@ -370,7 +370,7 @@ recurring_op_for_active(pe_resource_t *rsc, pe_action_t *start,
  * \param[in]     interval_ms  Action interval (in milliseconds)
  */
 static void
-cancel_if_running(pe_resource_t *rsc, const pe_node_t *node, const char *key,
+cancel_if_running(pe_resource_t *rsc, const pcmk_node_t *node, const char *key,
                   const char *name, guint interval_ms)
 {
     GList *possible_matches = find_actions_exact(rsc->actions, key, node);
@@ -414,7 +414,7 @@ cancel_if_running(pe_resource_t *rsc, const pe_node_t *node, const char *key,
  * \param[in,out] action  Action to order after probes of \p rsc on \p node
  */
 static void
-order_after_probes(pe_resource_t *rsc, const pe_node_t *node,
+order_after_probes(pe_resource_t *rsc, const pcmk_node_t *node,
                    pe_action_t *action)
 {
     GList *probes = pe__resource_actions(rsc, node, PCMK_ACTION_MONITOR, FALSE);
@@ -435,7 +435,7 @@ order_after_probes(pe_resource_t *rsc, const pe_node_t *node,
  * \param[in,out] action  Action to order after stops of \p rsc on \p node
  */
 static void
-order_after_stops(pe_resource_t *rsc, const pe_node_t *node,
+order_after_stops(pe_resource_t *rsc, const pcmk_node_t *node,
                   pe_action_t *action)
 {
     GList *stop_ops = pe__resource_actions(rsc, node, PCMK_ACTION_STOP, TRUE);
@@ -477,7 +477,7 @@ order_after_stops(pe_resource_t *rsc, const pe_node_t *node,
  * \param[in]     op     Resource history entry
  */
 static void
-recurring_op_for_inactive(pe_resource_t *rsc, const pe_node_t *node,
+recurring_op_for_inactive(pe_resource_t *rsc, const pcmk_node_t *node,
                           const struct op_history *op)
 {
     GList *possible_matches = NULL;
@@ -497,7 +497,7 @@ recurring_op_for_inactive(pe_resource_t *rsc, const pe_node_t *node,
                       "where it should not be running", op->id, rsc->id);
 
     for (GList *iter = rsc->cluster->nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *stop_node = (pe_node_t *) iter->data;
+        pcmk_node_t *stop_node = (pcmk_node_t *) iter->data;
 
         bool is_optional = true;
         pe_action_t *stopped_mon = NULL;
@@ -622,7 +622,7 @@ pcmk__create_recurring_actions(pe_resource_t *rsc)
  */
 pe_action_t *
 pcmk__new_cancel_action(pe_resource_t *rsc, const char *task, guint interval_ms,
-                        const pe_node_t *node)
+                        const pcmk_node_t *node)
 {
     pe_action_t *cancel_op = NULL;
     char *key = NULL;
@@ -660,7 +660,7 @@ pcmk__new_cancel_action(pe_resource_t *rsc, const char *task, guint interval_ms,
  */
 void
 pcmk__schedule_cancel(pe_resource_t *rsc, const char *call_id, const char *task,
-                      guint interval_ms, const pe_node_t *node,
+                      guint interval_ms, const pcmk_node_t *node,
                       const char *reason)
 {
     pe_action_t *cancel = NULL;
@@ -691,7 +691,7 @@ pcmk__schedule_cancel(pe_resource_t *rsc, const char *call_id, const char *task,
  */
 void
 pcmk__reschedule_recurring(pe_resource_t *rsc, const char *task,
-                           guint interval_ms, pe_node_t *node)
+                           guint interval_ms, pcmk_node_t *node)
 {
     pe_action_t *op = NULL;
 

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -188,7 +188,7 @@ is_recurring_history(const pcmk_resource_t *rsc, const xmlNode *xml,
 static bool
 active_recurring_should_be_optional(const pcmk_resource_t *rsc,
                                     const pcmk_node_t *node, const char *key,
-                                    pe_action_t *start)
+                                    pcmk_action_t *start)
 {
     GList *possible_matches = NULL;
 
@@ -215,7 +215,7 @@ active_recurring_should_be_optional(const pcmk_resource_t *rsc,
     for (const GList *iter = possible_matches;
          iter != NULL; iter = iter->next) {
 
-        const pe_action_t *op = (const pe_action_t *) iter->data;
+        const pcmk_action_t *op = (const pcmk_action_t *) iter->data;
 
         if (pcmk_is_set(op->flags, pcmk_action_reschedule)) {
             pe_rsc_trace(rsc,
@@ -240,10 +240,10 @@ active_recurring_should_be_optional(const pcmk_resource_t *rsc,
  * \param[in]     op     Resource history entry
  */
 static void
-recurring_op_for_active(pcmk_resource_t *rsc, pe_action_t *start,
+recurring_op_for_active(pcmk_resource_t *rsc, pcmk_action_t *start,
                         const pcmk_node_t *node, const struct op_history *op)
 {
-    pe_action_t *mon = NULL;
+    pcmk_action_t *mon = NULL;
     bool is_optional = true;
     const bool is_default_role = (op->role == pcmk_role_unknown);
 
@@ -261,9 +261,9 @@ recurring_op_for_active(pcmk_resource_t *rsc, pe_action_t *start,
 
         if (is_optional) { // It's running, so cancel it
             char *after_key = NULL;
-            pe_action_t *cancel_op = pcmk__new_cancel_action(rsc, op->name,
-                                                             op->interval_ms,
-                                                             node);
+            pcmk_action_t *cancel_op = pcmk__new_cancel_action(rsc, op->name,
+                                                               op->interval_ms,
+                                                               node);
 
             switch (rsc->role) {
                 case pcmk_role_unpromoted:
@@ -374,7 +374,7 @@ cancel_if_running(pcmk_resource_t *rsc, const pcmk_node_t *node,
                   const char *key, const char *name, guint interval_ms)
 {
     GList *possible_matches = find_actions_exact(rsc->actions, key, node);
-    pe_action_t *cancel_op = NULL;
+    pcmk_action_t *cancel_op = NULL;
 
     if (possible_matches == NULL) {
         return; // Recurring action isn't running on this node
@@ -415,12 +415,12 @@ cancel_if_running(pcmk_resource_t *rsc, const pcmk_node_t *node,
  */
 static void
 order_after_probes(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                   pe_action_t *action)
+                   pcmk_action_t *action)
 {
     GList *probes = pe__resource_actions(rsc, node, PCMK_ACTION_MONITOR, FALSE);
 
     for (GList *iter = probes; iter != NULL; iter = iter->next) {
-        order_actions((pe_action_t *) iter->data, action,
+        order_actions((pcmk_action_t *) iter->data, action,
                       pcmk__ar_unrunnable_first_blocks);
     }
     g_list_free(probes);
@@ -436,12 +436,12 @@ order_after_probes(pcmk_resource_t *rsc, const pcmk_node_t *node,
  */
 static void
 order_after_stops(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                  pe_action_t *action)
+                  pcmk_action_t *action)
 {
     GList *stop_ops = pe__resource_actions(rsc, node, PCMK_ACTION_STOP, TRUE);
 
     for (GList *iter = stop_ops; iter != NULL; iter = iter->next) {
-        pe_action_t *stop = (pe_action_t *) iter->data;
+        pcmk_action_t *stop = (pcmk_action_t *) iter->data;
 
         if (!pcmk_is_set(stop->flags, pcmk_action_optional)
             && !pcmk_is_set(action->flags, pcmk_action_optional)
@@ -500,7 +500,7 @@ recurring_op_for_inactive(pcmk_resource_t *rsc, const pcmk_node_t *node,
         pcmk_node_t *stop_node = (pcmk_node_t *) iter->data;
 
         bool is_optional = true;
-        pe_action_t *stopped_mon = NULL;
+        pcmk_action_t *stopped_mon = NULL;
 
         // Cancel action on node where resource will be active
         if ((node != NULL)
@@ -560,7 +560,7 @@ recurring_op_for_inactive(pcmk_resource_t *rsc, const pcmk_node_t *node,
 void
 pcmk__create_recurring_actions(pcmk_resource_t *rsc)
 {
-    pe_action_t *start = NULL;
+    pcmk_action_t *start = NULL;
 
     if (pcmk_is_set(rsc->flags, pcmk_rsc_blocked)) {
         pe_rsc_trace(rsc, "Skipping recurring actions for blocked resource %s",
@@ -620,11 +620,11 @@ pcmk__create_recurring_actions(pcmk_resource_t *rsc)
  *
  * \return Created op
  */
-pe_action_t *
+pcmk_action_t *
 pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *task,
                         guint interval_ms, const pcmk_node_t *node)
 {
-    pe_action_t *cancel_op = NULL;
+    pcmk_action_t *cancel_op = NULL;
     char *key = NULL;
     char *interval_ms_s = NULL;
 
@@ -663,7 +663,7 @@ pcmk__schedule_cancel(pcmk_resource_t *rsc, const char *call_id,
                       const char *task, guint interval_ms,
                       const pcmk_node_t *node, const char *reason)
 {
-    pe_action_t *cancel = NULL;
+    pcmk_action_t *cancel = NULL;
 
     CRM_CHECK((rsc != NULL) && (task != NULL)
               && (node != NULL) && (reason != NULL),
@@ -693,7 +693,7 @@ void
 pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
                            guint interval_ms, pcmk_node_t *node)
 {
-    pe_action_t *op = NULL;
+    pcmk_action_t *op = NULL;
 
     trigger_unfencing(rsc, node, "Device parameters changed (reschedule)",
                       NULL, rsc->cluster);
@@ -711,7 +711,7 @@ pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
  * \return true if \p action has a nonzero interval, otherwise false
  */
 bool
-pcmk__action_is_recurring(const pe_action_t *action)
+pcmk__action_is_recurring(const pcmk_action_t *action)
 {
     guint interval_ms = 0;
 

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -59,7 +59,7 @@ state2text(enum remote_connection_state state)
  */
 
 static inline void
-order_start_then_action(pe_resource_t *first_rsc, pe_action_t *then_action,
+order_start_then_action(pcmk_resource_t *first_rsc, pe_action_t *then_action,
                         uint32_t extra)
 {
     if ((first_rsc != NULL) && (then_action != NULL)) {
@@ -73,7 +73,7 @@ order_start_then_action(pe_resource_t *first_rsc, pe_action_t *then_action,
 }
 
 static inline void
-order_action_then_stop(pe_action_t *first_action, pe_resource_t *then_rsc,
+order_action_then_stop(pe_action_t *first_action, pcmk_resource_t *then_rsc,
                        uint32_t extra)
 {
     if ((first_action != NULL) && (then_rsc != NULL)) {
@@ -86,7 +86,7 @@ order_action_then_stop(pe_action_t *first_action, pe_resource_t *then_rsc,
 static enum remote_connection_state
 get_remote_node_state(const pcmk_node_t *node)
 {
-    const pe_resource_t *remote_rsc = NULL;
+    const pcmk_resource_t *remote_rsc = NULL;
     const pcmk_node_t *cluster_node = NULL;
 
     CRM_ASSERT(node != NULL);
@@ -168,7 +168,7 @@ get_remote_node_state(const pcmk_node_t *node)
 static void
 apply_remote_ordering(pe_action_t *action)
 {
-    pe_resource_t *remote_rsc = NULL;
+    pcmk_resource_t *remote_rsc = NULL;
     enum action_tasks task = text2task(action->task);
     enum remote_connection_state state = get_remote_node_state(action->node);
 
@@ -304,8 +304,8 @@ apply_container_ordering(pe_action_t *action)
      * This allows us to be smarter about the type and extent of
      * recovery actions required in various scenarios
      */
-    pe_resource_t *remote_rsc = NULL;
-    pe_resource_t *container = NULL;
+    pcmk_resource_t *remote_rsc = NULL;
+    pcmk_resource_t *container = NULL;
     enum action_tasks task = text2task(action->task);
 
     CRM_ASSERT(action->rsc != NULL);
@@ -406,7 +406,7 @@ pcmk__order_remote_connection_actions(pe_working_set_t *data_set)
 
     for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
         pe_action_t *action = iter->data;
-        pe_resource_t *remote = NULL;
+        pcmk_resource_t *remote = NULL;
 
         // We are only interested in resource actions
         if (action->rsc == NULL) {
@@ -520,7 +520,7 @@ pcmk__is_failed_remote_node(const pcmk_node_t *node)
  *         resource, otherwise false
  */
 bool
-pcmk__rsc_corresponds_to_guest(const pe_resource_t *rsc,
+pcmk__rsc_corresponds_to_guest(const pcmk_resource_t *rsc,
                                const pcmk_node_t *node)
 {
     return (rsc != NULL) && (rsc->fillers != NULL) && (node != NULL)
@@ -652,7 +652,7 @@ pcmk__connection_host_for_action(const pe_action_t *action)
  * \param[in,out] params  Resource parameters evaluated per node
  */
 void
-pcmk__substitute_remote_addr(pe_resource_t *rsc, GHashTable *params)
+pcmk__substitute_remote_addr(pcmk_resource_t *rsc, GHashTable *params)
 {
     const char *remote_addr = g_hash_table_lookup(params,
                                                   XML_RSC_ATTR_REMOTE_RA_ADDR);

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -396,7 +396,7 @@ apply_container_ordering(pcmk_action_t *action)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__order_remote_connection_actions(pe_working_set_t *data_set)
+pcmk__order_remote_connection_actions(pcmk_scheduler_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_have_remote_nodes)) {
         return;

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -59,7 +59,7 @@ state2text(enum remote_connection_state state)
  */
 
 static inline void
-order_start_then_action(pcmk_resource_t *first_rsc, pe_action_t *then_action,
+order_start_then_action(pcmk_resource_t *first_rsc, pcmk_action_t *then_action,
                         uint32_t extra)
 {
     if ((first_rsc != NULL) && (then_action != NULL)) {
@@ -73,7 +73,7 @@ order_start_then_action(pcmk_resource_t *first_rsc, pe_action_t *then_action,
 }
 
 static inline void
-order_action_then_stop(pe_action_t *first_action, pcmk_resource_t *then_rsc,
+order_action_then_stop(pcmk_action_t *first_action, pcmk_resource_t *then_rsc,
                        uint32_t extra)
 {
     if ((first_action != NULL) && (then_rsc != NULL)) {
@@ -166,7 +166,7 @@ get_remote_node_state(const pcmk_node_t *node)
  * \param[in,out] action    An action scheduled on a Pacemaker Remote node
  */
 static void
-apply_remote_ordering(pe_action_t *action)
+apply_remote_ordering(pcmk_action_t *action)
 {
     pcmk_resource_t *remote_rsc = NULL;
     enum action_tasks task = text2task(action->task);
@@ -295,7 +295,7 @@ apply_remote_ordering(pe_action_t *action)
 }
 
 static void
-apply_container_ordering(pe_action_t *action)
+apply_container_ordering(pcmk_action_t *action)
 {
     /* VMs are also classified as containers for these purposes... in
      * that they both involve a 'thing' running on a real or remote
@@ -405,7 +405,7 @@ pcmk__order_remote_connection_actions(pe_working_set_t *data_set)
     crm_trace("Creating remote connection orderings");
 
     for (GList *iter = data_set->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *action = iter->data;
+        pcmk_action_t *action = iter->data;
         pcmk_resource_t *remote = NULL;
 
         // We are only interested in resource actions
@@ -462,7 +462,7 @@ pcmk__order_remote_connection_actions(pe_working_set_t *data_set)
         if (pcmk__str_eq(action->task, PCMK_ACTION_START, pcmk__str_none)) {
             for (GList *item = action->rsc->actions; item != NULL;
                  item = item->next) {
-                pe_action_t *rsc_action = item->data;
+                pcmk_action_t *rsc_action = item->data;
 
                 if (!pe__same_node(rsc_action->node, action->node)
                     && pcmk__str_eq(rsc_action->task, PCMK_ACTION_STOP,
@@ -543,7 +543,7 @@ pcmk__rsc_corresponds_to_guest(const pcmk_resource_t *rsc,
  *         otherwise NULL
  */
 pcmk_node_t *
-pcmk__connection_host_for_action(const pe_action_t *action)
+pcmk__connection_host_for_action(const pcmk_action_t *action)
 {
     pcmk_node_t *began_on = NULL;
     pcmk_node_t *ended_on = NULL;
@@ -680,7 +680,7 @@ pcmk__substitute_remote_addr(pcmk_resource_t *rsc, GHashTable *params)
  * \param[in]     action    Action to check
  */
 void
-pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
+pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pcmk_action_t *action)
 {
     const pcmk_node_t *guest = action->node;
     const pcmk_node_t *host = NULL;

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -84,10 +84,10 @@ order_action_then_stop(pe_action_t *first_action, pe_resource_t *then_rsc,
 }
 
 static enum remote_connection_state
-get_remote_node_state(const pe_node_t *node)
+get_remote_node_state(const pcmk_node_t *node)
 {
     const pe_resource_t *remote_rsc = NULL;
-    const pe_node_t *cluster_node = NULL;
+    const pcmk_node_t *cluster_node = NULL;
 
     CRM_ASSERT(node != NULL);
 
@@ -266,7 +266,7 @@ apply_remote_ordering(pe_action_t *action)
                                         pcmk__ar_first_implies_then);
 
             } else {
-                pe_node_t *cluster_node = pe__current_node(remote_rsc);
+                pcmk_node_t *cluster_node = pe__current_node(remote_rsc);
 
                 if ((task == pcmk_action_monitor) && (state == remote_state_failed)) {
                     /* We would only be here if we do not know the state of the
@@ -503,7 +503,7 @@ pcmk__order_remote_connection_actions(pe_working_set_t *data_set)
  * \return true if \p node is a failed remote node, false otherwise
  */
 bool
-pcmk__is_failed_remote_node(const pe_node_t *node)
+pcmk__is_failed_remote_node(const pcmk_node_t *node)
 {
     return pe__is_remote_node(node) && (node->details->remote_rsc != NULL)
            && (get_remote_node_state(node) == remote_state_failed);
@@ -520,7 +520,8 @@ pcmk__is_failed_remote_node(const pe_node_t *node)
  *         resource, otherwise false
  */
 bool
-pcmk__rsc_corresponds_to_guest(const pe_resource_t *rsc, const pe_node_t *node)
+pcmk__rsc_corresponds_to_guest(const pe_resource_t *rsc,
+                               const pcmk_node_t *node)
 {
     return (rsc != NULL) && (rsc->fillers != NULL) && (node != NULL)
             && (node->details->remote_rsc != NULL)
@@ -541,11 +542,11 @@ pcmk__rsc_corresponds_to_guest(const pe_resource_t *rsc, const pe_node_t *node)
  * \return Connection host that action should be routed through if remote,
  *         otherwise NULL
  */
-pe_node_t *
+pcmk_node_t *
 pcmk__connection_host_for_action(const pe_action_t *action)
 {
-    pe_node_t *began_on = NULL;
-    pe_node_t *ended_on = NULL;
+    pcmk_node_t *began_on = NULL;
+    pcmk_node_t *ended_on = NULL;
     bool partial_migration = false;
     const char *task = action->task;
 
@@ -681,8 +682,8 @@ pcmk__substitute_remote_addr(pe_resource_t *rsc, GHashTable *params)
 void
 pcmk__add_bundle_meta_to_xml(xmlNode *args_xml, const pe_action_t *action)
 {
-    const pe_node_t *guest = action->node;
-    const pe_node_t *host = NULL;
+    const pcmk_node_t *guest = action->node;
+    const pcmk_node_t *host = NULL;
     enum action_tasks task;
 
     if (!pe__is_guest_node(guest)) {

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -108,7 +108,7 @@ static resource_alloc_functions_t assignment_methods[] = {
  * \return true if agent for \p rsc changed, otherwise false
  */
 bool
-pcmk__rsc_agent_changed(pe_resource_t *rsc, pe_node_t *node,
+pcmk__rsc_agent_changed(pe_resource_t *rsc, pcmk_node_t *node,
                         const xmlNode *rsc_entry, bool active_on_node)
 {
     bool changed = false;
@@ -314,8 +314,8 @@ pcmk__noop_add_graph_meta(const pe_resource_t *rsc, xmlNode *xml)
 void
 pcmk__output_resource_actions(pe_resource_t *rsc)
 {
-    pe_node_t *next = NULL;
-    pe_node_t *current = NULL;
+    pcmk_node_t *next = NULL;
+    pcmk_node_t *current = NULL;
     pcmk__output_t *out = NULL;
 
     CRM_ASSERT(rsc != NULL);
@@ -357,7 +357,7 @@ pcmk__output_resource_actions(pe_resource_t *rsc)
  * \param[in]     rsc   Resource to add
  */
 static inline void
-add_assigned_resource(pe_node_t *node, pe_resource_t *rsc)
+add_assigned_resource(pcmk_node_t *node, pe_resource_t *rsc)
 {
     node->details->allocated_rsc = g_list_prepend(node->details->allocated_rsc,
                                                   rsc);
@@ -399,7 +399,7 @@ add_assigned_resource(pe_node_t *node, pe_resource_t *rsc)
  *       roles or actions.
  */
 bool
-pcmk__assign_resource(pe_resource_t *rsc, pe_node_t *node, bool force,
+pcmk__assign_resource(pe_resource_t *rsc, pcmk_node_t *node, bool force,
                       bool stop_if_fail)
 {
     bool changed = false;
@@ -522,7 +522,7 @@ pcmk__assign_resource(pe_resource_t *rsc, pe_node_t *node, bool force,
 void
 pcmk__unassign_resource(pe_resource_t *rsc)
 {
-    pe_node_t *old = rsc->allocated_to;
+    pcmk_node_t *old = rsc->allocated_to;
 
     if (old == NULL) {
         crm_info("Unassigning %s", rsc->id);
@@ -538,7 +538,7 @@ pcmk__unassign_resource(pe_resource_t *rsc)
         }
         rsc->allocated_to = NULL;
 
-        /* We're going to free the pe_node_t, but its details member is shared
+        /* We're going to free the pcmk_node_t, but its details member is shared
          * and will remain, so update that appropriately first.
          */
         old->details->allocated_rsc = g_list_remove(old->details->allocated_rsc,
@@ -566,7 +566,7 @@ pcmk__unassign_resource(pe_resource_t *rsc)
  * \return true if the migration threshold has been reached, false otherwise
  */
 bool
-pcmk__threshold_reached(pe_resource_t *rsc, const pe_node_t *node,
+pcmk__threshold_reached(pe_resource_t *rsc, const pcmk_node_t *node,
                         pe_resource_t **failed)
 {
     int fail_count, remaining_tries;
@@ -626,9 +626,9 @@ pcmk__threshold_reached(pe_resource_t *rsc, const pe_node_t *node,
  * \return Node's score, or -INFINITY if not found
  */
 static int
-get_node_score(const pe_node_t *node, GHashTable *nodes)
+get_node_score(const pcmk_node_t *node, GHashTable *nodes)
 {
-    pe_node_t *found_node = NULL;
+    pcmk_node_t *found_node = NULL;
 
     if ((node != NULL) && (nodes != NULL)) {
         found_node = g_hash_table_lookup(nodes, node->details->id);
@@ -661,8 +661,8 @@ cmp_resources(gconstpointer a, gconstpointer b, gpointer data)
     int rc = 0;
     int r1_score = -INFINITY;
     int r2_score = -INFINITY;
-    pe_node_t *r1_node = NULL;
-    pe_node_t *r2_node = NULL;
+    pcmk_node_t *r1_node = NULL;
+    pcmk_node_t *r2_node = NULL;
     GHashTable *r1_nodes = NULL;
     GHashTable *r2_nodes = NULL;
     const char *reason = NULL;
@@ -720,7 +720,7 @@ cmp_resources(gconstpointer a, gconstpointer b, gpointer data)
     // Otherwise a higher score on any node will do
     reason = "score";
     for (const GList *iter = nodes; iter != NULL; iter = iter->next) {
-        const pe_node_t *node = (const pe_node_t *) iter->data;
+        const pcmk_node_t *node = (const pcmk_node_t *) iter->data;
 
         r1_score = get_node_score(node, r1_nodes);
         r2_score = get_node_score(node, r2_nodes);

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -180,7 +180,7 @@ add_rsc_if_matching(GList *result, pcmk_resource_t *rsc, const char *id)
  *       g_list_free().
  */
 GList *
-pcmk__rscs_matching_id(const char *id, const pe_working_set_t *data_set)
+pcmk__rscs_matching_id(const char *id, const pcmk_scheduler_t *data_set)
 {
     GList *result = NULL;
 
@@ -215,7 +215,7 @@ set_assignment_methods_for_rsc(gpointer data, gpointer user_data)
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__set_assignment_methods(pe_working_set_t *data_set)
+pcmk__set_assignment_methods(pcmk_scheduler_t *data_set)
 {
     g_list_foreach(data_set->resources, set_assignment_methods_for_rsc, NULL);
 }
@@ -762,7 +762,7 @@ done:
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__sort_resources(pe_working_set_t *data_set)
+pcmk__sort_resources(pcmk_scheduler_t *data_set)
 {
     GList *nodes = g_list_copy(data_set->nodes);
 

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -458,7 +458,7 @@ pcmk__assign_resource(pcmk_resource_t *rsc, pcmk_node_t *node, bool force,
         pe__set_next_role(rsc, pcmk_role_stopped, "unable to assign");
 
         for (GList *iter = rsc->actions; iter != NULL; iter = iter->next) {
-            pe_action_t *op = (pe_action_t *) iter->data;
+            pcmk_action_t *op = (pcmk_action_t *) iter->data;
 
             pe_rsc_debug(rsc, "Updating %s for %s assignment failure",
                          op->uuid, rsc->id);

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -28,7 +28,7 @@ enum loss_ticket_policy {
 
 typedef struct {
     const char *id;
-    pe_resource_t *rsc;
+    pcmk_resource_t *rsc;
     pe_ticket_t *ticket;
     enum loss_ticket_policy loss_policy;
     int role;
@@ -44,7 +44,7 @@ typedef struct {
  *            constraint's, otherwise false
  */
 static bool
-ticket_role_matches(const pe_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
+ticket_role_matches(const pcmk_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
 {
     if ((rsc_ticket->role == pcmk_role_unknown)
         || (rsc_ticket->role == rsc->role)) {
@@ -62,7 +62,7 @@ ticket_role_matches(const pe_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
  * \param[in]     rsc_ticket  Ticket
  */
 static void
-constraints_for_ticket(pe_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
+constraints_for_ticket(pcmk_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
 {
     GList *iter = NULL;
 
@@ -75,7 +75,7 @@ constraints_for_ticket(pe_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
     if (rsc->children) {
         pe_rsc_trace(rsc, "Processing ticket dependencies from %s", rsc->id);
         for (iter = rsc->children; iter != NULL; iter = iter->next) {
-            constraints_for_ticket((pe_resource_t *) iter->data, rsc_ticket);
+            constraints_for_ticket((pcmk_resource_t *) iter->data, rsc_ticket);
         }
         return;
     }
@@ -144,7 +144,7 @@ constraints_for_ticket(pe_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
 }
 
 static void
-rsc_ticket_new(const char *id, pe_resource_t *rsc, pe_ticket_t *ticket,
+rsc_ticket_new(const char *id, pcmk_resource_t *rsc, pe_ticket_t *ticket,
                const char *state, const char *loss_policy)
 {
     rsc_ticket_t *new_rsc_ticket = NULL;
@@ -255,7 +255,7 @@ unpack_rsc_ticket_set(xmlNode *set, pe_ticket_t *ticket,
     for (xmlNode *xml_rsc = first_named_child(set, XML_TAG_RESOURCE_REF);
          xml_rsc != NULL; xml_rsc = crm_next_same_xml(xml_rsc)) {
 
-        pe_resource_t *resource = NULL;
+        pcmk_resource_t *resource = NULL;
 
         resource = pcmk__find_constraint_resource(data_set->resources,
                                                   ID(xml_rsc));
@@ -290,7 +290,7 @@ unpack_simple_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set)
     const char *instance = crm_element_value(xml_obj,
                                              XML_COLOC_ATTR_SOURCE_INSTANCE);
 
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
 
     if (instance != NULL) {
         pe_warn_once(pcmk__wo_coloc_inst,
@@ -362,7 +362,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     const char *rsc_id = NULL;
     const char *state = NULL;
 
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     pe_tag_t *tag = NULL;
 
     xmlNode *rsc_set = NULL;
@@ -517,7 +517,7 @@ pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set)
  * \param[in,out] rsc  Resource to check
  */
 void
-pcmk__require_promotion_tickets(pe_resource_t *rsc)
+pcmk__require_promotion_tickets(pcmk_resource_t *rsc)
 {
     for (GList *item = rsc->rsc_tickets; item != NULL; item = item->next) {
         rsc_ticket_t *rsc_ticket = (rsc_ticket_t *) item->data;

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -109,7 +109,7 @@ constraints_for_ticket(pe_resource_t *rsc, const rsc_ticket_t *rsc_ticket)
                                   rsc->cluster);
 
                 for (iter = rsc->running_on; iter != NULL; iter = iter->next) {
-                    pe_fence_node(rsc->cluster, (pe_node_t *) iter->data,
+                    pe_fence_node(rsc->cluster, (pcmk_node_t *) iter->data,
                                   "deadman ticket was lost", FALSE);
                 }
                 break;

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -235,7 +235,7 @@ rsc_ticket_new(const char *id, pcmk_resource_t *rsc, pe_ticket_t *ticket,
 // \return Standard Pacemaker return code
 static int
 unpack_rsc_ticket_set(xmlNode *set, pe_ticket_t *ticket,
-                      const char *loss_policy, pe_working_set_t *data_set)
+                      const char *loss_policy, pcmk_scheduler_t *data_set)
 {
     const char *set_id = NULL;
     const char *role = NULL;
@@ -273,7 +273,7 @@ unpack_rsc_ticket_set(xmlNode *set, pe_ticket_t *ticket,
 }
 
 static void
-unpack_simple_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set)
+unpack_simple_rsc_ticket(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     const char *id = NULL;
     const char *ticket_str = crm_element_value(xml_obj, XML_TICKET_ATTR_TICKET);
@@ -356,7 +356,7 @@ unpack_simple_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set)
 // \return Standard Pacemaker return code
 static int
 unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
-                       pe_working_set_t *data_set)
+                       pcmk_scheduler_t *data_set)
 {
     const char *id = NULL;
     const char *rsc_id = NULL;
@@ -428,7 +428,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 }
 
 void
-pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pe_working_set_t *data_set)
+pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     xmlNode *set = NULL;
     bool any_sets = false;

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -452,7 +452,7 @@ pcmk__create_utilization_constraints(pcmk_resource_t *rsc,
  * \param[in,out] data_set  Cluster working set
  */
 void
-pcmk__show_node_capacities(const char *desc, pe_working_set_t *data_set)
+pcmk__show_node_capacities(const char *desc, pcmk_scheduler_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_show_utilization)) {
         return;

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -391,12 +391,12 @@ pcmk__ban_insufficient_capacity(pcmk_resource_t *rsc)
  *
  * \return Newly created load_stopped op
  */
-static pe_action_t *
+static pcmk_action_t *
 new_load_stopped_op(pcmk_node_t *node)
 {
     char *load_stopped_task = crm_strdup_printf(PCMK_ACTION_LOAD_STOPPED "_%s",
                                                 node->details->uname);
-    pe_action_t *load_stopped = get_pseudo_op(load_stopped_task,
+    pcmk_action_t *load_stopped = get_pseudo_op(load_stopped_task,
                                               node->details->data_set);
 
     if (load_stopped->node == NULL) {
@@ -419,7 +419,7 @@ pcmk__create_utilization_constraints(pcmk_resource_t *rsc,
                                      const GList *allowed_nodes)
 {
     const GList *iter = NULL;
-    pe_action_t *load_stopped = NULL;
+    pcmk_action_t *load_stopped = NULL;
 
     pe_rsc_trace(rsc, "Creating utilization constraints for %s - strategy: %s",
                  rsc->id, rsc->cluster->placement_strategy);

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -165,7 +165,7 @@ update_utilization_value(gpointer key, gpointer value, gpointer user_data)
  */
 void
 pcmk__consume_node_capacity(GHashTable *current_utilization,
-                            const pe_resource_t *rsc)
+                            const pcmk_resource_t *rsc)
 {
     struct calculate_data data = {
         .current_utilization = current_utilization,
@@ -184,7 +184,7 @@ pcmk__consume_node_capacity(GHashTable *current_utilization,
  */
 void
 pcmk__release_node_capacity(GHashTable *current_utilization,
-                            const pe_resource_t *rsc)
+                            const pcmk_resource_t *rsc)
 {
     struct calculate_data data = {
         .current_utilization = current_utilization,
@@ -271,12 +271,12 @@ have_enough_capacity(const pcmk_node_t *node, const char *rsc_id,
  *       g_hash_table_destroy().
  */
 static GHashTable *
-sum_resource_utilization(const pe_resource_t *orig_rsc, GList *rscs)
+sum_resource_utilization(const pcmk_resource_t *orig_rsc, GList *rscs)
 {
     GHashTable *utilization = pcmk__strkey_table(free, free);
 
     for (GList *iter = rscs; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         rsc->cmds->add_utilization(rsc, orig_rsc, rscs, utilization);
     }
@@ -293,7 +293,7 @@ sum_resource_utilization(const pe_resource_t *orig_rsc, GList *rscs)
  *         nodes with enough capacity for \p rsc and all its colocated resources
  */
 const pcmk_node_t *
-pcmk__ban_insufficient_capacity(pe_resource_t *rsc)
+pcmk__ban_insufficient_capacity(pcmk_resource_t *rsc)
 {
     bool any_capable = false;
     char *rscs_id = NULL;
@@ -415,7 +415,7 @@ new_load_stopped_op(pcmk_node_t *node)
  * \param[in]     allowed_nodes  List of allowed next nodes for \p rsc
  */
 void
-pcmk__create_utilization_constraints(pe_resource_t *rsc,
+pcmk__create_utilization_constraints(pcmk_resource_t *rsc,
                                      const GList *allowed_nodes)
 {
     const GList *iter = NULL;

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -43,8 +43,8 @@ utilization_value(const char *s)
  */
 
 struct compare_data {
-    const pe_node_t *node1;
-    const pe_node_t *node2;
+    const pcmk_node_t *node1;
+    const pcmk_node_t *node2;
     bool node2_only;
     int result;
 };
@@ -99,7 +99,8 @@ compare_utilization_value(gpointer key, gpointer value, gpointer user_data)
  *         if node2 has more free capacity
  */
 int
-pcmk__compare_node_capacities(const pe_node_t *node1, const pe_node_t *node2)
+pcmk__compare_node_capacities(const pcmk_node_t *node1,
+                              const pcmk_node_t *node2)
 {
     struct compare_data data = {
         .node1      = node1,
@@ -199,7 +200,7 @@ pcmk__release_node_capacity(GHashTable *current_utilization,
  */
 
 struct capacity_data {
-    const pe_node_t *node;
+    const pcmk_node_t *node;
     const char *rsc_id;
     bool is_enough;
 };
@@ -245,7 +246,7 @@ check_capacity(gpointer key, gpointer value, gpointer user_data)
  * \return true if node has sufficient capacity for resource, otherwise false
  */
 static bool
-have_enough_capacity(const pe_node_t *node, const char *rsc_id,
+have_enough_capacity(const pcmk_node_t *node, const char *rsc_id,
                      GHashTable *utilization)
 {
     struct capacity_data data = {
@@ -291,13 +292,13 @@ sum_resource_utilization(const pe_resource_t *orig_rsc, GList *rscs)
  * \return Allowed node for \p rsc with most spare capacity, if there are no
  *         nodes with enough capacity for \p rsc and all its colocated resources
  */
-const pe_node_t *
+const pcmk_node_t *
 pcmk__ban_insufficient_capacity(pe_resource_t *rsc)
 {
     bool any_capable = false;
     char *rscs_id = NULL;
-    pe_node_t *node = NULL;
-    const pe_node_t *most_capable_node = NULL;
+    pcmk_node_t *node = NULL;
+    const pcmk_node_t *most_capable_node = NULL;
     GList *colocated_rscs = NULL;
     GHashTable *unassigned_utilization = NULL;
     GHashTableIter iter;
@@ -391,7 +392,7 @@ pcmk__ban_insufficient_capacity(pe_resource_t *rsc)
  * \return Newly created load_stopped op
  */
 static pe_action_t *
-new_load_stopped_op(pe_node_t *node)
+new_load_stopped_op(pcmk_node_t *node)
 {
     char *load_stopped_task = crm_strdup_printf(PCMK_ACTION_LOAD_STOPPED "_%s",
                                                 node->details->uname);
@@ -457,7 +458,7 @@ pcmk__show_node_capacities(const char *desc, pe_working_set_t *data_set)
         return;
     }
     for (const GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-        const pe_node_t *node = (const pe_node_t *) iter->data;
+        const pcmk_node_t *node = (const pcmk_node_t *) iter->data;
         pcmk__output_t *out = data_set->priv;
 
         out->message(out, "node-capacity", node, desc);

--- a/lib/pacemaker/pcmk_scheduler.c
+++ b/lib/pacemaker/pcmk_scheduler.c
@@ -365,7 +365,7 @@ clear_failcounts_if_orphaned(gpointer data, gpointer user_data)
 
     for (GList *iter = rsc->cluster->nodes; iter != NULL; iter = iter->next) {
         pcmk_node_t *node = (pcmk_node_t *) iter->data;
-        pe_action_t *clear_op = NULL;
+        pcmk_action_t *clear_op = NULL;
 
         if (!node->details->online) {
             continue;
@@ -504,7 +504,7 @@ needs_shutdown(const pcmk_node_t *node)
  * \return (Possibly new) head of \p list
  */
 static GList *
-add_nondc_fencing(GList *list, pe_action_t *action,
+add_nondc_fencing(GList *list, pcmk_action_t *action,
                   const pe_working_set_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_concurrent_fencing)
@@ -514,7 +514,7 @@ add_nondc_fencing(GList *list, pe_action_t *action,
          * shutdown, it will be ordered after the last action in the
          * chain later.
          */
-        order_actions((pe_action_t *) list->data, action, pcmk__ar_ordered);
+        order_actions((pcmk_action_t *) list->data, action, pcmk__ar_ordered);
     }
     return g_list_prepend(list, action);
 }
@@ -525,10 +525,10 @@ add_nondc_fencing(GList *list, pe_action_t *action,
  *
  * \param[in,out] node      Node that requires fencing
  */
-static pe_action_t *
+static pcmk_action_t *
 schedule_fencing(pcmk_node_t *node)
 {
-    pe_action_t *fencing = pe_fence_op(node, NULL, FALSE, "node is unclean",
+    pcmk_action_t *fencing = pe_fence_op(node, NULL, FALSE, "node is unclean",
                                        FALSE, node->details->data_set);
 
     pe_warn("Scheduling node %s for fencing", pe__node_name(node));
@@ -545,7 +545,7 @@ schedule_fencing(pcmk_node_t *node)
 static void
 schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
 {
-    pe_action_t *dc_down = NULL;
+    pcmk_action_t *dc_down = NULL;
     bool integrity_lost = false;
     bool have_managed = any_managed_resources(data_set);
     GList *fencing_ops = NULL;
@@ -560,7 +560,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
     // Check each node for whether it needs fencing or shutdown
     for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
         pcmk_node_t *node = (pcmk_node_t *) iter->data;
-        pe_action_t *fencing = NULL;
+        pcmk_action_t *fencing = NULL;
 
         /* Guest nodes are "fenced" by recovering their container resource,
          * so handle them separately.
@@ -584,7 +584,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
             }
 
         } else if (needs_shutdown(node)) {
-            pe_action_t *down_op = pcmk__new_shutdown_action(node);
+            pcmk_action_t *down_op = pcmk__new_shutdown_action(node);
 
             // Track DC and non-DC shutdown actions separately
             if (node->details->is_dc) {
@@ -639,7 +639,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
              * the DC fencing after the last action in the chain (which is the
              * first item in the list).
              */
-            order_actions((pe_action_t *) fencing_ops->data, dc_down,
+            order_actions((pcmk_action_t *) fencing_ops->data, dc_down,
                           pcmk__ar_ordered);
         }
     }
@@ -716,7 +716,7 @@ log_unrunnable_actions(const pe_working_set_t *data_set)
     for (const GList *iter = data_set->actions;
          iter != NULL; iter = iter->next) {
 
-        const pe_action_t *action = (const pe_action_t *) iter->data;
+        const pcmk_action_t *action = (const pcmk_action_t *) iter->data;
 
         if (!pcmk_any_flags_set(action->flags, flags)) {
             pcmk__log_action("\t", action, true);

--- a/lib/pacemaker/pcmk_scheduler.c
+++ b/lib/pacemaker/pcmk_scheduler.c
@@ -229,7 +229,7 @@ apply_stickiness(gpointer data, gpointer user_data)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-apply_shutdown_locks(pe_working_set_t *data_set)
+apply_shutdown_locks(pcmk_scheduler_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_shutdown_lock)) {
         return;
@@ -248,7 +248,7 @@ apply_shutdown_locks(pe_working_set_t *data_set)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-count_available_nodes(pe_working_set_t *data_set)
+count_available_nodes(pcmk_scheduler_t *data_set)
 {
     if (pcmk_is_set(data_set->flags, pcmk_sched_no_compat)) {
         return;
@@ -275,7 +275,7 @@ count_available_nodes(pe_working_set_t *data_set)
  * migration thresholds, and exclusive resource discovery.
  */
 static void
-apply_node_criteria(pe_working_set_t *data_set)
+apply_node_criteria(pcmk_scheduler_t *data_set)
 {
     crm_trace("Applying node-specific scheduling criteria");
     apply_shutdown_locks(data_set);
@@ -300,7 +300,7 @@ apply_node_criteria(pe_working_set_t *data_set)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-assign_resources(pe_working_set_t *data_set)
+assign_resources(pcmk_scheduler_t *data_set)
 {
     GList *iter = NULL;
 
@@ -392,7 +392,7 @@ clear_failcounts_if_orphaned(gpointer data, gpointer user_data)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-schedule_resource_actions(pe_working_set_t *data_set)
+schedule_resource_actions(pcmk_scheduler_t *data_set)
 {
     // Process deferred action checks
     pe__foreach_param_check(data_set, check_params);
@@ -446,7 +446,7 @@ is_managed(const pcmk_resource_t *rsc)
  * \return true if any resource is managed, otherwise false
  */
 static bool
-any_managed_resources(const pe_working_set_t *data_set)
+any_managed_resources(const pcmk_scheduler_t *data_set)
 {
     for (const GList *iter = data_set->resources;
          iter != NULL; iter = iter->next) {
@@ -505,7 +505,7 @@ needs_shutdown(const pcmk_node_t *node)
  */
 static GList *
 add_nondc_fencing(GList *list, pcmk_action_t *action,
-                  const pe_working_set_t *data_set)
+                  const pcmk_scheduler_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_concurrent_fencing)
         && (list != NULL)) {
@@ -543,7 +543,7 @@ schedule_fencing(pcmk_node_t *node)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
+schedule_fencing_and_shutdowns(pcmk_scheduler_t *data_set)
 {
     pcmk_action_t *dc_down = NULL;
     bool integrity_lost = false;
@@ -648,7 +648,7 @@ schedule_fencing_and_shutdowns(pe_working_set_t *data_set)
 }
 
 static void
-log_resource_details(pe_working_set_t *data_set)
+log_resource_details(pcmk_scheduler_t *data_set)
 {
     pcmk__output_t *out = data_set->priv;
     GList *all = NULL;
@@ -673,7 +673,7 @@ log_resource_details(pe_working_set_t *data_set)
 }
 
 static void
-log_all_actions(pe_working_set_t *data_set)
+log_all_actions(pcmk_scheduler_t *data_set)
 {
     /* This only ever outputs to the log, so ignore whatever output object was
      * previously set and just log instead.
@@ -706,7 +706,7 @@ log_all_actions(pe_working_set_t *data_set)
  * \param[in] data_set  Cluster working set
  */
 static void
-log_unrunnable_actions(const pe_working_set_t *data_set)
+log_unrunnable_actions(const pcmk_scheduler_t *data_set)
 {
     const uint64_t flags = pcmk_action_optional
                            |pcmk_action_runnable
@@ -733,7 +733,7 @@ log_unrunnable_actions(const pe_working_set_t *data_set)
  * \param[in,out] data_set  Cluster working set
  */
 static void
-unpack_cib(xmlNode *cib, unsigned long long flags, pe_working_set_t *data_set)
+unpack_cib(xmlNode *cib, unsigned long long flags, pcmk_scheduler_t *data_set)
 {
     const char* localhost_save = NULL;
 
@@ -776,7 +776,7 @@ unpack_cib(xmlNode *cib, unsigned long long flags, pe_working_set_t *data_set)
  */
 void
 pcmk__schedule_actions(xmlNode *cib, unsigned long long flags,
-                       pe_working_set_t *data_set)
+                       pcmk_scheduler_t *data_set)
 {
     unpack_cib(cib, flags, data_set);
     pcmk__set_assignment_methods(data_set);

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -41,7 +41,7 @@ static void set_effective_date(pe_working_set_t *data_set, bool print_original,
  * \note It is the caller's responsibility to free the result.
  */
 static char *
-create_action_name(const pe_action_t *action, bool verbose)
+create_action_name(const pcmk_action_t *action, bool verbose)
 {
     char *action_name = NULL;
     const char *prefix = "";
@@ -231,7 +231,7 @@ write_sim_dotfile(pe_working_set_t *data_set, const char *dot_file,
 
     fprintf(dot_strm, " digraph \"g\" {\n");
     for (iter = data_set->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *action = (pe_action_t *) iter->data;
+        pcmk_action_t *action = (pcmk_action_t *) iter->data;
         const char *style = "dashed";
         const char *font = "black";
         const char *color = "black";
@@ -272,7 +272,7 @@ write_sim_dotfile(pe_working_set_t *data_set, const char *dot_file,
     }
 
     for (iter = data_set->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *action = (pe_action_t *) iter->data;
+        pcmk_action_t *action = (pcmk_action_t *) iter->data;
 
         for (GList *before_iter = action->actions_before;
              before_iter != NULL; before_iter = before_iter->next) {

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -27,7 +27,7 @@ static cib_t *fake_cib = NULL;
 static GList *fake_resource_list = NULL;
 static const GList *fake_op_fail_list = NULL;
 
-static void set_effective_date(pe_working_set_t *data_set, bool print_original,
+static void set_effective_date(pcmk_scheduler_t *data_set, bool print_original,
                                const char *use_date);
 
 /*!
@@ -135,7 +135,7 @@ create_action_name(const pcmk_action_t *action, bool verbose)
  * \param[in]     print_spacer  Whether to display a spacer first
  */
 static void
-print_cluster_status(pe_working_set_t *data_set, uint32_t show_opts,
+print_cluster_status(pcmk_scheduler_t *data_set, uint32_t show_opts,
                      uint32_t section_opts, const char *title,
                      bool print_spacer)
 {
@@ -167,7 +167,7 @@ print_cluster_status(pe_working_set_t *data_set, uint32_t show_opts,
  * \param[in]     print_spacer  Whether to display a spacer first
  */
 static void
-print_transition_summary(pe_working_set_t *data_set, bool print_spacer)
+print_transition_summary(pcmk_scheduler_t *data_set, bool print_spacer)
 {
     pcmk__output_t *out = data_set->priv;
 
@@ -188,7 +188,7 @@ print_transition_summary(pe_working_set_t *data_set, bool print_spacer)
  * \param[in]     flags     Group of enum pcmk_scheduler_flags to set
  */
 static void
-reset(pe_working_set_t *data_set, xmlNodePtr input, pcmk__output_t *out,
+reset(pcmk_scheduler_t *data_set, xmlNodePtr input, pcmk__output_t *out,
       const char *use_date, unsigned int flags)
 {
     data_set->input = input;
@@ -219,7 +219,7 @@ reset(pe_working_set_t *data_set, xmlNodePtr input, pcmk__output_t *out,
  * \return Standard Pacemaker return code
  */
 static int
-write_sim_dotfile(pe_working_set_t *data_set, const char *dot_file,
+write_sim_dotfile(pcmk_scheduler_t *data_set, const char *dot_file,
                   bool all_actions, bool verbose)
 {
     GList *iter = NULL;
@@ -326,7 +326,7 @@ write_sim_dotfile(pe_working_set_t *data_set, const char *dot_file,
  * \param[in]     use_date  The date to set the cluster's time to (may be NULL)
  */
 static void
-profile_file(const char *xml_file, long long repeat, pe_working_set_t *data_set,
+profile_file(const char *xml_file, long long repeat, pcmk_scheduler_t *data_set,
              const char *use_date)
 {
     pcmk__output_t *out = data_set->priv;
@@ -375,7 +375,7 @@ profile_file(const char *xml_file, long long repeat, pe_working_set_t *data_set,
 }
 
 void
-pcmk__profile_dir(const char *dir, long long repeat, pe_working_set_t *data_set,
+pcmk__profile_dir(const char *dir, long long repeat, pcmk_scheduler_t *data_set,
                   const char *use_date)
 {
     pcmk__output_t *out = data_set->priv;
@@ -428,7 +428,7 @@ pcmk__profile_dir(const char *dir, long long repeat, pe_working_set_t *data_set,
  *                                (may be NULL)
  */
 static void
-set_effective_date(pe_working_set_t *data_set, bool print_original,
+set_effective_date(pcmk_scheduler_t *data_set, bool print_original,
                    const char *use_date)
 {
     pcmk__output_t *out = data_set->priv;
@@ -730,7 +730,7 @@ simulate_fencing_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 }
 
 enum pcmk__graph_status
-pcmk__simulate_transition(pe_working_set_t *data_set, cib_t *cib,
+pcmk__simulate_transition(pcmk_scheduler_t *data_set, cib_t *cib,
                           const GList *op_fail_list)
 {
     pcmk__graph_t *transition = NULL;
@@ -785,7 +785,7 @@ pcmk__simulate_transition(pe_working_set_t *data_set, cib_t *cib,
 }
 
 int
-pcmk__simulate(pe_working_set_t *data_set, pcmk__output_t *out,
+pcmk__simulate(pcmk_scheduler_t *data_set, pcmk__output_t *out,
                const pcmk_injections_t *injections, unsigned int flags,
                uint32_t section_opts, const char *use_date,
                const char *input_file, const char *graph_file,
@@ -982,7 +982,7 @@ simulate_done:
 }
 
 int
-pcmk_simulate(xmlNodePtr *xml, pe_working_set_t *data_set,
+pcmk_simulate(xmlNodePtr *xml, pcmk_scheduler_t *data_set,
               const pcmk_injections_t *injections, unsigned int flags,
               unsigned int section_opts, const char *use_date,
               const char *input_file, const char *graph_file,

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -80,7 +80,7 @@ pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith, cib_t *cib,
     xmlNode *cib_copy = copy_xml(current_cib);
     stonith_history_t *stonith_history = NULL;
     int history_rc = 0;
-    pe_working_set_t *data_set = NULL;
+    pcmk_scheduler_t *data_set = NULL;
     GList *unames = NULL;
     GList *resources = NULL;
 
@@ -303,7 +303,7 @@ done:
  */
 int
 pcmk__output_simple_status(pcmk__output_t *out,
-                           const pe_working_set_t *data_set)
+                           const pcmk_scheduler_t *data_set)
 {
     int nodes_online = 0;
     int nodes_standby = 0;

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -319,7 +319,7 @@ pcmk__output_simple_status(pcmk__output_t *out,
     }
 
     for (GList *iter = data_set->nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk_node_t *node = (pcmk_node_t *) iter->data;
 
         if (node->details->standby && node->details->online) {
             nodes_standby++;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -935,7 +935,7 @@ pe__bundle_needs_remote_name(pcmk_resource_t *rsc)
 }
 
 const char *
-pe__add_bundle_remote_name(pcmk_resource_t *rsc, pe_working_set_t *data_set,
+pe__add_bundle_remote_name(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set,
                            xmlNode *xml, const char *field)
 {
     // REMOTE_CONTAINER_HACK: Allow remote nodes that start containers with pacemaker remote inside
@@ -981,7 +981,7 @@ pe__add_bundle_remote_name(pcmk_resource_t *rsc, pe_working_set_t *data_set,
     } while (0)
 
 gboolean
-pe__unpack_bundle(pcmk_resource_t *rsc, pe_working_set_t *data_set)
+pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     const char *value = NULL;
     xmlNode *xml_obj = NULL;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -158,7 +158,8 @@ pe__get_rsc_in_container(const pe_resource_t *instance)
  * \return true if \p node is an instance of \p bundle, otherwise false
  */
 bool
-pe__node_is_bundle_instance(const pe_resource_t *bundle, const pe_node_t *node)
+pe__node_is_bundle_instance(const pe_resource_t *bundle,
+                            const pcmk_node_t *node)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
 
@@ -667,8 +668,8 @@ disallow_node(pe_resource_t *rsc, const char *uname)
     gpointer match = g_hash_table_lookup(rsc->allowed_nodes, uname);
 
     if (match) {
-        ((pe_node_t *) match)->weight = -INFINITY;
-        ((pe_node_t *) match)->rsc_discover_mode = pcmk_probe_never;
+        ((pcmk_node_t *) match)->weight = -INFINITY;
+        ((pcmk_node_t *) match)->rsc_discover_mode = pcmk_probe_never;
     }
     if (rsc->children) {
         g_list_foreach(rsc->children, (GFunc) disallow_node, (gpointer) uname);
@@ -681,7 +682,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 {
     if (replica->child && valid_network(data)) {
         GHashTableIter gIter;
-        pe_node_t *node = NULL;
+        pcmk_node_t *node = NULL;
         xmlNode *xml_remote = NULL;
         char *id = crm_strdup_printf("%s-%d", data->prefix, replica->offset);
         char *port_s = NULL;
@@ -741,9 +742,9 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
         node->rsc_discover_mode = pcmk_probe_never;
 
         /* unpack_remote_nodes() ensures that each remote node and guest node
-         * has a pe_node_t entry. Ideally, it would do the same for bundle nodes.
-         * Unfortunately, a bundle has to be mostly unpacked before it's obvious
-         * what nodes will be needed, so we do it just above.
+         * has a pcmk_node_t entry. Ideally, it would do the same for bundle
+         * nodes. Unfortunately, a bundle has to be mostly unpacked before it's
+         * obvious what nodes will be needed, so we do it just above.
          *
          * Worse, that means that the node may have been utilized while
          * unpacking other resources, without our weight correction. The most
@@ -774,7 +775,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
                             pe__copy_node(replica->node));
 
         {
-            pe_node_t *copy = pe__copy_node(replica->node);
+            pcmk_node_t *copy = pe__copy_node(replica->node);
             copy->weight = -INFINITY;
             g_hash_table_insert(replica->child->parent->allowed_nodes,
                                 (gpointer) replica->node->details->id, copy);
@@ -939,7 +940,7 @@ pe__add_bundle_remote_name(pe_resource_t *rsc, pe_working_set_t *data_set,
 {
     // REMOTE_CONTAINER_HACK: Allow remote nodes that start containers with pacemaker remote inside
 
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
     pe__bundle_replica_t *replica = NULL;
 
     if (!pe__bundle_needs_remote_name(rsc)) {
@@ -1363,7 +1364,7 @@ pe__bundle_active(pe_resource_t *rsc, gboolean all)
  * \return Bundle replica if found, NULL otherwise
  */
 pe_resource_t *
-pe__find_bundle_replica(const pe_resource_t *bundle, const pe_node_t *node)
+pe__find_bundle_replica(const pe_resource_t *bundle, const pcmk_node_t *node)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
     CRM_ASSERT(bundle && node);
@@ -1551,7 +1552,7 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
 static void
 pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replica,
-                               pe_node_t *node, uint32_t show_opts)
+                               pcmk_node_t *node, uint32_t show_opts)
 {
     pe_resource_t *rsc = replica->child;
 
@@ -1705,7 +1706,7 @@ pe__bundle_html(pcmk__output_t *out, va_list args)
 
 static void
 pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replica,
-                               pe_node_t *node, uint32_t show_opts)
+                               pcmk_node_t *node, uint32_t show_opts)
 {
     const pe_resource_t *rsc = replica->child;
 
@@ -1844,7 +1845,7 @@ static void
 print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
                      long options, void *print_data)
 {
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
     pe_resource_t *rsc = replica->child;
 
     int offset = 0;
@@ -2121,12 +2122,12 @@ pe__bundle_containers(const pe_resource_t *bundle)
 }
 
 // Bundle implementation of resource_object_functions_t:active_node()
-pe_node_t *
+pcmk_node_t *
 pe__bundle_active_node(const pe_resource_t *rsc, unsigned int *count_all,
                        unsigned int *count_clean)
 {
-    pe_node_t *active = NULL;
-    pe_node_t *node = NULL;
+    pcmk_node_t *active = NULL;
+    pcmk_node_t *node = NULL;
     pe_resource_t *container = NULL;
     GList *containers = NULL;
     GList *iter = NULL;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -69,7 +69,7 @@ typedef struct pe__bundle_variant_data_s {
         char *launcher_options;
         const char *attribute_target;
 
-        pe_resource_t *child;
+        pcmk_resource_t *child;
 
         GList *replicas;    // pe__bundle_replica_t *
         GList *ports;       // pe__bundle_port_t *
@@ -93,7 +93,7 @@ typedef struct pe__bundle_variant_data_s {
  * \return Maximum replicas for bundle corresponding to \p rsc
  */
 int
-pe__bundle_max(const pe_resource_t *rsc)
+pe__bundle_max(const pcmk_resource_t *rsc)
 {
     const pe__bundle_variant_data_t *bundle_data = NULL;
 
@@ -109,8 +109,8 @@ pe__bundle_max(const pe_resource_t *rsc)
  *
  * \return Resource inside \p bundle if any, otherwise NULL
  */
-pe_resource_t *
-pe__bundled_resource(const pe_resource_t *rsc)
+pcmk_resource_t *
+pe__bundled_resource(const pcmk_resource_t *rsc)
 {
     const pe__bundle_variant_data_t *bundle_data = NULL;
 
@@ -127,11 +127,11 @@ pe__bundled_resource(const pe_resource_t *rsc)
  * \return Bundled resource instance inside \p instance if it is a bundle
  *         container instance, otherwise NULL
  */
-const pe_resource_t *
-pe__get_rsc_in_container(const pe_resource_t *instance)
+const pcmk_resource_t *
+pe__get_rsc_in_container(const pcmk_resource_t *instance)
 {
     const pe__bundle_variant_data_t *data = NULL;
-    const pe_resource_t *top = pe__const_top_resource(instance, true);
+    const pcmk_resource_t *top = pe__const_top_resource(instance, true);
 
     if ((top == NULL) || (top->variant != pcmk_rsc_variant_bundle)) {
         return NULL;
@@ -158,7 +158,7 @@ pe__get_rsc_in_container(const pe_resource_t *instance)
  * \return true if \p node is an instance of \p bundle, otherwise false
  */
 bool
-pe__node_is_bundle_instance(const pe_resource_t *bundle,
+pe__node_is_bundle_instance(const pcmk_resource_t *bundle,
                             const pcmk_node_t *node)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
@@ -183,8 +183,8 @@ pe__node_is_bundle_instance(const pe_resource_t *bundle,
  * \return Container resource from first replica of \p bundle if any,
  *         otherwise NULL
  */
-pe_resource_t *
-pe__first_container(const pe_resource_t *bundle)
+pcmk_resource_t *
+pe__first_container(const pcmk_resource_t *bundle)
 {
     const pe__bundle_variant_data_t *bundle_data = NULL;
     const pe__bundle_replica_t *replica = NULL;
@@ -207,7 +207,7 @@ pe__first_container(const pe_resource_t *bundle)
  * \param[in,out] user_data  Pointer to pass to \p fn
  */
 void
-pe__foreach_bundle_replica(pe_resource_t *bundle,
+pe__foreach_bundle_replica(pcmk_resource_t *bundle,
                            bool (*fn)(pe__bundle_replica_t *, void *),
                            void *user_data)
 {
@@ -231,7 +231,7 @@ pe__foreach_bundle_replica(pe_resource_t *bundle,
  * \param[in,out] user_data  Pointer to pass to \p fn
  */
 void
-pe__foreach_const_bundle_replica(const pe_resource_t *bundle,
+pe__foreach_const_bundle_replica(const pcmk_resource_t *bundle,
                                  bool (*fn)(const pe__bundle_replica_t *,
                                             void *),
                                  void *user_data)
@@ -359,7 +359,7 @@ valid_network(pe__bundle_variant_data_t *data)
 }
 
 static int
-create_ip_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
+create_ip_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
                    pe__bundle_replica_t *replica)
 {
     if(data->ip_range_start) {
@@ -419,7 +419,7 @@ container_agent_str(enum pe__container_agent t)
 }
 
 static int
-create_container_resource(pe_resource_t *parent,
+create_container_resource(pcmk_resource_t *parent,
                           const pe__bundle_variant_data_t *data,
                           pe__bundle_replica_t *replica)
 {
@@ -663,7 +663,7 @@ create_container_resource(pe_resource_t *parent,
  * \param[in]     uname  Name of node to ban
  */
 static void
-disallow_node(pe_resource_t *rsc, const char *uname)
+disallow_node(pcmk_resource_t *rsc, const char *uname)
 {
     gpointer match = g_hash_table_lookup(rsc->allowed_nodes, uname);
 
@@ -677,7 +677,7 @@ disallow_node(pe_resource_t *rsc, const char *uname)
 }
 
 static int
-create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
+create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
                        pe__bundle_replica_t *replica)
 {
     if (replica->child && valid_network(data)) {
@@ -819,7 +819,7 @@ create_remote_resource(pe_resource_t *parent, pe__bundle_variant_data_t *data,
 }
 
 static int
-create_replica_resources(pe_resource_t *parent, pe__bundle_variant_data_t *data,
+create_replica_resources(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
                          pe__bundle_replica_t *replica)
 {
     int rc = pcmk_rc_ok;
@@ -890,9 +890,9 @@ port_free(pe__bundle_port_t *port)
 }
 
 static pe__bundle_replica_t *
-replica_for_remote(pe_resource_t *remote)
+replica_for_remote(pcmk_resource_t *remote)
 {
-    pe_resource_t *top = remote;
+    pcmk_resource_t *top = remote;
     pe__bundle_variant_data_t *bundle_data = NULL;
 
     if (top == NULL) {
@@ -917,7 +917,7 @@ replica_for_remote(pe_resource_t *remote)
 }
 
 bool
-pe__bundle_needs_remote_name(pe_resource_t *rsc)
+pe__bundle_needs_remote_name(pcmk_resource_t *rsc)
 {
     const char *value;
     GHashTable *params = NULL;
@@ -935,7 +935,7 @@ pe__bundle_needs_remote_name(pe_resource_t *rsc)
 }
 
 const char *
-pe__add_bundle_remote_name(pe_resource_t *rsc, pe_working_set_t *data_set,
+pe__add_bundle_remote_name(pcmk_resource_t *rsc, pe_working_set_t *data_set,
                            xmlNode *xml, const char *field)
 {
     // REMOTE_CONTAINER_HACK: Allow remote nodes that start containers with pacemaker remote inside
@@ -981,7 +981,7 @@ pe__add_bundle_remote_name(pe_resource_t *rsc, pe_working_set_t *data_set,
     } while (0)
 
 gboolean
-pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
+pe__unpack_bundle(pcmk_resource_t *rsc, pe_working_set_t *data_set)
 {
     const char *value = NULL;
     xmlNode *xml_obj = NULL;
@@ -1301,7 +1301,7 @@ pe__unpack_bundle(pe_resource_t *rsc, pe_working_set_t *data_set)
 }
 
 static int
-replica_resource_active(pe_resource_t *rsc, gboolean all)
+replica_resource_active(pcmk_resource_t *rsc, gboolean all)
 {
     if (rsc) {
         gboolean child_active = rsc->fns->active(rsc, all);
@@ -1316,7 +1316,7 @@ replica_resource_active(pe_resource_t *rsc, gboolean all)
 }
 
 gboolean
-pe__bundle_active(pe_resource_t *rsc, gboolean all)
+pe__bundle_active(pcmk_resource_t *rsc, gboolean all)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
     GList *iter = NULL;
@@ -1363,8 +1363,8 @@ pe__bundle_active(pe_resource_t *rsc, gboolean all)
  *
  * \return Bundle replica if found, NULL otherwise
  */
-pe_resource_t *
-pe__find_bundle_replica(const pe_resource_t *bundle, const pcmk_node_t *node)
+pcmk_resource_t *
+pe__find_bundle_replica(const pcmk_resource_t *bundle, const pcmk_node_t *node)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
     CRM_ASSERT(bundle && node);
@@ -1387,7 +1387,7 @@ pe__find_bundle_replica(const pe_resource_t *bundle, const pcmk_node_t *node)
  * \deprecated This function will be removed in a future release
  */
 static void
-print_rsc_in_list(pe_resource_t *rsc, const char *pre_text, long options,
+print_rsc_in_list(pcmk_resource_t *rsc, const char *pre_text, long options,
                   void *print_data)
 {
     if (rsc != NULL) {
@@ -1406,7 +1406,7 @@ print_rsc_in_list(pe_resource_t *rsc, const char *pre_text, long options,
  * \deprecated This function will be removed in a future release
  */
 static void
-bundle_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+bundle_print_xml(pcmk_resource_t *rsc, const char *pre_text, long options,
                  void *print_data)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
@@ -1447,12 +1447,13 @@ bundle_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
     free(child_text);
 }
 
-PCMK__OUTPUT_ARGS("bundle", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("bundle", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__bundle_xml(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -1554,7 +1555,7 @@ static void
 pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replica,
                                pcmk_node_t *node, uint32_t show_opts)
 {
-    pe_resource_t *rsc = replica->child;
+    pcmk_resource_t *rsc = replica->child;
 
     int offset = 0;
     char buffer[LINE_MAX];
@@ -1588,7 +1589,7 @@ pe__bundle_replica_output_html(pcmk__output_t *out, pe__bundle_replica_t *replic
  *         otherwise unmanaged, or an empty string otherwise
  */
 static const char *
-get_unmanaged_str(const pe_resource_t *rsc)
+get_unmanaged_str(const pcmk_resource_t *rsc)
 {
     if (pcmk_is_set(rsc->flags, pcmk_rsc_maintenance)) {
         return " (maintenance)";
@@ -1599,12 +1600,13 @@ get_unmanaged_str(const pe_resource_t *rsc)
     return "";
 }
 
-PCMK__OUTPUT_ARGS("bundle", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("bundle", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__bundle_html(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -1708,7 +1710,7 @@ static void
 pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replica,
                                pcmk_node_t *node, uint32_t show_opts)
 {
-    const pe_resource_t *rsc = replica->child;
+    const pcmk_resource_t *rsc = replica->child;
 
     int offset = 0;
     char buffer[LINE_MAX];
@@ -1732,12 +1734,13 @@ pe__bundle_replica_output_text(pcmk__output_t *out, pe__bundle_replica_t *replic
     pe__common_output_text(out, rsc, buffer, node, show_opts);
 }
 
-PCMK__OUTPUT_ARGS("bundle", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("bundle", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__bundle_text(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -1846,7 +1849,7 @@ print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
                      long options, void *print_data)
 {
     pcmk_node_t *node = NULL;
-    pe_resource_t *rsc = replica->child;
+    pcmk_resource_t *rsc = replica->child;
 
     int offset = 0;
     char buffer[LINE_MAX];
@@ -1876,7 +1879,7 @@ print_bundle_replica(pe__bundle_replica_t *replica, const char *pre_text,
  * \deprecated This function will be removed in a future release
  */
 void
-pe__print_bundle(pe_resource_t *rsc, const char *pre_text, long options,
+pe__print_bundle(pcmk_resource_t *rsc, const char *pre_text, long options,
                  void *print_data)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
@@ -1978,7 +1981,7 @@ free_bundle_replica(pe__bundle_replica_t *replica)
 }
 
 void
-pe__free_bundle(pe_resource_t *rsc)
+pe__free_bundle(pcmk_resource_t *rsc)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
     CRM_CHECK(rsc != NULL, return);
@@ -2012,7 +2015,7 @@ pe__free_bundle(pe_resource_t *rsc)
 }
 
 enum rsc_role_e
-pe__bundle_resource_state(const pe_resource_t *rsc, gboolean current)
+pe__bundle_resource_state(const pcmk_resource_t *rsc, gboolean current)
 {
     enum rsc_role_e container_role = pcmk_role_unknown;
     return container_role;
@@ -2026,7 +2029,7 @@ pe__bundle_resource_state(const pe_resource_t *rsc, gboolean current)
  * \return Number of configured replicas, or 0 on error
  */
 int
-pe_bundle_replicas(const pe_resource_t *rsc)
+pe_bundle_replicas(const pcmk_resource_t *rsc)
 {
     if ((rsc == NULL) || (rsc->variant != pcmk_rsc_variant_bundle)) {
         return 0;
@@ -2039,7 +2042,7 @@ pe_bundle_replicas(const pe_resource_t *rsc)
 }
 
 void
-pe__count_bundle(pe_resource_t *rsc)
+pe__count_bundle(pcmk_resource_t *rsc)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
 
@@ -2063,7 +2066,7 @@ pe__count_bundle(pe_resource_t *rsc)
 }
 
 gboolean
-pe__bundle_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+pe__bundle_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                        gboolean check_parent)
 {
     gboolean passes = FALSE;
@@ -2107,7 +2110,7 @@ pe__bundle_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
  *       g_list_free().
  */
 GList *
-pe__bundle_containers(const pe_resource_t *bundle)
+pe__bundle_containers(const pcmk_resource_t *bundle)
 {
     GList *containers = NULL;
     const pe__bundle_variant_data_t *data = NULL;
@@ -2123,12 +2126,12 @@ pe__bundle_containers(const pe_resource_t *bundle)
 
 // Bundle implementation of resource_object_functions_t:active_node()
 pcmk_node_t *
-pe__bundle_active_node(const pe_resource_t *rsc, unsigned int *count_all,
+pe__bundle_active_node(const pcmk_resource_t *rsc, unsigned int *count_all,
                        unsigned int *count_clean)
 {
     pcmk_node_t *active = NULL;
     pcmk_node_t *node = NULL;
-    pe_resource_t *container = NULL;
+    pcmk_resource_t *container = NULL;
     GList *containers = NULL;
     GList *iter = NULL;
     GHashTable *nodes = NULL;
@@ -2206,7 +2209,7 @@ done:
  * \return Maximum number of \p rsc instances that can be active on one node
  */
 unsigned int
-pe__bundle_max_per_node(const pe_resource_t *rsc)
+pe__bundle_max_per_node(const pcmk_resource_t *rsc)
 {
     pe__bundle_variant_data_t *bundle_data = NULL;
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -208,7 +208,7 @@ clone_header(pcmk__output_t *out, int *rc, const pcmk_resource_t *rsc,
 
 void
 pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,
-               pe_working_set_t *data_set)
+               pcmk_scheduler_t *data_set)
 {
     if (pe_rsc_is_clone(rsc)) {
         clone_variant_data_t *clone_data = rsc->variant_opaque;
@@ -242,7 +242,7 @@ find_clone_instance(const pcmk_resource_t *rsc, const char *sub_id)
 }
 
 pcmk_resource_t *
-pe__create_clone_child(pcmk_resource_t *rsc, pe_working_set_t *data_set)
+pe__create_clone_child(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     gboolean as_orphan = FALSE;
     char *inc_num = NULL;
@@ -322,7 +322,7 @@ unpack_meta_int(const pcmk_resource_t *rsc, const char *meta_name,
 }
 
 gboolean
-clone_unpack(pcmk_resource_t * rsc, pe_working_set_t * data_set)
+clone_unpack(pcmk_resource_t * rsc, pcmk_scheduler_t * data_set)
 {
     int lpc = 0;
     xmlNode *a_child = NULL;
@@ -1238,7 +1238,7 @@ clone_resource_state(const pcmk_resource_t * rsc, gboolean current)
  */
 bool
 pe__is_universal_clone(const pcmk_resource_t *rsc,
-                       const pe_working_set_t *data_set)
+                       const pcmk_scheduler_t *data_set)
 {
     if (pe_rsc_is_clone(rsc)) {
         clone_variant_data_t *clone_data = rsc->variant_opaque;

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -1362,8 +1362,8 @@ void
 pe__create_promotable_pseudo_ops(pcmk_resource_t *clone, bool any_promoting,
                                  bool any_demoting)
 {
-    pe_action_t *action = NULL;
-    pe_action_t *action_complete = NULL;
+    pcmk_action_t *action = NULL;
+    pcmk_action_t *action_complete = NULL;
     clone_variant_data_t *clone_data = NULL;
 
     get_clone_variant_data(clone_data, clone);
@@ -1473,8 +1473,8 @@ pe__free_clone_notification_data(pcmk_resource_t *clone)
  */
 void
 pe__create_clone_notif_pseudo_ops(pcmk_resource_t *clone,
-                                  pe_action_t *start, pe_action_t *started,
-                                  pe_action_t *stop, pe_action_t *stopped)
+                                  pcmk_action_t *start, pcmk_action_t *started,
+                                  pcmk_action_t *stop, pcmk_action_t *stopped)
 {
     clone_variant_data_t *clone_data = NULL;
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -60,7 +60,7 @@ typedef struct clone_variant_data_s {
  * \return Maximum instances for \p clone
  */
 int
-pe__clone_max(const pe_resource_t *clone)
+pe__clone_max(const pcmk_resource_t *clone)
 {
     const clone_variant_data_t *clone_data = NULL;
 
@@ -77,7 +77,7 @@ pe__clone_max(const pe_resource_t *clone)
  * \return Maximum allowed instances per node for \p clone
  */
 int
-pe__clone_node_max(const pe_resource_t *clone)
+pe__clone_node_max(const pcmk_resource_t *clone)
 {
     const clone_variant_data_t *clone_data = NULL;
 
@@ -94,7 +94,7 @@ pe__clone_node_max(const pe_resource_t *clone)
  * \return Maximum promoted instances for \p clone
  */
 int
-pe__clone_promoted_max(const pe_resource_t *clone)
+pe__clone_promoted_max(const pcmk_resource_t *clone)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -111,7 +111,7 @@ pe__clone_promoted_max(const pe_resource_t *clone)
  * \return Maximum promoted instances for \p clone
  */
 int
-pe__clone_promoted_node_max(const pe_resource_t *clone)
+pe__clone_promoted_node_max(const pcmk_resource_t *clone)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -168,7 +168,7 @@ node_list_to_str(const GList *list)
 }
 
 static void
-clone_header(pcmk__output_t *out, int *rc, const pe_resource_t *rsc,
+clone_header(pcmk__output_t *out, int *rc, const pcmk_resource_t *rsc,
              clone_variant_data_t *clone_data, const char *desc)
 {
     GString *attrs = NULL;
@@ -207,7 +207,7 @@ clone_header(pcmk__output_t *out, int *rc, const pe_resource_t *rsc,
 }
 
 void
-pe__force_anon(const char *standard, pe_resource_t *rsc, const char *rid,
+pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,
                pe_working_set_t *data_set)
 {
     if (pe_rsc_is_clone(rsc)) {
@@ -223,11 +223,11 @@ pe__force_anon(const char *standard, pe_resource_t *rsc, const char *rid,
     }
 }
 
-pe_resource_t *
-find_clone_instance(const pe_resource_t *rsc, const char *sub_id)
+pcmk_resource_t *
+find_clone_instance(const pcmk_resource_t *rsc, const char *sub_id)
 {
     char *child_id = NULL;
-    pe_resource_t *child = NULL;
+    pcmk_resource_t *child = NULL;
     const char *child_base = NULL;
     clone_variant_data_t *clone_data = NULL;
 
@@ -241,13 +241,13 @@ find_clone_instance(const pe_resource_t *rsc, const char *sub_id)
     return child;
 }
 
-pe_resource_t *
-pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
+pcmk_resource_t *
+pe__create_clone_child(pcmk_resource_t *rsc, pe_working_set_t *data_set)
 {
     gboolean as_orphan = FALSE;
     char *inc_num = NULL;
     char *inc_max = NULL;
-    pe_resource_t *child_rsc = NULL;
+    pcmk_resource_t *child_rsc = NULL;
     xmlNode *child_copy = NULL;
     clone_variant_data_t *clone_data = NULL;
 
@@ -306,7 +306,7 @@ pe__create_clone_child(pe_resource_t *rsc, pe_working_set_t *data_set)
  *         nonnegative integer, \p default_value if unset, or 0 if invalid
  */
 static int
-unpack_meta_int(const pe_resource_t *rsc, const char *meta_name,
+unpack_meta_int(const pcmk_resource_t *rsc, const char *meta_name,
                 const char *deprecated_name, int default_value)
 {
     int integer = default_value;
@@ -322,7 +322,7 @@ unpack_meta_int(const pe_resource_t *rsc, const char *meta_name,
 }
 
 gboolean
-clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
+clone_unpack(pcmk_resource_t * rsc, pe_working_set_t * data_set)
 {
     int lpc = 0;
     xmlNode *a_child = NULL;
@@ -439,12 +439,12 @@ clone_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 gboolean
-clone_active(pe_resource_t * rsc, gboolean all)
+clone_active(pcmk_resource_t * rsc, gboolean all)
 {
     GList *gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
         gboolean child_active = child_rsc->fns->active(child_rsc, all);
 
         if (all == FALSE && child_active) {
@@ -492,20 +492,22 @@ short_print(const char *list, const char *prefix, const char *type,
 }
 
 static const char *
-configured_role_str(pe_resource_t * rsc)
+configured_role_str(pcmk_resource_t * rsc)
 {
     const char *target_role = g_hash_table_lookup(rsc->meta,
                                                   XML_RSC_ATTR_TARGET_ROLE);
 
     if ((target_role == NULL) && rsc->children && rsc->children->data) {
-        target_role = g_hash_table_lookup(((pe_resource_t*)rsc->children->data)->meta,
+        pcmk_resource_t *instance = rsc->children->data; // Any instance will do
+
+        target_role = g_hash_table_lookup(instance->meta,
                                           XML_RSC_ATTR_TARGET_ROLE);
     }
     return target_role;
 }
 
 static enum rsc_role_e
-configured_role(pe_resource_t * rsc)
+configured_role(pcmk_resource_t *rsc)
 {
     const char *target_role = configured_role_str(rsc);
 
@@ -520,7 +522,7 @@ configured_role(pe_resource_t * rsc)
  * \deprecated This function will be removed in a future release
  */
 static void
-clone_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+clone_print_xml(pcmk_resource_t *rsc, const char *pre_text, long options,
                 void *print_data)
 {
     char *child_text = crm_strdup_printf("%s    ", pre_text);
@@ -543,7 +545,7 @@ clone_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
     status_print(">\n");
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         child_rsc->fns->print(child_rsc, child_text, options, print_data);
     }
@@ -553,7 +555,7 @@ clone_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
 }
 
 bool
-is_set_recursive(const pe_resource_t *rsc, long long flag, bool any)
+is_set_recursive(const pcmk_resource_t *rsc, long long flag, bool any)
 {
     GList *gIter;
     bool all = !any;
@@ -588,7 +590,7 @@ is_set_recursive(const pe_resource_t *rsc, long long flag, bool any)
  * \deprecated This function will be removed in a future release
  */
 void
-clone_print(pe_resource_t *rsc, const char *pre_text, long options,
+clone_print(pcmk_resource_t *rsc, const char *pre_text, long options,
             void *print_data)
 {
     GString *list_text = NULL;
@@ -630,7 +632,7 @@ clone_print(pe_resource_t *rsc, const char *pre_text, long options,
 
     for (; gIter != NULL; gIter = gIter->next) {
         gboolean print_full = FALSE;
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
         gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
 
         if (options & pe_print_clone_details) {
@@ -812,12 +814,13 @@ clone_print(pe_resource_t *rsc, const char *pre_text, long options,
     free(child_text);
 }
 
-PCMK__OUTPUT_ARGS("clone", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("clone", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__clone_xml(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -841,7 +844,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     all = g_list_prepend(all, (gpointer) "*");
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         if (pcmk__rsc_filtered_by_node(child_rsc, only_node)) {
             continue;
@@ -884,12 +887,13 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("clone", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("clone", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__clone_default(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -921,7 +925,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
 
     for (; gIter != NULL; gIter = gIter->next) {
         gboolean print_full = FALSE;
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
         gboolean partially_active = child_rsc->fns->active(child_rsc, FALSE);
 
         if (pcmk__rsc_filtered_by_node(child_rsc, only_node)) {
@@ -1173,7 +1177,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
 }
 
 void
-clone_free(pe_resource_t * rsc)
+clone_free(pcmk_resource_t * rsc)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -1182,7 +1186,7 @@ clone_free(pe_resource_t * rsc)
     pe_rsc_trace(rsc, "Freeing %s", rsc->id);
 
     for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         CRM_ASSERT(child_rsc);
         pe_rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
@@ -1207,13 +1211,13 @@ clone_free(pe_resource_t * rsc)
 }
 
 enum rsc_role_e
-clone_resource_state(const pe_resource_t * rsc, gboolean current)
+clone_resource_state(const pcmk_resource_t * rsc, gboolean current)
 {
     enum rsc_role_e clone_role = pcmk_role_unknown;
     GList *gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
         enum rsc_role_e a_role = child_rsc->fns->state(child_rsc, current);
 
         if (a_role > clone_role) {
@@ -1233,7 +1237,7 @@ clone_resource_state(const pe_resource_t * rsc, gboolean current)
  * \param[in] data_set  Cluster state
  */
 bool
-pe__is_universal_clone(const pe_resource_t *rsc,
+pe__is_universal_clone(const pcmk_resource_t *rsc,
                        const pe_working_set_t *data_set)
 {
     if (pe_rsc_is_clone(rsc)) {
@@ -1247,7 +1251,7 @@ pe__is_universal_clone(const pe_resource_t *rsc,
 }
 
 gboolean
-pe__clone_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+pe__clone_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                       gboolean check_parent)
 {
     gboolean passes = FALSE;
@@ -1263,9 +1267,9 @@ pe__clone_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
             for (const GList *iter = rsc->children;
                  iter != NULL; iter = iter->next) {
 
-                const pe_resource_t *child_rsc = NULL;
+                const pcmk_resource_t *child_rsc = NULL;
 
-                child_rsc = (const pe_resource_t *) iter->data;
+                child_rsc = (const pcmk_resource_t *) iter->data;
                 if (!child_rsc->fns->is_filtered(child_rsc, only_rsc, FALSE)) {
                     passes = TRUE;
                     break;
@@ -1277,7 +1281,7 @@ pe__clone_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
 }
 
 const char *
-pe__clone_child_id(const pe_resource_t *rsc)
+pe__clone_child_id(const pcmk_resource_t *rsc)
 {
     clone_variant_data_t *clone_data = NULL;
     get_clone_variant_data(clone_data, rsc);
@@ -1293,7 +1297,7 @@ pe__clone_child_id(const pe_resource_t *rsc)
  * \return true if clone is ordered, otherwise false
  */
 bool
-pe__clone_is_ordered(const pe_resource_t *clone)
+pe__clone_is_ordered(const pcmk_resource_t *clone)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -1312,7 +1316,7 @@ pe__clone_is_ordered(const pe_resource_t *clone)
  *         already set or pcmk_rc_already if it was)
  */
 int
-pe__set_clone_flag(pe_resource_t *clone, enum pcmk__clone_flags flag)
+pe__set_clone_flag(pcmk_resource_t *clone, enum pcmk__clone_flags flag)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -1336,7 +1340,7 @@ pe__set_clone_flag(pe_resource_t *clone, enum pcmk__clone_flags flag)
  * \return \c true if all \p flags are set for \p clone, otherwise \c false
  */
 bool
-pe__clone_flag_is_set(const pe_resource_t *clone, uint32_t flags)
+pe__clone_flag_is_set(const pcmk_resource_t *clone, uint32_t flags)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -1355,7 +1359,7 @@ pe__clone_flag_is_set(const pe_resource_t *clone, uint32_t flags)
  * \param[in]     any_demoting   Whether any instance will be demoted
  */
 void
-pe__create_promotable_pseudo_ops(pe_resource_t *clone, bool any_promoting,
+pe__create_promotable_pseudo_ops(pcmk_resource_t *clone, bool any_promoting,
                                  bool any_demoting)
 {
     pe_action_t *action = NULL;
@@ -1419,7 +1423,7 @@ pe__create_promotable_pseudo_ops(pe_resource_t *clone, bool any_promoting,
  * \param[in,out] clone  Clone to create notifications for
  */
 void
-pe__create_clone_notifications(pe_resource_t *clone)
+pe__create_clone_notifications(pcmk_resource_t *clone)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -1438,7 +1442,7 @@ pe__create_clone_notifications(pe_resource_t *clone)
  * \param[in,out] clone  Clone to free notification data for
  */
 void
-pe__free_clone_notification_data(pe_resource_t *clone)
+pe__free_clone_notification_data(pcmk_resource_t *clone)
 {
     clone_variant_data_t *clone_data = NULL;
 
@@ -1468,7 +1472,7 @@ pe__free_clone_notification_data(pe_resource_t *clone)
  * \param[in,out] stopped  Stopped action for \p clone
  */
 void
-pe__create_clone_notif_pseudo_ops(pe_resource_t *clone,
+pe__create_clone_notif_pseudo_ops(pcmk_resource_t *clone,
                                   pe_action_t *start, pe_action_t *started,
                                   pe_action_t *stop, pe_action_t *stopped)
 {
@@ -1503,7 +1507,7 @@ pe__create_clone_notif_pseudo_ops(pe_resource_t *clone,
  * \return Maximum number of \p rsc instances that can be active on one node
  */
 unsigned int
-pe__clone_max_per_node(const pe_resource_t *rsc)
+pe__clone_max_per_node(const pcmk_resource_t *rsc)
 {
     const clone_variant_data_t *clone_data = NULL;
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -670,8 +670,9 @@ clone_print(pe_resource_t *rsc, const char *pre_text, long options,
         } else if (child_rsc->fns->active(child_rsc, TRUE)) {
             // Instance of fully active anonymous clone
 
-            pe_node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+            pcmk_node_t *location = NULL;
 
+            location = child_rsc->fns->location(child_rsc, NULL, TRUE);
             if (location) {
                 // Instance is active on a single node
 
@@ -711,7 +712,7 @@ clone_print(pe_resource_t *rsc, const char *pre_text, long options,
     /* Promoted */
     promoted_list = g_list_sort(promoted_list, pe__cmp_node_name);
     for (gIter = promoted_list; gIter; gIter = gIter->next) {
-        pe_node_t *host = gIter->data;
+        pcmk_node_t *host = gIter->data;
 
         pcmk__add_word(&list_text, 1024, host->details->uname);
         active_instances++;
@@ -727,7 +728,7 @@ clone_print(pe_resource_t *rsc, const char *pre_text, long options,
     /* Started/Unpromoted */
     started_list = g_list_sort(started_list, pe__cmp_node_name);
     for (gIter = started_list; gIter; gIter = gIter->next) {
-        pe_node_t *host = gIter->data;
+        pcmk_node_t *host = gIter->data;
 
         pcmk__add_word(&list_text, 1024, host->details->uname);
         active_instances++;
@@ -782,7 +783,7 @@ clone_print(pe_resource_t *rsc, const char *pre_text, long options,
 
             list = g_list_sort(list, pe__cmp_node_name);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
-                pe_node_t *node = (pe_node_t *)nIter->data;
+                pcmk_node_t *node = (pcmk_node_t *) nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL) {
                     pcmk__add_word(&stopped_list, 1024, node->details->uname);
@@ -971,8 +972,9 @@ pe__clone_default(pcmk__output_t *out, va_list args)
         } else if (child_rsc->fns->active(child_rsc, TRUE)) {
             // Instance of fully active anonymous clone
 
-            pe_node_t *location = child_rsc->fns->location(child_rsc, NULL, TRUE);
+            pcmk_node_t *location = NULL;
 
+            location = child_rsc->fns->location(child_rsc, NULL, TRUE);
             if (location) {
                 // Instance is active on a single node
 
@@ -1019,7 +1021,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
     /* Promoted */
     promoted_list = g_list_sort(promoted_list, pe__cmp_node_name);
     for (gIter = promoted_list; gIter; gIter = gIter->next) {
-        pe_node_t *host = gIter->data;
+        pcmk_node_t *host = gIter->data;
 
         if (!pcmk__str_in_list(host->details->uname, only_node,
                                pcmk__str_star_matches|pcmk__str_casei)) {
@@ -1042,7 +1044,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
     /* Started/Unpromoted */
     started_list = g_list_sort(started_list, pe__cmp_node_name);
     for (gIter = started_list; gIter; gIter = gIter->next) {
-        pe_node_t *host = gIter->data;
+        pcmk_node_t *host = gIter->data;
 
         if (!pcmk__str_in_list(host->details->uname, only_node,
                                pcmk__str_star_matches|pcmk__str_casei)) {
@@ -1101,7 +1103,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
 
             list = g_list_sort(list, pe__cmp_node_name);
             for (nIter = list; nIter != NULL; nIter = nIter->next) {
-                pe_node_t *node = (pe_node_t *)nIter->data;
+                pcmk_node_t *node = (pcmk_node_t *) nIter->data;
 
                 if (pe_find_node(rsc->running_on, node->details->uname) == NULL &&
                     pcmk__str_in_list(node->details->uname, only_node,

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -543,7 +543,7 @@ add_hash_param(GHashTable * hash, const char *name, const char *value)
  * \note If \p force_host is \c true, \p node \e must be a guest node.
  */
 const char *
-pe__node_attribute_calculated(const pe_node_t *node, const char *name,
+pe__node_attribute_calculated(const pcmk_node_t *node, const char *name,
                               const pe_resource_t *rsc,
                               enum pcmk__rsc_node node_type,
                               bool force_host)
@@ -558,7 +558,7 @@ pe__node_attribute_calculated(const pe_node_t *node, const char *name,
     const char *reason = NULL;
 
     const pe_resource_t *container = NULL;
-    const pe_node_t *host = NULL;
+    const pcmk_node_t *host = NULL;
 
     CRM_ASSERT((node != NULL) && (name != NULL) && (rsc != NULL)
                && (!force_host || is_guest));
@@ -618,7 +618,7 @@ pe__node_attribute_calculated(const pe_node_t *node, const char *name,
 }
 
 const char *
-pe_node_attribute_raw(const pe_node_t *node, const char *name)
+pe_node_attribute_raw(const pcmk_node_t *node, const char *name)
 {
     if(node == NULL) {
         return NULL;

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -544,7 +544,7 @@ add_hash_param(GHashTable * hash, const char *name, const char *value)
  */
 const char *
 pe__node_attribute_calculated(const pcmk_node_t *node, const char *name,
-                              const pe_resource_t *rsc,
+                              const pcmk_resource_t *rsc,
                               enum pcmk__rsc_node node_type,
                               bool force_host)
 {
@@ -557,7 +557,7 @@ pe__node_attribute_calculated(const pcmk_node_t *node, const char *name,
     const char *node_type_s = NULL;
     const char *reason = NULL;
 
-    const pe_resource_t *container = NULL;
+    const pcmk_resource_t *container = NULL;
     const pcmk_node_t *host = NULL;
 
     CRM_ASSERT((node != NULL) && (name != NULL) && (rsc != NULL)

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -19,8 +19,9 @@
 
 void populate_hash(xmlNode * nvpair_list, GHashTable * hash, const char **attrs, int attrs_length);
 
-static pe_node_t *active_node(const pe_resource_t *rsc, unsigned int *count_all,
-                              unsigned int *count_clean);
+static pcmk_node_t *active_node(const pe_resource_t *rsc,
+                                unsigned int *count_all,
+                                unsigned int *count_clean);
 
 resource_object_functions_t resource_class_functions[] = {
     {
@@ -152,7 +153,7 @@ expand_parents_fixed_nvpairs(pe_resource_t * rsc, pe_rule_eval_data_t * rule_dat
 }
 void
 get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
-                    pe_node_t * node, pe_working_set_t * data_set)
+                    pcmk_node_t *node, pe_working_set_t *data_set)
 {
     pe_rsc_eval_data_t rsc_rule_data = {
         .standard = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS),
@@ -202,7 +203,7 @@ get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
 
 void
 get_rsc_attributes(GHashTable *meta_hash, const pe_resource_t *rsc,
-                   const pe_node_t *node, pe_working_set_t *data_set)
+                   const pcmk_node_t *node, pe_working_set_t *data_set)
 {
     pe_rule_eval_data_t rule_data = {
         .node_hash = NULL,
@@ -437,7 +438,7 @@ free_params_table(gpointer data)
  *       callers should not destroy it.
  */
 GHashTable *
-pe_rsc_params(pe_resource_t *rsc, const pe_node_t *node,
+pe_rsc_params(pe_resource_t *rsc, const pcmk_node_t *node,
               pe_working_set_t *data_set)
 {
     GHashTable *params_on_node = NULL;
@@ -1048,8 +1049,8 @@ common_free(pe_resource_t * rsc)
  * \return true if the count should continue, or false if sufficiently known
  */
 bool
-pe__count_active_node(const pe_resource_t *rsc, pe_node_t *node,
-                      pe_node_t **active, unsigned int *count_all,
+pe__count_active_node(const pe_resource_t *rsc, pcmk_node_t *node,
+                      pcmk_node_t **active, unsigned int *count_all,
                       unsigned int *count_clean)
 {
     bool keep_looking = false;
@@ -1091,11 +1092,11 @@ pe__count_active_node(const pe_resource_t *rsc, pe_node_t *node,
 }
 
 // Shared implementation of resource_object_functions_t:active_node()
-static pe_node_t *
+static pcmk_node_t *
 active_node(const pe_resource_t *rsc, unsigned int *count_all,
             unsigned int *count_clean)
 {
-    pe_node_t *active = NULL;
+    pcmk_node_t *active = NULL;
 
     if (count_all != NULL) {
         *count_all = 0;
@@ -1107,7 +1108,7 @@ active_node(const pe_resource_t *rsc, unsigned int *count_all,
         return NULL;
     }
     for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
-        if (!pe__count_active_node(rsc, (pe_node_t *) iter->data, &active,
+        if (!pe__count_active_node(rsc, (pcmk_node_t *) iter->data, &active,
                                    count_all, count_clean)) {
             break; // Don't waste time iterating if we don't have to
         }
@@ -1128,7 +1129,7 @@ active_node(const pe_resource_t *rsc, unsigned int *count_all,
  *       active nodes or only clean active nodes is desired according to the
  *       "requires" meta-attribute.
  */
-pe_node_t *
+pcmk_node_t *
 pe__find_active_requires(const pe_resource_t *rsc, unsigned int *count)
 {
     if (rsc == NULL) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -19,7 +19,7 @@
 
 void populate_hash(xmlNode * nvpair_list, GHashTable * hash, const char **attrs, int attrs_length);
 
-static pcmk_node_t *active_node(const pe_resource_t *rsc,
+static pcmk_node_t *active_node(const pcmk_resource_t *rsc,
                                 unsigned int *count_all,
                                 unsigned int *count_clean);
 
@@ -112,10 +112,12 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
-expand_parents_fixed_nvpairs(pe_resource_t * rsc, pe_rule_eval_data_t * rule_data, GHashTable * meta_hash, pe_working_set_t * data_set)
+expand_parents_fixed_nvpairs(pcmk_resource_t *rsc,
+                             pe_rule_eval_data_t *rule_data,
+                             GHashTable *meta_hash, pe_working_set_t *data_set)
 {
     GHashTable *parent_orig_meta = pcmk__strkey_table(free, free);
-    pe_resource_t *p = rsc->parent;
+    pcmk_resource_t *p = rsc->parent;
 
     if (p == NULL) {
         return ;
@@ -152,7 +154,7 @@ expand_parents_fixed_nvpairs(pe_resource_t * rsc, pe_rule_eval_data_t * rule_dat
 
 }
 void
-get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
+get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t * rsc,
                     pcmk_node_t *node, pe_working_set_t *data_set)
 {
     pe_rsc_eval_data_t rsc_rule_data = {
@@ -202,7 +204,7 @@ get_meta_attributes(GHashTable * meta_hash, pe_resource_t * rsc,
 }
 
 void
-get_rsc_attributes(GHashTable *meta_hash, const pe_resource_t *rsc,
+get_rsc_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
                    const pcmk_node_t *node, pe_working_set_t *data_set)
 {
     pe_rule_eval_data_t rule_data = {
@@ -398,7 +400,7 @@ add_template_rsc(xmlNode * xml_obj, pe_working_set_t * data_set)
 }
 
 static bool
-detect_promotable(pe_resource_t *rsc)
+detect_promotable(pcmk_resource_t *rsc)
 {
     const char *promotable = g_hash_table_lookup(rsc->meta,
                                                  XML_RSC_ATTR_PROMOTABLE);
@@ -438,7 +440,7 @@ free_params_table(gpointer data)
  *       callers should not destroy it.
  */
 GHashTable *
-pe_rsc_params(pe_resource_t *rsc, const pcmk_node_t *node,
+pe_rsc_params(pcmk_resource_t *rsc, const pcmk_node_t *node,
               pe_working_set_t *data_set)
 {
     GHashTable *params_on_node = NULL;
@@ -483,7 +485,7 @@ pe_rsc_params(pe_resource_t *rsc, const pcmk_node_t *node,
  * \param[in]     is_default  Whether \p value was selected by default
  */
 static void
-unpack_requires(pe_resource_t *rsc, const char *value, bool is_default)
+unpack_requires(pcmk_resource_t *rsc, const char *value, bool is_default)
 {
     if (pcmk__str_eq(value, PCMK__VALUE_NOTHING, pcmk__str_casei)) {
 
@@ -558,7 +560,7 @@ unpack_requires(pe_resource_t *rsc, const char *value, bool is_default)
 
 #ifndef PCMK__COMPAT_2_0
 static void
-warn_about_deprecated_classes(pe_resource_t *rsc)
+warn_about_deprecated_classes(pcmk_resource_t *rsc)
 {
     const char *std = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
 
@@ -582,7 +584,7 @@ warn_about_deprecated_classes(pe_resource_t *rsc)
  * \brief Unpack configuration XML for a given resource
  *
  * Unpack the XML object containing a resource's configuration into a new
- * \c pe_resource_t object.
+ * \c pcmk_resource_t object.
  *
  * \param[in]     xml_obj   XML node containing the resource's configuration
  * \param[out]    rsc       Where to store the unpacked resource information
@@ -595,8 +597,8 @@ warn_about_deprecated_classes(pe_resource_t *rsc)
  *       free() method. Otherwise, \p *rsc is guaranteed to be NULL.
  */
 int
-pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
-                    pe_resource_t *parent, pe_working_set_t *data_set)
+pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
+                    pcmk_resource_t *parent, pe_working_set_t *data_set)
 {
     xmlNode *expanded_xml = NULL;
     xmlNode *ops = NULL;
@@ -634,7 +636,7 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
         return pcmk_rc_unpack_error;
     }
 
-    *rsc = calloc(1, sizeof(pe_resource_t));
+    *rsc = calloc(1, sizeof(pcmk_resource_t));
     if (*rsc == NULL) {
         crm_crit("Unable to allocate memory for resource '%s'", id);
         return ENOMEM;
@@ -910,9 +912,9 @@ pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
 }
 
 gboolean
-is_parent(pe_resource_t *child, pe_resource_t *rsc)
+is_parent(pcmk_resource_t *child, pcmk_resource_t *rsc)
 {
-    pe_resource_t *parent = child;
+    pcmk_resource_t *parent = child;
 
     if (parent == NULL || rsc == NULL) {
         return FALSE;
@@ -926,10 +928,10 @@ is_parent(pe_resource_t *child, pe_resource_t *rsc)
     return FALSE;
 }
 
-pe_resource_t *
-uber_parent(pe_resource_t * rsc)
+pcmk_resource_t *
+uber_parent(pcmk_resource_t *rsc)
 {
-    pe_resource_t *parent = rsc;
+    pcmk_resource_t *parent = rsc;
 
     if (parent == NULL) {
         return NULL;
@@ -952,10 +954,10 @@ uber_parent(pe_resource_t * rsc)
  *         the bundle if \p rsc is bundled and \p include_bundle is true,
  *         otherwise the topmost parent of \p rsc up to a clone
  */
-const pe_resource_t *
-pe__const_top_resource(const pe_resource_t *rsc, bool include_bundle)
+const pcmk_resource_t *
+pe__const_top_resource(const pcmk_resource_t *rsc, bool include_bundle)
 {
-    const pe_resource_t *parent = rsc;
+    const pcmk_resource_t *parent = rsc;
 
     if (parent == NULL) {
         return NULL;
@@ -971,7 +973,7 @@ pe__const_top_resource(const pe_resource_t *rsc, bool include_bundle)
 }
 
 void
-common_free(pe_resource_t * rsc)
+common_free(pcmk_resource_t * rsc)
 {
     if (rsc == NULL) {
         return;
@@ -1049,7 +1051,7 @@ common_free(pe_resource_t * rsc)
  * \return true if the count should continue, or false if sufficiently known
  */
 bool
-pe__count_active_node(const pe_resource_t *rsc, pcmk_node_t *node,
+pe__count_active_node(const pcmk_resource_t *rsc, pcmk_node_t *node,
                       pcmk_node_t **active, unsigned int *count_all,
                       unsigned int *count_clean)
 {
@@ -1093,7 +1095,7 @@ pe__count_active_node(const pe_resource_t *rsc, pcmk_node_t *node,
 
 // Shared implementation of resource_object_functions_t:active_node()
 static pcmk_node_t *
-active_node(const pe_resource_t *rsc, unsigned int *count_all,
+active_node(const pcmk_resource_t *rsc, unsigned int *count_all,
             unsigned int *count_clean)
 {
     pcmk_node_t *active = NULL;
@@ -1130,7 +1132,7 @@ active_node(const pe_resource_t *rsc, unsigned int *count_all,
  *       "requires" meta-attribute.
  */
 pcmk_node_t *
-pe__find_active_requires(const pe_resource_t *rsc, unsigned int *count)
+pe__find_active_requires(const pcmk_resource_t *rsc, unsigned int *count)
 {
     if (rsc == NULL) {
         if (count != NULL) {
@@ -1147,11 +1149,11 @@ pe__find_active_requires(const pe_resource_t *rsc, unsigned int *count)
 }
 
 void
-pe__count_common(pe_resource_t *rsc)
+pe__count_common(pcmk_resource_t *rsc)
 {
     if (rsc->children != NULL) {
         for (GList *item = rsc->children; item != NULL; item = item->next) {
-            ((pe_resource_t *) item->data)->fns->count(item->data);
+            ((pcmk_resource_t *) item->data)->fns->count(item->data);
         }
 
     } else if (!pcmk_is_set(rsc->flags, pcmk_rsc_removed)
@@ -1175,7 +1177,7 @@ pe__count_common(pe_resource_t *rsc)
  * \param[in]     why   Human-friendly reason why role is changing (for logs)
  */
 void
-pe__set_next_role(pe_resource_t *rsc, enum rsc_role_e role, const char *why)
+pe__set_next_role(pcmk_resource_t *rsc, enum rsc_role_e role, const char *why)
 {
     CRM_ASSERT((rsc != NULL) && (why != NULL));
     if (rsc->next_role != role) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -114,7 +114,7 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 static void
 expand_parents_fixed_nvpairs(pcmk_resource_t *rsc,
                              pe_rule_eval_data_t *rule_data,
-                             GHashTable *meta_hash, pe_working_set_t *data_set)
+                             GHashTable *meta_hash, pcmk_scheduler_t *data_set)
 {
     GHashTable *parent_orig_meta = pcmk__strkey_table(free, free);
     pcmk_resource_t *p = rsc->parent;
@@ -155,7 +155,7 @@ expand_parents_fixed_nvpairs(pcmk_resource_t *rsc,
 }
 void
 get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t * rsc,
-                    pcmk_node_t *node, pe_working_set_t *data_set)
+                    pcmk_node_t *node, pcmk_scheduler_t *data_set)
 {
     pe_rsc_eval_data_t rsc_rule_data = {
         .standard = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS),
@@ -205,7 +205,7 @@ get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t * rsc,
 
 void
 get_rsc_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
-                   const pcmk_node_t *node, pe_working_set_t *data_set)
+                   const pcmk_node_t *node, pcmk_scheduler_t *data_set)
 {
     pe_rule_eval_data_t rule_data = {
         .node_hash = NULL,
@@ -252,7 +252,8 @@ template_op_key(xmlNode * op)
 }
 
 static gboolean
-unpack_template(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * data_set)
+unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
+                pcmk_scheduler_t *data_set)
 {
     xmlNode *cib_resources = NULL;
     xmlNode *template = NULL;
@@ -366,7 +367,7 @@ unpack_template(xmlNode * xml_obj, xmlNode ** expanded_xml, pe_working_set_t * d
 }
 
 static gboolean
-add_template_rsc(xmlNode * xml_obj, pe_working_set_t * data_set)
+add_template_rsc(xmlNode *xml_obj, pcmk_scheduler_t *data_set)
 {
     const char *template_ref = NULL;
     const char *id = NULL;
@@ -441,7 +442,7 @@ free_params_table(gpointer data)
  */
 GHashTable *
 pe_rsc_params(pcmk_resource_t *rsc, const pcmk_node_t *node,
-              pe_working_set_t *data_set)
+              pcmk_scheduler_t *data_set)
 {
     GHashTable *params_on_node = NULL;
 
@@ -598,7 +599,7 @@ warn_about_deprecated_classes(pcmk_resource_t *rsc)
  */
 int
 pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
-                    pcmk_resource_t *parent, pe_working_set_t *data_set)
+                    pcmk_resource_t *parent, pcmk_scheduler_t *data_set)
 {
     xmlNode *expanded_xml = NULL;
     xmlNode *ops = NULL;

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -77,7 +77,7 @@ is_matched_failure(const char *rsc_id, const xmlNode *conf_op_xml,
 }
 
 static gboolean
-block_failure(const pcmk_node_t *node, pe_resource_t *rsc,
+block_failure(const pcmk_node_t *node, pcmk_resource_t *rsc,
               const xmlNode *xml_op)
 {
     char *xml_name = clone_strip(rsc->id);
@@ -181,7 +181,7 @@ block_failure(const pcmk_node_t *node, pe_resource_t *rsc,
  * \note The caller is responsible for freeing the result.
  */
 static inline char *
-rsc_fail_name(const pe_resource_t *rsc)
+rsc_fail_name(const pcmk_resource_t *rsc)
 {
     const char *name = (rsc->clone_name? rsc->clone_name : rsc->id);
 
@@ -245,7 +245,7 @@ generate_fail_regex(const char *prefix, const char *rsc_name,
  *       regfree().
  */
 static int
-generate_fail_regexes(const pe_resource_t *rsc,
+generate_fail_regexes(const pcmk_resource_t *rsc,
                       regex_t *failcount_re, regex_t *lastfailure_re)
 {
     int rc = pcmk_rc_ok;
@@ -276,7 +276,7 @@ generate_fail_regexes(const pe_resource_t *rsc,
 // Data for fail-count-related iterators
 struct failcount_data {
     const pcmk_node_t *node;// Node to check for fail count
-    pe_resource_t *rsc;     // Resource to check for fail count
+    pcmk_resource_t *rsc;     // Resource to check for fail count
     uint32_t flags;         // Fail count flags
     const xmlNode *xml_op;  // History entry for expiration purposes (or NULL)
     regex_t failcount_re;   // Fail count regular expression to match
@@ -330,7 +330,7 @@ update_failcount_for_attr(gpointer key, gpointer value, gpointer user_data)
 static void
 update_failcount_for_filler(gpointer data, gpointer user_data)
 {
-    pe_resource_t *filler = data;
+    pcmk_resource_t *filler = data;
     struct failcount_data *fc_data = user_data;
     time_t filler_last_failure = 0;
 
@@ -357,7 +357,7 @@ update_failcount_for_filler(gpointer data, gpointer user_data)
  * \return Fail count for \p rsc on \p node according to \p flags
  */
 int
-pe_get_failcount(const pcmk_node_t *node, pe_resource_t *rsc,
+pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
                  time_t *last_failure, uint32_t flags, const xmlNode *xml_op)
 {
     struct failcount_data fc_data = {
@@ -450,7 +450,7 @@ pe_get_failcount(const pcmk_node_t *node, pe_resource_t *rsc,
  * \return Scheduled action
  */
 pe_action_t *
-pe__clear_failcount(pe_resource_t *rsc, const pcmk_node_t *node,
+pe__clear_failcount(pcmk_resource_t *rsc, const pcmk_node_t *node,
                     const char *reason, pe_working_set_t *data_set)
 {
     char *key = NULL;

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -77,7 +77,8 @@ is_matched_failure(const char *rsc_id, const xmlNode *conf_op_xml,
 }
 
 static gboolean
-block_failure(const pe_node_t *node, pe_resource_t *rsc, const xmlNode *xml_op)
+block_failure(const pcmk_node_t *node, pe_resource_t *rsc,
+              const xmlNode *xml_op)
 {
     char *xml_name = clone_strip(rsc->id);
 
@@ -274,7 +275,7 @@ generate_fail_regexes(const pe_resource_t *rsc,
 
 // Data for fail-count-related iterators
 struct failcount_data {
-    const pe_node_t *node;  // Node to check for fail count
+    const pcmk_node_t *node;// Node to check for fail count
     pe_resource_t *rsc;     // Resource to check for fail count
     uint32_t flags;         // Fail count flags
     const xmlNode *xml_op;  // History entry for expiration purposes (or NULL)
@@ -356,7 +357,7 @@ update_failcount_for_filler(gpointer data, gpointer user_data)
  * \return Fail count for \p rsc on \p node according to \p flags
  */
 int
-pe_get_failcount(const pe_node_t *node, pe_resource_t *rsc,
+pe_get_failcount(const pcmk_node_t *node, pe_resource_t *rsc,
                  time_t *last_failure, uint32_t flags, const xmlNode *xml_op)
 {
     struct failcount_data fc_data = {
@@ -449,7 +450,7 @@ pe_get_failcount(const pe_node_t *node, pe_resource_t *rsc,
  * \return Scheduled action
  */
 pe_action_t *
-pe__clear_failcount(pe_resource_t *rsc, const pe_node_t *node,
+pe__clear_failcount(pe_resource_t *rsc, const pcmk_node_t *node,
                     const char *reason, pe_working_set_t *data_set)
 {
     char *key = NULL;

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -451,7 +451,7 @@ pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
  */
 pcmk_action_t *
 pe__clear_failcount(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                    const char *reason, pe_working_set_t *data_set)
+                    const char *reason, pcmk_scheduler_t *data_set)
 {
     char *key = NULL;
     pcmk_action_t *clear = NULL;

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -449,12 +449,12 @@ pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
  *
  * \return Scheduled action
  */
-pe_action_t *
+pcmk_action_t *
 pe__clear_failcount(pcmk_resource_t *rsc, const pcmk_node_t *node,
                     const char *reason, pe_working_set_t *data_set)
 {
     char *key = NULL;
-    pe_action_t *clear = NULL;
+    pcmk_action_t *clear = NULL;
 
     CRM_CHECK(rsc && node && reason && data_set, return NULL);
 

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -21,8 +21,8 @@
 #include <pe_status_private.h>
 
 typedef struct group_variant_data_s {
-    pe_resource_t *last_child;  // Last group member
-    uint32_t flags;             // Group of enum pcmk__group_flags
+    pcmk_resource_t *last_child;    // Last group member
+    uint32_t flags;                 // Group of enum pcmk__group_flags
 } group_variant_data_t;
 
 /*!
@@ -33,8 +33,8 @@ typedef struct group_variant_data_s {
  *
  * \return Last member of \p group if any, otherwise NULL
  */
-pe_resource_t *
-pe__last_group_member(const pe_resource_t *group)
+pcmk_resource_t *
+pe__last_group_member(const pcmk_resource_t *group)
 {
     if (group != NULL) {
         CRM_CHECK((group->variant == pcmk_rsc_variant_group)
@@ -54,7 +54,7 @@ pe__last_group_member(const pe_resource_t *group)
  * \return true if all \p flags are set for \p group, otherwise false
  */
 bool
-pe__group_flag_is_set(const pe_resource_t *group, uint32_t flags)
+pe__group_flag_is_set(const pcmk_resource_t *group, uint32_t flags)
 {
     group_variant_data_t *group_data = NULL;
 
@@ -74,7 +74,7 @@ pe__group_flag_is_set(const pe_resource_t *group, uint32_t flags)
  * \param[in]     wo_bit  "Warn once" flag to use for deprecation warning
  */
 static void
-set_group_flag(pe_resource_t *group, const char *option, uint32_t flag,
+set_group_flag(pcmk_resource_t *group, const char *option, uint32_t flag,
                uint32_t wo_bit)
 {
     const char *value_s = NULL;
@@ -97,12 +97,12 @@ set_group_flag(pe_resource_t *group, const char *option, uint32_t flag,
 }
 
 static int
-inactive_resources(pe_resource_t *rsc)
+inactive_resources(pcmk_resource_t *rsc)
 {
     int retval = 0;
 
     for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         if (!child_rsc->fns->active(child_rsc, TRUE)) {
             retval++;
@@ -113,7 +113,7 @@ inactive_resources(pe_resource_t *rsc)
 }
 
 static void
-group_header(pcmk__output_t *out, int *rc, const pe_resource_t *rsc,
+group_header(pcmk__output_t *out, int *rc, const pcmk_resource_t *rsc,
              int n_inactive, bool show_inactive, const char *desc)
 {
     GString *attrs = NULL;
@@ -150,8 +150,8 @@ group_header(pcmk__output_t *out, int *rc, const pe_resource_t *rsc,
 }
 
 static bool
-skip_child_rsc(pe_resource_t *rsc, pe_resource_t *child, gboolean parent_passes,
-               GList *only_rsc, uint32_t show_opts)
+skip_child_rsc(pcmk_resource_t *rsc, pcmk_resource_t *child,
+               gboolean parent_passes, GList *only_rsc, uint32_t show_opts)
 {
     bool star_list = pcmk__list_of_1(only_rsc) &&
                      pcmk__str_eq("*", g_list_first(only_rsc)->data, pcmk__str_none);
@@ -177,7 +177,7 @@ skip_child_rsc(pe_resource_t *rsc, pe_resource_t *child, gboolean parent_passes,
 }
 
 gboolean
-group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
+group_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set)
 {
     xmlNode *xml_obj = rsc->xml;
     xmlNode *xml_native_rsc = NULL;
@@ -203,7 +203,7 @@ group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 
         if (pcmk__str_eq((const char *)xml_native_rsc->name,
                          XML_CIB_TAG_RESOURCE, pcmk__str_none)) {
-            pe_resource_t *new_rsc = NULL;
+            pcmk_resource_t *new_rsc = NULL;
 
             crm_xml_add(xml_native_rsc, XML_RSC_ATTR_INCARNATION, clone_id);
             if (pe__unpack_resource(xml_native_rsc, &new_rsc, rsc,
@@ -233,14 +233,14 @@ group_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 gboolean
-group_active(pe_resource_t * rsc, gboolean all)
+group_active(pcmk_resource_t *rsc, gboolean all)
 {
     gboolean c_all = TRUE;
     gboolean c_any = FALSE;
     GList *gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         if (child_rsc->fns->active(child_rsc, all)) {
             c_any = TRUE;
@@ -262,7 +262,7 @@ group_active(pe_resource_t * rsc, gboolean all)
  * \deprecated This function will be removed in a future release
  */
 static void
-group_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+group_print_xml(pcmk_resource_t *rsc, const char *pre_text, long options,
                 void *print_data)
 {
     GList *gIter = rsc->children;
@@ -273,7 +273,7 @@ group_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
     status_print(">\n");
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         child_rsc->fns->print(child_rsc, child_text, options, print_data);
     }
@@ -287,7 +287,7 @@ group_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
  * \deprecated This function will be removed in a future release
  */
 void
-group_print(pe_resource_t *rsc, const char *pre_text, long options,
+group_print(pcmk_resource_t *rsc, const char *pre_text, long options,
             void *print_data)
 {
     char *child_text = NULL;
@@ -318,7 +318,7 @@ group_print(pe_resource_t *rsc, const char *pre_text, long options,
 
     } else {
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+            pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
             if (options & pe_print_html) {
                 status_print("<li>\n");
@@ -336,12 +336,13 @@ group_print(pe_resource_t *rsc, const char *pre_text, long options,
     free(child_text);
 }
 
-PCMK__OUTPUT_ARGS("group", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("group", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__group_xml(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
     
@@ -360,7 +361,7 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     }
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         if (skip_child_rsc(rsc, child_rsc, parent_passes, only_rsc, show_opts)) {
             continue;
@@ -394,12 +395,13 @@ pe__group_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("group", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("group", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__group_default(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -432,7 +434,7 @@ pe__group_default(pcmk__output_t *out, va_list args)
 
     } else {
         for (GList *gIter = rsc->children; gIter; gIter = gIter->next) {
-            pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+            pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
             if (skip_child_rsc(rsc, child_rsc, parent_passes, only_rsc, show_opts)) {
                 continue;
@@ -451,14 +453,14 @@ pe__group_default(pcmk__output_t *out, va_list args)
 }
 
 void
-group_free(pe_resource_t * rsc)
+group_free(pcmk_resource_t * rsc)
 {
     CRM_CHECK(rsc != NULL, return);
 
     pe_rsc_trace(rsc, "Freeing %s", rsc->id);
 
     for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
 
         CRM_ASSERT(child_rsc);
         pe_rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
@@ -472,13 +474,13 @@ group_free(pe_resource_t * rsc)
 }
 
 enum rsc_role_e
-group_resource_state(const pe_resource_t * rsc, gboolean current)
+group_resource_state(const pcmk_resource_t * rsc, gboolean current)
 {
     enum rsc_role_e group_role = pcmk_role_unknown;
     GList *gIter = rsc->children;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child_rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
         enum rsc_role_e role = child_rsc->fns->state(child_rsc, current);
 
         if (role > group_role) {
@@ -491,7 +493,7 @@ group_resource_state(const pe_resource_t * rsc, gboolean current)
 }
 
 gboolean
-pe__group_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+pe__group_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                       gboolean check_parent)
 {
     gboolean passes = FALSE;
@@ -509,7 +511,7 @@ pe__group_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
         for (const GList *iter = rsc->children;
              iter != NULL; iter = iter->next) {
 
-            const pe_resource_t *child_rsc = (const pe_resource_t *) iter->data;
+            const pcmk_resource_t *child_rsc = iter->data;
 
             if (!child_rsc->fns->is_filtered(child_rsc, only_rsc, FALSE)) {
                 passes = TRUE;
@@ -530,7 +532,7 @@ pe__group_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
  * \return Maximum number of \p rsc instances that can be active on one node
  */
 unsigned int
-pe__group_max_per_node(const pe_resource_t *rsc)
+pe__group_max_per_node(const pcmk_resource_t *rsc)
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_group));
     return 1U;

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -177,7 +177,7 @@ skip_child_rsc(pcmk_resource_t *rsc, pcmk_resource_t *child,
 }
 
 gboolean
-group_unpack(pcmk_resource_t *rsc, pe_working_set_t *data_set)
+group_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_obj = rsc->xml;
     xmlNode *xml_native_rsc = NULL;

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -88,7 +88,7 @@ native_priority_to_node(pcmk_resource_t *rsc, pcmk_node_t *node,
 
 void
 native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
-                   pe_working_set_t *data_set, gboolean failed)
+                   pcmk_scheduler_t *data_set, gboolean failed)
 {
     GList *gIter = rsc->running_on;
 
@@ -202,7 +202,7 @@ recursive_clear_unique(pcmk_resource_t *rsc, gpointer user_data)
 }
 
 gboolean
-native_unpack(pcmk_resource_t * rsc, pe_working_set_t * data_set)
+native_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     pcmk_resource_t *parent = uber_parent(rsc);
     const char *standard = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
@@ -326,7 +326,7 @@ native_find_rsc(pcmk_resource_t *rsc, const char *id,
 // create is ignored
 char *
 native_parameter(pcmk_resource_t *rsc, pcmk_node_t *node, gboolean create,
-                 const char *name, pe_working_set_t *data_set)
+                 const char *name, pcmk_scheduler_t *data_set)
 {
     char *value_copy = NULL;
     const char *value = NULL;

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -30,7 +30,7 @@
  * \brief Check whether a resource is active on multiple nodes
  */
 static bool
-is_multiply_active(const pe_resource_t *rsc)
+is_multiply_active(const pcmk_resource_t *rsc)
 {
     unsigned int count = 0;
 
@@ -41,7 +41,8 @@ is_multiply_active(const pe_resource_t *rsc)
 }
 
 static void
-native_priority_to_node(pe_resource_t *rsc, pcmk_node_t *node, gboolean failed)
+native_priority_to_node(pcmk_resource_t *rsc, pcmk_node_t *node,
+                        gboolean failed)
 {
     int priority = 0;
 
@@ -86,7 +87,7 @@ native_priority_to_node(pe_resource_t *rsc, pcmk_node_t *node, gboolean failed)
 }
 
 void
-native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
+native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
                    pe_working_set_t *data_set, gboolean failed)
 {
     GList *gIter = rsc->running_on;
@@ -118,7 +119,7 @@ native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
     }
 
     if (!pcmk_is_set(rsc->flags, pcmk_rsc_managed)) {
-        pe_resource_t *p = rsc->parent;
+        pcmk_resource_t *p = rsc->parent;
 
         pe_rsc_info(rsc, "resource %s isn't managed", rsc->id);
         resource_location(rsc, node, INFINITY, "not_managed_default", data_set);
@@ -163,7 +164,7 @@ native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
                     GList *gIter = rsc->parent->children;
 
                     for (; gIter != NULL; gIter = gIter->next) {
-                        pe_resource_t *child = (pe_resource_t *) gIter->data;
+                        pcmk_resource_t *child = gIter->data;
 
                         pe__clear_resource_flags(child, pcmk_rsc_managed);
                         pe__set_resource_flags(child, pcmk_rsc_blocked);
@@ -193,7 +194,7 @@ native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
 }
 
 static void
-recursive_clear_unique(pe_resource_t *rsc, gpointer user_data)
+recursive_clear_unique(pcmk_resource_t *rsc, gpointer user_data)
 {
     pe__clear_resource_flags(rsc, pcmk_rsc_unique);
     add_hash_param(rsc->meta, XML_RSC_ATTR_UNIQUE, XML_BOOLEAN_FALSE);
@@ -201,9 +202,9 @@ recursive_clear_unique(pe_resource_t *rsc, gpointer user_data)
 }
 
 gboolean
-native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
+native_unpack(pcmk_resource_t * rsc, pe_working_set_t * data_set)
 {
-    pe_resource_t *parent = uber_parent(rsc);
+    pcmk_resource_t *parent = uber_parent(rsc);
     const char *standard = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
     uint32_t ra_caps = pcmk_get_ra_caps(standard);
 
@@ -241,7 +242,7 @@ native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 static bool
-rsc_is_on_node(pe_resource_t *rsc, const pcmk_node_t *node, int flags)
+rsc_is_on_node(pcmk_resource_t *rsc, const pcmk_node_t *node, int flags)
 {
     pe_rsc_trace(rsc, "Checking whether %s is on %s",
                  rsc->id, pe__node_name(node));
@@ -269,12 +270,12 @@ rsc_is_on_node(pe_resource_t *rsc, const pcmk_node_t *node, int flags)
     return false;
 }
 
-pe_resource_t *
-native_find_rsc(pe_resource_t *rsc, const char *id, const pcmk_node_t *on_node,
-                int flags)
+pcmk_resource_t *
+native_find_rsc(pcmk_resource_t *rsc, const char *id,
+                const pcmk_node_t *on_node, int flags)
 {
     bool match = false;
-    pe_resource_t *result = NULL;
+    pcmk_resource_t *result = NULL;
 
     CRM_CHECK(id && rsc && rsc->id, return NULL);
 
@@ -312,7 +313,7 @@ native_find_rsc(pe_resource_t *rsc, const char *id, const pcmk_node_t *on_node,
     }
 
     for (GList *gIter = rsc->children; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *child = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *child = (pcmk_resource_t *) gIter->data;
 
         result = rsc->fns->find_rsc(child, id, on_node, flags);
         if (result) {
@@ -324,7 +325,7 @@ native_find_rsc(pe_resource_t *rsc, const char *id, const pcmk_node_t *on_node,
 
 // create is ignored
 char *
-native_parameter(pe_resource_t *rsc, pcmk_node_t *node, gboolean create,
+native_parameter(pcmk_resource_t *rsc, pcmk_node_t *node, gboolean create,
                  const char *name, pe_working_set_t *data_set)
 {
     char *value_copy = NULL;
@@ -346,7 +347,7 @@ native_parameter(pe_resource_t *rsc, pcmk_node_t *node, gboolean create,
 }
 
 gboolean
-native_active(pe_resource_t * rsc, gboolean all)
+native_active(pcmk_resource_t * rsc, gboolean all)
 {
     for (GList *gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
         pcmk_node_t *a_node = (pcmk_node_t *) gIter->data;
@@ -374,7 +375,7 @@ struct print_data_s {
 };
 
 static const char *
-native_pending_state(const pe_resource_t *rsc)
+native_pending_state(const pcmk_resource_t *rsc)
 {
     const char *pending_state = NULL;
 
@@ -407,7 +408,7 @@ native_pending_state(const pe_resource_t *rsc)
 }
 
 static const char *
-native_pending_task(const pe_resource_t *rsc)
+native_pending_task(const pcmk_resource_t *rsc)
 {
     const char *pending_task = NULL;
 
@@ -429,7 +430,7 @@ native_pending_task(const pe_resource_t *rsc)
 }
 
 static enum rsc_role_e
-native_displayable_role(const pe_resource_t *rsc)
+native_displayable_role(const pcmk_resource_t *rsc)
 {
     enum rsc_role_e role = rsc->role;
 
@@ -443,7 +444,7 @@ native_displayable_role(const pe_resource_t *rsc)
 }
 
 static const char *
-native_displayable_state(const pe_resource_t *rsc, bool print_pending)
+native_displayable_state(const pcmk_resource_t *rsc, bool print_pending)
 {
     const char *rsc_state = NULL;
 
@@ -461,7 +462,7 @@ native_displayable_state(const pe_resource_t *rsc, bool print_pending)
  * \deprecated This function will be removed in a future release
  */
 static void
-native_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
+native_print_xml(pcmk_resource_t *rsc, const char *pre_text, long options,
                  void *print_data)
 {
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
@@ -558,7 +559,7 @@ add_output_node(GString *s, const char *node, bool have_nodes)
  * \note Caller must free the result with g_free().
  */
 gchar *
-pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
+pcmk__native_output_string(const pcmk_resource_t *rsc, const char *name,
                            const pcmk_node_t *node, uint32_t show_opts,
                            const char *target_role, bool show_nodes)
 {
@@ -712,7 +713,7 @@ pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
 }
 
 int
-pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
+pe__common_output_html(pcmk__output_t *out, const pcmk_resource_t *rsc,
                        const char *name, const pcmk_node_t *node,
                        uint32_t show_opts)
 {
@@ -770,7 +771,7 @@ pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
 }
 
 int
-pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
+pe__common_output_text(pcmk__output_t *out, const pcmk_resource_t *rsc,
                        const char *name, const pcmk_node_t *node,
                        uint32_t show_opts)
 {
@@ -806,7 +807,7 @@ pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
  * \deprecated This function will be removed in a future release
  */
 void
-common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
+common_print(pcmk_resource_t *rsc, const char *pre_text, const char *name,
              const pcmk_node_t *node, long options, void *print_data)
 {
     const char *target_role = NULL;
@@ -926,7 +927,7 @@ common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
  * \deprecated This function will be removed in a future release
  */
 void
-native_print(pe_resource_t *rsc, const char *pre_text, long options,
+native_print(pcmk_resource_t *rsc, const char *pre_text, long options,
              void *print_data)
 {
     const pcmk_node_t *node = NULL;
@@ -947,12 +948,13 @@ native_print(pe_resource_t *rsc, const char *pre_text, long options,
     common_print(rsc, pre_text, rsc_printable_id(rsc), node, options, print_data);
 }
 
-PCMK__OUTPUT_ARGS("primitive", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("primitive", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__resource_xml(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node G_GNUC_UNUSED = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -1029,12 +1031,13 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("primitive", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("primitive", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__resource_html(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node G_GNUC_UNUSED = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -1053,12 +1056,13 @@ pe__resource_html(pcmk__output_t *out, va_list args)
     return pe__common_output_html(out, rsc, rsc_printable_id(rsc), node, show_opts);
 }
 
-PCMK__OUTPUT_ARGS("primitive", "uint32_t", "pe_resource_t *", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("primitive", "uint32_t", "pcmk_resource_t *", "GList *",
+                  "GList *")
 int
 pe__resource_text(pcmk__output_t *out, va_list args)
 {
     uint32_t show_opts = va_arg(args, uint32_t);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     GList *only_node G_GNUC_UNUSED = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
@@ -1078,14 +1082,14 @@ pe__resource_text(pcmk__output_t *out, va_list args)
 }
 
 void
-native_free(pe_resource_t * rsc)
+native_free(pcmk_resource_t * rsc)
 {
     pe_rsc_trace(rsc, "Freeing resource action list (not the data)");
     common_free(rsc);
 }
 
 enum rsc_role_e
-native_resource_state(const pe_resource_t * rsc, gboolean current)
+native_resource_state(const pcmk_resource_t * rsc, gboolean current)
 {
     enum rsc_role_e role = rsc->next_role;
 
@@ -1108,7 +1112,7 @@ native_resource_state(const pe_resource_t * rsc, gboolean current)
  * \return If list contains only one node, that node, or NULL otherwise
  */
 pcmk_node_t *
-native_location(const pe_resource_t *rsc, GList **list, int current)
+native_location(const pcmk_resource_t *rsc, GList **list, int current)
 {
     // @COMPAT: Accept a pcmk__rsc_node argument instead of int current
     pcmk_node_t *one = NULL;
@@ -1118,7 +1122,7 @@ native_location(const pe_resource_t *rsc, GList **list, int current)
         GList *gIter = rsc->children;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_resource_t *child = (pe_resource_t *) gIter->data;
+            pcmk_resource_t *child = (pcmk_resource_t *) gIter->data;
 
             child->fns->location(child, &result, current);
         }
@@ -1163,7 +1167,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
     GList *gIter = rsc_list;
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) gIter->data;
 
         const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
         const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);
@@ -1417,14 +1421,14 @@ pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, uint32_t show_opts)
 }
 
 gboolean
-pe__native_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
+pe__native_is_filtered(const pcmk_resource_t *rsc, GList *only_rsc,
                        gboolean check_parent)
 {
     if (pcmk__str_in_list(rsc_printable_id(rsc), only_rsc, pcmk__str_star_matches) ||
         pcmk__str_in_list(rsc->id, only_rsc, pcmk__str_star_matches)) {
         return FALSE;
     } else if (check_parent && rsc->parent) {
-        const pe_resource_t *up = pe__const_top_resource(rsc, true);
+        const pcmk_resource_t *up = pe__const_top_resource(rsc, true);
 
         return up->fns->is_filtered(up, only_rsc, FALSE);
     }
@@ -1441,7 +1445,7 @@ pe__native_is_filtered(const pe_resource_t *rsc, GList *only_rsc,
  * \return Maximum number of \p rsc instances that can be active on one node
  */
 unsigned int
-pe__primitive_max_per_node(const pe_resource_t *rsc)
+pe__primitive_max_per_node(const pcmk_resource_t *rsc)
 {
     CRM_ASSERT((rsc != NULL) && (rsc->variant == pcmk_rsc_variant_primitive));
     return 1U;

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -41,7 +41,7 @@ is_multiply_active(const pe_resource_t *rsc)
 }
 
 static void
-native_priority_to_node(pe_resource_t * rsc, pe_node_t * node, gboolean failed)
+native_priority_to_node(pe_resource_t *rsc, pcmk_node_t *node, gboolean failed)
 {
     int priority = 0;
 
@@ -71,7 +71,7 @@ native_priority_to_node(pe_resource_t * rsc, pe_node_t * node, gboolean failed)
         GList *gIter = node->details->remote_rsc->container->running_on;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_node_t *a_node = gIter->data;
+            pcmk_node_t *a_node = gIter->data;
 
             a_node->details->priority += priority;
             pe_rsc_trace(rsc, "%s now has priority %d with %s'%s' (priority: %d%s) "
@@ -86,13 +86,14 @@ native_priority_to_node(pe_resource_t * rsc, pe_node_t * node, gboolean failed)
 }
 
 void
-native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * data_set, gboolean failed)
+native_add_running(pe_resource_t *rsc, pcmk_node_t *node,
+                   pe_working_set_t *data_set, gboolean failed)
 {
     GList *gIter = rsc->running_on;
 
     CRM_CHECK(node != NULL, return);
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *a_node = (pe_node_t *) gIter->data;
+        pcmk_node_t *a_node = (pcmk_node_t *) gIter->data;
 
         CRM_CHECK(a_node != NULL, return);
         if (pcmk__str_eq(a_node->details->id, node->details->id, pcmk__str_casei)) {
@@ -135,7 +136,7 @@ native_add_running(pe_resource_t * rsc, pe_node_t * node, pe_working_set_t * dat
             case pcmk_multiply_active_stop:
                 {
                     GHashTableIter gIter;
-                    pe_node_t *local_node = NULL;
+                    pcmk_node_t *local_node = NULL;
 
                     /* make sure it doesn't come up again */
                     if (rsc->allowed_nodes != NULL) {
@@ -240,7 +241,7 @@ native_unpack(pe_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 static bool
-rsc_is_on_node(pe_resource_t *rsc, const pe_node_t *node, int flags)
+rsc_is_on_node(pe_resource_t *rsc, const pcmk_node_t *node, int flags)
 {
     pe_rsc_trace(rsc, "Checking whether %s is on %s",
                  rsc->id, pe__node_name(node));
@@ -249,7 +250,7 @@ rsc_is_on_node(pe_resource_t *rsc, const pe_node_t *node, int flags)
         && (rsc->running_on != NULL)) {
 
         for (GList *iter = rsc->running_on; iter; iter = iter->next) {
-            pe_node_t *loc = (pe_node_t *) iter->data;
+            pcmk_node_t *loc = (pcmk_node_t *) iter->data;
 
             if (loc->details == node->details) {
                 return true;
@@ -269,7 +270,7 @@ rsc_is_on_node(pe_resource_t *rsc, const pe_node_t *node, int flags)
 }
 
 pe_resource_t *
-native_find_rsc(pe_resource_t * rsc, const char *id, const pe_node_t *on_node,
+native_find_rsc(pe_resource_t *rsc, const char *id, const pcmk_node_t *on_node,
                 int flags)
 {
     bool match = false;
@@ -323,8 +324,8 @@ native_find_rsc(pe_resource_t * rsc, const char *id, const pe_node_t *on_node,
 
 // create is ignored
 char *
-native_parameter(pe_resource_t * rsc, pe_node_t * node, gboolean create, const char *name,
-                 pe_working_set_t * data_set)
+native_parameter(pe_resource_t *rsc, pcmk_node_t *node, gboolean create,
+                 const char *name, pe_working_set_t *data_set)
 {
     char *value_copy = NULL;
     const char *value = NULL;
@@ -348,7 +349,7 @@ gboolean
 native_active(pe_resource_t * rsc, gboolean all)
 {
     for (GList *gIter = rsc->running_on; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *a_node = (pe_node_t *) gIter->data;
+        pcmk_node_t *a_node = (pcmk_node_t *) gIter->data;
 
         if (a_node->details->unclean) {
             pe_rsc_trace(rsc, "Resource %s: %s is unclean",
@@ -511,7 +512,7 @@ native_print_xml(pe_resource_t *rsc, const char *pre_text, long options,
 
         status_print(">\n");
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_node_t *node = (pe_node_t *) gIter->data;
+            pcmk_node_t *node = (pcmk_node_t *) gIter->data;
 
             status_print("%s    <node name=\"%s\" " XML_ATTR_ID "=\"%s\" "
                          "cached=\"%s\"/>\n",
@@ -558,7 +559,7 @@ add_output_node(GString *s, const char *node, bool have_nodes)
  */
 gchar *
 pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
-                           const pe_node_t *node, uint32_t show_opts,
+                           const pcmk_node_t *node, uint32_t show_opts,
                            const char *target_role, bool show_nodes)
 {
     const char *class = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
@@ -698,7 +699,7 @@ pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
         bool have_nodes = false;
 
         for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
-            pe_node_t *n = (pe_node_t *) iter->data;
+            pcmk_node_t *n = (pcmk_node_t *) iter->data;
 
             have_nodes = add_output_node(outstr, n->details->uname, have_nodes);
         }
@@ -712,7 +713,7 @@ pcmk__native_output_string(const pe_resource_t *rsc, const char *name,
 
 int
 pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
-                       const char *name, const pe_node_t *node,
+                       const char *name, const pcmk_node_t *node,
                        uint32_t show_opts)
 {
     const char *kind = crm_element_value(rsc->xml, XML_ATTR_TYPE);
@@ -770,7 +771,7 @@ pe__common_output_html(pcmk__output_t *out, const pe_resource_t *rsc,
 
 int
 pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
-                       const char *name, const pe_node_t *node,
+                       const char *name, const pcmk_node_t *node,
                        uint32_t show_opts)
 {
     const char *target_role = NULL;
@@ -806,7 +807,7 @@ pe__common_output_text(pcmk__output_t *out, const pe_resource_t *rsc,
  */
 void
 common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
-             const pe_node_t *node, long options, void *print_data)
+             const pcmk_node_t *node, long options, void *print_data)
 {
     const char *target_role = NULL;
 
@@ -880,7 +881,7 @@ common_print(pe_resource_t *rsc, const char *pre_text, const char *name,
         }
 
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_node_t *n = (pe_node_t *) gIter->data;
+            pcmk_node_t *n = (pcmk_node_t *) gIter->data;
 
             counter++;
 
@@ -928,7 +929,7 @@ void
 native_print(pe_resource_t *rsc, const char *pre_text, long options,
              void *print_data)
 {
-    const pe_node_t *node = NULL;
+    const pcmk_node_t *node = NULL;
 
     CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
     if (options & pe_print_xml) {
@@ -1014,7 +1015,7 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
         GList *gIter = rsc->running_on;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_node_t *node = (pe_node_t *) gIter->data;
+            pcmk_node_t *node = (pcmk_node_t *) gIter->data;
 
             rc = pe__name_and_nvpairs_xml(out, false, "node", 3,
                      "name", node->details->uname,
@@ -1037,7 +1038,7 @@ pe__resource_html(pcmk__output_t *out, va_list args)
     GList *only_node G_GNUC_UNUSED = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
-    const pe_node_t *node = pe__current_node(rsc);
+    const pcmk_node_t *node = pe__current_node(rsc);
 
     if (rsc->fns->is_filtered(rsc, only_rsc, TRUE)) {
         return pcmk_rc_no_output;
@@ -1061,7 +1062,7 @@ pe__resource_text(pcmk__output_t *out, va_list args)
     GList *only_node G_GNUC_UNUSED = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
 
-    const pe_node_t *node = pe__current_node(rsc);
+    const pcmk_node_t *node = pe__current_node(rsc);
 
     CRM_ASSERT(rsc->variant == pcmk_rsc_variant_primitive);
 
@@ -1106,11 +1107,11 @@ native_resource_state(const pe_resource_t * rsc, gboolean current)
  *
  * \return If list contains only one node, that node, or NULL otherwise
  */
-pe_node_t *
+pcmk_node_t *
 native_location(const pe_resource_t *rsc, GList **list, int current)
 {
     // @COMPAT: Accept a pcmk__rsc_node argument instead of int current
-    pe_node_t *one = NULL;
+    pcmk_node_t *one = NULL;
     GList *result = NULL;
 
     if (rsc->children) {
@@ -1144,7 +1145,7 @@ native_location(const pe_resource_t *rsc, GList **list, int current)
         GList *gIter = result;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_node_t *node = (pe_node_t *) gIter->data;
+            pcmk_node_t *node = (pcmk_node_t *) gIter->data;
 
             if (*list == NULL || pe_find_node_id(*list, node->details->id) == NULL) {
                 *list = g_list_append(*list, node);
@@ -1203,7 +1204,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
             GList *gIter2 = rsc->running_on;
 
             for (; gIter2 != NULL; gIter2 = gIter2->next) {
-                pe_node_t *node = (pe_node_t *) gIter2->data;
+                pcmk_node_t *node = (pcmk_node_t *) gIter2->data;
                 GHashTable *node_table = NULL;
 
                 if (node->details->unclean == FALSE && node->details->online == FALSE &&

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -19,12 +19,12 @@
 #include <crm/common/xml_internal.h>
 #include "pe_status_private.h"
 
-static void unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
+static void unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
                              const pcmk_resource_t *container,
                              guint interval_ms);
 
 static void
-add_singleton(pe_working_set_t *data_set, pe_action_t *action)
+add_singleton(pe_working_set_t *data_set, pcmk_action_t *action)
 {
     if (data_set->singletons == NULL) {
         data_set->singletons = pcmk__strkey_table(NULL, NULL);
@@ -32,7 +32,7 @@ add_singleton(pe_working_set_t *data_set, pe_action_t *action)
     g_hash_table_insert(data_set->singletons, action->uuid, action);
 }
 
-static pe_action_t *
+static pcmk_action_t *
 lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
 {
     if (data_set->singletons == NULL) {
@@ -52,12 +52,12 @@ lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
  *
  * \return Existing action that matches arguments (or NULL if none)
  */
-static pe_action_t *
+static pcmk_action_t *
 find_existing_action(const char *key, const pcmk_resource_t *rsc,
                      const pcmk_node_t *node, const pe_working_set_t *data_set)
 {
     GList *matches = NULL;
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
 
     /* When rsc is NULL, it would be quicker to check data_set->singletons,
      * but checking all data_set->actions takes the node into account.
@@ -166,12 +166,12 @@ find_rsc_op_entry(const pcmk_resource_t *rsc, const char *key)
  * \note This function takes ownership of \p key. It is the caller's
  *       responsibility to free the return value with pe_free_action().
  */
-static pe_action_t *
+static pcmk_action_t *
 new_action(char *key, const char *task, pcmk_resource_t *rsc,
            const pcmk_node_t *node, bool optional, bool for_graph,
            pe_working_set_t *data_set)
 {
-    pe_action_t *action = calloc(1, sizeof(pe_action_t));
+    pcmk_action_t *action = calloc(1, sizeof(pcmk_action_t));
 
     CRM_ASSERT(action != NULL);
 
@@ -232,7 +232,7 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
  * \param[in,out] data_set  Cluster working set
  */
 static void
-unpack_action_node_attributes(pe_action_t *action, pe_working_set_t *data_set)
+unpack_action_node_attributes(pcmk_action_t *action, pe_working_set_t *data_set)
 {
     if (!pcmk_is_set(action->flags, pcmk_action_attrs_evaluated)
         && (action->op_entry != NULL)) {
@@ -261,7 +261,7 @@ unpack_action_node_attributes(pe_action_t *action, pe_working_set_t *data_set)
  * \param[in]     optional  Requested optional status
  */
 static void
-update_action_optional(pe_action_t *action, gboolean optional)
+update_action_optional(pcmk_action_t *action, gboolean optional)
 {
     // Force a non-recurring action to be optional if its resource is unmanaged
     if ((action->rsc != NULL) && (action->node != NULL)
@@ -318,7 +318,7 @@ effective_quorum_policy(pcmk_resource_t *rsc, pe_working_set_t *data_set)
  * \note This may also schedule fencing if a stop is unrunnable.
  */
 static void
-update_resource_action_runnable(pe_action_t *action, bool for_graph,
+update_resource_action_runnable(pcmk_action_t *action, bool for_graph,
                                 pe_working_set_t *data_set)
 {
     if (pcmk_is_set(action->flags, pcmk_action_pseudo)) {
@@ -409,7 +409,7 @@ update_resource_action_runnable(pe_action_t *action, bool for_graph,
  */
 static void
 update_resource_flags_for_action(pcmk_resource_t *rsc,
-                                 const pe_action_t *action)
+                                 const pcmk_action_t *action)
 {
     /* @COMPAT pcmk_rsc_starting and pcmk_rsc_stopping are deprecated and unused
      * within Pacemaker, and will eventually be removed
@@ -844,7 +844,7 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
  * \param[in]     interval_ms  How frequently to perform the operation
  */
 static void
-unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
+unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
                  const pcmk_resource_t *container, guint interval_ms)
 {
     const char *value = NULL;
@@ -1033,12 +1033,12 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
  *       otherwise it is the caller's responsibility to free the return value
  *       with pe_free_action().
  */
-pe_action_t *
+pcmk_action_t *
 custom_action(pcmk_resource_t *rsc, char *key, const char *task,
               const pcmk_node_t *on_node, gboolean optional,
               gboolean save_action, pe_working_set_t *data_set)
 {
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
 
     CRM_ASSERT((key != NULL) && (task != NULL) && (data_set != NULL));
 
@@ -1070,10 +1070,10 @@ custom_action(pcmk_resource_t *rsc, char *key, const char *task,
     return action;
 }
 
-pe_action_t *
+pcmk_action_t *
 get_pseudo_op(const char *name, pe_working_set_t * data_set)
 {
-    pe_action_t *op = lookup_singleton(data_set, name);
+    pcmk_action_t *op = lookup_singleton(data_set, name);
 
     if (op == NULL) {
         op = custom_action(NULL, strdup(name), name, NULL, TRUE, TRUE, data_set);
@@ -1175,12 +1175,12 @@ node_priority_fencing_delay(const pcmk_node_t *node,
     return data_set->priority_fencing_delay;
 }
 
-pe_action_t *
+pcmk_action_t *
 pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
             const char *reason, bool priority_delay, pe_working_set_t *data_set)
 {
     char *op_key = NULL;
-    pe_action_t *stonith_op = NULL;
+    pcmk_action_t *stonith_op = NULL;
 
     if(op == NULL) {
         op = data_set->stonith_action;
@@ -1290,7 +1290,7 @@ pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
 }
 
 void
-pe_free_action(pe_action_t * action)
+pe_free_action(pcmk_action_t *action)
 {
     if (action == NULL) {
         return;
@@ -1392,14 +1392,14 @@ get_complex_task(const pcmk_resource_t *rsc, const char *name)
  *
  * \return First action in list that matches criteria, or NULL if none
  */
-pe_action_t *
+pcmk_action_t *
 find_first_action(const GList *input, const char *uuid, const char *task,
                   const pcmk_node_t *on_node)
 {
     CRM_CHECK(uuid || task, return NULL);
 
     for (const GList *gIter = input; gIter != NULL; gIter = gIter->next) {
-        pe_action_t *action = (pe_action_t *) gIter->data;
+        pcmk_action_t *action = (pcmk_action_t *) gIter->data;
 
         if (uuid != NULL && !pcmk__str_eq(uuid, action->uuid, pcmk__str_casei)) {
             continue;
@@ -1430,7 +1430,7 @@ find_actions(GList *input, const char *key, const pcmk_node_t *on_node)
     CRM_CHECK(key != NULL, return NULL);
 
     for (; gIter != NULL; gIter = gIter->next) {
-        pe_action_t *action = (pe_action_t *) gIter->data;
+        pcmk_action_t *action = (pcmk_action_t *) gIter->data;
 
         if (!pcmk__str_eq(key, action->uuid, pcmk__str_casei)) {
             continue;
@@ -1467,7 +1467,7 @@ find_actions_exact(GList *input, const char *key, const pcmk_node_t *on_node)
     }
 
     for (GList *gIter = input; gIter != NULL; gIter = gIter->next) {
-        pe_action_t *action = (pe_action_t *) gIter->data;
+        pcmk_action_t *action = (pcmk_action_t *) gIter->data;
 
         if ((action->node != NULL)
             && pcmk__str_eq(key, action->uuid, pcmk__str_casei)
@@ -1521,7 +1521,7 @@ pe__resource_actions(const pcmk_resource_t *rsc, const pcmk_node_t *node,
  * \note It is the caller's responsibility to free() the result.
  */
 char *
-pe__action2reason(const pe_action_t *action, enum pe_action_flags flag)
+pe__action2reason(const pcmk_action_t *action, enum pe_action_flags flag)
 {
     const char *change = NULL;
 
@@ -1546,7 +1546,8 @@ pe__action2reason(const pe_action_t *action, enum pe_action_flags flag)
                              action->task);
 }
 
-void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrite) 
+void pe_action_set_reason(pcmk_action_t *action, const char *reason,
+                          bool overwrite)
 {
     if (action->reason != NULL && overwrite) {
         pe_rsc_trace(action->rsc, "Changing %s reason from '%s' to '%s'",
@@ -1740,11 +1741,11 @@ sort_op_by_callid(gconstpointer a, gconstpointer b)
  *
  * \return New action object corresponding to arguments
  */
-pe_action_t *
+pcmk_action_t *
 pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task, bool optional,
                           bool runnable)
 {
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
 
     CRM_ASSERT((rsc != NULL) && (task != NULL));
 
@@ -1767,7 +1768,7 @@ pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task, bool optional,
  * \note This is more efficient than calling add_hash_param().
  */
 void
-pe__add_action_expected_result(pe_action_t *action, int expected_result)
+pe__add_action_expected_result(pcmk_action_t *action, int expected_result)
 {
     char *name = NULL;
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -24,7 +24,7 @@ static void unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
                              guint interval_ms);
 
 static void
-add_singleton(pe_working_set_t *data_set, pcmk_action_t *action)
+add_singleton(pcmk_scheduler_t *data_set, pcmk_action_t *action)
 {
     if (data_set->singletons == NULL) {
         data_set->singletons = pcmk__strkey_table(NULL, NULL);
@@ -33,7 +33,7 @@ add_singleton(pe_working_set_t *data_set, pcmk_action_t *action)
 }
 
 static pcmk_action_t *
-lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
+lookup_singleton(pcmk_scheduler_t *data_set, const char *action_uuid)
 {
     if (data_set->singletons == NULL) {
         return NULL;
@@ -54,7 +54,7 @@ lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
  */
 static pcmk_action_t *
 find_existing_action(const char *key, const pcmk_resource_t *rsc,
-                     const pcmk_node_t *node, const pe_working_set_t *data_set)
+                     const pcmk_node_t *node, const pcmk_scheduler_t *data_set)
 {
     GList *matches = NULL;
     pcmk_action_t *action = NULL;
@@ -169,7 +169,7 @@ find_rsc_op_entry(const pcmk_resource_t *rsc, const char *key)
 static pcmk_action_t *
 new_action(char *key, const char *task, pcmk_resource_t *rsc,
            const pcmk_node_t *node, bool optional, bool for_graph,
-           pe_working_set_t *data_set)
+           pcmk_scheduler_t *data_set)
 {
     pcmk_action_t *action = calloc(1, sizeof(pcmk_action_t));
 
@@ -232,7 +232,7 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
  * \param[in,out] data_set  Cluster working set
  */
 static void
-unpack_action_node_attributes(pcmk_action_t *action, pe_working_set_t *data_set)
+unpack_action_node_attributes(pcmk_action_t *action, pcmk_scheduler_t *data_set)
 {
     if (!pcmk_is_set(action->flags, pcmk_action_attrs_evaluated)
         && (action->op_entry != NULL)) {
@@ -282,7 +282,7 @@ update_action_optional(pcmk_action_t *action, gboolean optional)
 }
 
 static enum pe_quorum_policy
-effective_quorum_policy(pcmk_resource_t *rsc, pe_working_set_t *data_set)
+effective_quorum_policy(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     enum pe_quorum_policy policy = data_set->no_quorum_policy;
 
@@ -319,7 +319,7 @@ effective_quorum_policy(pcmk_resource_t *rsc, pe_working_set_t *data_set)
  */
 static void
 update_resource_action_runnable(pcmk_action_t *action, bool for_graph,
-                                pe_working_set_t *data_set)
+                                pcmk_scheduler_t *data_set)
 {
     if (pcmk_is_set(action->flags, pcmk_action_pseudo)) {
         return;
@@ -1036,7 +1036,7 @@ unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
 pcmk_action_t *
 custom_action(pcmk_resource_t *rsc, char *key, const char *task,
               const pcmk_node_t *on_node, gboolean optional,
-              gboolean save_action, pe_working_set_t *data_set)
+              gboolean save_action, pcmk_scheduler_t *data_set)
 {
     pcmk_action_t *action = NULL;
 
@@ -1071,7 +1071,7 @@ custom_action(pcmk_resource_t *rsc, char *key, const char *task,
 }
 
 pcmk_action_t *
-get_pseudo_op(const char *name, pe_working_set_t * data_set)
+get_pseudo_op(const char *name, pcmk_scheduler_t * data_set)
 {
     pcmk_action_t *op = lookup_singleton(data_set, name);
 
@@ -1109,7 +1109,7 @@ find_unfencing_devices(GList *candidates, GList *matches)
 
 static int
 node_priority_fencing_delay(const pcmk_node_t *node,
-                            const pe_working_set_t *data_set)
+                            const pcmk_scheduler_t *data_set)
 {
     int member_count = 0;
     int online_count = 0;
@@ -1177,7 +1177,7 @@ node_priority_fencing_delay(const pcmk_node_t *node,
 
 pcmk_action_t *
 pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
-            const char *reason, bool priority_delay, pe_working_set_t *data_set)
+            const char *reason, bool priority_delay, pcmk_scheduler_t *data_set)
 {
     char *op_key = NULL;
     pcmk_action_t *stonith_op = NULL;
@@ -1313,7 +1313,7 @@ pe_free_action(pcmk_action_t *action)
 
 int
 pe_get_configured_timeout(pcmk_resource_t *rsc, const char *action,
-                          pe_working_set_t *data_set)
+                          pcmk_scheduler_t *data_set)
 {
     xmlNode *child = NULL;
     GHashTable *action_meta = NULL;

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -53,7 +53,7 @@ lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
  */
 static pe_action_t *
 find_existing_action(const char *key, const pe_resource_t *rsc,
-                     const pe_node_t *node, const pe_working_set_t *data_set)
+                     const pcmk_node_t *node, const pe_working_set_t *data_set)
 {
     GList *matches = NULL;
     pe_action_t *action = NULL;
@@ -167,7 +167,7 @@ find_rsc_op_entry(const pe_resource_t *rsc, const char *key)
  */
 static pe_action_t *
 new_action(char *key, const char *task, pe_resource_t *rsc,
-           const pe_node_t *node, bool optional, bool for_graph,
+           const pcmk_node_t *node, bool optional, bool for_graph,
            pe_working_set_t *data_set)
 {
     pe_action_t *action = calloc(1, sizeof(pe_action_t));
@@ -679,7 +679,7 @@ find_min_interval_mon(pe_resource_t * rsc, gboolean include_disabled)
  * \return Newly allocated hash table with normalized action meta-attributes
  */
 GHashTable *
-pcmk__unpack_action_meta(pe_resource_t *rsc, const pe_node_t *node,
+pcmk__unpack_action_meta(pe_resource_t *rsc, const pcmk_node_t *node,
                          const char *action_name, guint interval_ms,
                          const xmlNode *action_config)
 {
@@ -1033,8 +1033,8 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
  */
 pe_action_t *
 custom_action(pe_resource_t *rsc, char *key, const char *task,
-              const pe_node_t *on_node, gboolean optional, gboolean save_action,
-              pe_working_set_t *data_set)
+              const pcmk_node_t *on_node, gboolean optional,
+              gboolean save_action, pe_working_set_t *data_set)
 {
     pe_action_t *action = NULL;
 
@@ -1106,7 +1106,7 @@ find_unfencing_devices(GList *candidates, GList *matches)
 }
 
 static int
-node_priority_fencing_delay(const pe_node_t *node,
+node_priority_fencing_delay(const pcmk_node_t *node,
                             const pe_working_set_t *data_set)
 {
     int member_count = 0;
@@ -1132,7 +1132,7 @@ node_priority_fencing_delay(const pe_node_t *node,
     }
 
     for (gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *n =  gIter->data;
+        pcmk_node_t *n = gIter->data;
 
         if (n->details->type != pcmk_node_variant_cluster) {
             continue;
@@ -1174,7 +1174,7 @@ node_priority_fencing_delay(const pe_node_t *node,
 }
 
 pe_action_t *
-pe_fence_op(pe_node_t *node, const char *op, bool optional,
+pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
             const char *reason, bool priority_delay, pe_working_set_t *data_set)
 {
     char *op_key = NULL;
@@ -1391,7 +1391,7 @@ get_complex_task(const pe_resource_t *rsc, const char *name)
  */
 pe_action_t *
 find_first_action(const GList *input, const char *uuid, const char *task,
-                  const pe_node_t *on_node)
+                  const pcmk_node_t *on_node)
 {
     CRM_CHECK(uuid || task, return NULL);
 
@@ -1419,7 +1419,7 @@ find_first_action(const GList *input, const char *uuid, const char *task,
 }
 
 GList *
-find_actions(GList *input, const char *key, const pe_node_t *on_node)
+find_actions(GList *input, const char *key, const pcmk_node_t *on_node)
 {
     GList *gIter = input;
     GList *result = NULL;
@@ -1453,7 +1453,7 @@ find_actions(GList *input, const char *key, const pe_node_t *on_node)
 }
 
 GList *
-find_actions_exact(GList *input, const char *key, const pe_node_t *on_node)
+find_actions_exact(GList *input, const char *key, const pcmk_node_t *on_node)
 {
     GList *result = NULL;
 
@@ -1492,7 +1492,7 @@ find_actions_exact(GList *input, const char *key, const pe_node_t *on_node)
  *       without a node will be assigned to node.
  */
 GList *
-pe__resource_actions(const pe_resource_t *rsc, const pe_node_t *node,
+pe__resource_actions(const pe_resource_t *rsc, const pcmk_node_t *node,
                      const char *task, bool require_node)
 {
     GList *result = NULL;
@@ -1567,7 +1567,7 @@ void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrit
  * \param[in]     node      Node to clear history on
  */
 void
-pe__clear_resource_history(pe_resource_t *rsc, const pe_node_t *node)
+pe__clear_resource_history(pe_resource_t *rsc, const pcmk_node_t *node)
 {
     CRM_ASSERT((rsc != NULL) && (node != NULL));
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -20,7 +20,8 @@
 #include "pe_status_private.h"
 
 static void unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
-                             const pe_resource_t *container, guint interval_ms);
+                             const pcmk_resource_t *container,
+                             guint interval_ms);
 
 static void
 add_singleton(pe_working_set_t *data_set, pe_action_t *action)
@@ -52,7 +53,7 @@ lookup_singleton(pe_working_set_t *data_set, const char *action_uuid)
  * \return Existing action that matches arguments (or NULL if none)
  */
 static pe_action_t *
-find_existing_action(const char *key, const pe_resource_t *rsc,
+find_existing_action(const char *key, const pcmk_resource_t *rsc,
                      const pcmk_node_t *node, const pe_working_set_t *data_set)
 {
     GList *matches = NULL;
@@ -74,7 +75,7 @@ find_existing_action(const char *key, const pe_resource_t *rsc,
 }
 
 static xmlNode *
-find_rsc_op_entry_helper(const pe_resource_t *rsc, const char *key,
+find_rsc_op_entry_helper(const pcmk_resource_t *rsc, const char *key,
                          gboolean include_disabled)
 {
     guint interval_ms = 0;
@@ -144,7 +145,7 @@ find_rsc_op_entry_helper(const pe_resource_t *rsc, const char *key,
 }
 
 xmlNode *
-find_rsc_op_entry(const pe_resource_t *rsc, const char *key)
+find_rsc_op_entry(const pcmk_resource_t *rsc, const char *key)
 {
     return find_rsc_op_entry_helper(rsc, key, FALSE);
 }
@@ -166,7 +167,7 @@ find_rsc_op_entry(const pe_resource_t *rsc, const char *key)
  *       responsibility to free the return value with pe_free_action().
  */
 static pe_action_t *
-new_action(char *key, const char *task, pe_resource_t *rsc,
+new_action(char *key, const char *task, pcmk_resource_t *rsc,
            const pcmk_node_t *node, bool optional, bool for_graph,
            pe_working_set_t *data_set)
 {
@@ -281,7 +282,7 @@ update_action_optional(pe_action_t *action, gboolean optional)
 }
 
 static enum pe_quorum_policy
-effective_quorum_policy(pe_resource_t *rsc, pe_working_set_t *data_set)
+effective_quorum_policy(pcmk_resource_t *rsc, pe_working_set_t *data_set)
 {
     enum pe_quorum_policy policy = data_set->no_quorum_policy;
 
@@ -407,7 +408,8 @@ update_resource_action_runnable(pe_action_t *action, bool for_graph,
  * \param[in]     action  New action
  */
 static void
-update_resource_flags_for_action(pe_resource_t *rsc, const pe_action_t *action)
+update_resource_flags_for_action(pcmk_resource_t *rsc,
+                                 const pe_action_t *action)
 {
     /* @COMPAT pcmk_rsc_starting and pcmk_rsc_stopping are deprecated and unused
      * within Pacemaker, and will eventually be removed
@@ -440,7 +442,7 @@ valid_stop_on_fail(const char *value)
  * \param[in,out] meta           Table of action meta-attributes
  */
 static void
-validate_on_fail(const pe_resource_t *rsc, const char *action_name,
+validate_on_fail(const pcmk_resource_t *rsc, const char *action_name,
                  const xmlNode *action_config, GHashTable *meta)
 {
     const char *name = NULL;
@@ -623,7 +625,7 @@ unpack_start_delay(const char *value, GHashTable *meta)
 }
 
 static xmlNode *
-find_min_interval_mon(pe_resource_t * rsc, gboolean include_disabled)
+find_min_interval_mon(pcmk_resource_t * rsc, gboolean include_disabled)
 {
     guint interval_ms = 0;
     guint min_interval_ms = G_MAXUINT;
@@ -679,7 +681,7 @@ find_min_interval_mon(pe_resource_t * rsc, gboolean include_disabled)
  * \return Newly allocated hash table with normalized action meta-attributes
  */
 GHashTable *
-pcmk__unpack_action_meta(pe_resource_t *rsc, const pcmk_node_t *node,
+pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
                          const char *action_name, guint interval_ms,
                          const xmlNode *action_config)
 {
@@ -843,7 +845,7 @@ pcmk__unpack_action_meta(pe_resource_t *rsc, const pcmk_node_t *node,
  */
 static void
 unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
-                 const pe_resource_t *container, guint interval_ms)
+                 const pcmk_resource_t *container, guint interval_ms)
 {
     const char *value = NULL;
 
@@ -1032,7 +1034,7 @@ unpack_operation(pe_action_t *action, const xmlNode *xml_obj,
  *       with pe_free_action().
  */
 pe_action_t *
-custom_action(pe_resource_t *rsc, char *key, const char *task,
+custom_action(pcmk_resource_t *rsc, char *key, const char *task,
               const pcmk_node_t *on_node, gboolean optional,
               gboolean save_action, pe_working_set_t *data_set)
 {
@@ -1084,7 +1086,7 @@ static GList *
 find_unfencing_devices(GList *candidates, GList *matches) 
 {
     for (GList *gIter = candidates; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *candidate = gIter->data;
+        pcmk_resource_t *candidate = gIter->data;
 
         if (candidate->children != NULL) {
             matches = find_unfencing_devices(candidate->children, matches);
@@ -1208,7 +1210,7 @@ pe_fence_op(pcmk_node_t *node, const char *op, bool optional,
             char *value = NULL;
 
             for (GList *gIter = matches; gIter != NULL; gIter = gIter->next) {
-                pe_resource_t *match = gIter->data;
+                pcmk_resource_t *match = gIter->data;
                 const char *agent = g_hash_table_lookup(match->meta,
                                                         XML_ATTR_TYPE);
                 op_digest_cache_t *data = NULL;
@@ -1310,7 +1312,8 @@ pe_free_action(pe_action_t * action)
 }
 
 int
-pe_get_configured_timeout(pe_resource_t *rsc, const char *action, pe_working_set_t *data_set)
+pe_get_configured_timeout(pcmk_resource_t *rsc, const char *action,
+                          pe_working_set_t *data_set)
 {
     xmlNode *child = NULL;
     GHashTable *action_meta = NULL;
@@ -1357,7 +1360,7 @@ pe_get_configured_timeout(pe_resource_t *rsc, const char *action, pe_working_set
 }
 
 enum action_tasks
-get_complex_task(const pe_resource_t *rsc, const char *name)
+get_complex_task(const pcmk_resource_t *rsc, const char *name)
 {
     enum action_tasks task = text2task(name);
 
@@ -1492,7 +1495,7 @@ find_actions_exact(GList *input, const char *key, const pcmk_node_t *on_node)
  *       without a node will be assigned to node.
  */
 GList *
-pe__resource_actions(const pe_resource_t *rsc, const pcmk_node_t *node,
+pe__resource_actions(const pcmk_resource_t *rsc, const pcmk_node_t *node,
                      const char *task, bool require_node)
 {
     GList *result = NULL;
@@ -1567,7 +1570,7 @@ void pe_action_set_reason(pe_action_t *action, const char *reason, bool overwrit
  * \param[in]     node      Node to clear history on
  */
 void
-pe__clear_resource_history(pe_resource_t *rsc, const pcmk_node_t *node)
+pe__clear_resource_history(pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     CRM_ASSERT((rsc != NULL) && (node != NULL));
 
@@ -1738,7 +1741,7 @@ sort_op_by_callid(gconstpointer a, gconstpointer b)
  * \return New action object corresponding to arguments
  */
 pe_action_t *
-pe__new_rsc_pseudo_action(pe_resource_t *rsc, const char *task, bool optional,
+pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task, bool optional,
                           bool runnable)
 {
     pe_action_t *action = NULL;

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -97,7 +97,7 @@ attr_in_string(xmlAttrPtr a, void *user_data)
  */
 static void
 calculate_main_digest(op_digest_cache_t *data, pe_resource_t *rsc,
-                      const pe_node_t *node, GHashTable *params,
+                      const pcmk_node_t *node, GHashTable *params,
                       const char *task, guint *interval_ms,
                       const xmlNode *xml_op, const char *op_version,
                       GHashTable *overrides, pe_working_set_t *data_set)
@@ -296,7 +296,7 @@ calculate_restart_digest(op_digest_cache_t *data, const xmlNode *xml_op,
  */
 op_digest_cache_t *
 pe__calculate_digests(pe_resource_t *rsc, const char *task, guint *interval_ms,
-                      const pe_node_t *node, const xmlNode *xml_op,
+                      const pcmk_node_t *node, const xmlNode *xml_op,
                       GHashTable *overrides, bool calc_secure,
                       pe_working_set_t *data_set)
 {
@@ -349,7 +349,7 @@ pe__calculate_digests(pe_resource_t *rsc, const char *task, guint *interval_ms,
  */
 static op_digest_cache_t *
 rsc_action_digest(pe_resource_t *rsc, const char *task, guint interval_ms,
-                  pe_node_t *node, const xmlNode *xml_op,
+                  pcmk_node_t *node, const xmlNode *xml_op,
                   bool calc_secure, pe_working_set_t *data_set)
 {
     op_digest_cache_t *data = NULL;
@@ -379,7 +379,7 @@ rsc_action_digest(pe_resource_t *rsc, const char *task, guint interval_ms,
  */
 op_digest_cache_t *
 rsc_action_digest_cmp(pe_resource_t *rsc, const xmlNode *xml_op,
-                      pe_node_t *node, pe_working_set_t *data_set)
+                      pcmk_node_t *node, pe_working_set_t *data_set)
 {
     op_digest_cache_t *data = NULL;
     guint interval_ms = 0;
@@ -530,7 +530,7 @@ unfencing_digest_matches(const char *rsc_id, const char *agent,
  */
 op_digest_cache_t *
 pe__compare_fencing_digest(pe_resource_t *rsc, const char *agent,
-                           pe_node_t *node, pe_working_set_t *data_set)
+                           pcmk_node_t *node, pe_working_set_t *data_set)
 {
     const char *node_summary = NULL;
 

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -96,7 +96,7 @@ attr_in_string(xmlAttrPtr a, void *user_data)
  * \param[in,out] data_set     Cluster working set
  */
 static void
-calculate_main_digest(op_digest_cache_t *data, pe_resource_t *rsc,
+calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
                       const pcmk_node_t *node, GHashTable *params,
                       const char *task, guint *interval_ms,
                       const xmlNode *xml_op, const char *op_version,
@@ -177,7 +177,7 @@ is_fence_param(xmlAttrPtr attr, void *user_data)
  * \param[in]  overrides   Key/value hash table to override resource parameters
  */
 static void
-calculate_secure_digest(op_digest_cache_t *data, const pe_resource_t *rsc,
+calculate_secure_digest(op_digest_cache_t *data, const pcmk_resource_t *rsc,
                         GHashTable *params, const xmlNode *xml_op,
                         const char *op_version, GHashTable *overrides)
 {
@@ -295,10 +295,10 @@ calculate_restart_digest(op_digest_cache_t *data, const xmlNode *xml_op,
  *       pe__free_digests().
  */
 op_digest_cache_t *
-pe__calculate_digests(pe_resource_t *rsc, const char *task, guint *interval_ms,
-                      const pcmk_node_t *node, const xmlNode *xml_op,
-                      GHashTable *overrides, bool calc_secure,
-                      pe_working_set_t *data_set)
+pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
+                      guint *interval_ms, const pcmk_node_t *node,
+                      const xmlNode *xml_op, GHashTable *overrides,
+                      bool calc_secure, pe_working_set_t *data_set)
 {
     op_digest_cache_t *data = calloc(1, sizeof(op_digest_cache_t));
     const char *op_version = NULL;
@@ -348,7 +348,7 @@ pe__calculate_digests(pe_resource_t *rsc, const char *task, guint *interval_ms,
  * \return Pointer to node's digest cache entry
  */
 static op_digest_cache_t *
-rsc_action_digest(pe_resource_t *rsc, const char *task, guint interval_ms,
+rsc_action_digest(pcmk_resource_t *rsc, const char *task, guint interval_ms,
                   pcmk_node_t *node, const xmlNode *xml_op,
                   bool calc_secure, pe_working_set_t *data_set)
 {
@@ -378,7 +378,7 @@ rsc_action_digest(pe_resource_t *rsc, const char *task, guint interval_ms,
  * \return Pointer to node's digest cache entry, with comparison result set
  */
 op_digest_cache_t *
-rsc_action_digest_cmp(pe_resource_t *rsc, const xmlNode *xml_op,
+rsc_action_digest_cmp(pcmk_resource_t *rsc, const xmlNode *xml_op,
                       pcmk_node_t *node, pe_working_set_t *data_set)
 {
     op_digest_cache_t *data = NULL;
@@ -529,7 +529,7 @@ unfencing_digest_matches(const char *rsc_id, const char *agent,
  * \return Node's digest cache entry
  */
 op_digest_cache_t *
-pe__compare_fencing_digest(pe_resource_t *rsc, const char *agent,
+pe__compare_fencing_digest(pcmk_resource_t *rsc, const char *agent,
                            pcmk_node_t *node, pe_working_set_t *data_set)
 {
     const char *node_summary = NULL;

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -102,7 +102,7 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
                       const xmlNode *xml_op, const char *op_version,
                       GHashTable *overrides, pe_working_set_t *data_set)
 {
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
 
     data->params_all = create_xml_node(NULL, XML_TAG_PARAMS);
 

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -100,7 +100,7 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
                       const pcmk_node_t *node, GHashTable *params,
                       const char *task, guint *interval_ms,
                       const xmlNode *xml_op, const char *op_version,
-                      GHashTable *overrides, pe_working_set_t *data_set)
+                      GHashTable *overrides, pcmk_scheduler_t *data_set)
 {
     pcmk_action_t *action = NULL;
 
@@ -298,7 +298,7 @@ op_digest_cache_t *
 pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
                       guint *interval_ms, const pcmk_node_t *node,
                       const xmlNode *xml_op, GHashTable *overrides,
-                      bool calc_secure, pe_working_set_t *data_set)
+                      bool calc_secure, pcmk_scheduler_t *data_set)
 {
     op_digest_cache_t *data = calloc(1, sizeof(op_digest_cache_t));
     const char *op_version = NULL;
@@ -350,7 +350,7 @@ pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
 static op_digest_cache_t *
 rsc_action_digest(pcmk_resource_t *rsc, const char *task, guint interval_ms,
                   pcmk_node_t *node, const xmlNode *xml_op,
-                  bool calc_secure, pe_working_set_t *data_set)
+                  bool calc_secure, pcmk_scheduler_t *data_set)
 {
     op_digest_cache_t *data = NULL;
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
@@ -379,7 +379,7 @@ rsc_action_digest(pcmk_resource_t *rsc, const char *task, guint interval_ms,
  */
 op_digest_cache_t *
 rsc_action_digest_cmp(pcmk_resource_t *rsc, const xmlNode *xml_op,
-                      pcmk_node_t *node, pe_working_set_t *data_set)
+                      pcmk_node_t *node, pcmk_scheduler_t *data_set)
 {
     op_digest_cache_t *data = NULL;
     guint interval_ms = 0;
@@ -530,7 +530,7 @@ unfencing_digest_matches(const char *rsc_id, const char *agent,
  */
 op_digest_cache_t *
 pe__compare_fencing_digest(pcmk_resource_t *rsc, const char *agent,
-                           pcmk_node_t *node, pe_working_set_t *data_set)
+                           pcmk_node_t *node, pcmk_scheduler_t *data_set)
 {
     const char *node_summary = NULL;
 

--- a/lib/pengine/pe_health.c
+++ b/lib/pengine/pe_health.c
@@ -20,7 +20,7 @@
  * \param[in,out] data_set  Cluster working set
  */
 void
-pe__unpack_node_health_scores(pe_working_set_t *data_set)
+pe__unpack_node_health_scores(pcmk_scheduler_t *data_set)
 {
     switch (pe__health_strategy(data_set)) {
         case pcmk__health_strategy_none:

--- a/lib/pengine/pe_health.c
+++ b/lib/pengine/pe_health.c
@@ -93,7 +93,7 @@ add_node_health_value(gpointer key, gpointer value, gpointer user_data)
  * \return Sum of all health attribute scores of \p node plus \p base_health
  */
 int
-pe__sum_node_health_scores(const pe_node_t *node, int base_health)
+pe__sum_node_health_scores(const pcmk_node_t *node, int base_health)
 {
     CRM_ASSERT(node != NULL);
     g_hash_table_foreach(node->details->attrs, add_node_health_value,
@@ -111,7 +111,7 @@ pe__sum_node_health_scores(const pe_node_t *node, int base_health)
  *          otherwise 0 if any attribute is yellow, otherwise a positive value.
  */
 int
-pe__node_health(pe_node_t *node)
+pe__node_health(pcmk_node_t *node)
 {
     GHashTableIter iter;
     const char *name = NULL;

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -16,7 +16,7 @@
 #include "pe_status_private.h"
 
 typedef struct notify_entry_s {
-    const pe_resource_t *rsc;
+    const pcmk_resource_t *rsc;
     const pcmk_node_t *node;
 } notify_entry_t;
 
@@ -279,7 +279,7 @@ add_notify_data_to_action_meta(const notify_data_t *n_data, pe_action_t *action)
  * \return Newly created notify pseudo-action
  */
 static pe_action_t *
-new_notify_pseudo_action(pe_resource_t *rsc, const pe_action_t *action,
+new_notify_pseudo_action(pcmk_resource_t *rsc, const pe_action_t *action,
                          const char *notif_action, const char *notif_type)
 {
     pe_action_t *notify = NULL;
@@ -308,8 +308,9 @@ new_notify_pseudo_action(pe_resource_t *rsc, const pe_action_t *action,
  * \return Newly created notify action
  */
 static pe_action_t *
-new_notify_action(pe_resource_t *rsc, const pcmk_node_t *node, pe_action_t *op,
-                  pe_action_t *notify_done, const notify_data_t *n_data)
+new_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
+                  pe_action_t *op, pe_action_t *notify_done,
+                  const notify_data_t *n_data)
 {
     char *key = NULL;
     pe_action_t *notify_action = NULL;
@@ -366,7 +367,7 @@ new_notify_action(pe_resource_t *rsc, const pcmk_node_t *node, pe_action_t *op,
  * \param[in,out] n_data  Notification values to add to action meta-data
  */
 static void
-new_post_notify_action(pe_resource_t *rsc, const pcmk_node_t *node,
+new_post_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
                        notify_data_t *n_data)
 {
     pe_action_t *notify = NULL;
@@ -430,7 +431,7 @@ new_post_notify_action(pe_resource_t *rsc, const pcmk_node_t *node,
  * \return Newly created notification data
  */
 notify_data_t *
-pe__action_notif_pseudo_ops(pe_resource_t *rsc, const char *task,
+pe__action_notif_pseudo_ops(pcmk_resource_t *rsc, const char *task,
                             pe_action_t *action, pe_action_t *complete)
 {
     notify_data_t *n_data = NULL;
@@ -519,7 +520,7 @@ pe__action_notif_pseudo_ops(pe_resource_t *rsc, const char *task,
  * \note The caller is responsible for freeing the return value.
  */
 static notify_entry_t *
-new_notify_entry(const pe_resource_t *rsc, const pcmk_node_t *node)
+new_notify_entry(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     notify_entry_t *entry = calloc(1, sizeof(notify_entry_t));
 
@@ -538,7 +539,7 @@ new_notify_entry(const pe_resource_t *rsc, const pcmk_node_t *node)
  * \param[in,out] n_data    Notification data for clone
  */
 static void
-collect_resource_data(const pe_resource_t *rsc, bool activity,
+collect_resource_data(const pcmk_resource_t *rsc, bool activity,
                       notify_data_t *n_data)
 {
     const GList *iter = NULL;
@@ -556,7 +557,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
     // If this is a clone, call recursively for each instance
     if (rsc->children != NULL) {
         for (iter = rsc->children; iter != NULL; iter = iter->next) {
-            const pe_resource_t *child = (const pe_resource_t *) iter->data;
+            const pcmk_resource_t *child = (const pcmk_resource_t *) iter->data;
 
             collect_resource_data(child, activity, n_data);
         }
@@ -667,7 +668,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
  * \param[in,out] n_data    Notification data
  */
 static void
-add_notif_keys(const pe_resource_t *rsc, notify_data_t *n_data)
+add_notif_keys(const pcmk_resource_t *rsc, notify_data_t *n_data)
 {
     bool required = false; // Whether to make notify actions required
     GString *rsc_list = NULL;
@@ -783,7 +784,7 @@ static pe_action_t *
 find_remote_start(pe_action_t *action)
 {
     if ((action != NULL) && (action->node != NULL)) {
-        pe_resource_t *remote_rsc = action->node->details->remote_rsc;
+        pcmk_resource_t *remote_rsc = action->node->details->remote_rsc;
 
         if (remote_rsc != NULL) {
             return find_first_action(remote_rsc->actions, NULL,
@@ -802,7 +803,7 @@ find_remote_start(pe_action_t *action)
  * \param[in,out] n_data  Clone notification data for some action
  */
 static void
-create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
+create_notify_actions(pcmk_resource_t *rsc, notify_data_t *n_data)
 {
     GList *iter = NULL;
     pe_action_t *stop = NULL;
@@ -938,7 +939,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
  * \param[in,out] n_data  Clone notification data for some action
  */
 void
-pe__create_action_notifications(pe_resource_t *rsc, notify_data_t *n_data)
+pe__create_action_notifications(pcmk_resource_t *rsc, notify_data_t *n_data)
 {
     if ((rsc == NULL) || (n_data == NULL)) {
         return;
@@ -987,7 +988,7 @@ pe__free_action_notification_data(notify_data_t *n_data)
  * \param[in,out] stonith_op  Fencing action that implies \p stop
  */
 void
-pe__order_notifs_after_fencing(const pe_action_t *stop, pe_resource_t *rsc,
+pe__order_notifs_after_fencing(const pe_action_t *stop, pcmk_resource_t *rsc,
                                pe_action_t *stonith_op)
 {
     notify_data_t *n_data;

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -17,7 +17,7 @@
 
 typedef struct notify_entry_s {
     const pe_resource_t *rsc;
-    const pe_node_t *node;
+    const pcmk_node_t *node;
 } notify_entry_t;
 
 /*!
@@ -107,7 +107,7 @@ dup_notify_entry(const notify_entry_t *entry)
  * \internal
  * \brief Given a list of nodes, create strings with node names
  *
- * \param[in]  list             List of nodes (as pe_node_t *)
+ * \param[in]  list             List of nodes (as pcmk_node_t *)
  * \param[out] all_node_names   If not NULL, will be set to space-separated list
  *                              of the names of all nodes in \p list
  * \param[out] host_node_names  Same as \p all_node_names, except active
@@ -128,7 +128,7 @@ get_node_names(const GList *list, GString **all_node_names,
     }
 
     for (const GList *iter = list; iter != NULL; iter = iter->next) {
-        const pe_node_t *node = (const pe_node_t *) iter->data;
+        const pcmk_node_t *node = (const pcmk_node_t *) iter->data;
 
         if (node->details->uname == NULL) {
             continue;
@@ -308,7 +308,7 @@ new_notify_pseudo_action(pe_resource_t *rsc, const pe_action_t *action,
  * \return Newly created notify action
  */
 static pe_action_t *
-new_notify_action(pe_resource_t *rsc, const pe_node_t *node, pe_action_t *op,
+new_notify_action(pe_resource_t *rsc, const pcmk_node_t *node, pe_action_t *op,
                   pe_action_t *notify_done, const notify_data_t *n_data)
 {
     char *key = NULL;
@@ -366,7 +366,7 @@ new_notify_action(pe_resource_t *rsc, const pe_node_t *node, pe_action_t *op,
  * \param[in,out] n_data  Notification values to add to action meta-data
  */
 static void
-new_post_notify_action(pe_resource_t *rsc, const pe_node_t *node,
+new_post_notify_action(pe_resource_t *rsc, const pcmk_node_t *node,
                        notify_data_t *n_data)
 {
     pe_action_t *notify = NULL;
@@ -519,7 +519,7 @@ pe__action_notif_pseudo_ops(pe_resource_t *rsc, const char *task,
  * \note The caller is responsible for freeing the return value.
  */
 static notify_entry_t *
-new_notify_entry(const pe_resource_t *rsc, const pe_node_t *node)
+new_notify_entry(const pe_resource_t *rsc, const pcmk_node_t *node)
 {
     notify_entry_t *entry = calloc(1, sizeof(notify_entry_t));
 
@@ -543,7 +543,7 @@ collect_resource_data(const pe_resource_t *rsc, bool activity,
 {
     const GList *iter = NULL;
     notify_entry_t *entry = NULL;
-    const pe_node_t *node = NULL;
+    const pcmk_node_t *node = NULL;
 
     if (n_data == NULL) {
         return;
@@ -875,7 +875,7 @@ create_notify_actions(pe_resource_t *rsc, notify_data_t *n_data)
         stop = find_first_action(rsc->actions, NULL, PCMK_ACTION_STOP, NULL);
 
         for (iter = rsc->running_on; iter != NULL; iter = iter->next) {
-            pe_node_t *current_node = (pe_node_t *) iter->data;
+            pcmk_node_t *current_node = (pcmk_node_t *) iter->data;
 
             /* If a stop is a pseudo-action implied by fencing, don't try to
              * notify the node getting fenced.

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -244,7 +244,7 @@ notify_entries_to_strings(GList *list, GString **rsc_names,
 static void
 copy_meta_to_notify(gpointer key, gpointer value, gpointer user_data)
 {
-    pe_action_t *notify = (pe_action_t *) user_data;
+    pcmk_action_t *notify = (pcmk_action_t *) user_data;
 
     /* Any existing meta-attributes (for example, the action timeout) are for
      * the notify action itself, so don't override those.
@@ -258,7 +258,8 @@ copy_meta_to_notify(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
-add_notify_data_to_action_meta(const notify_data_t *n_data, pe_action_t *action)
+add_notify_data_to_action_meta(const notify_data_t *n_data,
+                               pcmk_action_t *action)
 {
     for (const GSList *item = n_data->keys; item; item = item->next) {
         const pcmk_nvpair_t *nvpair = (const pcmk_nvpair_t *) item->data;
@@ -278,11 +279,11 @@ add_notify_data_to_action_meta(const notify_data_t *n_data, pe_action_t *action)
  *
  * \return Newly created notify pseudo-action
  */
-static pe_action_t *
-new_notify_pseudo_action(pcmk_resource_t *rsc, const pe_action_t *action,
+static pcmk_action_t *
+new_notify_pseudo_action(pcmk_resource_t *rsc, const pcmk_action_t *action,
                          const char *notif_action, const char *notif_type)
 {
-    pe_action_t *notify = NULL;
+    pcmk_action_t *notify = NULL;
 
     notify = custom_action(rsc,
                            pcmk__notify_key(rsc->id, notif_type, action->task),
@@ -307,13 +308,13 @@ new_notify_pseudo_action(pcmk_resource_t *rsc, const pe_action_t *action,
  *
  * \return Newly created notify action
  */
-static pe_action_t *
+static pcmk_action_t *
 new_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                  pe_action_t *op, pe_action_t *notify_done,
+                  pcmk_action_t *op, pcmk_action_t *notify_done,
                   const notify_data_t *n_data)
 {
     char *key = NULL;
-    pe_action_t *notify_action = NULL;
+    pcmk_action_t *notify_action = NULL;
     const char *value = NULL;
     const char *task = NULL;
     const char *skip_reason = NULL;
@@ -370,7 +371,7 @@ static void
 new_post_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
                        notify_data_t *n_data)
 {
-    pe_action_t *notify = NULL;
+    pcmk_action_t *notify = NULL;
 
     CRM_ASSERT(n_data != NULL);
 
@@ -386,7 +387,7 @@ new_post_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
         return;
     }
     for (GList *iter = rsc->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *mon = (pe_action_t *) iter->data;
+        pcmk_action_t *mon = (pcmk_action_t *) iter->data;
         const char *interval_ms_s = NULL;
 
         interval_ms_s = g_hash_table_lookup(mon->meta,
@@ -432,7 +433,7 @@ new_post_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
  */
 notify_data_t *
 pe__action_notif_pseudo_ops(pcmk_resource_t *rsc, const char *task,
-                            pe_action_t *action, pe_action_t *complete)
+                            pcmk_action_t *action, pcmk_action_t *complete)
 {
     notify_data_t *n_data = NULL;
 
@@ -607,7 +608,7 @@ collect_resource_data(const pcmk_resource_t *rsc, bool activity,
 
     // Add notification entries for each of the resource's actions
     for (iter = rsc->actions; iter != NULL; iter = iter->next) {
-        const pe_action_t *op = (const pe_action_t *) iter->data;
+        const pcmk_action_t *op = (const pcmk_action_t *) iter->data;
 
         if (!pcmk_is_set(op->flags, pcmk_action_optional)
             && (op->node != NULL)) {
@@ -780,8 +781,8 @@ add_notif_keys(const pcmk_resource_t *rsc, notify_data_t *n_data)
  *
  * \return If action is behind a remote connection, connection's start
  */
-static pe_action_t *
-find_remote_start(pe_action_t *action)
+static pcmk_action_t *
+find_remote_start(pcmk_action_t *action)
 {
     if ((action != NULL) && (action->node != NULL)) {
         pcmk_resource_t *remote_rsc = action->node->details->remote_rsc;
@@ -806,8 +807,8 @@ static void
 create_notify_actions(pcmk_resource_t *rsc, notify_data_t *n_data)
 {
     GList *iter = NULL;
-    pe_action_t *stop = NULL;
-    pe_action_t *start = NULL;
+    pcmk_action_t *stop = NULL;
+    pcmk_action_t *start = NULL;
     enum action_tasks task = text2task(n_data->action);
 
     // If this is a clone, call recursively for each instance
@@ -818,7 +819,7 @@ create_notify_actions(pcmk_resource_t *rsc, notify_data_t *n_data)
 
     // Add notification meta-attributes to original actions
     for (iter = rsc->actions; iter != NULL; iter = iter->next) {
-        pe_action_t *op = (pe_action_t *) iter->data;
+        pcmk_action_t *op = (pcmk_action_t *) iter->data;
 
         if (!pcmk_is_set(op->flags, pcmk_action_optional)
             && (op->node != NULL)) {
@@ -904,7 +905,7 @@ create_notify_actions(pcmk_resource_t *rsc, notify_data_t *n_data)
 
         start = find_first_action(rsc->actions, NULL, PCMK_ACTION_START, NULL);
         if (start != NULL) {
-            pe_action_t *remote_start = find_remote_start(start);
+            pcmk_action_t *remote_start = find_remote_start(start);
 
             if ((remote_start != NULL)
                 && !pcmk_is_set(remote_start->flags, pcmk_action_runnable)) {
@@ -988,8 +989,8 @@ pe__free_action_notification_data(notify_data_t *n_data)
  * \param[in,out] stonith_op  Fencing action that implies \p stop
  */
 void
-pe__order_notifs_after_fencing(const pe_action_t *stop, pcmk_resource_t *rsc,
-                               pe_action_t *stonith_op)
+pe__order_notifs_after_fencing(const pcmk_action_t *stop, pcmk_resource_t *rsc,
+                               pcmk_action_t *stonith_op)
 {
     notify_data_t *n_data;
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -61,7 +61,7 @@ compare_attribute(gconstpointer a, gconstpointer b)
  */
 static bool
 add_extra_info(const pcmk_node_t *node, GList *rsc_list,
-               pe_working_set_t *data_set, const char *attrname,
+               pcmk_scheduler_t *data_set, const char *attrname,
                int *expected_score)
 {
     GList *gIter = NULL;
@@ -194,7 +194,7 @@ append_dump_text(gpointer key, gpointer value, gpointer user_data)
 }
 
 static const char *
-get_cluster_stack(pe_working_set_t *data_set)
+get_cluster_stack(pcmk_scheduler_t *data_set)
 {
     xmlNode *stack = get_xpath_object("//nvpair[@name='cluster-infrastructure']",
                                       data_set->input, LOG_DEBUG);
@@ -349,7 +349,8 @@ get_node_feature_set(pcmk_node_t *node)
 }
 
 static bool
-is_mixed_version(pe_working_set_t *data_set) {
+is_mixed_version(pcmk_scheduler_t *data_set)
+{
     const char *feature_set = NULL;
     for (GList *gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
         pcmk_node_t *node = gIter->data;
@@ -375,11 +376,11 @@ formatted_xml_buf(const pcmk_resource_t *rsc, bool raw)
     }
 }
 
-PCMK__OUTPUT_ARGS("cluster-summary", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("cluster-summary", "pcmk_scheduler_t *",
                   "enum pcmk_pacemakerd_state", "uint32_t", "uint32_t")
 static int
 cluster_summary(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     enum pcmk_pacemakerd_state pcmkd_state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     uint32_t section_opts = va_arg(args, uint32_t);
@@ -443,11 +444,11 @@ cluster_summary(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("cluster-summary", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("cluster-summary", "pcmk_scheduler_t *",
                   "enum pcmk_pacemakerd_state", "uint32_t", "uint32_t")
 static int
 cluster_summary_html(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     enum pcmk_pacemakerd_state pcmkd_state =
         (enum pcmk_pacemakerd_state) va_arg(args, int);
     uint32_t section_opts = va_arg(args, uint32_t);
@@ -679,11 +680,11 @@ ban_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ban-list", "pe_working_set_t *", "const char *", "GList *",
+PCMK__OUTPUT_ARGS("ban-list", "pcmk_scheduler_t *", "const char *", "GList *",
                   "uint32_t", "bool")
 static int
 ban_list(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     const char *prefix = va_arg(args, const char *);
     GList *only_rsc = va_arg(args, GList *);
     uint32_t show_opts = va_arg(args, uint32_t);
@@ -955,10 +956,10 @@ cluster_maint_mode_text(pcmk__output_t *out, va_list args) {
     }
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pcmk_scheduler_t *")
 static int
 cluster_options_html(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
 
     if (pcmk_is_set(data_set->flags, pcmk_sched_fencing_enabled)) {
         out->list_item(out, NULL, "STONITH of failed nodes enabled");
@@ -1016,10 +1017,10 @@ cluster_options_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pcmk_scheduler_t *")
 static int
 cluster_options_log(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
 
     if (pcmk_is_set(data_set->flags, pcmk_sched_in_maintenance)) {
         return out->info(out, "Resource management is DISABLED.  The cluster will not attempt to start, stop or recover services.");
@@ -1030,10 +1031,10 @@ cluster_options_log(pcmk__output_t *out, va_list args) {
     }
 }
 
-PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pcmk_scheduler_t *")
 static int
 cluster_options_text(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
 
     if (pcmk_is_set(data_set->flags, pcmk_sched_fencing_enabled)) {
         out->list_item(out, NULL, "STONITH of failed nodes enabled");
@@ -1075,10 +1076,10 @@ cluster_options_text(pcmk__output_t *out, va_list args) {
 
 #define bv(flag) pcmk__btoa(pcmk_is_set(data_set->flags, (flag)))
 
-PCMK__OUTPUT_ARGS("cluster-options", "pe_working_set_t *")
+PCMK__OUTPUT_ARGS("cluster-options", "pcmk_scheduler_t *")
 static int
 cluster_options_xml(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
 
     const char *no_quorum_policy = NULL;
     char *stonith_timeout_str = pcmk__itoa(data_set->stonith_timeout);
@@ -1518,11 +1519,11 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("failed-action-list", "pe_working_set_t *", "GList *",
+PCMK__OUTPUT_ARGS("failed-action-list", "pcmk_scheduler_t *", "GList *",
                   "GList *", "uint32_t", "bool")
 static int
 failed_action_list(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
     uint32_t show_opts = va_arg(args, uint32_t);
@@ -1983,10 +1984,10 @@ node_attribute_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-and-op", "pe_working_set_t *", "xmlNodePtr")
+PCMK__OUTPUT_ARGS("node-and-op", "pcmk_scheduler_t *", "xmlNodePtr")
 static int
 node_and_op(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     xmlNodePtr xml_op = va_arg(args, xmlNodePtr);
 
     pcmk_resource_t *rsc = NULL;
@@ -2038,10 +2039,10 @@ node_and_op(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-and-op", "pe_working_set_t *", "xmlNodePtr")
+PCMK__OUTPUT_ARGS("node-and-op", "pcmk_scheduler_t *", "xmlNodePtr")
 static int
 node_and_op_xml(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     xmlNodePtr xml_op = va_arg(args, xmlNodePtr);
 
     pcmk_resource_t *rsc = NULL;
@@ -2110,11 +2111,11 @@ node_attribute_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-attribute-list", "pe_working_set_t *", "uint32_t",
+PCMK__OUTPUT_ARGS("node-attribute-list", "pcmk_scheduler_t *", "uint32_t",
                   "bool", "GList *", "GList *")
 static int
 node_attribute_list(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     uint32_t show_opts = va_arg(args, uint32_t);
     bool print_spacer = va_arg(args, int);
     GList *only_node = va_arg(args, GList *);
@@ -2209,11 +2210,11 @@ node_capacity_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-history-list", "pe_working_set_t *", "pcmk_node_t *",
+PCMK__OUTPUT_ARGS("node-history-list", "pcmk_scheduler_t *", "pcmk_node_t *",
                   "xmlNodePtr", "GList *", "GList *", "uint32_t", "uint32_t")
 static int
 node_history_list(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     xmlNode *node_state = va_arg(args, xmlNode *);
     GList *only_node = va_arg(args, GList *);
@@ -2454,11 +2455,11 @@ node_list_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-summary", "pe_working_set_t *", "GList *", "GList *",
+PCMK__OUTPUT_ARGS("node-summary", "pcmk_scheduler_t *", "GList *", "GList *",
                   "uint32_t", "uint32_t", "bool")
 static int
 node_summary(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
     uint32_t section_opts = va_arg(args, uint32_t);
@@ -2761,12 +2762,12 @@ print_resource_header(pcmk__output_t *out, uint32_t show_opts)
 }
 
 
-PCMK__OUTPUT_ARGS("resource-list", "pe_working_set_t *", "uint32_t", "bool",
+PCMK__OUTPUT_ARGS("resource-list", "pcmk_scheduler_t *", "uint32_t", "bool",
                   "GList *", "GList *", "bool")
 static int
 resource_list(pcmk__output_t *out, va_list args)
 {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     uint32_t show_opts = va_arg(args, uint32_t);
     bool print_summary = va_arg(args, int);
     GList *only_node = va_arg(args, GList *);
@@ -2869,12 +2870,12 @@ resource_list(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("resource-operation-list", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("resource-operation-list", "pcmk_scheduler_t *",
                   "pcmk_resource_t *", "pcmk_node_t *", "GList *", "uint32_t")
 static int
 resource_operation_list(pcmk__output_t *out, va_list args)
 {
-    pe_working_set_t *data_set G_GNUC_UNUSED = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set G_GNUC_UNUSED = va_arg(args, pcmk_scheduler_t *);
     pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     GList *op_list = va_arg(args, GList *);
@@ -3028,10 +3029,10 @@ ticket_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ticket-list", "pe_working_set_t *", "bool")
+PCMK__OUTPUT_ARGS("ticket-list", "pcmk_scheduler_t *", "bool")
 static int
 ticket_list(pcmk__output_t *out, va_list args) {
-    pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
+    pcmk_scheduler_t *data_set = va_arg(args, pcmk_scheduler_t *);
     bool print_spacer = va_arg(args, int);
 
     GHashTableIter iter;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -60,8 +60,9 @@ compare_attribute(gconstpointer a, gconstpointer b)
  *       or degraded.
  */
 static bool
-add_extra_info(const pe_node_t *node, GList *rsc_list, pe_working_set_t *data_set,
-               const char *attrname, int *expected_score)
+add_extra_info(const pcmk_node_t *node, GList *rsc_list,
+               pe_working_set_t *data_set, const char *attrname,
+               int *expected_score)
 {
     GList *gIter = NULL;
 
@@ -331,7 +332,8 @@ resource_history_string(pe_resource_t *rsc, const char *rsc_id, bool all,
 }
 
 static const char *
-get_node_feature_set(pe_node_t *node) {
+get_node_feature_set(pcmk_node_t *node)
+{
     const char *feature_set = NULL;
 
     if (node->details->online && !pe__is_guest_or_remote_node(node)) {
@@ -350,7 +352,7 @@ static bool
 is_mixed_version(pe_working_set_t *data_set) {
     const char *feature_set = NULL;
     for (GList *gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = gIter->data;
+        pcmk_node_t *node = gIter->data;
         const char *node_feature_set = get_node_feature_set(node);
         if (node_feature_set != NULL) {
             if (feature_set == NULL) {
@@ -517,7 +519,7 @@ cluster_summary_html(pcmk__output_t *out, va_list args) {
 }
 
 char *
-pe__node_display_name(pe_node_t *node, bool print_detail)
+pe__node_display_name(pcmk_node_t *node, bool print_detail)
 {
     char *node_name;
     const char *node_host = NULL;
@@ -529,7 +531,7 @@ pe__node_display_name(pe_node_t *node, bool print_detail)
     /* Host is displayed only if this is a guest node and detail is requested */
     if (print_detail && pe__is_guest_node(node)) {
         const pe_resource_t *container = node->details->remote_rsc->container;
-        const pe_node_t *host_node = pe__current_node(container);
+        const pcmk_node_t *host_node = pe__current_node(container);
 
         if (host_node && host_node->details) {
             node_host = host_node->details->uname;
@@ -611,10 +613,10 @@ role_desc(enum rsc_role_e role)
     return "";
 }
 
-PCMK__OUTPUT_ARGS("ban", "pe_node_t *", "pe__location_t *", "uint32_t")
+PCMK__OUTPUT_ARGS("ban", "pcmk_node_t *", "pe__location_t *", "uint32_t")
 static int
 ban_html(pcmk__output_t *out, va_list args) {
-    pe_node_t *pe_node = va_arg(args, pe_node_t *);
+    pcmk_node_t *pe_node = va_arg(args, pcmk_node_t *);
     pe__location_t *location = va_arg(args, pe__location_t *);
     uint32_t show_opts = va_arg(args, uint32_t);
 
@@ -631,10 +633,10 @@ ban_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ban", "pe_node_t *", "pe__location_t *", "uint32_t")
+PCMK__OUTPUT_ARGS("ban", "pcmk_node_t *", "pe__location_t *", "uint32_t")
 static int
 ban_text(pcmk__output_t *out, va_list args) {
-    pe_node_t *pe_node = va_arg(args, pe_node_t *);
+    pcmk_node_t *pe_node = va_arg(args, pcmk_node_t *);
     pe__location_t *location = va_arg(args, pe__location_t *);
     uint32_t show_opts = va_arg(args, uint32_t);
 
@@ -648,10 +650,10 @@ ban_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ban", "pe_node_t *", "pe__location_t *", "uint32_t")
+PCMK__OUTPUT_ARGS("ban", "pcmk_node_t *", "pe__location_t *", "uint32_t")
 static int
 ban_xml(pcmk__output_t *out, va_list args) {
-    pe_node_t *pe_node = va_arg(args, pe_node_t *);
+    pcmk_node_t *pe_node = va_arg(args, pcmk_node_t *);
     pe__location_t *location = va_arg(args, pe__location_t *);
     uint32_t show_opts G_GNUC_UNUSED = va_arg(args, uint32_t);
 
@@ -707,7 +709,7 @@ ban_list(pcmk__output_t *out, va_list args) {
         }
 
         for (gIter2 = location->node_list_rh; gIter2 != NULL; gIter2 = gIter2->next) {
-            pe_node_t *node = (pe_node_t *) gIter2->data;
+            pcmk_node_t *node = (pcmk_node_t *) gIter2->data;
 
             if (node->weight < 0) {
                 PCMK__OUTPUT_LIST_HEADER(out, print_spacer, rc, "Negative Location Constraints");
@@ -846,11 +848,11 @@ cluster_counts_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-dc", "pe_node_t *", "const char *", "const char *",
+PCMK__OUTPUT_ARGS("cluster-dc", "pcmk_node_t *", "const char *", "const char *",
                   "char *", "int")
 static int
 cluster_dc_html(pcmk__output_t *out, va_list args) {
-    pe_node_t *dc = va_arg(args, pe_node_t *);
+    pcmk_node_t *dc = va_arg(args, pcmk_node_t *);
     const char *quorum = va_arg(args, const char *);
     const char *dc_version_s = va_arg(args, const char *);
     char *dc_name = va_arg(args, char *);
@@ -884,11 +886,11 @@ cluster_dc_html(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-dc", "pe_node_t *", "const char *", "const char *",
+PCMK__OUTPUT_ARGS("cluster-dc", "pcmk_node_t *", "const char *", "const char *",
                   "char *", "int")
 static int
 cluster_dc_text(pcmk__output_t *out, va_list args) {
-    pe_node_t *dc = va_arg(args, pe_node_t *);
+    pcmk_node_t *dc = va_arg(args, pcmk_node_t *);
     const char *quorum = va_arg(args, const char *);
     const char *dc_version_s = va_arg(args, const char *);
     char *dc_name = va_arg(args, char *);
@@ -907,11 +909,11 @@ cluster_dc_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("cluster-dc", "pe_node_t *", "const char *", "const char *",
+PCMK__OUTPUT_ARGS("cluster-dc", "pcmk_node_t *", "const char *", "const char *",
                   "char *", "int")
 static int
 cluster_dc_xml(pcmk__output_t *out, va_list args) {
-    pe_node_t *dc = va_arg(args, pe_node_t *);
+    pcmk_node_t *dc = va_arg(args, pcmk_node_t *);
     const char *quorum = va_arg(args, const char *);
     const char *dc_version_s = va_arg(args, const char *);
     char *dc_name G_GNUC_UNUSED = va_arg(args, char *);
@@ -1566,7 +1568,7 @@ failed_action_list(pcmk__output_t *out, va_list args) {
 }
 
 static void
-status_node(pe_node_t *node, xmlNodePtr parent, uint32_t show_opts)
+status_node(pcmk_node_t *node, xmlNodePtr parent, uint32_t show_opts)
 {
     int health = pe__node_health(node);
 
@@ -1618,11 +1620,11 @@ status_node(pe_node_t *node, xmlNodePtr parent, uint32_t show_opts)
     }
 }
 
-PCMK__OUTPUT_ARGS("node", "pe_node_t *", "uint32_t", "bool",
+PCMK__OUTPUT_ARGS("node", "pcmk_node_t *", "uint32_t", "bool",
                   "GList *", "GList *")
 static int
 node_html(pcmk__output_t *out, va_list args) {
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     uint32_t show_opts = va_arg(args, uint32_t);
     bool full = va_arg(args, int);
     GList *only_node = va_arg(args, GList *);
@@ -1699,7 +1701,7 @@ node_html(pcmk__output_t *out, va_list args) {
  * \return String representation of node's status
  */
 static const char *
-node_text_status(const pe_node_t *node)
+node_text_status(const pcmk_node_t *node)
 {
     if (node->details->unclean) {
         if (node->details->online) {
@@ -1743,10 +1745,11 @@ node_text_status(const pe_node_t *node)
     return "OFFLINE";
 }
 
-PCMK__OUTPUT_ARGS("node", "pe_node_t *", "uint32_t", "bool", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("node", "pcmk_node_t *", "uint32_t", "bool", "GList *",
+                  "GList *")
 static int
 node_text(pcmk__output_t *out, va_list args) {
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     uint32_t show_opts = va_arg(args, uint32_t);
     bool full = va_arg(args, int);
     GList *only_node = va_arg(args, GList *);
@@ -1829,10 +1832,11 @@ node_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node", "pe_node_t *", "uint32_t", "bool", "GList *", "GList *")
+PCMK__OUTPUT_ARGS("node", "pcmk_node_t *", "uint32_t", "bool", "GList *",
+                  "GList *")
 static int
 node_xml(pcmk__output_t *out, va_list args) {
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     uint32_t show_opts G_GNUC_UNUSED = va_arg(args, uint32_t);
     bool full = va_arg(args, int);
     GList *only_node = va_arg(args, GList *);
@@ -1999,7 +2003,7 @@ node_and_op(pcmk__output_t *out, va_list args) {
     rsc = pe_find_resource(data_set->resources, op_rsc);
 
     if (rsc) {
-        const pe_node_t *node = pe__current_node(rsc);
+        const pcmk_node_t *node = pe__current_node(rsc);
         const char *target_role = g_hash_table_lookup(rsc->meta, XML_RSC_ATTR_TARGET_ROLE);
         uint32_t show_opts = pcmk_show_rsc_only | pcmk_show_pending;
 
@@ -2120,7 +2124,7 @@ node_attribute_list(pcmk__output_t *out, va_list args) {
 
     /* Display each node's attributes */
     for (GList *gIter = data_set->nodes; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = gIter->data;
+        pcmk_node_t *node = gIter->data;
 
         GList *attr_list = NULL;
         GHashTableIter iter;
@@ -2172,11 +2176,11 @@ node_attribute_list(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("node-capacity", "const pe_node_t *", "const char *")
+PCMK__OUTPUT_ARGS("node-capacity", "const pcmk_node_t *", "const char *")
 static int
 node_capacity(pcmk__output_t *out, va_list args)
 {
-    const pe_node_t *node = va_arg(args, pe_node_t *);
+    const pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     const char *comment = va_arg(args, const char *);
 
     char *dump_text = crm_strdup_printf("%s: %s capacity:",
@@ -2189,11 +2193,11 @@ node_capacity(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-capacity", "const pe_node_t *", "const char *")
+PCMK__OUTPUT_ARGS("node-capacity", "const pcmk_node_t *", "const char *")
 static int
 node_capacity_xml(pcmk__output_t *out, va_list args)
 {
-    const pe_node_t *node = va_arg(args, pe_node_t *);
+    const pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     const char *comment = va_arg(args, const char *);
 
     xmlNodePtr xml_node = pcmk__output_create_xml_node(out, "capacity",
@@ -2205,12 +2209,12 @@ node_capacity_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-history-list", "pe_working_set_t *", "pe_node_t *", "xmlNodePtr",
-                  "GList *", "GList *", "uint32_t", "uint32_t")
+PCMK__OUTPUT_ARGS("node-history-list", "pe_working_set_t *", "pcmk_node_t *",
+                  "xmlNodePtr", "GList *", "GList *", "uint32_t", "uint32_t")
 static int
 node_history_list(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     xmlNode *node_state = va_arg(args, xmlNode *);
     GList *only_node = va_arg(args, GList *);
     GList *only_rsc = va_arg(args, GList *);
@@ -2305,7 +2309,7 @@ node_list_html(pcmk__output_t *out, va_list args) {
     int rc = pcmk_rc_no_output;
 
     for (GList *gIter = nodes; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = (pe_node_t *) gIter->data;
+        pcmk_node_t *node = (pcmk_node_t *) gIter->data;
 
         if (!pcmk__str_in_list(node->details->uname, only_node,
                                pcmk__str_star_matches|pcmk__str_casei)) {
@@ -2340,7 +2344,7 @@ node_list_text(pcmk__output_t *out, va_list args) {
     int rc = pcmk_rc_no_output;
 
     for (GList *gIter = nodes; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = (pe_node_t *) gIter->data;
+        pcmk_node_t *node = (pcmk_node_t *) gIter->data;
         char *node_name = pe__node_display_name(node, pcmk_is_set(show_opts, pcmk_show_node_id));
 
         if (!pcmk__str_in_list(node->details->uname, only_node,
@@ -2436,7 +2440,7 @@ node_list_xml(pcmk__output_t *out, va_list args) {
 
     out->begin_list(out, NULL, NULL, "nodes");
     for (GList *gIter = nodes; gIter != NULL; gIter = gIter->next) {
-        pe_node_t *node = (pe_node_t *) gIter->data;
+        pcmk_node_t *node = (pcmk_node_t *) gIter->data;
 
         if (!pcmk__str_in_list(node->details->uname, only_node,
                                pcmk__str_star_matches|pcmk__str_casei)) {
@@ -2472,7 +2476,7 @@ node_summary(pcmk__output_t *out, va_list args) {
 
     for (node_state = first_named_child(cib_status, XML_CIB_TAG_STATE);
          node_state != NULL; node_state = crm_next_same_xml(node_state)) {
-        pe_node_t *node = pe_find_node_id(data_set->nodes, ID(node_state));
+        pcmk_node_t *node = pe_find_node_id(data_set->nodes, ID(node_state));
 
         if (!node || !node->details || !node->details->online) {
             continue;
@@ -2607,12 +2611,13 @@ op_history_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("promotion-score", "pe_resource_t *", "pe_node_t *", "const char *")
+PCMK__OUTPUT_ARGS("promotion-score", "pe_resource_t *", "pcmk_node_t *",
+                  "const char *")
 static int
 promotion_score(pcmk__output_t *out, va_list args)
 {
     pe_resource_t *child_rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *chosen = va_arg(args, pe_node_t *);
+    pcmk_node_t *chosen = va_arg(args, pcmk_node_t *);
     const char *score = va_arg(args, const char *);
 
     out->list_item(out, NULL, "%s promotion score on %s: %s",
@@ -2622,12 +2627,13 @@ promotion_score(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("promotion-score", "pe_resource_t *", "pe_node_t *", "const char *")
+PCMK__OUTPUT_ARGS("promotion-score", "pe_resource_t *", "pcmk_node_t *",
+                  "const char *")
 static int
 promotion_score_xml(pcmk__output_t *out, va_list args)
 {
     pe_resource_t *child_rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *chosen = va_arg(args, pe_node_t *);
+    pcmk_node_t *chosen = va_arg(args, pcmk_node_t *);
     const char *score = va_arg(args, const char *);
 
     xmlNodePtr node = pcmk__output_create_xml_node(out, "promotion_score",
@@ -2862,13 +2868,13 @@ resource_list(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("resource-operation-list", "pe_working_set_t *", "pe_resource_t *",
-                  "pe_node_t *", "GList *", "uint32_t")
+                  "pcmk_node_t *", "GList *", "uint32_t")
 static int
 resource_operation_list(pcmk__output_t *out, va_list args)
 {
     pe_working_set_t *data_set G_GNUC_UNUSED = va_arg(args, pe_working_set_t *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     GList *op_list = va_arg(args, GList *);
     uint32_t show_opts = va_arg(args, uint32_t);
 
@@ -2915,12 +2921,13 @@ resource_operation_list(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("resource-util", "pe_resource_t *", "pe_node_t *", "const char *")
+PCMK__OUTPUT_ARGS("resource-util", "pe_resource_t *", "pcmk_node_t *",
+                  "const char *")
 static int
 resource_util(pcmk__output_t *out, va_list args)
 {
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     const char *fn = va_arg(args, const char *);
 
     char *dump_text = crm_strdup_printf("%s: %s utilization on %s:",
@@ -2933,12 +2940,13 @@ resource_util(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-util", "pe_resource_t *", "pe_node_t *", "const char *")
+PCMK__OUTPUT_ARGS("resource-util", "pe_resource_t *", "pcmk_node_t *",
+                  "const char *")
 static int
 resource_util_xml(pcmk__output_t *out, va_list args)
 {
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     const char *fn = va_arg(args, const char *);
 
     xmlNodePtr xml_node = pcmk__output_create_xml_node(out, "utilization",

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -19,7 +19,7 @@
 #include <crm/pengine/internal.h>
 
 const char *
-pe__resource_description(const pe_resource_t *rsc, uint32_t show_opts)
+pe__resource_description(const pcmk_resource_t *rsc, uint32_t show_opts)
 {
     const char * desc = NULL;
     // User-supplied description
@@ -67,7 +67,7 @@ add_extra_info(const pcmk_node_t *node, GList *rsc_list,
     GList *gIter = NULL;
 
     for (gIter = rsc_list; gIter != NULL; gIter = gIter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) gIter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) gIter->data;
         const char *type = g_hash_table_lookup(rsc->meta, "type");
         const char *name = NULL;
         GHashTable *params = NULL;
@@ -296,7 +296,7 @@ op_history_string(xmlNode *xml_op, const char *task, const char *interval_ms_s,
 }
 
 static char *
-resource_history_string(pe_resource_t *rsc, const char *rsc_id, bool all,
+resource_history_string(pcmk_resource_t *rsc, const char *rsc_id, bool all,
                         int failcount, time_t last_failure) {
     char *buf = NULL;
 
@@ -366,7 +366,7 @@ is_mixed_version(pe_working_set_t *data_set) {
 }
 
 static char *
-formatted_xml_buf(const pe_resource_t *rsc, bool raw)
+formatted_xml_buf(const pcmk_resource_t *rsc, bool raw)
 {
     if (raw) {
         return dump_xml_formatted(rsc->orig_xml ? rsc->orig_xml : rsc->xml);
@@ -530,7 +530,7 @@ pe__node_display_name(pcmk_node_t *node, bool print_detail)
 
     /* Host is displayed only if this is a guest node and detail is requested */
     if (print_detail && pe__is_guest_node(node)) {
-        const pe_resource_t *container = node->details->remote_rsc->container;
+        const pcmk_resource_t *container = node->details->remote_rsc->container;
         const pcmk_node_t *host_node = pe__current_node(container);
 
         if (host_node && host_node->details) {
@@ -695,7 +695,7 @@ ban_list(pcmk__output_t *out, va_list args) {
     /* Print each ban */
     for (gIter = data_set->placement_constraints; gIter != NULL; gIter = gIter->next) {
         pe__location_t *location = gIter->data;
-        const pe_resource_t *rsc = location->rsc_lh;
+        const pcmk_resource_t *rsc = location->rsc_lh;
 
         if (prefix != NULL && !g_str_has_prefix(location->id, prefix)) {
             continue;
@@ -1663,7 +1663,7 @@ node_html(pcmk__output_t *out, va_list args) {
             status_node(node, item_node, show_opts);
 
             for (lpc2 = node->details->running_rsc; lpc2 != NULL; lpc2 = lpc2->next) {
-                pe_resource_t *rsc = (pe_resource_t *) lpc2->data;
+                pcmk_resource_t *rsc = (pcmk_resource_t *) lpc2->data;
                 PCMK__OUTPUT_LIST_HEADER(out, false, rc, "Resources");
 
                 show_opts |= pcmk_show_rsc_only;
@@ -1807,7 +1807,7 @@ node_text(pcmk__output_t *out, va_list args) {
                 out->begin_list(out, NULL, NULL, "Resources");
 
                 for (gIter2 = node->details->running_rsc; gIter2 != NULL; gIter2 = gIter2->next) {
-                    pe_resource_t *rsc = (pe_resource_t *) gIter2->data;
+                    pcmk_resource_t *rsc = (pcmk_resource_t *) gIter2->data;
 
                     show_opts |= pcmk_show_rsc_only;
                     out->message(out, crm_map_element_name(rsc->xml), show_opts,
@@ -1897,7 +1897,7 @@ node_xml(pcmk__output_t *out, va_list args) {
             GList *lpc = NULL;
 
             for (lpc = node->details->running_rsc; lpc != NULL; lpc = lpc->next) {
-                pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+                pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
 
                 show_opts |= pcmk_show_rsc_only;
                 out->message(out, crm_map_element_name(rsc->xml), show_opts,
@@ -1989,7 +1989,7 @@ node_and_op(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
     xmlNodePtr xml_op = va_arg(args, xmlNodePtr);
 
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     gchar *node_str = NULL;
     char *last_change_str = NULL;
 
@@ -2044,7 +2044,7 @@ node_and_op_xml(pcmk__output_t *out, va_list args) {
     pe_working_set_t *data_set = va_arg(args, pe_working_set_t *);
     xmlNodePtr xml_op = va_arg(args, xmlNodePtr);
 
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     const char *op_rsc = crm_element_value(xml_op, "resource");
     int status;
     time_t last_change = 0;
@@ -2232,8 +2232,8 @@ node_history_list(pcmk__output_t *out, va_list args) {
     for (rsc_entry = first_named_child(lrm_rsc, XML_LRM_TAG_RESOURCE);
          rsc_entry != NULL; rsc_entry = crm_next_same_xml(rsc_entry)) {
         const char *rsc_id = crm_element_value(rsc_entry, XML_ATTR_ID);
-        pe_resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
-        const pe_resource_t *parent = pe__const_top_resource(rsc, false);
+        pcmk_resource_t *rsc = pe_find_resource(data_set->resources, rsc_id);
+        const pcmk_resource_t *parent = pe__const_top_resource(rsc, false);
 
         /* We can't use is_filtered here to filter group resources.  For is_filtered,
          * we have to decide whether to check the parent or not.  If we check the
@@ -2275,7 +2275,7 @@ node_history_list(pcmk__output_t *out, va_list args) {
                          failcount, last_failure, false);
         } else {
             GList *op_list = get_operation_list(rsc_entry);
-            pe_resource_t *rsc = pe_find_resource(data_set->resources,
+            pcmk_resource_t *rsc = pe_find_resource(data_set->resources,
                                                   crm_element_value(rsc_entry, XML_ATTR_ID));
 
             if (op_list == NULL) {
@@ -2498,12 +2498,12 @@ node_summary(pcmk__output_t *out, va_list args) {
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("node-weight", "const pe_resource_t *", "const char *",
+PCMK__OUTPUT_ARGS("node-weight", "const pcmk_resource_t *", "const char *",
                   "const char *", "const char *")
 static int
 node_weight(pcmk__output_t *out, va_list args)
 {
-    const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
+    const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     const char *prefix = va_arg(args, const char *);
     const char *uname = va_arg(args, const char *);
     const char *score = va_arg(args, const char *);
@@ -2518,12 +2518,12 @@ node_weight(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("node-weight", "const pe_resource_t *", "const char *",
+PCMK__OUTPUT_ARGS("node-weight", "const pcmk_resource_t *", "const char *",
                   "const char *", "const char *")
 static int
 node_weight_xml(pcmk__output_t *out, va_list args)
 {
-    const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
+    const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     const char *prefix = va_arg(args, const char *);
     const char *uname = va_arg(args, const char *);
     const char *score = va_arg(args, const char *);
@@ -2611,12 +2611,12 @@ op_history_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("promotion-score", "pe_resource_t *", "pcmk_node_t *",
+PCMK__OUTPUT_ARGS("promotion-score", "pcmk_resource_t *", "pcmk_node_t *",
                   "const char *")
 static int
 promotion_score(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *child_rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *child_rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *chosen = va_arg(args, pcmk_node_t *);
     const char *score = va_arg(args, const char *);
 
@@ -2627,12 +2627,12 @@ promotion_score(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("promotion-score", "pe_resource_t *", "pcmk_node_t *",
+PCMK__OUTPUT_ARGS("promotion-score", "pcmk_resource_t *", "pcmk_node_t *",
                   "const char *")
 static int
 promotion_score_xml(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *child_rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *child_rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *chosen = va_arg(args, pcmk_node_t *);
     const char *score = va_arg(args, const char *);
 
@@ -2648,10 +2648,10 @@ promotion_score_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-config", "const pe_resource_t *", "bool")
+PCMK__OUTPUT_ARGS("resource-config", "const pcmk_resource_t *", "bool")
 static int
 resource_config(pcmk__output_t *out, va_list args) {
-    const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
+    const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     bool raw = va_arg(args, int);
 
     char *rsc_xml = formatted_xml_buf(rsc, raw);
@@ -2662,10 +2662,10 @@ resource_config(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-config", "const pe_resource_t *", "bool")
+PCMK__OUTPUT_ARGS("resource-config", "const pcmk_resource_t *", "bool")
 static int
 resource_config_text(pcmk__output_t *out, va_list args) {
-    const pe_resource_t *rsc = va_arg(args, const pe_resource_t *);
+    const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     bool raw = va_arg(args, int);
 
     char *rsc_xml = formatted_xml_buf(rsc, raw);
@@ -2677,10 +2677,11 @@ resource_config_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-history", "pe_resource_t *", "const char *", "bool", "int", "time_t", "bool")
+PCMK__OUTPUT_ARGS("resource-history", "pcmk_resource_t *", "const char *",
+                  "bool", "int", "time_t", "bool")
 static int
 resource_history_text(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     const char *rsc_id = va_arg(args, const char *);
     bool all = va_arg(args, int);
     int failcount = va_arg(args, int);
@@ -2699,10 +2700,11 @@ resource_history_text(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-history", "pe_resource_t *", "const char *", "bool", "int", "time_t", "bool")
+PCMK__OUTPUT_ARGS("resource-history", "pcmk_resource_t *", "const char *",
+                  "bool", "int", "time_t", "bool")
 static int
 resource_history_xml(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     const char *rsc_id = va_arg(args, const char *);
     bool all = va_arg(args, int);
     int failcount = va_arg(args, int);
@@ -2798,7 +2800,7 @@ resource_list(pcmk__output_t *out, va_list args)
 
     /* For each resource, display it if appropriate */
     for (rsc_iter = data_set->resources; rsc_iter != NULL; rsc_iter = rsc_iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) rsc_iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) rsc_iter->data;
         int x;
 
         /* Complex resources may have some sub-resources active and some inactive */
@@ -2867,13 +2869,13 @@ resource_list(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("resource-operation-list", "pe_working_set_t *", "pe_resource_t *",
-                  "pcmk_node_t *", "GList *", "uint32_t")
+PCMK__OUTPUT_ARGS("resource-operation-list", "pe_working_set_t *",
+                  "pcmk_resource_t *", "pcmk_node_t *", "GList *", "uint32_t")
 static int
 resource_operation_list(pcmk__output_t *out, va_list args)
 {
     pe_working_set_t *data_set G_GNUC_UNUSED = va_arg(args, pe_working_set_t *);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     GList *op_list = va_arg(args, GList *);
     uint32_t show_opts = va_arg(args, uint32_t);
@@ -2921,12 +2923,12 @@ resource_operation_list(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("resource-util", "pe_resource_t *", "pcmk_node_t *",
+PCMK__OUTPUT_ARGS("resource-util", "pcmk_resource_t *", "pcmk_node_t *",
                   "const char *")
 static int
 resource_util(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     const char *fn = va_arg(args, const char *);
 
@@ -2940,12 +2942,12 @@ resource_util(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-util", "pe_resource_t *", "pcmk_node_t *",
+PCMK__OUTPUT_ARGS("resource-util", "pcmk_resource_t *", "pcmk_node_t *",
                   "const char *")
 static int
 resource_util_xml(pcmk__output_t *out, va_list args)
 {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
     const char *fn = va_arg(args, const char *);
 

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -112,7 +112,7 @@ gboolean unpack_status(xmlNode *status, pe_working_set_t *data_set);
 G_GNUC_INTERNAL
 op_digest_cache_t *pe__compare_fencing_digest(pe_resource_t *rsc,
                                               const char *agent,
-                                              pe_node_t *node,
+                                              pcmk_node_t *node,
                                               pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
@@ -136,9 +136,9 @@ unsigned int pe__clone_max_per_node(const pe_resource_t *rsc);
 // Bundle resource methods
 
 G_GNUC_INTERNAL
-pe_node_t *pe__bundle_active_node(const pe_resource_t *rsc,
-                                  unsigned int *count_all,
-                                  unsigned int *count_clean);
+pcmk_node_t *pe__bundle_active_node(const pe_resource_t *rsc,
+                                    unsigned int *count_all,
+                                    unsigned int *count_clean);
 
 G_GNUC_INTERNAL
 unsigned int pe__bundle_max_per_node(const pe_resource_t *rsc);

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -22,7 +22,7 @@
 #include <glib.h>                 // GSList, GList, GHashTable
 #include <libxml/tree.h>          // xmlNode
 
-#include <crm/pengine/status.h>   // pe_action_t, pcmk_resource_t, etc.
+#include <crm/pengine/status.h>   // pcmk_action_t, pcmk_resource_t, etc.
 
 /*!
  * \internal
@@ -48,10 +48,10 @@ typedef struct notify_data_s {
 
     const char *action;
 
-    pe_action_t *pre;
-    pe_action_t *post;
-    pe_action_t *pre_done;
-    pe_action_t *post_done;
+    pcmk_action_t *pre;
+    pcmk_action_t *post;
+    pcmk_action_t *pre_done;
+    pcmk_action_t *post_done;
 
     GList *active;            /* notify_entry_t*  */
     GList *inactive;          /* notify_entry_t*  */
@@ -78,8 +78,8 @@ void pe__free_action_notification_data(notify_data_t *n_data);
 G_GNUC_INTERNAL
 notify_data_t *pe__action_notif_pseudo_ops(pcmk_resource_t *rsc,
                                            const char *task,
-                                           pe_action_t *action,
-                                           pe_action_t *complete);
+                                           pcmk_action_t *action,
+                                           pcmk_action_t *complete);
 
 G_GNUC_INTERNAL
 void pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -22,7 +22,7 @@
 #include <glib.h>                 // GSList, GList, GHashTable
 #include <libxml/tree.h>          // xmlNode
 
-#include <crm/pengine/status.h>   // pe_action_t, pe_resource_t, etc.
+#include <crm/pengine/status.h>   // pe_action_t, pcmk_resource_t, etc.
 
 /*!
  * \internal
@@ -65,30 +65,33 @@ typedef struct notify_data_s {
 } notify_data_t;
 
 G_GNUC_INTERNAL
-pe_resource_t *pe__create_clone_child(pe_resource_t *rsc,
+pcmk_resource_t *pe__create_clone_child(pcmk_resource_t *rsc,
                                       pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-void pe__create_action_notifications(pe_resource_t *rsc, notify_data_t *n_data);
+void pe__create_action_notifications(pcmk_resource_t *rsc,
+                                     notify_data_t *n_data);
 
 G_GNUC_INTERNAL
 void pe__free_action_notification_data(notify_data_t *n_data);
 
 G_GNUC_INTERNAL
-notify_data_t *pe__action_notif_pseudo_ops(pe_resource_t *rsc, const char *task,
+notify_data_t *pe__action_notif_pseudo_ops(pcmk_resource_t *rsc,
+                                           const char *task,
                                            pe_action_t *action,
                                            pe_action_t *complete);
 
 G_GNUC_INTERNAL
-void pe__force_anon(const char *standard, pe_resource_t *rsc, const char *rid,
+void pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,
                     pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 gint pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
 
 G_GNUC_INTERNAL
-gboolean pe__unpack_resource(xmlNode *xml_obj, pe_resource_t **rsc,
-                             pe_resource_t *parent, pe_working_set_t *data_set);
+gboolean pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
+                             pcmk_resource_t *parent,
+                             pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
 gboolean unpack_remote_nodes(xmlNode *xml_resources, pe_working_set_t *data_set);
@@ -110,7 +113,7 @@ G_GNUC_INTERNAL
 gboolean unpack_status(xmlNode *status, pe_working_set_t *data_set);
 
 G_GNUC_INTERNAL
-op_digest_cache_t *pe__compare_fencing_digest(pe_resource_t *rsc,
+op_digest_cache_t *pe__compare_fencing_digest(pcmk_resource_t *rsc,
                                               const char *agent,
                                               pcmk_node_t *node,
                                               pe_working_set_t *data_set);
@@ -121,26 +124,26 @@ void pe__unpack_node_health_scores(pe_working_set_t *data_set);
 // Primitive resource methods
 
 G_GNUC_INTERNAL
-unsigned int pe__primitive_max_per_node(const pe_resource_t *rsc);
+unsigned int pe__primitive_max_per_node(const pcmk_resource_t *rsc);
 
 // Group resource methods
 
 G_GNUC_INTERNAL
-unsigned int pe__group_max_per_node(const pe_resource_t *rsc);
+unsigned int pe__group_max_per_node(const pcmk_resource_t *rsc);
 
 // Clone resource methods
 
 G_GNUC_INTERNAL
-unsigned int pe__clone_max_per_node(const pe_resource_t *rsc);
+unsigned int pe__clone_max_per_node(const pcmk_resource_t *rsc);
 
 // Bundle resource methods
 
 G_GNUC_INTERNAL
-pcmk_node_t *pe__bundle_active_node(const pe_resource_t *rsc,
+pcmk_node_t *pe__bundle_active_node(const pcmk_resource_t *rsc,
                                     unsigned int *count_all,
                                     unsigned int *count_clean);
 
 G_GNUC_INTERNAL
-unsigned int pe__bundle_max_per_node(const pe_resource_t *rsc);
+unsigned int pe__bundle_max_per_node(const pcmk_resource_t *rsc);
 
 #endif  // PE_STATUS_PRIVATE__H

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -66,7 +66,7 @@ typedef struct notify_data_s {
 
 G_GNUC_INTERNAL
 pcmk_resource_t *pe__create_clone_child(pcmk_resource_t *rsc,
-                                      pe_working_set_t *data_set);
+                                      pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 void pe__create_action_notifications(pcmk_resource_t *rsc,
@@ -83,7 +83,7 @@ notify_data_t *pe__action_notif_pseudo_ops(pcmk_resource_t *rsc,
 
 G_GNUC_INTERNAL
 void pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,
-                    pe_working_set_t *data_set);
+                    pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 gint pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
@@ -91,35 +91,35 @@ gint pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
 G_GNUC_INTERNAL
 gboolean pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
                              pcmk_resource_t *parent,
-                             pe_working_set_t *data_set);
+                             pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-gboolean unpack_remote_nodes(xmlNode *xml_resources, pe_working_set_t *data_set);
+gboolean unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 gboolean unpack_resources(const xmlNode *xml_resources,
-                          pe_working_set_t *data_set);
+                          pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-gboolean unpack_config(xmlNode *config, pe_working_set_t *data_set);
+gboolean unpack_config(xmlNode *config, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-gboolean unpack_nodes(xmlNode *xml_nodes, pe_working_set_t *data_set);
+gboolean unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-gboolean unpack_tags(xmlNode *xml_tags, pe_working_set_t *data_set);
+gboolean unpack_tags(xmlNode *xml_tags, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-gboolean unpack_status(xmlNode *status, pe_working_set_t *data_set);
+gboolean unpack_status(xmlNode *status, pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
 op_digest_cache_t *pe__compare_fencing_digest(pcmk_resource_t *rsc,
                                               const char *agent,
                                               pcmk_node_t *node,
-                                              pe_working_set_t *data_set);
+                                              pcmk_scheduler_t *data_set);
 
 G_GNUC_INTERNAL
-void pe__unpack_node_health_scores(pe_working_set_t *data_set);
+void pe__unpack_node_health_scores(pcmk_scheduler_t *data_set);
 
 // Primitive resource methods
 

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -63,7 +63,7 @@ pe__is_bundle_node(const pcmk_node_t *node)
  * \return Filler resource with remote connection, or NULL if none found
  */
 pcmk_resource_t *
-pe__resource_contains_guest_node(const pe_working_set_t *data_set,
+pe__resource_contains_guest_node(const pcmk_scheduler_t *data_set,
                                  const pcmk_resource_t *rsc)
 {
     if ((rsc != NULL) && (data_set != NULL)
@@ -117,7 +117,7 @@ xml_contains_remote_node(xmlNode *xml)
  * \param[in,out] user_data  Pointer to pass to helper function
  */
 void
-pe_foreach_guest_node(const pe_working_set_t *data_set, const pcmk_node_t *host,
+pe_foreach_guest_node(const pcmk_scheduler_t *data_set, const pcmk_node_t *host,
                       void (*helper)(const pcmk_node_t*, void*),
                       void *user_data)
 {
@@ -223,7 +223,7 @@ struct check_op {
 void
 pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
                     pcmk_node_t *node, enum pcmk__check_parameters flag,
-                    pe_working_set_t *data_set)
+                    pcmk_scheduler_t *data_set)
 {
     struct check_op *check_op = NULL;
 
@@ -248,7 +248,7 @@ pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
  * \param[in]     cb        Function to be called
  */
 void
-pe__foreach_param_check(pe_working_set_t *data_set,
+pe__foreach_param_check(pcmk_scheduler_t *data_set,
                        void (*cb)(pcmk_resource_t*, pcmk_node_t*,
                                   const xmlNode*, enum pcmk__check_parameters))
 {
@@ -263,7 +263,7 @@ pe__foreach_param_check(pe_working_set_t *data_set,
 }
 
 void
-pe__free_param_checks(pe_working_set_t *data_set)
+pe__free_param_checks(pcmk_scheduler_t *data_set)
 {
     if (data_set && data_set->param_check) {
         g_list_free_full(data_set->param_check, free);

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -15,7 +15,7 @@
 #include <glib.h>
 
 bool
-pe__resource_is_remote_conn(const pe_resource_t *rsc)
+pe__resource_is_remote_conn(const pcmk_resource_t *rsc)
 {
     return (rsc != NULL) && rsc->is_remote_node
            && pe__is_remote_node(pe_find_node(rsc->cluster->nodes, rsc->id));
@@ -62,15 +62,15 @@ pe__is_bundle_node(const pcmk_node_t *node)
  *
  * \return Filler resource with remote connection, or NULL if none found
  */
-pe_resource_t *
+pcmk_resource_t *
 pe__resource_contains_guest_node(const pe_working_set_t *data_set,
-                                 const pe_resource_t *rsc)
+                                 const pcmk_resource_t *rsc)
 {
     if ((rsc != NULL) && (data_set != NULL)
         && pcmk_is_set(data_set->flags, pcmk_sched_have_remote_nodes)) {
 
         for (GList *gIter = rsc->fillers; gIter != NULL; gIter = gIter->next) {
-            pe_resource_t *filler = gIter->data;
+            pcmk_resource_t *filler = gIter->data;
 
             if (filler->is_remote_node) {
                 return filler;
@@ -128,7 +128,7 @@ pe_foreach_guest_node(const pe_working_set_t *data_set, const pcmk_node_t *host,
         return;
     }
     for (iter = host->details->running_rsc; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (rsc->is_remote_node && (rsc->container != NULL)) {
             pcmk_node_t *guest_node = pe_find_node(data_set->nodes, rsc->id);
@@ -214,14 +214,14 @@ pe_create_remote_xml(xmlNode *parent, const char *uname,
 
 // History entry to be checked for fail count clearing
 struct check_op {
-    const xmlNode *rsc_op; // History entry XML
-    pe_resource_t *rsc;    // Known resource corresponding to history entry
-    pcmk_node_t *node; // Known node corresponding to history entry
+    const xmlNode *rsc_op;  // History entry XML
+    pcmk_resource_t *rsc;   // Known resource corresponding to history entry
+    pcmk_node_t *node;      // Known node corresponding to history entry
     enum pcmk__check_parameters check_type; // What needs checking
 };
 
 void
-pe__add_param_check(const xmlNode *rsc_op, pe_resource_t *rsc,
+pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
                     pcmk_node_t *node, enum pcmk__check_parameters flag,
                     pe_working_set_t *data_set)
 {
@@ -249,8 +249,8 @@ pe__add_param_check(const xmlNode *rsc_op, pe_resource_t *rsc,
  */
 void
 pe__foreach_param_check(pe_working_set_t *data_set,
-                       void (*cb)(pe_resource_t*, pcmk_node_t*, const xmlNode*,
-                                  enum pcmk__check_parameters))
+                       void (*cb)(pcmk_resource_t*, pcmk_node_t*,
+                                  const xmlNode*, enum pcmk__check_parameters))
 {
     CRM_CHECK(data_set && cb, return);
 

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -22,7 +22,7 @@ pe__resource_is_remote_conn(const pe_resource_t *rsc)
 }
 
 bool
-pe__is_remote_node(const pe_node_t *node)
+pe__is_remote_node(const pcmk_node_t *node)
 {
     return (node != NULL) && (node->details->type == pcmk_node_variant_remote)
            && ((node->details->remote_rsc == NULL)
@@ -30,7 +30,7 @@ pe__is_remote_node(const pe_node_t *node)
 }
 
 bool
-pe__is_guest_node(const pe_node_t *node)
+pe__is_guest_node(const pcmk_node_t *node)
 {
     return (node != NULL) && (node->details->type == pcmk_node_variant_remote)
            && (node->details->remote_rsc != NULL)
@@ -38,13 +38,13 @@ pe__is_guest_node(const pe_node_t *node)
 }
 
 bool
-pe__is_guest_or_remote_node(const pe_node_t *node)
+pe__is_guest_or_remote_node(const pcmk_node_t *node)
 {
     return (node != NULL) && (node->details->type == pcmk_node_variant_remote);
 }
 
 bool
-pe__is_bundle_node(const pe_node_t *node)
+pe__is_bundle_node(const pcmk_node_t *node)
 {
     return pe__is_guest_node(node)
            && pe_rsc_is_bundled(node->details->remote_rsc);
@@ -117,8 +117,9 @@ xml_contains_remote_node(xmlNode *xml)
  * \param[in,out] user_data  Pointer to pass to helper function
  */
 void
-pe_foreach_guest_node(const pe_working_set_t *data_set, const pe_node_t *host,
-                      void (*helper)(const pe_node_t*, void*), void *user_data)
+pe_foreach_guest_node(const pe_working_set_t *data_set, const pcmk_node_t *host,
+                      void (*helper)(const pcmk_node_t*, void*),
+                      void *user_data)
 {
     GList *iter;
 
@@ -130,7 +131,7 @@ pe_foreach_guest_node(const pe_working_set_t *data_set, const pe_node_t *host,
         pe_resource_t *rsc = (pe_resource_t *) iter->data;
 
         if (rsc->is_remote_node && (rsc->container != NULL)) {
-            pe_node_t *guest_node = pe_find_node(data_set->nodes, rsc->id);
+            pcmk_node_t *guest_node = pe_find_node(data_set->nodes, rsc->id);
 
             if (guest_node) {
                 (*helper)(guest_node, user_data);
@@ -215,13 +216,13 @@ pe_create_remote_xml(xmlNode *parent, const char *uname,
 struct check_op {
     const xmlNode *rsc_op; // History entry XML
     pe_resource_t *rsc;    // Known resource corresponding to history entry
-    pe_node_t *node; // Known node corresponding to history entry
+    pcmk_node_t *node; // Known node corresponding to history entry
     enum pcmk__check_parameters check_type; // What needs checking
 };
 
 void
 pe__add_param_check(const xmlNode *rsc_op, pe_resource_t *rsc,
-                    pe_node_t *node, enum pcmk__check_parameters flag,
+                    pcmk_node_t *node, enum pcmk__check_parameters flag,
                     pe_working_set_t *data_set)
 {
     struct check_op *check_op = NULL;
@@ -248,7 +249,7 @@ pe__add_param_check(const xmlNode *rsc_op, pe_resource_t *rsc,
  */
 void
 pe__foreach_param_check(pe_working_set_t *data_set,
-                       void (*cb)(pe_resource_t*, pe_node_t*, const xmlNode*,
+                       void (*cb)(pe_resource_t*, pcmk_node_t*, const xmlNode*,
                                   enum pcmk__check_parameters))
 {
     CRM_CHECK(data_set && cb, return);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -24,16 +24,16 @@
  * \brief Create a new working set
  *
  * \return New, initialized working set on success, else NULL (and set errno)
- * \note Only pe_working_set_t objects created with this function (as opposed
+ * \note Only pcmk_scheduler_t objects created with this function (as opposed
  *       to statically declared or directly allocated) should be used with the
  *       functions in this library, to allow for future extensions to the
  *       data type. The caller is responsible for freeing the memory with
  *       pe_free_working_set() when the instance is no longer needed.
  */
-pe_working_set_t *
+pcmk_scheduler_t *
 pe_new_working_set(void)
 {
-    pe_working_set_t *data_set = calloc(1, sizeof(pe_working_set_t));
+    pcmk_scheduler_t *data_set = calloc(1, sizeof(pcmk_scheduler_t));
 
     if (data_set != NULL) {
         set_working_set_defaults(data_set);
@@ -47,7 +47,7 @@ pe_new_working_set(void)
  * \param[in,out] data_set  Working set to free
  */
 void
-pe_free_working_set(pe_working_set_t *data_set)
+pe_free_working_set(pcmk_scheduler_t *data_set)
 {
     if (data_set != NULL) {
         pe_reset_working_set(data_set);
@@ -68,7 +68,7 @@ pe_free_working_set(pe_working_set_t *data_set)
  *  - A list of the possible stop/start actions (without dependencies)
  */
 gboolean
-cluster_status(pe_working_set_t * data_set)
+cluster_status(pcmk_scheduler_t * data_set)
 {
     xmlNode *section = NULL;
 
@@ -276,7 +276,7 @@ pe__free_location(GList *constraints)
  *             pe_reset_working_set() should be used instead.
  */
 void
-cleanup_calculations(pe_working_set_t * data_set)
+cleanup_calculations(pcmk_scheduler_t * data_set)
 {
     if (data_set == NULL) {
         return;
@@ -335,7 +335,7 @@ cleanup_calculations(pe_working_set_t * data_set)
  * \param[in,out] data_set  Working set to reset
  */
 void
-pe_reset_working_set(pe_working_set_t *data_set)
+pe_reset_working_set(pcmk_scheduler_t *data_set)
 {
     if (data_set == NULL) {
         return;
@@ -365,11 +365,11 @@ pe_reset_working_set(pe_working_set_t *data_set)
 }
 
 void
-set_working_set_defaults(pe_working_set_t * data_set)
+set_working_set_defaults(pcmk_scheduler_t * data_set)
 {
     void *priv = data_set->priv;
 
-    memset(data_set, 0, sizeof(pe_working_set_t));
+    memset(data_set, 0, sizeof(pcmk_scheduler_t));
 
     data_set->priv = priv;
     data_set->order_id = 1;

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -137,7 +137,7 @@ cluster_status(pe_working_set_t * data_set)
     if (!pcmk_is_set(data_set->flags, pcmk_sched_no_counts)) {
         for (GList *item = data_set->resources; item != NULL;
              item = item->next) {
-            ((pe_resource_t *) (item->data))->fns->count(item->data);
+            ((pcmk_resource_t *) (item->data))->fns->count(item->data);
         }
         crm_trace("Cluster resource count: %d (%d disabled, %d blocked)",
                   data_set->ninstances, data_set->disabled_resources,
@@ -150,7 +150,7 @@ cluster_status(pe_working_set_t * data_set)
 
 /*!
  * \internal
- * \brief Free a list of pe_resource_t
+ * \brief Free a list of pcmk_resource_t
  *
  * \param[in,out] resources  List to free
  *
@@ -162,11 +162,11 @@ cluster_status(pe_working_set_t * data_set)
 static void
 pe_free_resources(GList *resources)
 {
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     GList *iterator = resources;
 
     while (iterator != NULL) {
-        rsc = (pe_resource_t *) iterator->data;
+        rsc = (pcmk_resource_t *) iterator->data;
         iterator = iterator->next;
         rsc->fns->free(rsc);
     }
@@ -387,21 +387,21 @@ set_working_set_defaults(pe_working_set_t * data_set)
     }
 }
 
-pe_resource_t *
+pcmk_resource_t *
 pe_find_resource(GList *rsc_list, const char *id)
 {
     return pe_find_resource_with_flags(rsc_list, id, pcmk_rsc_match_history);
 }
 
-pe_resource_t *
+pcmk_resource_t *
 pe_find_resource_with_flags(GList *rsc_list, const char *id, enum pe_find flags)
 {
     GList *rIter = NULL;
 
     for (rIter = rsc_list; id && rIter; rIter = rIter->next) {
-        pe_resource_t *parent = rIter->data;
+        pcmk_resource_t *parent = rIter->data;
 
-        pe_resource_t *match =
+        pcmk_resource_t *match =
             parent->fns->find_rsc(parent, id, NULL, flags);
         if (match != NULL) {
             return match;

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -157,7 +157,7 @@ cluster_status(pe_working_set_t * data_set)
  * \note When a working set's resource list is freed, that includes the original
  *       storage for the uname and id of any Pacemaker Remote nodes in the
  *       working set's node list, so take care not to use those afterward.
- * \todo Refactor pe_node_t to strdup() the node name.
+ * \todo Refactor pcmk_node_t to strdup() the node name.
  */
 static void
 pe_free_resources(GList *resources)
@@ -193,7 +193,7 @@ static void
 pe_free_nodes(GList *nodes)
 {
     for (GList *iterator = nodes; iterator != NULL; iterator = iterator->next) {
-        pe_node_t *node = (pe_node_t *) iterator->data;
+        pcmk_node_t *node = (pcmk_node_t *) iterator->data;
 
         // Shouldn't be possible, but to be safe ...
         if (node == NULL) {
@@ -414,7 +414,7 @@ pe_find_resource_with_flags(GList *rsc_list, const char *id, enum pe_find flags)
 /*!
  * \brief Find a node by name or ID in a list of nodes
  *
- * \param[in] nodes      List of nodes (as pe_node_t*)
+ * \param[in] nodes      List of nodes (as pcmk_node_t*)
  * \param[in] id         If not NULL, ID of node to find
  * \param[in] node_name  If not NULL, name of node to find
  *
@@ -422,10 +422,10 @@ pe_find_resource_with_flags(GList *rsc_list, const char *id, enum pe_find flags)
  *         otherwise node from \p nodes that matches \p uname if any,
  *         otherwise NULL
  */
-pe_node_t *
+pcmk_node_t *
 pe_find_node_any(const GList *nodes, const char *id, const char *uname)
 {
-    pe_node_t *match = NULL;
+    pcmk_node_t *match = NULL;
 
     if (id != NULL) {
         match = pe_find_node_id(nodes, id);
@@ -439,16 +439,16 @@ pe_find_node_any(const GList *nodes, const char *id, const char *uname)
 /*!
  * \brief Find a node by ID in a list of nodes
  *
- * \param[in] nodes  List of nodes (as pe_node_t*)
+ * \param[in] nodes  List of nodes (as pcmk_node_t*)
  * \param[in] id     ID of node to find
  *
  * \return Node from \p nodes that matches \p id if any, otherwise NULL
  */
-pe_node_t *
+pcmk_node_t *
 pe_find_node_id(const GList *nodes, const char *id)
 {
     for (const GList *iter = nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk_node_t *node = (pcmk_node_t *) iter->data;
 
         /* @TODO Whether node IDs should be considered case-sensitive should
          * probably depend on the node type, so functionizing the comparison
@@ -464,16 +464,16 @@ pe_find_node_id(const GList *nodes, const char *id)
 /*!
  * \brief Find a node by name in a list of nodes
  *
- * \param[in] nodes      List of nodes (as pe_node_t*)
+ * \param[in] nodes      List of nodes (as pcmk_node_t*)
  * \param[in] node_name  Name of node to find
  *
  * \return Node from \p nodes that matches \p node_name if any, otherwise NULL
  */
-pe_node_t *
+pcmk_node_t *
 pe_find_node(const GList *nodes, const char *node_name)
 {
     for (const GList *iter = nodes; iter != NULL; iter = iter->next) {
-        pe_node_t *node = (pe_node_t *) iter->data;
+        pcmk_node_t *node = (pcmk_node_t *) iter->data;
 
         if (pcmk__str_eq(node->details->uname, node_name, pcmk__str_casei)) {
             return node;

--- a/lib/pengine/tags.c
+++ b/lib/pengine/tags.c
@@ -17,7 +17,7 @@
 #include <crm/pengine/pe_types.h>
 
 GList *
-pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name)
+pe__rscs_with_tag(pcmk_scheduler_t *data_set, const char *tag_name)
 {
     gpointer value;
     GList *retval = NULL;
@@ -49,7 +49,7 @@ pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name)
 }
 
 GList *
-pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name)
+pe__unames_with_tag(pcmk_scheduler_t *data_set, const char *tag_name)
 {
     gpointer value;
     GList *retval = NULL;
@@ -82,7 +82,8 @@ pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name)
 }
 
 bool
-pe__rsc_has_tag(pe_working_set_t *data_set, const char *rsc_name, const char *tag_name)
+pe__rsc_has_tag(pcmk_scheduler_t *data_set, const char *rsc_name,
+                const char *tag_name)
 {
     GList *rscs = pe__rscs_with_tag(data_set, tag_name);
     bool retval = false;
@@ -97,7 +98,8 @@ pe__rsc_has_tag(pe_working_set_t *data_set, const char *rsc_name, const char *ta
 }
 
 bool
-pe__uname_has_tag(pe_working_set_t *data_set, const char *node_name, const char *tag_name)
+pe__uname_has_tag(pcmk_scheduler_t *data_set, const char *node_name,
+                  const char *tag_name)
 {
     GList *unames = pe__unames_with_tag(data_set, tag_name);
     bool retval = false;

--- a/lib/pengine/tags.c
+++ b/lib/pengine/tags.c
@@ -35,8 +35,8 @@ pe__rscs_with_tag(pe_working_set_t *data_set, const char *tag_name)
     for (GList *refs = ((pe_tag_t *) value)->refs; refs; refs = refs->next) {
         const char *id = (const char *) refs->data;
         const uint32_t flags = pcmk_rsc_match_history|pcmk_rsc_match_basename;
-        pe_resource_t *rsc = pe_find_resource_with_flags(data_set->resources,
-                                                         id, flags);
+        pcmk_resource_t *rsc = pe_find_resource_with_flags(data_set->resources,
+                                                           id, flags);
 
         if (!rsc) {
             continue;

--- a/lib/pengine/tags.c
+++ b/lib/pengine/tags.c
@@ -68,7 +68,7 @@ pe__unames_with_tag(pe_working_set_t *data_set, const char *tag_name)
     for (GList *refs = ((pe_tag_t *) value)->refs; refs; refs = refs->next) {
         /* Find the node that has this ID. */
         const char *id = (const char *) refs->data;
-        pe_node_t *node = pe_find_node_id(data_set->nodes, id);
+        pcmk_node_t *node = pe_find_node_id(data_set->nodes, id);
 
         if (!node) {
             continue;

--- a/lib/pengine/tests/native/native_find_rsc_test.c
+++ b/lib/pengine/tests/native/native_find_rsc_test.c
@@ -19,8 +19,9 @@ xmlNode *input = NULL;
 pe_working_set_t *data_set = NULL;
 
 pcmk_node_t *cluster01, *cluster02, *httpd_bundle_0;
-pe_resource_t *exim_group, *inactive_group, *promotable_clone, *inactive_clone;
-pe_resource_t *httpd_bundle, *mysql_clone_group;
+pcmk_resource_t *exim_group, *inactive_group;
+pcmk_resource_t *promotable_clone, *inactive_clone;
+pcmk_resource_t *httpd_bundle, *mysql_clone_group;
 
 static int
 setup(void **state) {
@@ -55,7 +56,7 @@ setup(void **state) {
 
     /* Get references to several resources we use frequently. */
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "exim-group") == 0) {
             exim_group = rsc;
@@ -84,7 +85,7 @@ teardown(void **state) {
 
 static void
 bad_args(void **state) {
-    pe_resource_t *rsc = (pe_resource_t *) g_list_first(data_set->resources)->data;
+    pcmk_resource_t *rsc = g_list_first(data_set->resources)->data;
     char *id = rsc->id;
     char *name = NULL;
 
@@ -114,11 +115,11 @@ bad_args(void **state) {
 
 static void
 primitive_rsc(void **state) {
-    pe_resource_t *dummy = NULL;
+    pcmk_resource_t *dummy = NULL;
 
     /* Find the "dummy" resource, which is the only one with that ID in the set. */
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "dummy") == 0) {
             dummy = rsc;
@@ -207,11 +208,11 @@ inactive_group_rsc(void **state) {
 
 static void
 group_member_rsc(void **state) {
-    pe_resource_t *public_ip = NULL;
+    pcmk_resource_t *public_ip = NULL;
 
     /* Find the "Public-IP" resource, a member of "exim-group". */
     for (GList *iter = exim_group->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "Public-IP") == 0) {
             public_ip = rsc;
@@ -248,11 +249,11 @@ group_member_rsc(void **state) {
 
 static void
 inactive_group_member_rsc(void **state) {
-    pe_resource_t *inactive_dummy_1 = NULL;
+    pcmk_resource_t *inactive_dummy_1 = NULL;
 
     /* Find the "inactive-dummy-1" resource, a member of "inactive-group". */
     for (GList *iter = inactive_group->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "inactive-dummy-1") == 0) {
             inactive_dummy_1 = rsc;
@@ -347,12 +348,12 @@ inactive_clone_rsc(void **state) {
 
 static void
 clone_instance_rsc(void **state) {
-    pe_resource_t *promotable_0 = NULL;
-    pe_resource_t *promotable_1 = NULL;
+    pcmk_resource_t *promotable_0 = NULL;
+    pcmk_resource_t *promotable_1 = NULL;
 
     /* Find the "promotable-rsc:0" and "promotable-rsc:1" resources, members of "promotable-clone". */
     for (GList *iter = promotable_clone->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "promotable-rsc:0") == 0) {
             promotable_0 = rsc;
@@ -486,12 +487,12 @@ clone_instance_rsc(void **state) {
 
 static void
 renamed_rsc(void **state) {
-    pe_resource_t *promotable_0 = NULL;
-    pe_resource_t *promotable_1 = NULL;
+    pcmk_resource_t *promotable_0 = NULL;
+    pcmk_resource_t *promotable_1 = NULL;
 
     /* Find the "promotable-rsc:0" and "promotable-rsc:1" resources, members of "promotable-clone". */
     for (GList *iter = promotable_clone->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "promotable-rsc:0") == 0) {
             promotable_0 = rsc;
@@ -540,10 +541,10 @@ bundle_rsc(void **state) {
 static bool
 bundle_first_replica(pe__bundle_replica_t *replica, void *user_data)
 {
-    pe_resource_t *ip_0 = replica->ip;
-    pe_resource_t *child_0 = replica->child;
-    pe_resource_t *container_0 = replica->container;
-    pe_resource_t *remote_0 = replica->remote;
+    pcmk_resource_t *ip_0 = replica->ip;
+    pcmk_resource_t *child_0 = replica->child;
+    pcmk_resource_t *container_0 = replica->container;
+    pcmk_resource_t *remote_0 = replica->remote;
 
     assert_non_null(ip_0);
     assert_non_null(child_0);
@@ -705,12 +706,12 @@ clone_group_rsc(void **rsc) {
 
 static void
 clone_group_instance_rsc(void **rsc) {
-    pe_resource_t *mysql_group_0 = NULL;
-    pe_resource_t *mysql_group_1 = NULL;
+    pcmk_resource_t *mysql_group_0 = NULL;
+    pcmk_resource_t *mysql_group_1 = NULL;
 
     /* Find the "mysql-group:0" and "mysql-group:1" resources, members of "mysql-clone-group". */
     for (GList *iter = mysql_clone_group->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "mysql-group:0") == 0) {
             mysql_group_0 = rsc;
@@ -844,15 +845,15 @@ clone_group_instance_rsc(void **rsc) {
 
 static void
 clone_group_member_rsc(void **state) {
-    pe_resource_t *mysql_proxy = NULL;
+    pcmk_resource_t *mysql_proxy = NULL;
 
     /* Find the "mysql-proxy" resource, a member of "mysql-group". */
     for (GList *iter = mysql_clone_group->children; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "mysql-group:0") == 0) {
             for (GList *iter2 = rsc->children; iter2 != NULL; iter2 = iter2->next) {
-                pe_resource_t *child = (pe_resource_t *) iter2->data;
+                pcmk_resource_t *child = (pcmk_resource_t *) iter2->data;
 
                 if (strcmp(child->id, "mysql-proxy:0") == 0) {
                     mysql_proxy = child;

--- a/lib/pengine/tests/native/native_find_rsc_test.c
+++ b/lib/pengine/tests/native/native_find_rsc_test.c
@@ -16,7 +16,7 @@
 #include <crm/pengine/pe_types.h>
 
 xmlNode *input = NULL;
-pe_working_set_t *data_set = NULL;
+pcmk_scheduler_t *data_set = NULL;
 
 pcmk_node_t *cluster01, *cluster02, *httpd_bundle_0;
 pcmk_resource_t *exim_group, *inactive_group;

--- a/lib/pengine/tests/native/native_find_rsc_test.c
+++ b/lib/pengine/tests/native/native_find_rsc_test.c
@@ -18,7 +18,7 @@
 xmlNode *input = NULL;
 pe_working_set_t *data_set = NULL;
 
-pe_node_t *cluster01, *cluster02, *httpd_bundle_0;
+pcmk_node_t *cluster01, *cluster02, *httpd_bundle_0;
 pe_resource_t *exim_group, *inactive_group, *promotable_clone, *inactive_clone;
 pe_resource_t *httpd_bundle, *mysql_clone_group;
 

--- a/lib/pengine/tests/native/pe_base_name_eq_test.c
+++ b/lib/pengine/tests/native/pe_base_name_eq_test.c
@@ -17,7 +17,7 @@
 #include <crm/pengine/pe_types.h>
 
 xmlNode *input = NULL;
-pe_working_set_t *data_set = NULL;
+pcmk_scheduler_t *data_set = NULL;
 
 pcmk_resource_t *exim_group, *promotable_0, *promotable_1, *dummy;
 pcmk_resource_t *httpd_bundle, *mysql_group_0, *mysql_group_1;

--- a/lib/pengine/tests/native/pe_base_name_eq_test.c
+++ b/lib/pengine/tests/native/pe_base_name_eq_test.c
@@ -19,8 +19,8 @@
 xmlNode *input = NULL;
 pe_working_set_t *data_set = NULL;
 
-pe_resource_t *exim_group, *promotable_0, *promotable_1, *dummy;
-pe_resource_t *httpd_bundle, *mysql_group_0, *mysql_group_1;
+pcmk_resource_t *exim_group, *promotable_0, *promotable_1, *dummy;
+pcmk_resource_t *httpd_bundle, *mysql_group_0, *mysql_group_1;
 
 static int
 setup(void **state) {
@@ -50,7 +50,7 @@ setup(void **state) {
 
     /* Get references to several resources we use frequently. */
     for (GList *iter = data_set->resources; iter != NULL; iter = iter->next) {
-        pe_resource_t *rsc = (pe_resource_t *) iter->data;
+        pcmk_resource_t *rsc = (pcmk_resource_t *) iter->data;
 
         if (strcmp(rsc->id, "dummy") == 0) {
             dummy = rsc;
@@ -60,7 +60,7 @@ setup(void **state) {
             httpd_bundle = rsc;
         } else if (strcmp(rsc->id, "mysql-clone-group") == 0) {
             for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-                pe_resource_t *child = (pe_resource_t *) iter->data;
+                pcmk_resource_t *child = (pcmk_resource_t *) iter->data;
 
                 if (strcmp(child->id, "mysql-group:0") == 0) {
                     mysql_group_0 = child;
@@ -70,7 +70,7 @@ setup(void **state) {
             }
         } else if (strcmp(rsc->id, "promotable-clone") == 0) {
             for (GList *iter = rsc->children; iter != NULL; iter = iter->next) {
-                pe_resource_t *child = (pe_resource_t *) iter->data;
+                pcmk_resource_t *child = (pcmk_resource_t *) iter->data;
 
                 if (strcmp(child->id, "promotable-rsc:0") == 0) {
                     promotable_0 = child;

--- a/lib/pengine/tests/status/pe_find_node_any_test.c
+++ b/lib/pengine/tests/status/pe_find_node_any_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -24,8 +24,8 @@ static void
 non_null_list(void **state) {
     GList *nodes = NULL;
 
-    pe_node_t *a = calloc(1, sizeof(pe_node_t));
-    pe_node_t *b = calloc(1, sizeof(pe_node_t));
+    pcmk_node_t *a = calloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *b = calloc(1, sizeof(pcmk_node_t));
 
     a->details = calloc(1, sizeof(struct pe_node_shared_s));
     a->details->uname = "cluster1";

--- a/lib/pengine/tests/status/pe_find_node_id_test.c
+++ b/lib/pengine/tests/status/pe_find_node_id_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,8 +22,8 @@ static void
 non_null_list(void **state) {
     GList *nodes = NULL;
 
-    pe_node_t *a = calloc(1, sizeof(pe_node_t));
-    pe_node_t *b = calloc(1, sizeof(pe_node_t));
+    pcmk_node_t *a = calloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *b = calloc(1, sizeof(pcmk_node_t));
 
     a->details = calloc(1, sizeof(struct pe_node_shared_s));
     a->details->id = "id1";

--- a/lib/pengine/tests/status/pe_find_node_test.c
+++ b/lib/pengine/tests/status/pe_find_node_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,8 +22,8 @@ static void
 non_null_list(void **state) {
     GList *nodes = NULL;
 
-    pe_node_t *a = calloc(1, sizeof(pe_node_t));
-    pe_node_t *b = calloc(1, sizeof(pe_node_t));
+    pcmk_node_t *a = calloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *b = calloc(1, sizeof(pcmk_node_t));
 
     a->details = calloc(1, sizeof(struct pe_node_shared_s));
     a->details->uname = "cluster1";

--- a/lib/pengine/tests/status/pe_new_working_set_test.c
+++ b/lib/pengine/tests/status/pe_new_working_set_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,7 +19,7 @@ calloc_fails(void **state) {
     pcmk__mock_calloc = true;   // calloc() will return NULL
 
     expect_value(__wrap_calloc, nmemb, 1);
-    expect_value(__wrap_calloc, size, sizeof(pe_working_set_t));
+    expect_value(__wrap_calloc, size, sizeof(pcmk_scheduler_t));
     assert_null(pe_new_working_set());
 
     pcmk__mock_calloc = false;  // Use real calloc()
@@ -27,7 +27,7 @@ calloc_fails(void **state) {
 
 static void
 calloc_succeeds(void **state) {
-    pe_working_set_t *data_set = pe_new_working_set();
+    pcmk_scheduler_t *data_set = pe_new_working_set();
 
     /* Nothing else to test about this function, as all it does is call
      * set_working_set_defaults which is also a public function and should

--- a/lib/pengine/tests/status/set_working_set_defaults_test.c
+++ b/lib/pengine/tests/status/set_working_set_defaults_test.c
@@ -19,7 +19,7 @@
 static void
 check_defaults(void **state) {
     uint32_t flags;
-    pe_working_set_t *data_set = calloc(1, sizeof(pe_working_set_t));
+    pcmk_scheduler_t *data_set = calloc(1, sizeof(pcmk_scheduler_t));
 
     set_working_set_defaults(data_set);
 

--- a/lib/pengine/tests/utils/pe__cmp_node_name_test.c
+++ b/lib/pengine/tests/utils/pe__cmp_node_name_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2023 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -15,8 +15,8 @@
 struct pe_node_shared_s node1_details;
 struct pe_node_shared_s node2_details;
 
-pe_node_t node1 = {.details = &node1_details};
-pe_node_t node2 = {.details = &node2_details};
+pcmk_node_t node1 = { .details = &node1_details };
+pcmk_node_t node2 = { .details = &node2_details };
 
 static void
 nodes_equal(void **state)

--- a/lib/pengine/tests/utils/pe__cmp_rsc_priority_test.c
+++ b/lib/pengine/tests/utils/pe__cmp_rsc_priority_test.c
@@ -14,8 +14,8 @@
 
 #include "pe_status_private.h"
 
-pe_resource_t rsc1;
-pe_resource_t rsc2;
+pcmk_resource_t rsc1;
+pcmk_resource_t rsc2;
 
 static void
 rscs_equal(void **state)

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2392,7 +2392,7 @@ process_rsc_state(pcmk_resource_t *rsc, pcmk_node_t *node,
         GList *gIter = possible_matches;
 
         for (; gIter != NULL; gIter = gIter->next) {
-            pe_action_t *stop = (pe_action_t *) gIter->data;
+            pcmk_action_t *stop = (pcmk_action_t *) gIter->data;
 
             pe__set_action_flags(stop, pcmk_action_optional);
         }
@@ -3546,7 +3546,7 @@ unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
                       enum action_fail_response *on_fail)
 {
     bool is_probe = false;
-    pe_action_t *action = NULL;
+    pcmk_action_t *action = NULL;
     char *last_change_s = NULL;
 
     *last_failure = history->xml;
@@ -3977,14 +3977,14 @@ should_clear_for_param_change(const xmlNode *xml_op, const char *task,
 
 // Order action after fencing of remote node, given connection rsc
 static void
-order_after_remote_fencing(pe_action_t *action, pcmk_resource_t *remote_conn,
+order_after_remote_fencing(pcmk_action_t *action, pcmk_resource_t *remote_conn,
                            pe_working_set_t *data_set)
 {
     pcmk_node_t *remote_node = pe_find_node(data_set->nodes, remote_conn->id);
 
     if (remote_node) {
-        pe_action_t *fence = pe_fence_op(remote_node, NULL, TRUE, NULL,
-                                         FALSE, data_set);
+        pcmk_action_t *fence = pe_fence_op(remote_node, NULL, TRUE, NULL,
+                                           FALSE, data_set);
 
         order_actions(fence, action, pcmk__ar_first_implies_then);
     }
@@ -4141,10 +4141,11 @@ check_operation_expiry(struct action_history *history)
     }
 
     if (clear_reason != NULL) {
+        pcmk_action_t *clear_op = NULL;
+
         // Schedule clearing of the fail count
-        pe_action_t *clear_op = pe__clear_failcount(history->rsc, history->node,
-                                                    clear_reason,
-                                                    history->rsc->cluster);
+        clear_op = pe__clear_failcount(history->rsc, history->node,
+                                       clear_reason, history->rsc->cluster);
 
         if (pcmk_is_set(history->rsc->cluster->flags,
                         pcmk_sched_fencing_enabled)
@@ -4211,9 +4212,9 @@ static enum action_fail_response
 get_action_on_fail(struct action_history *history)
 {
     enum action_fail_response result = pcmk_on_fail_restart;
-    pe_action_t *action = custom_action(history->rsc, strdup(history->key),
-                                        history->task, NULL, TRUE, FALSE,
-                                        history->rsc->cluster);
+    pcmk_action_t *action = custom_action(history->rsc, strdup(history->key),
+                                          history->task, NULL, TRUE, FALSE,
+                                          history->rsc->cluster);
 
     result = action->on_fail;
     pe_free_action(action);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -69,16 +69,16 @@ struct action_history {
 static void unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node,
                           xmlNode *xml_op, xmlNode **last_failure,
                           enum action_fail_response *failed);
-static void determine_remote_online_status(pe_working_set_t *data_set,
+static void determine_remote_online_status(pcmk_scheduler_t *data_set,
                                            pcmk_node_t *this_node);
 static void add_node_attrs(const xmlNode *xml_obj, pcmk_node_t *node,
-                           bool overwrite, pe_working_set_t *data_set);
+                           bool overwrite, pcmk_scheduler_t *data_set);
 static void determine_online_status(const xmlNode *node_state,
                                     pcmk_node_t *this_node,
-                                    pe_working_set_t *data_set);
+                                    pcmk_scheduler_t *data_set);
 
 static void unpack_node_lrm(pcmk_node_t *node, const xmlNode *xml,
-                            pe_working_set_t *data_set);
+                            pcmk_scheduler_t *data_set);
 
 
 static gboolean
@@ -107,7 +107,7 @@ is_dangling_guest_node(pcmk_node_t *node)
  * \param[in]     priority_delay  Whether to consider `priority-fencing-delay`
  */
 void
-pe_fence_node(pe_working_set_t *data_set, pcmk_node_t *node,
+pe_fence_node(pcmk_scheduler_t *data_set, pcmk_node_t *node,
               const char *reason, bool priority_delay)
 {
     CRM_CHECK(node, return);
@@ -195,7 +195,7 @@ pe_fence_node(pe_working_set_t *data_set, pcmk_node_t *node,
     "/" XML_TAG_META_SETS "/" XPATH_UNFENCING_NVPAIR
 
 static void
-set_if_xpath(uint64_t flag, const char *xpath, pe_working_set_t *data_set)
+set_if_xpath(uint64_t flag, const char *xpath, pcmk_scheduler_t *data_set)
 {
     xmlXPathObjectPtr result = NULL;
 
@@ -209,7 +209,7 @@ set_if_xpath(uint64_t flag, const char *xpath, pe_working_set_t *data_set)
 }
 
 gboolean
-unpack_config(xmlNode * config, pe_working_set_t * data_set)
+unpack_config(xmlNode *config, pcmk_scheduler_t *data_set)
 {
     const char *value = NULL;
     GHashTable *config_hash = pcmk__strkey_table(free, free);
@@ -432,7 +432,7 @@ unpack_config(xmlNode * config, pe_working_set_t * data_set)
 
 pcmk_node_t *
 pe_create_node(const char *id, const char *uname, const char *type,
-               const char *score, pe_working_set_t * data_set)
+               const char *score, pcmk_scheduler_t *data_set)
 {
     pcmk_node_t *new_node = NULL;
 
@@ -505,7 +505,7 @@ pe_create_node(const char *id, const char *uname, const char *type,
 }
 
 static const char *
-expand_remote_rsc_meta(xmlNode *xml_obj, xmlNode *parent, pe_working_set_t *data)
+expand_remote_rsc_meta(xmlNode *xml_obj, xmlNode *parent, pcmk_scheduler_t *data)
 {
     xmlNode *attr_set = NULL;
     xmlNode *attr = NULL;
@@ -562,7 +562,7 @@ expand_remote_rsc_meta(xmlNode *xml_obj, xmlNode *parent, pe_working_set_t *data
 }
 
 static void
-handle_startup_fencing(pe_working_set_t *data_set, pcmk_node_t *new_node)
+handle_startup_fencing(pcmk_scheduler_t *data_set, pcmk_node_t *new_node)
 {
     if ((new_node->details->type == pcmk_node_variant_remote)
         && (new_node->details->remote_rsc == NULL)) {
@@ -588,7 +588,7 @@ handle_startup_fencing(pe_working_set_t *data_set, pcmk_node_t *new_node)
 }
 
 gboolean
-unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
+unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_obj = NULL;
     pcmk_node_t *new_node = NULL;
@@ -638,7 +638,7 @@ unpack_nodes(xmlNode * xml_nodes, pe_working_set_t * data_set)
 }
 
 static void
-setup_container(pcmk_resource_t * rsc, pe_working_set_t * data_set)
+setup_container(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set)
 {
     const char *container_id = NULL;
 
@@ -664,7 +664,7 @@ setup_container(pcmk_resource_t * rsc, pe_working_set_t * data_set)
 }
 
 gboolean
-unpack_remote_nodes(xmlNode * xml_resources, pe_working_set_t * data_set)
+unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_obj = NULL;
 
@@ -741,7 +741,7 @@ unpack_remote_nodes(xmlNode * xml_resources, pe_working_set_t * data_set)
  * easy access to the connection resource during the scheduler calculations.
  */
 static void
-link_rsc2remotenode(pe_working_set_t *data_set, pcmk_resource_t *new_rsc)
+link_rsc2remotenode(pcmk_scheduler_t *data_set, pcmk_resource_t *new_rsc)
 {
     pcmk_node_t *remote_node = NULL;
 
@@ -801,7 +801,7 @@ destroy_tag(gpointer data)
  *       be used when pe__unpack_resource() calls resource_location()
  */
 gboolean
-unpack_resources(const xmlNode *xml_resources, pe_working_set_t * data_set)
+unpack_resources(const xmlNode *xml_resources, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_obj = NULL;
     GList *gIter = NULL;
@@ -868,7 +868,7 @@ unpack_resources(const xmlNode *xml_resources, pe_working_set_t * data_set)
 }
 
 gboolean
-unpack_tags(xmlNode * xml_tags, pe_working_set_t * data_set)
+unpack_tags(xmlNode *xml_tags, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_tag = NULL;
 
@@ -917,7 +917,7 @@ unpack_tags(xmlNode * xml_tags, pe_working_set_t * data_set)
 /* The ticket state section:
  * "/cib/status/tickets/ticket_state" */
 static gboolean
-unpack_ticket_state(xmlNode * xml_ticket, pe_working_set_t * data_set)
+unpack_ticket_state(xmlNode *xml_ticket, pcmk_scheduler_t *data_set)
 {
     const char *ticket_id = NULL;
     const char *granted = NULL;
@@ -985,7 +985,7 @@ unpack_ticket_state(xmlNode * xml_ticket, pe_working_set_t * data_set)
 }
 
 static gboolean
-unpack_tickets_state(xmlNode * xml_tickets, pe_working_set_t * data_set)
+unpack_tickets_state(xmlNode *xml_tickets, pcmk_scheduler_t *data_set)
 {
     xmlNode *xml_obj = NULL;
 
@@ -1003,7 +1003,7 @@ unpack_tickets_state(xmlNode * xml_tickets, pe_working_set_t * data_set)
 
 static void
 unpack_handle_remote_attrs(pcmk_node_t *this_node, const xmlNode *state,
-                           pe_working_set_t *data_set)
+                           pcmk_scheduler_t *data_set)
 {
     const char *resource_discovery_enabled = NULL;
     const xmlNode *attrs = NULL;
@@ -1076,7 +1076,7 @@ unpack_handle_remote_attrs(pcmk_node_t *this_node, const xmlNode *state,
  */
 static void
 unpack_transient_attributes(const xmlNode *state, pcmk_node_t *node,
-                            pe_working_set_t *data_set)
+                            pcmk_scheduler_t *data_set)
 {
     const char *discovery = NULL;
     const xmlNode *attrs = find_xml_node(state, XML_TAG_TRANSIENT_NODEATTRS,
@@ -1115,7 +1115,7 @@ unpack_transient_attributes(const xmlNode *state, pcmk_node_t *node,
  * \param[in,out] data_set  Cluster working set
  */
 static void
-unpack_node_state(const xmlNode *state, pe_working_set_t *data_set)
+unpack_node_state(const xmlNode *state, pcmk_scheduler_t *data_set)
 {
     const char *id = NULL;
     const char *uname = NULL;
@@ -1202,7 +1202,7 @@ unpack_node_state(const xmlNode *state, pe_working_set_t *data_set)
  */
 static int
 unpack_node_history(const xmlNode *status, bool fence,
-                    pe_working_set_t *data_set)
+                    pcmk_scheduler_t *data_set)
 {
     int rc = pcmk_rc_ok;
 
@@ -1303,7 +1303,7 @@ unpack_node_history(const xmlNode *status, bool fence,
 /* create positive rsc_to_node constraints between resources and the nodes they are running on */
 /* anything else? */
 gboolean
-unpack_status(xmlNode * status, pe_working_set_t * data_set)
+unpack_status(xmlNode *status, pcmk_scheduler_t *data_set)
 {
     xmlNode *state = NULL;
 
@@ -1385,7 +1385,7 @@ unpack_status(xmlNode * status, pe_working_set_t * data_set)
  *         0 if not a member, or -1 if no valid information available
  */
 static long long
-unpack_node_member(const xmlNode *node_state, pe_working_set_t *data_set)
+unpack_node_member(const xmlNode *node_state, pcmk_scheduler_t *data_set)
 {
     const char *member_time = crm_element_value(node_state, PCMK__XA_IN_CCM);
     int member = 0;
@@ -1478,7 +1478,7 @@ unpack_node_terminate(const pcmk_node_t *node, const xmlNode *node_state)
 }
 
 static gboolean
-determine_online_status_no_fencing(pe_working_set_t *data_set,
+determine_online_status_no_fencing(pcmk_scheduler_t *data_set,
                                    const xmlNode *node_state,
                                    pcmk_node_t *this_node)
 {
@@ -1517,7 +1517,7 @@ determine_online_status_no_fencing(pe_working_set_t *data_set,
 }
 
 static bool
-determine_online_status_fencing(pe_working_set_t *data_set,
+determine_online_status_fencing(pcmk_scheduler_t *data_set,
                                 const xmlNode *node_state,
                                 pcmk_node_t *this_node)
 {
@@ -1622,7 +1622,7 @@ determine_online_status_fencing(pe_working_set_t *data_set,
 }
 
 static void
-determine_remote_online_status(pe_working_set_t *data_set,
+determine_remote_online_status(pcmk_scheduler_t *data_set,
                                pcmk_node_t *this_node)
 {
     pcmk_resource_t *rsc = this_node->details->remote_rsc;
@@ -1696,7 +1696,7 @@ remote_online_done:
 
 static void
 determine_online_status(const xmlNode *node_state, pcmk_node_t *this_node,
-                        pe_working_set_t *data_set)
+                        pcmk_scheduler_t *data_set)
 {
     gboolean online = FALSE;
     const char *exp_state = crm_element_value(node_state, PCMK__XA_EXPECTED);
@@ -1848,7 +1848,7 @@ clone_zero(const char *last_rsc_id)
 
 static pcmk_resource_t *
 create_fake_resource(const char *rsc_id, const xmlNode *rsc_entry,
-                     pe_working_set_t *data_set)
+                     pcmk_scheduler_t *data_set)
 {
     pcmk_resource_t *rsc = NULL;
     xmlNode *xml_rsc = create_xml_node(NULL, XML_CIB_TAG_RESOURCE);
@@ -1900,7 +1900,7 @@ create_fake_resource(const char *rsc_id, const xmlNode *rsc_entry,
  */
 static pcmk_resource_t *
 create_anonymous_orphan(pcmk_resource_t *parent, const char *rsc_id,
-                        const pcmk_node_t *node, pe_working_set_t *data_set)
+                        const pcmk_node_t *node, pcmk_scheduler_t *data_set)
 {
     pcmk_resource_t *top = pe__create_clone_child(parent, data_set);
 
@@ -1928,7 +1928,7 @@ create_anonymous_orphan(pcmk_resource_t *parent, const char *rsc_id,
  * \param[in]     rsc_id    Name of cloned resource in history (without instance)
  */
 static pcmk_resource_t *
-find_anonymous_clone(pe_working_set_t *data_set, const pcmk_node_t *node,
+find_anonymous_clone(pcmk_scheduler_t *data_set, const pcmk_node_t *node,
                      pcmk_resource_t *parent, const char *rsc_id)
 {
     GList *rIter = NULL;
@@ -2053,7 +2053,7 @@ find_anonymous_clone(pe_working_set_t *data_set, const pcmk_node_t *node,
 }
 
 static pcmk_resource_t *
-unpack_find_resource(pe_working_set_t *data_set, const pcmk_node_t *node,
+unpack_find_resource(pcmk_scheduler_t *data_set, const pcmk_node_t *node,
                      const char *rsc_id)
 {
     pcmk_resource_t *rsc = NULL;
@@ -2116,7 +2116,7 @@ unpack_find_resource(pe_working_set_t *data_set, const pcmk_node_t *node,
 
 static pcmk_resource_t *
 process_orphan_resource(const xmlNode *rsc_entry, const pcmk_node_t *node,
-                        pe_working_set_t *data_set)
+                        pcmk_scheduler_t *data_set)
 {
     pcmk_resource_t *rsc = NULL;
     const char *rsc_id = crm_element_value(rsc_entry, XML_ATTR_ID);
@@ -2417,7 +2417,7 @@ process_rsc_state(pcmk_resource_t *rsc, pcmk_node_t *node,
 static void
 process_recurring(pcmk_node_t *node, pcmk_resource_t *rsc,
                   int start_index, int stop_index,
-                  GList *sorted_op_list, pe_working_set_t * data_set)
+                  GList *sorted_op_list, pcmk_scheduler_t * data_set)
 {
     int counter = -1;
     const char *task = NULL;
@@ -2529,7 +2529,7 @@ calculate_active_ops(const GList *sorted_op_list, int *start_index,
 // If resource history entry has shutdown lock, remember lock node and time
 static void
 unpack_shutdown_lock(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
-                     const pcmk_node_t *node, pe_working_set_t *data_set)
+                     const pcmk_node_t *node, pcmk_scheduler_t *data_set)
 {
     time_t lock_time = 0;   // When lock started (i.e. node shutdown time)
 
@@ -2565,7 +2565,7 @@ unpack_shutdown_lock(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
  */
 static pcmk_resource_t *
 unpack_lrm_resource(pcmk_node_t *node, const xmlNode *lrm_resource,
-                    pe_working_set_t *data_set)
+                    pcmk_scheduler_t *data_set)
 {
     GList *gIter = NULL;
     int stop_index = -1;
@@ -2665,7 +2665,7 @@ unpack_lrm_resource(pcmk_node_t *node, const xmlNode *lrm_resource,
 
 static void
 handle_orphaned_container_fillers(const xmlNode *lrm_rsc_list,
-                                  pe_working_set_t *data_set)
+                                  pcmk_scheduler_t *data_set)
 {
     for (const xmlNode *rsc_entry = pcmk__xe_first_child(lrm_rsc_list);
          rsc_entry != NULL; rsc_entry = pcmk__xe_next(rsc_entry)) {
@@ -2713,7 +2713,7 @@ handle_orphaned_container_fillers(const xmlNode *lrm_rsc_list,
  */
 static void
 unpack_node_lrm(pcmk_node_t *node, const xmlNode *xml,
-                pe_working_set_t *data_set)
+                pcmk_scheduler_t *data_set)
 {
     bool found_orphaned_container_filler = false;
 
@@ -2777,7 +2777,7 @@ set_node_score(gpointer key, gpointer value, gpointer user_data)
 
 static xmlNode *
 find_lrm_op(const char *resource, const char *op, const char *node, const char *source,
-            int target_rc, pe_working_set_t *data_set)
+            int target_rc, pcmk_scheduler_t *data_set)
 {
     GString *xpath = NULL;
     xmlNode *xml = NULL;
@@ -2826,7 +2826,7 @@ find_lrm_op(const char *resource, const char *op, const char *node, const char *
 
 static xmlNode *
 find_lrm_resource(const char *rsc_id, const char *node_name,
-                  pe_working_set_t *data_set)
+                  pcmk_scheduler_t *data_set)
 {
     GString *xpath = NULL;
     xmlNode *xml = NULL;
@@ -2889,7 +2889,7 @@ unknown_on_node(pcmk_resource_t *rsc, const char *node_name)
 static bool
 monitor_not_running_after(const char *rsc_id, const char *node_name,
                           const xmlNode *xml_op, bool same_node,
-                          pe_working_set_t *data_set)
+                          pcmk_scheduler_t *data_set)
 {
     /* Any probe/monitor operation on the node indicating it was not running
      * there
@@ -2915,7 +2915,7 @@ monitor_not_running_after(const char *rsc_id, const char *node_name,
 static bool
 non_monitor_after(const char *rsc_id, const char *node_name,
                   const xmlNode *xml_op, bool same_node,
-                  pe_working_set_t *data_set)
+                  pcmk_scheduler_t *data_set)
 {
     xmlNode *lrm_resource = NULL;
 
@@ -2961,7 +2961,7 @@ static bool
 newer_state_after_migrate(const char *rsc_id, const char *node_name,
                           const xmlNode *migrate_to,
                           const xmlNode *migrate_from,
-                          pe_working_set_t *data_set)
+                          pcmk_scheduler_t *data_set)
 {
     const xmlNode *xml_op = migrate_to;
     const char *source = NULL;
@@ -3978,7 +3978,7 @@ should_clear_for_param_change(const xmlNode *xml_op, const char *task,
 // Order action after fencing of remote node, given connection rsc
 static void
 order_after_remote_fencing(pcmk_action_t *action, pcmk_resource_t *remote_conn,
-                           pe_working_set_t *data_set)
+                           pcmk_scheduler_t *data_set)
 {
     pcmk_node_t *remote_node = pe_find_node(data_set->nodes, remote_conn->id);
 
@@ -4819,7 +4819,7 @@ done:
 
 static void
 add_node_attrs(const xmlNode *xml_obj, pcmk_node_t *node, bool overwrite,
-               pe_working_set_t *data_set)
+               pcmk_scheduler_t *data_set)
 {
     const char *cluster_name = NULL;
 
@@ -4943,7 +4943,7 @@ extract_operations(const char *node, const char *rsc, xmlNode * rsc_entry, gbool
 
 GList *
 find_operations(const char *rsc, const char *node, gboolean active_filter,
-                pe_working_set_t * data_set)
+                pcmk_scheduler_t * data_set)
 {
     GList *output = NULL;
     GList *intermediate = NULL;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -447,7 +447,8 @@ get_target_role(const pcmk_resource_t *rsc, enum rsc_role_e *role)
 }
 
 gboolean
-order_actions(pe_action_t *lh_action, pe_action_t *rh_action, uint32_t flags)
+order_actions(pcmk_action_t *lh_action, pcmk_action_t *rh_action,
+              uint32_t flags)
 {
     GList *gIter = NULL;
     pe_action_wrapper_t *wrapper = NULL;
@@ -578,7 +579,7 @@ pe__set_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags)
 
 void
 trigger_unfencing(pcmk_resource_t *rsc, pcmk_node_t *node, const char *reason,
-                  pe_action_t *dependency, pe_working_set_t *data_set)
+                  pcmk_action_t *dependency, pe_working_set_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_enable_unfencing)) {
         /* No resources require it */
@@ -593,8 +594,8 @@ trigger_unfencing(pcmk_resource_t *rsc, pcmk_node_t *node, const char *reason,
               && node->details->online
               && node->details->unclean == FALSE
               && node->details->shutdown == FALSE) {
-        pe_action_t *unfence = pe_fence_op(node, PCMK_ACTION_ON, FALSE, reason,
-                                           FALSE, data_set);
+        pcmk_action_t *unfence = pe_fence_op(node, PCMK_ACTION_ON, FALSE,
+                                             reason, FALSE, data_set);
 
         if(dependency) {
             order_actions(unfence, dependency, pcmk__ar_ordered);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -33,7 +33,7 @@ gboolean ghash_free_str_str(gpointer key, gpointer value, gpointer user_data);
  * \return true if node can be fenced, false otherwise
  */
 bool
-pe_can_fence(const pe_working_set_t *data_set, const pcmk_node_t *node)
+pe_can_fence(const pcmk_scheduler_t *data_set, const pcmk_node_t *node)
 {
     if (pe__is_guest_node(node)) {
         /* Guest nodes are fenced by stopping their container resource. We can
@@ -175,7 +175,7 @@ pe__cmp_node_name(gconstpointer a, gconstpointer b)
  */
 static void
 pe__output_node_weights(const pcmk_resource_t *rsc, const char *comment,
-                        GHashTable *nodes, pe_working_set_t *data_set)
+                        GHashTable *nodes, pcmk_scheduler_t *data_set)
 {
     pcmk__output_t *out = data_set->priv;
 
@@ -250,7 +250,7 @@ void
 pe__show_node_scores_as(const char *file, const char *function, int line,
                         bool to_log, const pcmk_resource_t *rsc,
                         const char *comment, GHashTable *nodes,
-                        pe_working_set_t *data_set)
+                        pcmk_scheduler_t *data_set)
 {
     if ((rsc != NULL) && pcmk_is_set(rsc->flags, pcmk_rsc_removed)) {
         // Don't show allocation scores for orphans
@@ -358,7 +358,7 @@ resource_node_score(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
 
 void
 resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
-                  const char *tag, pe_working_set_t *data_set)
+                  const char *tag, pcmk_scheduler_t *data_set)
 {
     if (node != NULL) {
         resource_node_score(rsc, node, score, tag);
@@ -393,7 +393,7 @@ resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
 }
 
 time_t
-get_effective_time(pe_working_set_t * data_set)
+get_effective_time(pcmk_scheduler_t *data_set)
 {
     if(data_set) {
         if (data_set->now == NULL) {
@@ -507,7 +507,7 @@ destroy_ticket(gpointer data)
 }
 
 pe_ticket_t *
-ticket_new(const char *ticket_id, pe_working_set_t * data_set)
+ticket_new(const char *ticket_id, pcmk_scheduler_t *data_set)
 {
     pe_ticket_t *ticket = NULL;
 
@@ -559,7 +559,7 @@ pe__clear_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags)
 }
 
 void
-pe__clear_resource_flags_on_all(pe_working_set_t *data_set, uint64_t flag)
+pe__clear_resource_flags_on_all(pcmk_scheduler_t *data_set, uint64_t flag)
 {
     for (GList *lpc = data_set->resources; lpc != NULL; lpc = lpc->next) {
         pcmk_resource_t *r = (pcmk_resource_t *) lpc->data;
@@ -579,7 +579,7 @@ pe__set_resource_flags_recursive(pcmk_resource_t *rsc, uint64_t flags)
 
 void
 trigger_unfencing(pcmk_resource_t *rsc, pcmk_node_t *node, const char *reason,
-                  pcmk_action_t *dependency, pe_working_set_t *data_set)
+                  pcmk_action_t *dependency, pcmk_scheduler_t *data_set)
 {
     if (!pcmk_is_set(data_set->flags, pcmk_sched_enable_unfencing)) {
         /* No resources require it */
@@ -678,7 +678,7 @@ pe__shutdown_requested(const pcmk_node_t *node)
  * \param[in,out] data_set  Current working set
  */
 void
-pe__update_recheck_time(time_t recheck, pe_working_set_t *data_set)
+pe__update_recheck_time(time_t recheck, pcmk_scheduler_t *data_set)
 {
     if ((recheck > get_effective_time(data_set))
         && ((data_set->recheck_by == 0)
@@ -703,7 +703,7 @@ void
 pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
                            const pe_rule_eval_data_t *rule_data,
                            GHashTable *hash, const char *always_first,
-                           gboolean overwrite, pe_working_set_t *data_set)
+                           gboolean overwrite, pcmk_scheduler_t *data_set)
 {
     crm_time_t *next_change = crm_time_new_undefined();
 
@@ -794,7 +794,8 @@ pe__filter_rsc_list(GList *rscs, GList *filter)
 }
 
 GList *
-pe__build_node_name_list(pe_working_set_t *data_set, const char *s) {
+pe__build_node_name_list(pcmk_scheduler_t *data_set, const char *s)
+{
     GList *nodes = NULL;
 
     if (pcmk__str_eq(s, "*", pcmk__str_null_matches)) {
@@ -826,7 +827,8 @@ pe__build_node_name_list(pe_working_set_t *data_set, const char *s) {
 }
 
 GList *
-pe__build_rsc_list(pe_working_set_t *data_set, const char *s) {
+pe__build_rsc_list(pcmk_scheduler_t *data_set, const char *s)
+{
     GList *resources = NULL;
 
     if (pcmk__str_eq(s, "*", pcmk__str_null_matches)) {

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -438,7 +438,7 @@ cluster_maint_mode_console(pcmk__output_t *out, va_list args) {
     }
 }
 
-PCMK__OUTPUT_ARGS("cluster-status", "pe_working_set_t *",
+PCMK__OUTPUT_ARGS("cluster-status", "pcmk_scheduler_t *",
                   "enum pcmk_pacemakerd_state", "crm_exit_t",
                   "stonith_history_t *", "enum pcmk__fence_history", "uint32_t",
                   "uint32_t", "const char *", "GList *", "GList *")

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -969,7 +969,7 @@ static int
 ban_or_move(pcmk__output_t *out, pe_resource_t *rsc, const char *move_lifetime)
 {
     int rc = pcmk_rc_ok;
-    pe_node_t *current = NULL;
+    pcmk_node_t *current = NULL;
     unsigned int nactive = 0;
 
     CRM_CHECK(rsc != NULL, return EINVAL);
@@ -1025,7 +1025,7 @@ ban_or_move(pcmk__output_t *out, pe_resource_t *rsc, const char *move_lifetime)
 }
 
 static void
-cleanup(pcmk__output_t *out, pe_resource_t *rsc, pe_node_t *node)
+cleanup(pcmk__output_t *out, pe_resource_t *rsc, pcmk_node_t *node)
 {
     int rc = pcmk_rc_ok;
 
@@ -1055,7 +1055,7 @@ clear_constraints(pcmk__output_t *out, xmlNodePtr *cib_xml_copy)
     GList *after = NULL;
     GList *remaining = NULL;
     GList *ele = NULL;
-    pe_node_t *dest = NULL;
+    pcmk_node_t *dest = NULL;
     int rc = pcmk_rc_ok;
 
     if (!out->is_quiet(out)) {
@@ -1184,7 +1184,7 @@ refresh(pcmk__output_t *out)
     int attr_options = pcmk__node_attr_none;
 
     if (options.host_uname) {
-        pe_node_t *node = pe_find_node(data_set->nodes, options.host_uname);
+        pcmk_node_t *node = pe_find_node(data_set->nodes, options.host_uname);
 
         if (pe__is_guest_or_remote_node(node)) {
             node = pe__current_node(node->details->remote_rsc);
@@ -1221,7 +1221,7 @@ refresh(pcmk__output_t *out)
 }
 
 static void
-refresh_resource(pcmk__output_t *out, pe_resource_t *rsc, pe_node_t *node)
+refresh_resource(pcmk__output_t *out, pe_resource_t *rsc, pcmk_node_t *node)
 {
     int rc = pcmk_rc_ok;
 
@@ -1445,7 +1445,7 @@ main(int argc, char **argv)
 {
     xmlNode *cib_xml_copy = NULL;
     pe_resource_t *rsc = NULL;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
     int rc = pcmk_rc_ok;
 
     GOptionGroup *output_group = NULL;
@@ -1916,7 +1916,7 @@ main(int argc, char **argv)
         case cmd_get_param: {
             unsigned int count = 0;
             GHashTable *params = NULL;
-            pe_node_t *current = rsc->fns->active_node(rsc, &count, NULL);
+            pcmk_node_t *current = rsc->fns->active_node(rsc, &count, NULL);
             bool free_params = true;
             const char* value = NULL;
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -183,7 +183,7 @@ static GError *error = NULL;
 static GMainLoop *mainloop = NULL;
 static cib_t *cib_conn = NULL;
 static pcmk_ipc_api_t *controld_api = NULL;
-static pe_working_set_t *data_set = NULL;
+static pcmk_scheduler_t *data_set = NULL;
 
 #define MESSAGE_TIMEOUT_S 60
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -966,7 +966,8 @@ why_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **er
 }
 
 static int
-ban_or_move(pcmk__output_t *out, pe_resource_t *rsc, const char *move_lifetime)
+ban_or_move(pcmk__output_t *out, pcmk_resource_t *rsc,
+            const char *move_lifetime)
 {
     int rc = pcmk_rc_ok;
     pcmk_node_t *current = NULL;
@@ -987,7 +988,7 @@ ban_or_move(pcmk__output_t *out, pe_resource_t *rsc, const char *move_lifetime)
 
         current = NULL;
         for(iter = rsc->children; iter; iter = iter->next) {
-            pe_resource_t *child = (pe_resource_t *)iter->data;
+            pcmk_resource_t *child = (pcmk_resource_t *)iter->data;
             enum rsc_role_e child_role = child->fns->state(child, TRUE);
 
             if (child_role == pcmk_role_promoted) {
@@ -1025,7 +1026,7 @@ ban_or_move(pcmk__output_t *out, pe_resource_t *rsc, const char *move_lifetime)
 }
 
 static void
-cleanup(pcmk__output_t *out, pe_resource_t *rsc, pcmk_node_t *node)
+cleanup(pcmk__output_t *out, pcmk_resource_t *rsc, pcmk_node_t *node)
 {
     int rc = pcmk_rc_ok;
 
@@ -1221,7 +1222,7 @@ refresh(pcmk__output_t *out)
 }
 
 static void
-refresh_resource(pcmk__output_t *out, pe_resource_t *rsc, pcmk_node_t *node)
+refresh_resource(pcmk__output_t *out, pcmk_resource_t *rsc, pcmk_node_t *node)
 {
     int rc = pcmk_rc_ok;
 
@@ -1444,7 +1445,7 @@ int
 main(int argc, char **argv)
 {
     xmlNode *cib_xml_copy = NULL;
-    pe_resource_t *rsc = NULL;
+    pcmk_resource_t *rsc = NULL;
     pcmk_node_t *node = NULL;
     int rc = pcmk_rc_ok;
 

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -44,12 +44,13 @@ enum resource_check_flags {
 };
 
 typedef struct resource_checks_s {
-    pe_resource_t *rsc;     // Resource being checked
+    pcmk_resource_t *rsc;   // Resource being checked
     uint32_t flags;         // Group of enum resource_check_flags
     const char *lock_node;  // Node that resource is shutdown-locked to, if any
 } resource_checks_t;
 
-resource_checks_t *cli_check_resource(pe_resource_t *rsc, char *role_s, char *managed);
+resource_checks_t *cli_check_resource(pcmk_resource_t *rsc, char *role_s,
+                                      char *managed);
 
 /* ban */
 int cli_resource_prefer(pcmk__output_t *out, const char *rsc_id, const char *host,
@@ -64,32 +65,33 @@ int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_optio
                                    const char *rsc, const char *node, gboolean promoted_role_only);
 
 /* print */
-void cli_resource_print_cts(pe_resource_t * rsc, pcmk__output_t *out);
+void cli_resource_print_cts(pcmk_resource_t *rsc, pcmk__output_t *out);
 void cli_resource_print_cts_constraints(pe_working_set_t * data_set);
 
-int cli_resource_print(pe_resource_t *rsc, pe_working_set_t *data_set, bool expanded);
+int cli_resource_print(pcmk_resource_t *rsc, pe_working_set_t *data_set,
+                       bool expanded);
 int cli_resource_print_operations(const char *rsc_id, const char *host_uname,
                                   bool active, pe_working_set_t * data_set);
 
 /* runtime */
-int cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc,
+int cli_resource_check(pcmk__output_t *out, pcmk_resource_t *rsc,
                        pcmk_node_t *node);
 int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
                       const char *rsc_id, pe_working_set_t *data_set);
-GList *cli_resource_search(pe_resource_t *rsc, const char *requested_name,
+GList *cli_resource_search(pcmk_resource_t *rsc, const char *requested_name,
                              pe_working_set_t *data_set);
 int cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
-                        const pe_resource_t *rsc, const char *operation,
+                        const pcmk_resource_t *rsc, const char *operation,
                         const char *interval_spec, bool just_failures,
                         pe_working_set_t *data_set, gboolean force);
 int cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
                     const char *operation, const char *interval_spec,
                     pe_working_set_t *data_set);
-int cli_resource_restart(pcmk__output_t *out, pe_resource_t *rsc,
+int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                          const pcmk_node_t *node, const char *move_lifetime,
                          int timeout_ms, cib_t *cib, int cib_options,
                          gboolean promoted_role_only, gboolean force);
-int cli_resource_move(const pe_resource_t *rsc, const char *rsc_id,
+int cli_resource_move(const pcmk_resource_t *rsc, const char *rsc_id,
                       const char *host_name, const char *move_lifetime,
                       cib_t *cib, int cib_options, pe_working_set_t *data_set,
                       gboolean promoted_role_only, gboolean force);
@@ -99,17 +101,20 @@ crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc
                                             GHashTable *params, GHashTable *override_hash,
                                             int timeout_ms, int resource_verbose,
                                             gboolean force, int check_level);
-crm_exit_t cli_resource_execute(pe_resource_t *rsc, const char *requested_name,
+crm_exit_t cli_resource_execute(pcmk_resource_t *rsc,
+                                const char *requested_name,
                                 const char *rsc_action, GHashTable *override_hash,
                                 int timeout_ms, cib_t *cib, pe_working_set_t *data_set,
                                 int resource_verbose, gboolean force, int check_level);
 
-int cli_resource_update_attribute(pe_resource_t *rsc, const char *requested_name,
+int cli_resource_update_attribute(pcmk_resource_t *rsc,
+                                  const char *requested_name,
                                   const char *attr_set, const char *attr_set_type,
                                   const char *attr_id, const char *attr_name,
                                   const char *attr_value, gboolean recursive,
                                   cib_t *cib, int cib_options, gboolean force);
-int cli_resource_delete_attribute(pe_resource_t *rsc, const char *requested_name,
+int cli_resource_delete_attribute(pcmk_resource_t *rsc,
+                                  const char *requested_name,
                                   const char *attr_set, const char *attr_set_type,
                                   const char *attr_id, const char *attr_name,
                                   cib_t *cib, int cib_options, gboolean force);
@@ -117,6 +122,6 @@ int cli_resource_delete_attribute(pe_resource_t *rsc, const char *requested_name
 int update_working_set_xml(pe_working_set_t *data_set, xmlNode **xml);
 int wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib);
 
-bool resource_is_running_on(pe_resource_t *rsc, const char *host);
+bool resource_is_running_on(pcmk_resource_t *rsc, const char *host);
 
 void crm_resource_register_messages(pcmk__output_t *out);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -66,34 +66,34 @@ int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_optio
 
 /* print */
 void cli_resource_print_cts(pcmk_resource_t *rsc, pcmk__output_t *out);
-void cli_resource_print_cts_constraints(pe_working_set_t * data_set);
+void cli_resource_print_cts_constraints(pcmk_scheduler_t *data_set);
 
-int cli_resource_print(pcmk_resource_t *rsc, pe_working_set_t *data_set,
+int cli_resource_print(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set,
                        bool expanded);
 int cli_resource_print_operations(const char *rsc_id, const char *host_uname,
-                                  bool active, pe_working_set_t * data_set);
+                                  bool active, pcmk_scheduler_t *data_set);
 
 /* runtime */
 int cli_resource_check(pcmk__output_t *out, pcmk_resource_t *rsc,
                        pcmk_node_t *node);
 int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
-                      const char *rsc_id, pe_working_set_t *data_set);
+                      const char *rsc_id, pcmk_scheduler_t *data_set);
 GList *cli_resource_search(pcmk_resource_t *rsc, const char *requested_name,
-                             pe_working_set_t *data_set);
+                             pcmk_scheduler_t *data_set);
 int cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
                         const pcmk_resource_t *rsc, const char *operation,
                         const char *interval_spec, bool just_failures,
-                        pe_working_set_t *data_set, gboolean force);
+                        pcmk_scheduler_t *data_set, gboolean force);
 int cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
                     const char *operation, const char *interval_spec,
-                    pe_working_set_t *data_set);
+                    pcmk_scheduler_t *data_set);
 int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                          const pcmk_node_t *node, const char *move_lifetime,
                          int timeout_ms, cib_t *cib, int cib_options,
                          gboolean promoted_role_only, gboolean force);
 int cli_resource_move(const pcmk_resource_t *rsc, const char *rsc_id,
                       const char *host_name, const char *move_lifetime,
-                      cib_t *cib, int cib_options, pe_working_set_t *data_set,
+                      cib_t *cib, int cib_options, pcmk_scheduler_t *data_set,
                       gboolean promoted_role_only, gboolean force);
 crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                             const char *rsc_class, const char *rsc_prov,
@@ -104,7 +104,8 @@ crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc
 crm_exit_t cli_resource_execute(pcmk_resource_t *rsc,
                                 const char *requested_name,
                                 const char *rsc_action, GHashTable *override_hash,
-                                int timeout_ms, cib_t *cib, pe_working_set_t *data_set,
+                                int timeout_ms, cib_t *cib,
+                                pcmk_scheduler_t *data_set,
                                 int resource_verbose, gboolean force, int check_level);
 
 int cli_resource_update_attribute(pcmk_resource_t *rsc,
@@ -119,7 +120,7 @@ int cli_resource_delete_attribute(pcmk_resource_t *rsc,
                                   const char *attr_id, const char *attr_name,
                                   cib_t *cib, int cib_options, gboolean force);
 
-int update_working_set_xml(pe_working_set_t *data_set, xmlNode **xml);
+int update_working_set_xml(pcmk_scheduler_t *data_set, xmlNode **xml);
 int wait_till_stable(pcmk__output_t *out, int timeout_ms, cib_t * cib);
 
 bool resource_is_running_on(pcmk_resource_t *rsc, const char *host);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -73,7 +73,7 @@ int cli_resource_print_operations(const char *rsc_id, const char *host_uname,
 
 /* runtime */
 int cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc,
-                       pe_node_t *node);
+                       pcmk_node_t *node);
 int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
                       const char *rsc_id, pe_working_set_t *data_set);
 GList *cli_resource_search(pe_resource_t *rsc, const char *requested_name,
@@ -86,7 +86,7 @@ int cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
                     const char *operation, const char *interval_spec,
                     pe_working_set_t *data_set);
 int cli_resource_restart(pcmk__output_t *out, pe_resource_t *rsc,
-                         const pe_node_t *node, const char *move_lifetime,
+                         const pcmk_node_t *node, const char *move_lifetime,
                          int timeout_ms, cib_t *cib, int cib_options,
                          gboolean promoted_role_only, gboolean force);
 int cli_resource_move(const pe_resource_t *rsc, const char *rsc_id,

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -330,7 +330,7 @@ cli_resource_clear(const char *rsc_id, const char *host, GList *allnodes, cib_t 
          * On the first error, abort.
          */
         for(; n; n = n->next) {
-            pe_node_t *target = n->data;
+            pcmk_node_t *target = n->data;
 
             rc = cli_resource_clear(rsc_id, target->details->uname, NULL,
                                     cib_conn, cib_options, clear_ban_constraints,

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -66,7 +66,7 @@ cli_resource_print_cts(pe_resource_t * rsc, pcmk__output_t *out)
     const char *rtype = crm_element_value(rsc->xml, XML_ATTR_TYPE);
     const char *rprov = crm_element_value(rsc->xml, XML_AGENT_ATTR_PROVIDER);
     const char *rclass = crm_element_value(rsc->xml, XML_AGENT_ATTR_CLASS);
-    pe_node_t *node = pe__current_node(rsc);
+    pcmk_node_t *node = pe__current_node(rsc);
 
     if (pcmk__str_eq(rclass, PCMK_RESOURCE_CLASS_STONITH, pcmk__str_casei)) {
         needs_quorum = FALSE;
@@ -589,13 +589,13 @@ resource_search_list_xml(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pe_resource_t *",
-                  "pe_node_t *")
+                  "pcmk_node_t *")
 static int
 resource_reasons_list_default(pcmk__output_t *out, va_list args)
 {
     GList *resources = va_arg(args, GList *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
 
     const char *host_uname = (node == NULL)? NULL : node->details->uname;
 
@@ -671,13 +671,13 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pe_resource_t *",
-                  "pe_node_t *")
+                  "pcmk_node_t *")
 static int
 resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 {
     GList *resources = va_arg(args, GList *);
     pe_resource_t *rsc = va_arg(args, pe_resource_t *);
-    pe_node_t *node = va_arg(args, pe_node_t *);
+    pcmk_node_t *node = va_arg(args, pcmk_node_t *);
 
     const char *host_uname = (node == NULL)? NULL : node->details->uname;
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -20,7 +20,7 @@
 static int
 print_constraint(xmlNode *xml_obj, void *userdata)
 {
-    pe_working_set_t *data_set = (pe_working_set_t *) userdata;
+    pcmk_scheduler_t *data_set = (pcmk_scheduler_t *) userdata;
     pcmk__output_t *out = data_set->priv;
     xmlNode *lifetime = NULL;
     const char *id = crm_element_value(xml_obj, XML_ATTR_ID);
@@ -52,7 +52,7 @@ print_constraint(xmlNode *xml_obj, void *userdata)
 }
 
 void
-cli_resource_print_cts_constraints(pe_working_set_t * data_set)
+cli_resource_print_cts_constraints(pcmk_scheduler_t *data_set)
 {
     pcmk__xe_foreach_child(pcmk_find_cib_element(data_set->input, XML_CIB_TAG_CONSTRAINTS),
                            NULL, print_constraint, data_set);
@@ -90,7 +90,7 @@ cli_resource_print_cts(pcmk_resource_t *rsc, pcmk__output_t *out)
 // \return Standard Pacemaker return code
 int
 cli_resource_print_operations(const char *rsc_id, const char *host_uname,
-                              bool active, pe_working_set_t * data_set)
+                              bool active, pcmk_scheduler_t *data_set)
 {
     pcmk__output_t *out = data_set->priv;
     int rc = pcmk_rc_no_output;
@@ -114,7 +114,7 @@ cli_resource_print_operations(const char *rsc_id, const char *host_uname,
 
 // \return Standard Pacemaker return code
 int
-cli_resource_print(pcmk_resource_t *rsc, pe_working_set_t *data_set,
+cli_resource_print(pcmk_resource_t *rsc, pcmk_scheduler_t *data_set,
                    bool expanded)
 {
     pcmk__output_t *out = data_set->priv;

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -59,7 +59,7 @@ cli_resource_print_cts_constraints(pe_working_set_t * data_set)
 }
 
 void
-cli_resource_print_cts(pe_resource_t * rsc, pcmk__output_t *out)
+cli_resource_print_cts(pcmk_resource_t *rsc, pcmk__output_t *out)
 {
     const char *host = NULL;
     bool needs_quorum = TRUE;
@@ -114,7 +114,8 @@ cli_resource_print_operations(const char *rsc_id, const char *host_uname,
 
 // \return Standard Pacemaker return code
 int
-cli_resource_print(pe_resource_t *rsc, pe_working_set_t *data_set, bool expanded)
+cli_resource_print(pcmk_resource_t *rsc, pe_working_set_t *data_set,
+                   bool expanded)
 {
     pcmk__output_t *out = data_set->priv;
     uint32_t show_opts = pcmk_show_pending;
@@ -131,10 +132,11 @@ cli_resource_print(pe_resource_t *rsc, pe_working_set_t *data_set, bool expanded
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("attribute-list", "pe_resource_t *", "const char *", "const char *")
+PCMK__OUTPUT_ARGS("attribute-list", "pcmk_resource_t *", "const char *",
+                  "const char *")
 static int
 attribute_list_default(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     const char *attr = va_arg(args, char *);
     const char *value = va_arg(args, const char *);
 
@@ -224,10 +226,11 @@ agent_status_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("attribute-list", "pe_resource_t *", "const char *", "const char *")
+PCMK__OUTPUT_ARGS("attribute-list", "pcmk_resource_t *", "const char *",
+                  "const char *")
 static int
 attribute_list_text(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     const char *attr = va_arg(args, char *);
     const char *value = va_arg(args, const char *);
 
@@ -276,10 +279,10 @@ override_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("property-list", "pe_resource_t *", "const char *")
+PCMK__OUTPUT_ARGS("property-list", "pcmk_resource_t *", "const char *")
 static int
 property_list_default(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     const char *attr = va_arg(args, char *);
 
     const char *value = crm_element_value(rsc->xml, attr);
@@ -293,10 +296,10 @@ property_list_default(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("property-list", "pe_resource_t *", "const char *")
+PCMK__OUTPUT_ARGS("property-list", "pcmk_resource_t *", "const char *")
 static int
 property_list_text(pcmk__output_t *out, va_list args) {
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     const char *attr = va_arg(args, const char *);
 
     const char *value = crm_element_value(rsc->xml, attr);
@@ -442,7 +445,7 @@ static int
 resource_check_list_default(pcmk__output_t *out, va_list args) {
     resource_checks_t *checks = va_arg(args, resource_checks_t *);
 
-    const pe_resource_t *parent = pe__const_top_resource(checks->rsc, false);
+    const pcmk_resource_t *parent = pe__const_top_resource(checks->rsc, false);
 
     if (checks->flags == 0) {
         return pcmk_rc_no_output;
@@ -488,7 +491,7 @@ static int
 resource_check_list_xml(pcmk__output_t *out, va_list args) {
     resource_checks_t *checks = va_arg(args, resource_checks_t *);
 
-    const pe_resource_t *parent = pe__const_top_resource(checks->rsc, false);
+    const pcmk_resource_t *parent = pe__const_top_resource(checks->rsc, false);
 
     xmlNodePtr node = pcmk__output_create_xml_node(out, "check",
                                                    "id", parent->id,
@@ -588,13 +591,13 @@ resource_search_list_xml(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pcmk_resource_t *",
                   "pcmk_node_t *")
 static int
 resource_reasons_list_default(pcmk__output_t *out, va_list args)
 {
     GList *resources = va_arg(args, GList *);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
 
     const char *host_uname = (node == NULL)? NULL : node->details->uname;
@@ -606,7 +609,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
         GList *hosts = NULL;
 
         for (lpc = resources; lpc != NULL; lpc = lpc->next) {
-            pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
             rsc->fns->location(rsc, &hosts, TRUE);
 
             if (hosts == NULL) {
@@ -639,14 +642,14 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
         GList *lpc = NULL;
 
         for (lpc = activeResources; lpc != NULL; lpc = lpc->next) {
-            pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
             out->list_item(out, "reason", "Resource %s is running on host %s",
                            rsc->id, host_uname);
             cli_resource_check(out, rsc, node);
         }
 
         for(lpc = unactiveResources; lpc != NULL; lpc = lpc->next) {
-            pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
             out->list_item(out, "reason", "Resource %s is assigned to host %s but not running",
                            rsc->id, host_uname);
             cli_resource_check(out, rsc, node);
@@ -670,13 +673,13 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pe_resource_t *",
+PCMK__OUTPUT_ARGS("resource-reasons-list", "GList *", "pcmk_resource_t *",
                   "pcmk_node_t *")
 static int
 resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 {
     GList *resources = va_arg(args, GList *);
-    pe_resource_t *rsc = va_arg(args, pe_resource_t *);
+    pcmk_resource_t *rsc = va_arg(args, pcmk_resource_t *);
     pcmk_node_t *node = va_arg(args, pcmk_node_t *);
 
     const char *host_uname = (node == NULL)? NULL : node->details->uname;
@@ -690,7 +693,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
         pcmk__output_xml_create_parent(out, "resources", NULL);
 
         for (lpc = resources; lpc != NULL; lpc = lpc->next) {
-            pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
 
             rsc->fns->location(rsc, &hosts, TRUE);
 
@@ -724,7 +727,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
         pcmk__output_xml_create_parent(out, "resources", NULL);
 
         for (lpc = activeResources; lpc != NULL; lpc = lpc->next) {
-            pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
 
             pcmk__output_xml_create_parent(out, "resource",
                                            "id", rsc->id,
@@ -737,7 +740,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
         }
 
         for(lpc = unactiveResources; lpc != NULL; lpc = lpc->next) {
-            pe_resource_t *rsc = (pe_resource_t *) lpc->data;
+            pcmk_resource_t *rsc = (pcmk_resource_t *) lpc->data;
 
             pcmk__output_xml_create_parent(out, "resource",
                                            "id", rsc->id,
@@ -767,7 +770,8 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 }
 
 static void
-add_resource_name(pe_resource_t *rsc, pcmk__output_t *out) {
+add_resource_name(pcmk_resource_t *rsc, pcmk__output_t *out)
+{
     if (rsc->children == NULL) {
         out->list_item(out, "resource", "%s", rsc->id);
     } else {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -26,7 +26,7 @@ build_node_info_list(const pe_resource_t *rsc)
         for (const GList *iter2 = child->running_on;
              iter2 != NULL; iter2 = iter2->next) {
 
-            const pe_node_t *node = (const pe_node_t *) iter2->data;
+            const pcmk_node_t *node = (const pcmk_node_t *) iter2->data;
             node_info_t *ni = calloc(1, sizeof(node_info_t));
 
             ni->node_name = node->details->uname;
@@ -61,7 +61,7 @@ cli_resource_search(pe_resource_t *rsc, const char *requested_name,
 
     } else if (rsc->running_on != NULL) {
         for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
-            pe_node_t *node = (pe_node_t *) iter->data;
+            pcmk_node_t *node = (pcmk_node_t *) iter->data;
             node_info_t *ni = calloc(1, sizeof(node_info_t));
             ni->node_name = node->details->uname;
             ni->promoted = (rsc->fns->state(rsc, TRUE) == pcmk_role_promoted);
@@ -567,7 +567,7 @@ send_lrm_rsc_op(pcmk_ipc_api_t *controld_api, bool do_fail_resource,
     }
 
     {
-        pe_node_t *node = pe_find_node(data_set->nodes, host_uname);
+        pcmk_node_t *node = pe_find_node(data_set->nodes, host_uname);
 
         if (node == NULL) {
             out->err(out, "Node %s not found", host_uname);
@@ -742,7 +742,7 @@ clear_rsc_failures(pcmk__output_t *out, pcmk_ipc_api_t *controld_api,
 // \return Standard Pacemaker return code
 static int
 clear_rsc_fail_attrs(const pe_resource_t *rsc, const char *operation,
-                     const char *interval_spec, const pe_node_t *node)
+                     const char *interval_spec, const pcmk_node_t *node)
 {
     int rc = pcmk_rc_ok;
     int attr_options = pcmk__node_attr_none;
@@ -768,7 +768,7 @@ cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
 {
     pcmk__output_t *out = data_set->priv;
     int rc = pcmk_rc_ok;
-    pe_node_t *node = NULL;
+    pcmk_node_t *node = NULL;
 
     if (rsc == NULL) {
         return ENXIO;
@@ -795,7 +795,7 @@ cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
 
         } else if(nodes == NULL && rsc->exclusive_discover) {
             GHashTableIter iter;
-            pe_node_t *node = NULL;
+            pcmk_node_t *node = NULL;
 
             g_hash_table_iter_init(&iter, rsc->allowed_nodes);
             while (g_hash_table_iter_next(&iter, NULL, (void**)&node)) {
@@ -809,7 +809,7 @@ cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
         }
 
         for (lpc = nodes; lpc != NULL; lpc = lpc->next) {
-            node = (pe_node_t *) lpc->data;
+            node = (pcmk_node_t *) lpc->data;
 
             if (node->details->online) {
                 rc = cli_resource_delete(controld_api, node->details->uname, rsc,
@@ -886,7 +886,7 @@ cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
     }
 
     if (node_name) {
-        pe_node_t *node = pe_find_node(data_set->nodes, node_name);
+        pcmk_node_t *node = pe_find_node(data_set->nodes, node_name);
 
         if (node == NULL) {
             out->err(out, "Unknown node: %s", node_name);
@@ -915,7 +915,7 @@ cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
         }
     } else {
         for (GList *iter = data_set->nodes; iter; iter = iter->next) {
-            pe_node_t *node = (pe_node_t *) iter->data;
+            pcmk_node_t *node = (pcmk_node_t *) iter->data;
 
             rc = clear_rsc_failures(out, controld_api, node->details->uname, NULL,
                                     operation, interval_spec, data_set);
@@ -978,7 +978,7 @@ check_locked(resource_checks_t *checks)
 }
 
 static bool
-node_is_unhealthy(pe_node_t *node)
+node_is_unhealthy(pcmk_node_t *node)
 {
     switch (pe__health_strategy(node->details->data_set)) {
         case pcmk__health_strategy_none:
@@ -1008,7 +1008,7 @@ node_is_unhealthy(pe_node_t *node)
 }
 
 static void
-check_node_health(resource_checks_t *checks, pe_node_t *node)
+check_node_health(resource_checks_t *checks, pcmk_node_t *node)
 {
     if (node == NULL) {
         GHashTableIter iter;
@@ -1033,7 +1033,7 @@ check_node_health(resource_checks_t *checks, pe_node_t *node)
 }
 
 int
-cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc, pe_node_t *node)
+cli_resource_check(pcmk__output_t *out, pe_resource_t *rsc, pcmk_node_t *node)
 {
     resource_checks_t checks = { .rsc = rsc };
 
@@ -1055,7 +1055,7 @@ cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
 }
 
 static GHashTable *
-generate_resource_params(pe_resource_t *rsc, pe_node_t *node,
+generate_resource_params(pe_resource_t *rsc, pcmk_node_t *node,
                          pe_working_set_t *data_set)
 {
     GHashTable *params = NULL;
@@ -1102,7 +1102,7 @@ bool resource_is_running_on(pe_resource_t *rsc, const char *host)
 
     rsc->fns->location(rsc, &hosts, TRUE);
     for (hIter = hosts; host != NULL && hIter != NULL; hIter = hIter->next) {
-        pe_node_t *node = (pe_node_t *) hIter->data;
+        pcmk_node_t *node = (pcmk_node_t *) hIter->data;
 
         if (pcmk__strcase_any_of(host, node->details->uname, node->details->id, NULL)) {
             crm_trace("Resource %s is running on %s\n", rsc->id, host);
@@ -1429,7 +1429,7 @@ wait_time_estimate(pe_working_set_t *data_set, const GList *resources)
  */
 int
 cli_resource_restart(pcmk__output_t *out, pe_resource_t *rsc,
-                     const pe_node_t *node, const char *move_lifetime,
+                     const pcmk_node_t *node, const char *move_lifetime,
                      int timeout_ms, cib_t *cib, int cib_options,
                      gboolean promoted_role_only, gboolean force)
 {
@@ -2120,8 +2120,8 @@ cli_resource_move(const pe_resource_t *rsc, const char *rsc_id,
     pcmk__output_t *out = data_set->priv;
     int rc = pcmk_rc_ok;
     unsigned int count = 0;
-    pe_node_t *current = NULL;
-    pe_node_t *dest = pe_find_node(data_set->nodes, host_name);
+    pcmk_node_t *current = NULL;
+    pcmk_node_t *dest = pe_find_node(data_set->nodes, host_name);
     bool cur_is_dest = false;
 
     if (dest == NULL) {
@@ -2149,7 +2149,7 @@ cli_resource_move(const pe_resource_t *rsc, const char *rsc_id,
 
     if (pcmk_is_set(rsc->flags, pcmk_rsc_promotable)) {
         unsigned int promoted_count = 0;
-        pe_node_t *promoted_node = NULL;
+        pcmk_node_t *promoted_node = NULL;
 
         for (const GList *iter = rsc->children; iter; iter = iter->next) {
             const pe_resource_t *child = (const pe_resource_t *) iter->data;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1326,7 +1326,7 @@ update_dataset(cib_t *cib, pe_working_set_t * data_set, bool simulate)
 static int
 max_rsc_stop_timeout(pcmk_resource_t *rsc)
 {
-    pe_action_t *stop = NULL;
+    pcmk_action_t *stop = NULL;
     long long result_ll;
     int max_delay = 0;
 
@@ -1756,7 +1756,7 @@ done:
 }
 
 static inline bool
-action_is_pending(const pe_action_t *action)
+action_is_pending(const pcmk_action_t *action)
 {
     if (pcmk_any_flags_set(action->flags,
                            pcmk_action_optional|pcmk_action_pseudo)
@@ -1779,7 +1779,7 @@ static bool
 actions_are_pending(const GList *actions)
 {
     for (const GList *action = actions; action != NULL; action = action->next) {
-        const pe_action_t *a = (const pe_action_t *) action->data;
+        const pcmk_action_t *a = (const pcmk_action_t *) action->data;
 
         if (action_is_pending(a)) {
             crm_notice("Waiting for %s (flags=%#.8x)", a->uuid, a->flags);
@@ -1796,7 +1796,7 @@ print_pending_actions(pcmk__output_t *out, GList *actions)
 
     out->info(out, "Pending actions:");
     for (action = actions; action != NULL; action = action->next) {
-        pe_action_t *a = (pe_action_t *) action->data;
+        pcmk_action_t *a = (pcmk_action_t *) action->data;
 
         if (!action_is_pending(a)) {
             continue;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -451,7 +451,7 @@ int
 main(int argc, char **argv)
 {
     int rc = pcmk_rc_ok;
-    pe_working_set_t *data_set = NULL;
+    pcmk_scheduler_t *data_set = NULL;
     pcmk__output_t *out = NULL;
 
     GError *error = NULL;

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -255,7 +255,7 @@ static GOptionEntry deprecated_entries[] = {
 };
 
 static pe_ticket_t *
-find_ticket(gchar *ticket_id, pe_working_set_t * data_set)
+find_ticket(gchar *ticket_id, pcmk_scheduler_t *data_set)
 {
     return g_hash_table_lookup(data_set->tickets, ticket_id);
 }
@@ -326,7 +326,7 @@ print_ticket(pe_ticket_t * ticket, bool raw, bool details)
 }
 
 static void
-print_ticket_list(pe_working_set_t * data_set, bool raw, bool details)
+print_ticket_list(pcmk_scheduler_t *data_set, bool raw, bool details)
 {
     GHashTableIter iter;
     pe_ticket_t *ticket = NULL;
@@ -464,7 +464,7 @@ dump_constraints(cib_t * the_cib, gchar *ticket_id)
 
 static int
 get_ticket_state_attr(gchar *ticket_id, const char *attr_name, const char **attr_value,
-                      pe_working_set_t * data_set)
+                      pcmk_scheduler_t *data_set)
 {
     pe_ticket_t *ticket = NULL;
 
@@ -557,7 +557,7 @@ allow_modification(gchar *ticket_id)
 }
 
 static int
-modify_ticket_state(gchar * ticket_id, cib_t * cib, pe_working_set_t * data_set)
+modify_ticket_state(gchar *ticket_id, cib_t *cib, pcmk_scheduler_t *data_set)
 {
     int rc = pcmk_rc_ok;
     xmlNode *xml_top = NULL;
@@ -712,7 +712,7 @@ build_arg_context(pcmk__common_args_t *args) {
 int
 main(int argc, char **argv)
 {
-    pe_working_set_t *data_set = NULL;
+    pcmk_scheduler_t *data_set = NULL;
     xmlNode *cib_xml_copy = NULL;
 
     cib_t *cib_conn = NULL;

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -118,7 +118,7 @@ main(int argc, char **argv)
     xmlNode *cib_object = NULL;
     xmlNode *status = NULL;
 
-    pe_working_set_t *data_set = NULL;
+    pcmk_scheduler_t *data_set = NULL;
 
     int rc = pcmk_rc_ok;
     crm_exit_t exit_code = CRM_EX_OK;


### PR DESCRIPTION
This is part of a project to merge the functionality of libpe_rules and libpe_status into libcrmcommon, bringing the code up to current guidelines. This portion renames four key types.