### PR TITLE
Make unpacking action configuration more efficient

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -352,6 +352,9 @@ GHashTable *pcmk__unpack_action_rsc_params(const xmlNode *action_xml,
 xmlNode *pcmk__find_action_config(const pcmk_resource_t *rsc, const char *key,
                                   bool include_disabled);
 
+enum rsc_start_requirement pcmk__action_requires(const pcmk_resource_t *rsc,
+                                                 const char *action_name);
+
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,
                              gboolean foo, pcmk_scheduler_t *scheduler);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -355,6 +355,11 @@ xmlNode *pcmk__find_action_config(const pcmk_resource_t *rsc, const char *key,
 enum rsc_start_requirement pcmk__action_requires(const pcmk_resource_t *rsc,
                                                  const char *action_name);
 
+enum action_fail_response pcmk__parse_on_fail(const pcmk_resource_t *rsc,
+                                              const char *action_name,
+                                              guint interval_ms,
+                                              const char *value);
+
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,
                              gboolean foo, pcmk_scheduler_t *scheduler);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -348,6 +348,9 @@ GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
                                      const pcmk_node_t *node,
                                      const char *action_name, guint interval_ms,
                                      const xmlNode *action_config);
+GHashTable *pcmk__unpack_action_rsc_params(const xmlNode *action_xml,
+                                           GHashTable *node_attrs,
+                                           pcmk_scheduler_t *data_set);
 
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -349,7 +349,8 @@ GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
 GHashTable *pcmk__unpack_action_rsc_params(const xmlNode *action_xml,
                                            GHashTable *node_attrs,
                                            pcmk_scheduler_t *data_set);
-xmlNode *pcmk__find_action_config(const pcmk_resource_t *rsc, const char *key,
+xmlNode *pcmk__find_action_config(const pcmk_resource_t *rsc,
+                                  const char *action_name, guint interval_ms,
                                   bool include_disabled);
 
 enum rsc_start_requirement pcmk__action_requires(const pcmk_resource_t *rsc,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -342,8 +342,6 @@ void pe__show_node_scores_as(const char *file, const char *function,
         pe__show_node_scores_as(__FILE__, __func__, __LINE__,      \
                                 (level), (rsc), (text), (nodes), (scheduler))
 
-xmlNode *find_rsc_op_entry(const pcmk_resource_t *rsc, const char *key);
-
 GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
                                      const pcmk_node_t *node,
                                      const char *action_name, guint interval_ms,
@@ -351,6 +349,8 @@ GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
 GHashTable *pcmk__unpack_action_rsc_params(const xmlNode *action_xml,
                                            GHashTable *node_attrs,
                                            pcmk_scheduler_t *data_set);
+xmlNode *pcmk__find_action_config(const pcmk_resource_t *rsc, const char *key,
+                                  bool include_disabled);
 
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -367,33 +367,33 @@ enum rsc_role_e pcmk__role_after_failure(const pcmk_resource_t *rsc,
 
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,
-                             gboolean foo, pcmk_scheduler_t *scheduler);
+                             pcmk_scheduler_t *scheduler);
 
 #  define delete_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DELETE, 0)
 #  define delete_action(rsc, node, optional) custom_action(		\
 		rsc, delete_key(rsc), PCMK_ACTION_DELETE, node, \
-		optional, TRUE, rsc->cluster);
+		optional, rsc->cluster);
 
 #  define stop_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_STOP, 0)
 #  define stop_action(rsc, node, optional) custom_action(			\
 		rsc, stop_key(rsc), PCMK_ACTION_STOP, node,		\
-		optional, TRUE, rsc->cluster);
+		optional, rsc->cluster);
 
 #  define reload_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_RELOAD_AGENT, 0)
 #  define start_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_START, 0)
 #  define start_action(rsc, node, optional) custom_action(		\
 		rsc, start_key(rsc), PCMK_ACTION_START, node,           \
-		optional, TRUE, rsc->cluster)
+		optional, rsc->cluster)
 
 #  define promote_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_PROMOTE, 0)
 #  define promote_action(rsc, node, optional) custom_action(		\
 		rsc, promote_key(rsc), PCMK_ACTION_PROMOTE, node,	\
-		optional, TRUE, rsc->cluster)
+		optional, rsc->cluster)
 
 #  define demote_key(rsc) pcmk__op_key(rsc->id, PCMK_ACTION_DEMOTE, 0)
 #  define demote_action(rsc, node, optional) custom_action(		\
 		rsc, demote_key(rsc), PCMK_ACTION_DEMOTE, node, \
-		optional, TRUE, rsc->cluster)
+		optional, rsc->cluster)
 
 extern int pe_get_configured_timeout(pcmk_resource_t *rsc, const char *action,
                                      pcmk_scheduler_t *scheduler);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -360,6 +360,11 @@ enum action_fail_response pcmk__parse_on_fail(const pcmk_resource_t *rsc,
                                               guint interval_ms,
                                               const char *value);
 
