### PR TITLE
Mid: controld/schedulerd: Change the default value of node-pending-timeout to 0.

### DIFF
--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -123,7 +123,7 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="node-pending-timeout">
-      <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes.</longdesc>
+      <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes. Setting the value to 2h means fence nodes after 2 hours.</longdesc>
       <shortdesc lang="en">How long to wait for a node that has joined the cluster to join the controller process group</shortdesc>
       <content type="time" default=""/>
     </parameter>
@@ -355,7 +355,7 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="node-pending-timeout">
-      <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes.</longdesc>
+      <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes. Setting the value to 2h means fence nodes after 2 hours.</longdesc>
       <shortdesc lang="en">How long to wait for a node that has joined the cluster to join the controller process group</shortdesc>
       <content type="time" default=""/>
     </parameter>

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -679,13 +679,14 @@ static pcmk__cluster_option_t controller_options[] = {
     },
     {
         XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT, NULL, "time", NULL,
-        "2h", pcmk__valid_interval_spec,
+        "0", pcmk__valid_interval_spec,
         N_("How long to wait for a node that has joined the cluster to join "
            "the controller process group"),
         N_("Fence nodes that do not join the controller process group within "
            "this much time after joining the cluster, to allow the cluster "
-           "to continue managing resources. A value of 0 means never fence "
-           "pending nodes.")
+           "to continue managing resources. A value of 0 means never fence " 
+           "pending nodes. Setting the value to 2h means fence nodes after "
+           "2 hours.")
     },
 };
 

--- a/doc/sphinx/Pacemaker_Explained/options.rst
+++ b/doc/sphinx/Pacemaker_Explained/options.rst
@@ -639,11 +639,11 @@ values, by running the ``man pacemaker-schedulerd`` and
       
        node-pending-timeout
      - :ref:`duration <duration>`
-     - 2h
+     - 0
      - Fence nodes that do not join the controller process group within this
        much time after joining the cluster, to allow the cluster to continue
-       managing resources. A value of 0 means never fence pending nodes.
-       *(since 2.1.7)* 
+       managing resources. A value of 0 means never fence pending nodes. Setting the value to 2h means fence nodes after 2 hours. 
+       *(since 2.1.7)*
    * - .. _cluster_delay:
       
        .. index::

--- a/lib/pengine/common.c
+++ b/lib/pengine/common.c
@@ -158,16 +158,16 @@ static pcmk__cluster_option_t pe_opts[] = {
             "twice, the maximum `pcmk_delay_base/max`. By default, priority "
             "fencing delay is disabled.")
     },
-
     {
         XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT, NULL, "time", NULL,
-        "2h", pcmk__valid_interval_spec,
+        "0", pcmk__valid_interval_spec,
         N_("How long to wait for a node that has joined the cluster to join "
            "the controller process group"),
         N_("Fence nodes that do not join the controller process group within "
            "this much time after joining the cluster, to allow the cluster "
            "to continue managing resources. A value of 0 means never fence "
-           "pending nodes.")
+           "pending nodes. Setting the value to 2h means fence nodes after "
+           "2 hours.")
     },
     {
         "cluster-delay", NULL, "time", NULL,


### PR DESCRIPTION
Hi All,

This PR follows the next PR and changes the default value of node-pending-timeout to 0.
 - https://github.com/ClusterLabs/pacemaker/pull/3254

Best Regards,
Hideo Yamauchi.