### PR TITLE
Fix: libpe_status: Use pcmk_monitor_timeout for recurring monitors

### DIFF
--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1608,9 +1608,6 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
     const char *op_timeout = NULL;
     GHashTable *params = NULL;
 
-    xmlNode *primitive = NULL;
-    const char *class = NULL;
-
     const char *transition = NULL;
 
     CRM_ASSERT(rsc_id && operation);
@@ -1650,21 +1647,6 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
     if (pcmk__guint_from_hash(params, CRM_META "_" XML_LRM_ATTR_INTERVAL_MS, 0,
                               &(op->interval_ms)) != pcmk_rc_ok) {
         op->interval_ms = 0;
-    }
-
-    /* Use pcmk_monitor_timeout instead of meta timeout for stonith
-       recurring monitor, if set */
-    primitive = find_xml_node(rsc_op, XML_CIB_TAG_RESOURCE, FALSE);
-    class = crm_element_value(primitive, XML_AGENT_ATTR_CLASS);
-
-    if (pcmk_is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_fence_params)
-            && pcmk__str_eq(operation, PCMK_ACTION_MONITOR, pcmk__str_casei)
-            && (op->interval_ms > 0)) {
-
-        op_timeout = g_hash_table_lookup(params, "pcmk_monitor_timeout");
-        if (op_timeout != NULL) {
-            op->timeout = crm_get_msec(op_timeout);
-        }
     }
 
     if (!pcmk__str_eq(operation, PCMK_ACTION_STOP, pcmk__str_casei)) {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -773,9 +773,8 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
     }
 
     /* Timeout order of precedence (highest to lowest):
-     *   1. pcmk_monitor_timeout resource parameter (only for starts and probes
-     *      when rsc has pcmk_ra_cap_fence_params; this gets used for recurring
-     *      monitors via the executor instead)
+     *   1. pcmk_monitor_timeout resource parameter (only for starts and
+     *      monitors when rsc has pcmk_ra_cap_fence_params)
      *   2. timeout configured in <op> (with <op timeout> taking precedence over
      *      <op> <meta_attributes>)
      *   3. timeout configured in <op_defaults> <meta_attributes>
@@ -785,8 +784,8 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
     // Check for pcmk_monitor_timeout
     if (pcmk_is_set(pcmk_get_ra_caps(rsc_rule_data.standard),
                     pcmk_ra_cap_fence_params)
-        && (pcmk__str_eq(action_name, PCMK_ACTION_START, pcmk__str_none)
-            || pcmk_is_probe(action_name, interval_ms))) {
+        && pcmk__str_any_of(action_name, PCMK_ACTION_START, PCMK_ACTION_MONITOR,
+                            NULL)) {
 
         GHashTable *params = pe_rsc_params(rsc, node, rsc->cluster);
 


### PR DESCRIPTION
The executor uses `pcmk_monitor_timeout`, but the controller considers a recurring monitor to have timed out after its op timeout expires. If `pcmk_monitor_timeout` is very long (for example, 240 seconds), a stonith stop action can fail. In this situation, the monitor is declared as timed out before the `pcmk_monitor_timeout` expires, the stop action is requested, and its timer begins counting down. However, the stop action can't begin until after the monitor finishes or `pcmk_monitor_timeout` expires.

This also makes special handling in `controld_execd.c` unnecessary. `pcmk__unpack_action_meta()` has already replaced the meta timeout with the `pcmk_monitor_timeout`.

Closes RHEL-14826 (JIRA).