+enum rsc_role_e pcmk__role_after_failure(const pcmk_resource_t *rsc,
+                                         const char *action_name,
+                                         enum action_fail_response on_fail,
+                                         GHashTable *meta);
+
 pcmk_action_t *custom_action(pcmk_resource_t *rsc, char *key, const char *task,
                              const pcmk_node_t *on_node, gboolean optional,
                              gboolean foo, pcmk_scheduler_t *scheduler);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1454,14 +1454,15 @@ pcmk__output_actions(pcmk_scheduler_t *scheduler)
  * \param[in] task         Action's name
  * \param[in] interval_ms  Action's interval (in milliseconds)
  *
- * \return true if action is still in resource configuration, otherwise false
+ * \return true if action is still in resource configuration and enabled,
+ *         otherwise false
  */
 static bool
 action_in_config(const pcmk_resource_t *rsc, const char *task,
                  guint interval_ms)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
-    bool config = (find_rsc_op_entry(rsc, key) != NULL);
+    bool config = (pcmk__find_action_config(rsc, key, false) != NULL);
 
     free(key);
     return config;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1063,7 +1063,7 @@ pcmk__new_shutdown_action(pcmk_node_t *node)
                                     node->details->uname);
 
     shutdown_op = custom_action(NULL, shutdown_id, PCMK_ACTION_DO_SHUTDOWN,
-                                node, FALSE, TRUE, node->details->data_set);
+                                node, FALSE, node->details->data_set);
 
     pcmk__order_stops_before_shutdown(node, shutdown_op);
     add_hash_param(shutdown_op->meta, XML_ATTR_TE_NOWAIT, XML_BOOLEAN_TRUE);
@@ -1541,7 +1541,7 @@ force_restart(pcmk_resource_t *rsc, const char *task, guint interval_ms,
               pcmk_node_t *node)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
