### PR TITLE
Fix: libcrmcommon: Drop deprecated libxml2 symbols

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@
 |                 | libuuid-devel      | libuuid-devel      | uuid-dev       |
 | 0.27 or later   | pkgconfig          | pkgconfig          | pkg-config     |
 | 2.42.0 or later | glib2-devel        | glib2-devel        | libglib2.0-dev |
-|                 | libxml2-devel      | libxml2-devel      | libxml2-dev    |
+| 2.6.0 or later  | libxml2-devel      | libxml2-devel      | libxml2-dev    |
 |                 | libxslt-devel      | libxslt-devel      | libxslt-dev    |
 |                 | bzip2-devel        | libbz2-devel       | libbz2-dev     |
 | 0.17.0 or later | libqb-devel        | libqb-devel        | libqb-dev      |

--- a/configure.ac
+++ b/configure.ac
@@ -1090,7 +1090,7 @@ AS_IF([test x"$ac_cv_lib_c_dlopen" = x"yes"],
       [LIBADD_DL=-ldl],
       [LIBADD_DL=${lt_cv_dlopen_libs}])
 
-PKG_CHECK_MODULES(LIBXML2, [libxml-2.0],
+PKG_CHECK_MODULES(LIBXML2, [libxml-2.0 >= 2.6.0],
                   [CPPFLAGS="${CPPFLAGS} ${LIBXML2_CFLAGS}"
                    LIBS="${LIBS} ${LIBXML2_LIBS}"])
 

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -450,7 +450,6 @@ validate_with_relaxng(xmlDocPtr doc, gboolean to_logs, const char *relaxng_file,
         crm_debug("Creating RNG parser context");
         ctx = calloc(1, sizeof(relaxng_ctx_cache_t));
 
-        xmlLoadExtDtdDefaultValue = 1;
         ctx->parser = xmlRelaxNGNewParserCtxt(relaxng_file);
         CRM_CHECK(ctx->parser != NULL, goto cleanup);
 
@@ -487,7 +486,6 @@ validate_with_relaxng(xmlDocPtr doc, gboolean to_logs, const char *relaxng_file,
         }
     }
 
-    xmlLineNumbersDefault(1);
     rc = xmlRelaxNGValidateDoc(ctx->valid, doc);
     if (rc > 0) {
         valid = FALSE;
@@ -660,7 +658,7 @@ validate_xml_verbose(const xmlNode *xml_blob)
 
     dump_file(filename);
 
-    doc = xmlParseFile(filename);
+    doc = xmlReadFile(filename, NULL, 0);
     xml = xmlDocGetRootElement(doc);
     rc = validate_xml(xml, NULL, FALSE);
     free_xml(xml);
@@ -864,9 +862,6 @@ apply_transformation(xmlNode *xml, const char *transform, gboolean to_logs)
 
     xform = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_legacy_xslt,
                                     transform);
-
-    xmlLoadExtDtdDefaultValue = 1;
-    xmlSubstituteEntitiesDefault(1);
 
     /* for capturing, e.g., what's emitted via <xsl:message> */
     if (to_logs) {

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -802,7 +802,7 @@ string2xml(const char *input)
     xmlNode *xml = NULL;
     xmlDocPtr output = NULL;
     xmlParserCtxtPtr ctxt = NULL;
-    xmlErrorPtr last_error = NULL;
+    const xmlError *last_error = NULL;
 
     if (input == NULL) {
         crm_err("Can't parse NULL input");
@@ -993,7 +993,7 @@ filename2xml(const char *filename)
     xmlDocPtr output = NULL;
     bool uncompressed = true;
     xmlParserCtxtPtr ctxt = NULL;
-    xmlErrorPtr last_error = NULL;
+    const xmlError *last_error = NULL;
 
     /* create a parser context */
     ctxt = xmlNewParserCtxt();


### PR DESCRIPTION
xmlLoadExtDtdDefaultValue should be replaced by the XML_PARSE_DTDLOAD parser option. However, we don't call any function that accepts parser options where we currently use xmlLoadExtDtdDefaultValue. We also don't use an xmlParserCtxt, so we can't call xmlCtxtUseOptions(). (There's no analog for xmlRelaxNGParserCtxt.)

xmlSubstituteEntitiesDefault() should be replaced by XML_PARSE_NOENT. Similarly, we don't call any function that accepts parser options where we currently use xmlSubstituteEntitiesDefault().

xmlLineNumbersDefault() is always enabled by the modern parser API.

xmlParseFile() should be replaced by xmlReadFile(). Here we use a NULL encoding and no options.

Note that the "new" or "modern" libxml2 parser API was released over 20 years ago, and we already use it in other places. So backwards compatibility should not be a concern.

No regression tests change.

Fixes T719
Fixes CLBZ#5530