### PR TITLE
Refactor: libcrmcommon: Improve xml_find_x_0_schema_index.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2153,6 +2153,7 @@ AC_CONFIG_FILES(Makefile                                            \
                 lib/common/tests/output/Makefile                    \
                 lib/common/tests/procfs/Makefile                    \
                 lib/common/tests/results/Makefile                   \
+                lib/common/tests/schemas/Makefile                   \
                 lib/common/tests/scores/Makefile                    \
                 lib/common/tests/strings/Makefile                   \
                 lib/common/tests/utils/Makefile                     \

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -283,4 +283,30 @@ void pcmk__register_patchset_messages(pcmk__output_t *out);
 #define PCMK__PW_BUFFER_LEN 500
 
 
+/*
+ * Schemas
+ */
+typedef struct {
+    unsigned char v[2];
+} pcmk__schema_version_t;
+
+enum pcmk__schema_validator {
+    pcmk__schema_validator_none,
+    pcmk__schema_validator_rng
+};
+
+typedef struct {
+    char *name;
+    char *transform;
+    void *cache;
+    enum pcmk__schema_validator validator;
+    pcmk__schema_version_t version;
+    char *transform_enter;
+    bool transform_onleave;
+} pcmk__schema_t;
+
+G_GNUC_INTERNAL
+int pcmk__find_x_0_schema_index(GList *schemas);
+
+
 #endif  // CRMCOMMON_PRIVATE__H

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -26,9 +26,7 @@
 #include <crm/common/xml.h>
 #include <crm/common/xml_internal.h>  /* PCMK__XML_LOG_BASE */
 
-typedef struct {
-    unsigned char v[2];
-} pcmk__schema_version_t;
+#include "crmcommon_private.h"
 
 #define SCHEMA_ZERO { .v = { 0, 0 } }
 
@@ -40,21 +38,6 @@ typedef struct {
     xmlRelaxNGValidCtxtPtr valid;
     xmlRelaxNGParserCtxtPtr parser;
 } relaxng_ctx_cache_t;
-
-enum pcmk__schema_validator {
-    pcmk__schema_validator_none,
-    pcmk__schema_validator_rng
-};
-
-typedef struct {
-    char *name;
-    char *transform;
-    void *cache;
-    enum pcmk__schema_validator validator;
-    pcmk__schema_version_t version;
-    char *transform_enter;
-    bool transform_onleave;
-} pcmk__schema_t;
 
 static GList *known_schemas = NULL;
 static bool silent_logging = FALSE;
@@ -82,8 +65,8 @@ xml_latest_schema_index(GList *schemas)
 }
 
 /* Return the index of the most recent X.0 schema. */
-static int
-xml_find_x_0_schema_index(GList *schemas)
+int
+pcmk__find_x_0_schema_index(GList *schemas)
 {
     /* We can't just use best to determine whether we've found the index
      * or not.  What if we have a very long list of schemas all in the
@@ -1178,7 +1161,7 @@ cli_config_update(xmlNode **xml, int *best_version, gboolean to_logs)
 
     int version = get_schema_version(value);
     int orig_version = version;
-    int min_version = xml_find_x_0_schema_index(known_schemas);
+    int min_version = pcmk__find_x_0_schema_index(known_schemas);
 
     if (version < min_version) {
         // Current configuration schema is not acceptable, try to update

--- a/lib/common/tests/Makefile.am
+++ b/lib/common/tests/Makefile.am
@@ -21,6 +21,7 @@ SUBDIRS = \
 	options		\
 	output 		\
 	results		\
+	schemas		\
 	scores		\
 	strings		\
 	utils		\

--- a/lib/common/tests/schemas/Makefile.am
+++ b/lib/common/tests/schemas/Makefile.am
@@ -1,0 +1,16 @@
+#
+# Copyright 2023 the Pacemaker project contributors
+#
+# The version control history for this file may have further details.
+#
+# This source code is licensed under the GNU General Public License version 2
+# or later (GPLv2+) WITHOUT ANY WARRANTY.
+#
+
+include $(top_srcdir)/mk/tap.mk
+include $(top_srcdir)/mk/unittest.mk
+
+# Add "_test" to the end of all test program names to simplify .gitignore.
+check_PROGRAMS = pcmk__xml_find_x_0_schema_index_test
+
+TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/schemas/pcmk__xml_find_x_0_schema_index_test.c
+++ b/lib/common/tests/schemas/pcmk__xml_find_x_0_schema_index_test.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+#include <crm/common/unittest_internal.h>
+
+#include <glib.h>
+
+#include "crmcommon_private.h"
+
+static pcmk__schema_t *
+mk_schema(const char *name, unsigned char x, unsigned char y)
+{
+    pcmk__schema_t *schema = malloc(sizeof(pcmk__schema_t));
+
+    schema->name = strdup(name);
+    schema->version.v[0] = x;
+    schema->version.v[1] = y;
+    return schema;
+}
+
+static void
+free_schema(void *data)
+{
+    pcmk__schema_t *schema = data;
+    free(schema->name);
+    free(schema);
+}
+
+static void
+empty_schema_list(void **state)
+{
+    pcmk__assert_asserts(pcmk__find_x_0_schema_index(NULL));
+}
+
+static void
+singleton_schema_list(void **state)
+{
+    GList *schemas = NULL;
+
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
+    assert_int_equal(0, pcmk__find_x_0_schema_index(schemas));
+    g_list_free_full(schemas, free_schema);
+}
+
+static void
+one_major_version(void **state)
+{
+    GList *schemas = NULL;
+
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.2", 1, 2));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.3", 1, 3));
+    assert_int_equal(0, pcmk__find_x_0_schema_index(schemas));
+    g_list_free_full(schemas, free_schema);
+}
+
+static void
+first_version_is_not_0(void **state)
+{
+    GList *schemas = NULL;
+
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.1", 1, 1));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.2", 1, 2));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.3", 1, 3));
+    assert_int_equal(0, pcmk__find_x_0_schema_index(schemas));
+    g_list_free_full(schemas, free_schema);
+}
+
+static void
+multiple_major_versions(void **state)
+{
+    GList *schemas = NULL;
+
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.1", 1, 1));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-2.0", 2, 0));
+    assert_int_equal(2, pcmk__find_x_0_schema_index(schemas));
+    g_list_free_full(schemas, free_schema);
+}
+
+static void
+many_versions(void **state)
+{
+    GList *schemas = NULL;
+
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.1", 1, 1));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-1.2", 1, 2));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-2.0", 2, 0));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-2.1", 2, 1));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-2.2", 2, 2));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-3.0", 3, 0));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-3.1", 3, 1));
+    schemas = g_list_append(schemas, mk_schema("pacemaker-3.2", 3, 2));
+    assert_int_equal(6, pcmk__find_x_0_schema_index(schemas));
+    g_list_free_full(schemas, free_schema);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(empty_schema_list),
+                cmocka_unit_test(singleton_schema_list),
+                cmocka_unit_test(one_major_version),
+                cmocka_unit_test(first_version_is_not_0),
+                cmocka_unit_test(multiple_major_versions),
+                cmocka_unit_test(many_versions))


### PR DESCRIPTION
* Lots of comments to explain how it works.

* Walk the list backwards, stopping on the first one in the major version series.  This means the first one no longer has to be X.0.

* Require that known_schemas be non-NULL.

* Don't use the returned index to also mean we've found something since that means if the index we actually want to return is 0, the function will have to run every time.