-    pcmk_action_t *required = custom_action(rsc, key, task, NULL, FALSE, TRUE,
+    pcmk_action_t *required = custom_action(rsc, key, task, NULL, FALSE,
                                             rsc->cluster);
 
     pe_action_set_reason(required, "resource definition change", true);
@@ -1587,7 +1587,7 @@ schedule_reload(gpointer data, gpointer user_data)
     if (pcmk_is_set(rsc->flags, pcmk_rsc_start_pending)) {
         pe_rsc_trace(rsc, "%s: preventing agent reload because start pending",
                      rsc->id);
-        custom_action(rsc, stop_key(rsc), PCMK_ACTION_STOP, node, FALSE, TRUE,
+        custom_action(rsc, stop_key(rsc), PCMK_ACTION_STOP, node, FALSE,
                       rsc->cluster);
         return;
     }
@@ -1595,7 +1595,7 @@ schedule_reload(gpointer data, gpointer user_data)
     // Schedule the reload
     pe__set_resource_flags(rsc, pcmk_rsc_reload);
     reload = custom_action(rsc, reload_key(rsc), PCMK_ACTION_RELOAD_AGENT, node,
-                           FALSE, TRUE, rsc->cluster);
+                           FALSE, rsc->cluster);
     pe_action_set_reason(reload, "resource definition change", FALSE);
 
     // Set orderings so that a required stop or demote cancels the reload

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1448,28 +1448,6 @@ pcmk__output_actions(pcmk_scheduler_t *scheduler)
 
 /*!
  * \internal
- * \brief Check whether action from resource history is still in configuration
- *
- * \param[in] rsc          Resource that action is for
- * \param[in] task         Action's name
- * \param[in] interval_ms  Action's interval (in milliseconds)
- *
- * \return true if action is still in resource configuration and enabled,
- *         otherwise false
- */
-static bool
-action_in_config(const pcmk_resource_t *rsc, const char *task,
-                 guint interval_ms)
-{
-    char *key = pcmk__op_key(rsc->id, task, interval_ms);
-    bool config = (pcmk__find_action_config(rsc, key, false) != NULL);
-
-    free(key);
-    return config;
-}
-
-/*!
- * \internal
  * \brief Get action name needed to compare digest for configuration changes
  *
  * \param[in] task         Action name from history
@@ -1639,7 +1617,7 @@ pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
 
     // If this is a recurring action, check whether it has been orphaned
     if (interval_ms > 0) {
-        if (action_in_config(rsc, task, interval_ms)) {
+        if (pcmk__find_action_config(rsc, task, interval_ms, false) != NULL) {
             pe_rsc_trace(rsc, "%s-interval %s for %s on %s is in configuration",
                          pcmk__readable_interval(interval_ms), task, rsc->id,
                          pe__node_name(node));

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -100,7 +100,7 @@ static pcmk_action_t *
 create_group_pseudo_op(pcmk_resource_t *group, const char *action)
 {
     pcmk_action_t *op = custom_action(group, pcmk__op_key(group->id, action, 0),
-                                      action, NULL, TRUE, TRUE, group->cluster);
+                                      action, NULL, TRUE, group->cluster);
     pe__set_action_flags(op, pcmk_action_pseudo|pcmk_action_runnable);
     return op;
 }

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -60,14 +60,13 @@ pcmk__create_migration_actions(pcmk_resource_t *rsc, const pcmk_node_t *current)
     if (rsc->partial_migration_target == NULL) {
         migrate_to = custom_action(rsc, pcmk__op_key(rsc->id,
                                                      PCMK_ACTION_MIGRATE_TO, 0),
-                                   PCMK_ACTION_MIGRATE_TO, current, TRUE, TRUE,
+                                   PCMK_ACTION_MIGRATE_TO, current, TRUE,
                                    rsc->cluster);
     }
     migrate_from = custom_action(rsc, pcmk__op_key(rsc->id,
                                                    PCMK_ACTION_MIGRATE_FROM, 0),
                                  PCMK_ACTION_MIGRATE_FROM, rsc->allocated_to,
-                                 TRUE, TRUE,
-                                 rsc->cluster);
+                                 TRUE, rsc->cluster);
 
     pe__set_action_flags(start, pcmk_action_migratable);
     pe__set_action_flags(stop, pcmk_action_migratable);

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1335,7 +1335,7 @@ rsc_order_first(pcmk_resource_t *first_rsc, pe__ordering_t *order)
                          "Creating first (%s for %s) for constraint %d ",
                          order->lh_action_task, first_rsc->id, order->id);
             first_action = custom_action(first_rsc, key, op_type, NULL, TRUE,
-                                         TRUE, first_rsc->cluster);
+                                         first_rsc->cluster);
             first_actions = g_list_prepend(NULL, first_action);
         }
 

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -133,7 +133,7 @@ probe_action(pcmk_resource_t *rsc, pcmk_node_t *node)
     crm_debug("Scheduling probe of %s %s on %s",
               role2text(rsc->role), rsc->id, pe__node_name(node));
 
-    probe = custom_action(rsc, key, PCMK_ACTION_MONITOR, node, FALSE, TRUE,
+    probe = custom_action(rsc, key, PCMK_ACTION_MONITOR, node, FALSE,
                           rsc->cluster);
     pe__clear_action_flags(probe, pcmk_action_optional);
 
@@ -891,8 +891,7 @@ pcmk__schedule_probes(pcmk_scheduler_t *scheduler)
             probe_op = custom_action(NULL,
                                      crm_strdup_printf("%s-%s", CRM_OP_REPROBE,
                                                        node->details->uname),
-                                     CRM_OP_REPROBE, node, FALSE, TRUE,
-                                     scheduler);
+                                     CRM_OP_REPROBE, node, FALSE, scheduler);
             add_hash_param(probe_op->meta, XML_ATTR_TE_NOWAIT,
                            XML_BOOLEAN_TRUE);
             continue;

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -307,7 +307,7 @@ recurring_op_for_active(pcmk_resource_t *rsc, pcmk_action_t *start,
                  op->id, rsc->id, role2text(rsc->next_role),
                  pe__node_name(node));
 
-    mon = custom_action(rsc, strdup(op->key), op->name, node, is_optional, TRUE,
+    mon = custom_action(rsc, strdup(op->key), op->name, node, is_optional,
                         rsc->cluster);
 
     if (!pcmk_is_set(start->flags, pcmk_action_runnable)) {
@@ -524,7 +524,7 @@ recurring_op_for_inactive(pcmk_resource_t *rsc, const pcmk_node_t *node,
                      op->key, op->id, rsc->id, pe__node_name(stop_node));
 
         stopped_mon = custom_action(rsc, strdup(op->key), op->name, stop_node,
-                                    is_optional, TRUE, rsc->cluster);
+                                    is_optional, rsc->cluster);
 
         pe__add_action_expected_result(stopped_mon, CRM_EX_NOT_RUNNING);
 
@@ -635,7 +635,7 @@ pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *task,
     // @TODO dangerous if possible to schedule another action with this key
     key = pcmk__op_key(rsc->id, task, interval_ms);
 
-    cancel_op = custom_action(rsc, key, PCMK_ACTION_CANCEL, node, FALSE, TRUE,
+    cancel_op = custom_action(rsc, key, PCMK_ACTION_CANCEL, node, FALSE,
                               rsc->cluster);
 
     pcmk__str_update(&cancel_op->task, PCMK_ACTION_CANCEL);
@@ -700,7 +700,7 @@ pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
     trigger_unfencing(rsc, node, "Device parameters changed (reschedule)",
                       NULL, rsc->cluster);
     op = custom_action(rsc, pcmk__op_key(rsc->id, task, interval_ms),
-                       task, node, TRUE, TRUE, rsc->cluster);
+                       task, node, TRUE, rsc->cluster);
     pe__set_action_flags(op, pcmk_action_reschedule);
 }
 

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -159,6 +159,7 @@ is_recurring_history(const pcmk_resource_t *rsc, const xmlNode *xml,
         if (op->role == pcmk_role_unknown) {
             pcmk__config_err("Ignoring %s because %s is not a valid role",
                              op->id, role);
+            return false;
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -170,6 +170,7 @@ is_recurring_history(const pcmk_resource_t *rsc, const xmlNode *xml,
                      "it is disabled or no longer in configuration",
                      op->id, op->key);
         free(op->key);
+        op->key = NULL;
         return false;
     }
 

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -162,11 +162,13 @@ is_recurring_history(const pcmk_resource_t *rsc, const xmlNode *xml,
         }
     }
 
-    // Disabled resources don't get monitored
+    // Only actions that are still configured and enabled matter
     op->key = pcmk__op_key(rsc->id, op->name, op->interval_ms);
-    if (find_rsc_op_entry(rsc, op->key) == NULL) {
-        crm_trace("Not creating recurring action %s for disabled resource %s",
-                  op->id, rsc->id);
+    if (pcmk__find_action_config(rsc, op->key, false) == NULL) {
+        pe_rsc_trace(rsc,
+                     "Not counting action %s (%s) as recurring because "
+                     "it is disabled or no longer in configuration",
+                     op->id, op->key);
         free(op->key);
         return false;
     }

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -164,17 +164,17 @@ is_recurring_history(const pcmk_resource_t *rsc, const xmlNode *xml,
     }
 
     // Only actions that are still configured and enabled matter
-    op->key = pcmk__op_key(rsc->id, op->name, op->interval_ms);
-    if (pcmk__find_action_config(rsc, op->key, false) == NULL) {
+    if (pcmk__find_action_config(rsc, op->name, op->interval_ms,
+                                 false) == NULL) {
         pe_rsc_trace(rsc,
-                     "Not counting action %s (%s) as recurring because "
-                     "it is disabled or no longer in configuration",
-                     op->id, op->key);
-        free(op->key);
-        op->key = NULL;
+                     "Ignoring %s (%s-interval %s for %s) because it is "
+                     "disabled or no longer in configuration",
+                     op->id, pcmk__readable_interval(op->interval_ms), op->name,
+                     rsc->id);
         return false;
     }
 
+    op->key = pcmk__op_key(rsc->id, op->name, op->interval_ms);
     return true;
 }
 

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -136,7 +136,7 @@ pcmk__rsc_agent_changed(pcmk_resource_t *rsc, pcmk_node_t *node,
     }
     if (changed && active_on_node) {
         // Make sure the resource is restarted
-        custom_action(rsc, stop_key(rsc), PCMK_ACTION_STOP, node, FALSE, TRUE,
+        custom_action(rsc, stop_key(rsc), PCMK_ACTION_STOP, node, FALSE,
                       rsc->cluster);
         pe__set_resource_flags(rsc, pcmk_rsc_start_pending);
     }

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -460,7 +460,7 @@ pe__clear_failcount(pcmk_resource_t *rsc, const pcmk_node_t *node,
 
     key = pcmk__op_key(rsc->id, PCMK_ACTION_CLEAR_FAILCOUNT, 0);
     clear = custom_action(rsc, key, PCMK_ACTION_CLEAR_FAILCOUNT, node, FALSE,
-                          TRUE, scheduler);
+                          scheduler);
     add_hash_param(clear->meta, XML_ATTR_TE_NOWAIT, XML_BOOLEAN_TRUE);
     crm_notice("Clearing failure of %s on %s because %s " CRM_XS " %s",
                rsc->id, pe__node_name(node), reason, clear->uuid);

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -168,19 +168,6 @@ pcmk__find_action_config(const pcmk_resource_t *rsc, const char *key,
         }
     }
 
-    /* If the given key is for one of the many notification pseudo-actions
-     * (pre_notify_promote, etc.), the actual action name is "notify"
-     */
-    if (strstr(key, "_notify_")) {
-        retry_key = pcmk__op_key(rsc->id, PCMK_ACTION_NOTIFY, 0);
-        action_config = find_exact_action_config(rsc, retry_key,
-                                                 include_disabled);
-        free(retry_key);
-        if (action_config != NULL) {
-            return action_config;
-        }
-    }
-
     return NULL;
 }
 
