### PR TITLE
Mid: controld: Adding default value for node-pending-timeout.

### DIFF
--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -677,6 +677,16 @@ static pcmk__cluster_option_t controller_options[] = {
             "passed since the shutdown was initiated, even if the node has not "
             "rejoined.")
     },
+    {
+        XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT, NULL, "time", NULL,
+        "2h", pcmk__valid_interval_spec,
+        N_("How long to wait for a node that has joined the cluster to join "
+           "the controller process group"),
+        N_("Fence nodes that do not join the controller process group within "
+           "this much time after joining the cluster, to allow the cluster "
+           "to continue managing resources. A value of 0 means never fence "
+           "pending nodes.")
+    },
 };
 
 void


### PR DESCRIPTION
Hi All,

I don't think it's intentional, but the default value of contorld's node-pending-timeout is not set.

If this is intentional, this PR will be closed.

Best Regards, Hideo Yamauchi.