@@ -234,6 +221,17 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
 
         action->op_entry = pcmk__find_action_config(rsc, key, true);
         parse_op_key(key, NULL, NULL, &interval_ms);
+
+        /* If the given key is for one of the many notification pseudo-actions
+         * (pre_notify_promote, etc.), the actual action name is "notify"
+         */
+        if ((action->op_entry == NULL) && (strstr(key, "_notify_") != NULL)) {
+            char *notify_key = pcmk__op_key(rsc->id, PCMK_ACTION_NOTIFY, 0);
+
+            action->op_entry = find_exact_action_config(rsc, notify_key, true);
+            free(notify_key);
+        }
+
         unpack_operation(action, action->op_entry, interval_ms);
     }
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -143,8 +143,8 @@ find_exact_action_config(const pcmk_resource_t *rsc, const char *key,
  *
  * \return XML configuration of desired action if any, otherwise NULL
  */
-static xmlNode *
-find_rsc_op_entry_helper(const pcmk_resource_t *rsc, const char *key,
+xmlNode *
+pcmk__find_action_config(const pcmk_resource_t *rsc, const char *key,
                          bool include_disabled)
 {
     char *retry_key = NULL;
@@ -183,12 +183,6 @@ find_rsc_op_entry_helper(const pcmk_resource_t *rsc, const char *key,
     }
 
     return NULL;
-}
-
-xmlNode *
-find_rsc_op_entry(const pcmk_resource_t *rsc, const char *key)
-{
-    return find_rsc_op_entry_helper(rsc, key, false);
 }
 
 /*!
@@ -241,7 +235,7 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
     } else {
         guint interval_ms = 0;
 
-        action->op_entry = find_rsc_op_entry_helper(rsc, key, true);
+        action->op_entry = pcmk__find_action_config(rsc, key, true);
         parse_op_key(key, NULL, NULL, &interval_ms);
         unpack_operation(action, action->op_entry, rsc->container, interval_ms);
     }

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -158,8 +158,8 @@ find_rsc_op_entry_helper(const pcmk_resource_t *rsc, const char *key,
 
     // For migrate_to and migrate_from actions, retry with "migrate"
     // @TODO This should be either documented or deprecated
-    if ((strstr(key, PCMK_ACTION_MIGRATE_TO) != NULL)
-        || (strstr(key, PCMK_ACTION_MIGRATE_FROM) != NULL)) {
+    if (pcmk__ends_with(key, "_" PCMK_ACTION_MIGRATE_TO "_0")
+        || pcmk__ends_with(key, "_" PCMK_ACTION_MIGRATE_FROM "_0")) {
         retry_key = pcmk__op_key(rsc->id, "migrate", 0);
         action_config = find_exact_action_config(rsc, retry_key,
                                                  include_disabled);

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -20,7 +20,6 @@
 #include "pe_status_private.h"
 
 static void unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
-                             const pcmk_resource_t *container,
                              guint interval_ms);
 
 static void
@@ -237,7 +236,7 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
 
         action->op_entry = pcmk__find_action_config(rsc, key, true);
         parse_op_key(key, NULL, NULL, &interval_ms);
-        unpack_operation(action, action->op_entry, rsc->container, interval_ms);
+        unpack_operation(action, action->op_entry, interval_ms);
     }
 
     if (for_graph) {
@@ -919,12 +918,11 @@ pcmk__action_requires(const pcmk_resource_t *rsc, const char *action_name)
  *
  * \param[in,out] action       Resource action to unpack into
  * \param[in]     xml_obj      Action configuration XML (NULL for defaults only)
- * \param[in]     container    Resource that contains affected resource, if any
  * \param[in]     interval_ms  How frequently to perform the operation
  */
 static void
 unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
-                 const pcmk_resource_t *container, guint interval_ms)
+                 guint interval_ms)
 {
     const char *value = NULL;
 
@@ -974,7 +972,7 @@ unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
         value = "restart (and possibly migrate)";
 
     } else if (pcmk__str_eq(value, "restart-container", pcmk__str_casei)) {
-        if (container) {
+        if (action->rsc->container != NULL) {
             action->on_fail = pcmk_on_fail_restart_container;
             value = "restart container (and possibly migrate)";
 
@@ -992,7 +990,7 @@ unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
     }
 
     /* defaults */
-    if (value == NULL && container) {
+    if ((value == NULL) && (action->rsc->container != NULL)) {
         action->on_fail = pcmk_on_fail_restart_container;
         value = "restart container (and possibly migrate) (default)";
 

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -103,7 +103,6 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
                       GHashTable *overrides, pcmk_scheduler_t *scheduler)
 {
     xmlNode *action_config = NULL;
-    char *key = NULL;
 
     data->params_all = create_xml_node(NULL, XML_TAG_PARAMS);
 
@@ -135,9 +134,7 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
     g_hash_table_foreach(params, hash2field, data->params_all);
 
     // Find action configuration XML in CIB
-    key = pcmk__op_key(rsc->id, task, *interval_ms);
-    action_config = pcmk__find_action_config(rsc, key, true);
-    free(key);
+    action_config = pcmk__find_action_config(rsc, task, *interval_ms, true);
 
     /* Add action-specific resource instance attributes to the digest list.
      *

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -102,7 +102,8 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
                       const xmlNode *xml_op, const char *op_version,
                       GHashTable *overrides, pcmk_scheduler_t *scheduler)
 {
-    pcmk_action_t *action = NULL;
+    xmlNode *action_config = NULL;
+    char *key = NULL;
 
     data->params_all = create_xml_node(NULL, XML_TAG_PARAMS);
 
@@ -112,8 +113,8 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
     (void) pe__add_bundle_remote_name(rsc, scheduler, data->params_all,
                                       XML_RSC_ATTR_REMOTE_RA_ADDR);
 
-    // If interval was overridden, reset it
     if (overrides != NULL) {
+        // If interval was overridden, reset it
         const char *interval_s = g_hash_table_lookup(overrides, CRM_META "_"
                                                      XML_LRM_ATTR_INTERVAL);
 
@@ -125,34 +126,44 @@ calculate_main_digest(op_digest_cache_t *data, pcmk_resource_t *rsc,
                 *interval_ms = (guint) value_ll;
             }
         }
-    }
 
-    action = custom_action(rsc, pcmk__op_key(rsc->id, task, *interval_ms),
-                           task, node, TRUE, FALSE, scheduler);
-    if (overrides != NULL) {
+        // Add overrides to list of all parameters
         g_hash_table_foreach(overrides, hash2field, data->params_all);
     }
+
+    // Add provided instance parameters
     g_hash_table_foreach(params, hash2field, data->params_all);
-    g_hash_table_foreach(action->extra, hash2field, data->params_all);
-    g_hash_table_foreach(action->meta, hash2metafield, data->params_all);
 
-    pcmk__filter_op_for_digest(data->params_all);
+    // Find action configuration XML in CIB
+    key = pcmk__op_key(rsc->id, task, *interval_ms);
+    action_config = pcmk__find_action_config(rsc, key, true);
+    free(key);
 
-    /* Given a non-recurring operation with extra parameters configured,
-     * in case that the main digest doesn't match, even if the restart
-     * digest matches, enforce a restart rather than a reload-agent anyway.
-     * So that it ensures any changes of the extra parameters get applied
-     * for this specific operation, and the digests calculated for the
-     * resulting lrm_rsc_op will be correct.
-     * Mark the implied rc pcmk__digest_restart for the case that the main
-     * digest doesn't match.
+    /* Add action-specific resource instance attributes to the digest list.
+     *
+     * If this is a one-time action with action-specific instance attributes,
+     * enforce a restart instead of reload-agent in case the main digest doesn't
+     * match, even if the restart digest does. This ensures any changes of the
+     * action-specific parameters get applied for this specific action, and
+     * digests calculated for the resulting history will be correct. Default the
+     * result to RSC_DIGEST_RESTART for the case where the main digest doesn't
+     * match.
      */
-    if (*interval_ms == 0
-        && g_hash_table_size(action->extra) > 0) {
+    params = pcmk__unpack_action_rsc_params(action_config, node->details->attrs,
+                                            scheduler);
+    if ((*interval_ms == 0) && (g_hash_table_size(params) > 0)) {
         data->rc = pcmk__digest_restart;
     }
+    g_hash_table_foreach(params, hash2field, data->params_all);
+    g_hash_table_destroy(params);
 
-    pe_free_action(action);
+    // Add action meta-attributes
+    params = pcmk__unpack_action_meta(rsc, node, task, *interval_ms,
+                                      action_config);
+    g_hash_table_foreach(params, hash2metafield, data->params_all);
+    g_hash_table_destroy(params);
+
+    pcmk__filter_op_for_digest(data->params_all);
 
     data->digest_all_calc = calculate_operation_digest(data->params_all,
                                                        op_version);

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -289,7 +289,7 @@ new_notify_pseudo_action(pcmk_resource_t *rsc, const pcmk_action_t *action,
                            pcmk__notify_key(rsc->id, notif_type, action->task),
                            notif_action, NULL,
                            pcmk_is_set(action->flags, pcmk_action_optional),
-                           TRUE, rsc->cluster);
+                           rsc->cluster);
     pe__set_action_flags(notify, pcmk_action_pseudo);
     add_hash_param(notify->meta, "notify_key_type", notif_type);
     add_hash_param(notify->meta, "notify_key_operation", action->task);
@@ -347,7 +347,7 @@ new_notify_action(pcmk_resource_t *rsc, const pcmk_node_t *node,
     key = pcmk__notify_key(rsc->id, value, task);
     notify_action = custom_action(rsc, key, op->task, node,
                                   pcmk_is_set(op->flags, pcmk_action_optional),
-                                  TRUE, rsc->cluster);
+                                  rsc->cluster);
 
     // Add meta-data to notify action
     g_hash_table_foreach(op->meta, copy_meta_to_notify, notify_action);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3617,7 +3617,7 @@ unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
     free(last_change_s);
 
     action = custom_action(history->rsc, strdup(history->key), history->task,
-                           NULL, TRUE, FALSE, history->rsc->cluster);
+                           history->node, TRUE, FALSE, history->rsc->cluster);
     if (cmp_on_fail(*on_fail, action->on_fail) < 0) {
         pe_rsc_trace(history->rsc, "on-fail %s -> %s for %s (%s)",
                      fail2text(*on_fail), fail2text(action->on_fail),
@@ -4238,8 +4238,8 @@ get_action_on_fail(struct action_history *history)
 {
     enum action_fail_response result = pcmk_on_fail_restart;
     pcmk_action_t *action = custom_action(history->rsc, strdup(history->key),
-                                          history->task, NULL, TRUE, FALSE,
-                                          history->rsc->cluster);
+                                          history->task, history->node, TRUE,
+                                          FALSE, history->rsc->cluster);
 
     result = action->on_fail;
     pe_free_action(action);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3571,8 +3571,8 @@ unpack_failure_handling(struct action_history *history,
                         enum action_fail_response *on_fail,
                         enum rsc_role_e *fail_role)
 {
-    xmlNode *config = pcmk__find_action_config(history->rsc, history->key,
-                                               true);
+    xmlNode *config = pcmk__find_action_config(history->rsc, history->task,
+                                               history->interval_ms, true);
 
     GHashTable *meta = pcmk__unpack_action_meta(history->rsc, history->node,
                                                 history->task,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2494,7 +2494,7 @@ process_recurring(pcmk_node_t *node, pcmk_resource_t *rsc,
         /* create the action */
         key = pcmk__op_key(rsc->id, task, interval_ms);
         pe_rsc_trace(rsc, "Creating %s on %s", key, pe__node_name(node));
-        custom_action(rsc, key, task, node, TRUE, TRUE, scheduler);
+        custom_action(rsc, key, task, node, TRUE, scheduler);
     }
 }
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3560,18 +3560,50 @@ ban_from_all_nodes(pcmk_resource_t *rsc)
 
 /*!
  * \internal
- * \brief Update resource role, failure handling, etc., after a failed action
+ * \brief Get configured failure handling and role after failure for an action
  *
- * \param[in,out] history       Parsed action result history
- * \param[out]    last_failure  Set this to action XML
- * \param[in,out] on_fail       What should be done about the result
+ * \param[in,out] history    Unpacked action history entry
+ * \param[out]    on_fail    Where to set configured failure handling
+ * \param[out]    fail_role  Where to set to role after failure
  */
 static void
-unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
+unpack_failure_handling(struct action_history *history,
+                        enum action_fail_response *on_fail,
+                        enum rsc_role_e *fail_role)
+{
+    xmlNode *config = pcmk__find_action_config(history->rsc, history->key,
+                                               true);
+
+    GHashTable *meta = pcmk__unpack_action_meta(history->rsc, history->node,
+                                                history->task,
+                                                history->interval_ms, config);
+
+    const char *on_fail_str = g_hash_table_lookup(meta, XML_OP_ATTR_ON_FAIL);
+
+    *on_fail = pcmk__parse_on_fail(history->rsc, history->task,
+                                   history->interval_ms, on_fail_str);
+    *fail_role = pcmk__role_after_failure(history->rsc, history->task, *on_fail,
+                                          meta);
+    g_hash_table_destroy(meta);
+}
+
+/*!
+ * \internal
+ * \brief Update resource role, failure handling, etc., after a failed action
+ *
+ * \param[in,out] history         Parsed action result history
+ * \param[in]     config_on_fail  Action failure handling from configuration
+ * \param[in]     fail_role       Resource's role after failure of this action
+ * \param[out]    last_failure    This will be set to the history XML
+ * \param[in,out] on_fail         Actual handling of action result
+ */
+static void
+unpack_rsc_op_failure(struct action_history *history,
+                      enum action_fail_response config_on_fail,
+                      enum rsc_role_e fail_role, xmlNode **last_failure,
                       enum action_fail_response *on_fail)
 {
     bool is_probe = false;
-    pcmk_action_t *action = NULL;
     char *last_change_s = NULL;
 
     *last_failure = history->xml;
@@ -3616,13 +3648,11 @@ unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
 
     free(last_change_s);
 
-    action = custom_action(history->rsc, strdup(history->key), history->task,
-                           history->node, TRUE, FALSE, history->rsc->cluster);
-    if (cmp_on_fail(*on_fail, action->on_fail) < 0) {
-        pe_rsc_trace(history->rsc, "on-fail %s -> %s for %s (%s)",
-                     fail2text(*on_fail), fail2text(action->on_fail),
-                     action->uuid, history->key);
-        *on_fail = action->on_fail;
+    if (cmp_on_fail(*on_fail, config_on_fail) < 0) {
+        pe_rsc_trace(history->rsc, "on-fail %s -> %s for %s",
+                     fail2text(*on_fail), fail2text(config_on_fail),
+                     history->key);
+        *on_fail = config_on_fail;
     }
 
     if (strcmp(history->task, PCMK_ACTION_STOP) == 0) {
@@ -3639,7 +3669,7 @@ unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
         history->rsc->role = pcmk_role_promoted;
 
     } else if (strcmp(history->task, PCMK_ACTION_DEMOTE) == 0) {
-        if (action->on_fail == pcmk_on_fail_block) {
+        if (config_on_fail == pcmk_on_fail_block) {
             history->rsc->role = pcmk_role_promoted;
             pe__set_next_role(history->rsc, pcmk_role_stopped,
                               "demote with on-fail=block");
@@ -3671,18 +3701,16 @@ unpack_rsc_op_failure(struct action_history *history, xmlNode **last_failure,
                  "Resource %s: role=%s, unclean=%s, on_fail=%s, fail_role=%s",
                  history->rsc->id, role2text(history->rsc->role),
                  pcmk__btoa(history->node->details->unclean),
-                 fail2text(action->on_fail), role2text(action->fail_role));
+                 fail2text(config_on_fail), role2text(fail_role));
 
-    if ((action->fail_role != pcmk_role_started)
-        && (history->rsc->next_role < action->fail_role)) {
-        pe__set_next_role(history->rsc, action->fail_role, "failure");
+    if ((fail_role != pcmk_role_started)
+        && (history->rsc->next_role < fail_role)) {
+        pe__set_next_role(history->rsc, fail_role, "failure");
     }
 
-    if (action->fail_role == pcmk_role_stopped) {
+    if (fail_role == pcmk_role_stopped) {
         ban_from_all_nodes(history->rsc);
     }
-
-    pe_free_action(action);
 }
 
 /*!
@@ -4227,27 +4255,6 @@ pe__target_rc_from_xml(const xmlNode *xml_op)
 
 /*!
  * \internal
- * \brief Get the failure handling for an action
- *
- * \param[in,out] history  Parsed action history entry
- *
- * \return Failure handling appropriate to action
- */
-static enum action_fail_response
-get_action_on_fail(struct action_history *history)
-{
-    enum action_fail_response result = pcmk_on_fail_restart;
-    pcmk_action_t *action = custom_action(history->rsc, strdup(history->key),
-                                          history->task, history->node, TRUE,
-                                          FALSE, history->rsc->cluster);
-
-    result = action->on_fail;
-    pe_free_action(action);
-    return result;
-}
-
-/*!
- * \internal
  * \brief Update a resource's state for an action result
  *
  * \param[in,out] history       Parsed action history entry
@@ -4650,6 +4657,7 @@ unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node, xmlNode *xml_op,
     int old_rc = 0;
     bool expired = false;
     pcmk_resource_t *parent = rsc;
+    enum rsc_role_e fail_role = pcmk_role_unknown;
     enum action_fail_response failure_strategy = pcmk_on_fail_restart;
 
     struct action_history history = {
@@ -4734,7 +4742,7 @@ unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node, xmlNode *xml_op,
             goto done;
 
         case PCMK_EXEC_NOT_INSTALLED:
-            failure_strategy = get_action_on_fail(&history);
+            unpack_failure_handling(&history, &failure_strategy, &fail_role);
             if (failure_strategy == pcmk_on_fail_ignore) {
                 crm_warn("Cannot ignore failed %s of %s on %s: "
                          "Resource agent doesn't exist "
@@ -4749,7 +4757,8 @@ unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node, xmlNode *xml_op,
             }
             resource_location(parent, node, -INFINITY, "hard-error",
                               rsc->cluster);
-            unpack_rsc_op_failure(&history, last_failure, on_fail);
+            unpack_rsc_op_failure(&history, failure_strategy, fail_role,
+                                  last_failure, on_fail);
             goto done;
 
         case PCMK_EXEC_NOT_CONNECTED:
@@ -4779,7 +4788,7 @@ unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node, xmlNode *xml_op,
             break;
     }
 
-    failure_strategy = get_action_on_fail(&history);
+    unpack_failure_handling(&history, &failure_strategy, &fail_role);
     if ((failure_strategy == pcmk_on_fail_ignore)
         || ((failure_strategy == pcmk_on_fail_restart_container)
             && (strcmp(history.task, PCMK_ACTION_STOP) == 0))) {
@@ -4807,7 +4816,8 @@ unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node, xmlNode *xml_op,
         }
 
     } else {
-        unpack_rsc_op_failure(&history, last_failure, on_fail);
+        unpack_rsc_op_failure(&history, failure_strategy, fail_role,
+                              last_failure, on_fail);
 
         if (history.execution_status == PCMK_EXEC_ERROR_HARD) {
             uint8_t log_level = LOG_ERR;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1330,7 +1330,6 @@ max_rsc_stop_timeout(pcmk_resource_t *rsc)
 {
     long long result_ll;
     int max_delay = 0;
-    char *key = NULL;
     xmlNode *config = NULL;
     GHashTable *meta = NULL;
 
@@ -1355,9 +1354,7 @@ max_rsc_stop_timeout(pcmk_resource_t *rsc)
     }
 
     // Get resource's stop action configuration from CIB
-    key = stop_key(rsc);
-    config = pcmk__find_action_config(rsc, key, true);
-    free(key);
+    config = pcmk__find_action_config(rsc, PCMK_ACTION_STOP, 0, true);
 
     /* Get configured timeout for stop action (fully evaluated for rules,
      * defaults, etc.).


### PR DESCRIPTION
Previously, custom_action() took an argument for whether the action should be added to the transition graph or not. Callers that passed FALSE just needed to unpack the action configuration XML and didn't really need the entire action. Refactor and expose the action unpacking functions so that those callers can get just what they need, and custom_action() can always add the action to the graph.

This will help make T381 (per-action failure timeouts) easier.