### PR TITLE
Refactor: libcrmcommon: pcmk__xml_output_finish should take an exit c…

### DIFF
--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -918,7 +918,7 @@ G_GNUC_NULL_TERMINATED;
 void pcmk__output_and_clear_error(GError **error, pcmk__output_t *out);
 
 int pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml);
-void pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml);
+void pcmk__xml_output_finish(pcmk__output_t *out, crm_exit_t exit_status, xmlNodePtr *xml);
 int pcmk__log_output_new(pcmk__output_t **out);
 int pcmk__text_output_new(pcmk__output_t **out, const char *filename);
 

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -251,12 +251,15 @@ pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml) {
  * \internal
  * \brief  Finish and free an XML-only output object
  *
- * \param[in,out] out  Output object to free
- * \param[out]    xml  If not NULL, where to store XML output
+ * \param[in,out] out         Output object to free
+ * \param[in]     exit_status The exit value of the whole program
+ * \param[out]    xml         If not NULL, where to store XML output
  */
 void
-pcmk__xml_output_finish(pcmk__output_t *out, xmlNodePtr *xml) {
-    out->finish(out, 0, FALSE, (void **) xml);
+pcmk__xml_output_finish(pcmk__output_t *out, crm_exit_t exit_status,
+                        xmlNodePtr *xml)
+{
+    out->finish(out, exit_status, FALSE, (void **) xml);
     pcmk__output_free(out);
 }
 

--- a/lib/pacemaker/pcmk_agents.c
+++ b/lib/pacemaker/pcmk_agents.c
@@ -60,7 +60,7 @@ pcmk_list_alternatives(xmlNodePtr *xml, const char *agent_spec)
     lrmd__register_messages(out);
 
     rc = pcmk__list_alternatives(out, agent_spec);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -131,7 +131,7 @@ pcmk_list_agents(xmlNodePtr *xml, char *agent_spec)
     lrmd__register_messages(out);
 
     rc = pcmk__list_agents(out, agent_spec);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -187,7 +187,7 @@ pcmk_list_providers(xmlNodePtr *xml, const char *agent_spec)
     lrmd__register_messages(out);
 
     rc = pcmk__list_providers(out, agent_spec);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -238,6 +238,6 @@ pcmk_list_standards(xmlNodePtr *xml)
     lrmd__register_messages(out);
 
     rc = pcmk__list_standards(out);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -509,7 +509,7 @@ pcmk_controller_status(xmlNodePtr *xml, const char *node_name,
     pcmk__register_lib_messages(out);
 
     rc = pcmk__controller_status(out, node_name, message_timeout_ms);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -577,7 +577,7 @@ pcmk_designated_controller(xmlNodePtr *xml, unsigned int message_timeout_ms)
     pcmk__register_lib_messages(out);
 
     rc = pcmk__designated_controller(out, message_timeout_ms);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -707,7 +707,7 @@ pcmk_query_node_info(xmlNodePtr *xml, uint32_t *node_id, char **node_name,
     rc = pcmk__query_node_info(out, node_id, node_name, uuid, state,
                                have_quorum, is_remote, show_output,
                                message_timeout_ms);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -797,7 +797,7 @@ pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
     pcmk__register_lib_messages(out);
 
     rc = pcmk__pacemakerd_status(out, ipc_name, message_timeout_ms, true, NULL);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -894,6 +894,6 @@ pcmk_list_nodes(xmlNodePtr *xml, const char *node_types)
     pcmk__register_lib_messages(out);
 
     rc = pcmk__list_nodes(out, node_types, FALSE);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -320,7 +320,7 @@ pcmk_fence_history(xmlNodePtr *xml, stonith_t *st, const char *target,
 
     rc = pcmk__fence_history(out, st, target, timeout, verbose, broadcast,
                              cleanup);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif
@@ -364,7 +364,7 @@ pcmk_fence_installed(xmlNodePtr *xml, stonith_t *st, unsigned int timeout)
     stonith__register_messages(out);
 
     rc = pcmk__fence_installed(out, st, timeout);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif
@@ -402,7 +402,7 @@ pcmk_fence_last(xmlNodePtr *xml, const char *target, bool as_nodeid)
     stonith__register_messages(out);
 
     rc = pcmk__fence_last(out, target, as_nodeid);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif
@@ -449,7 +449,7 @@ pcmk_fence_list_targets(xmlNodePtr *xml, stonith_t *st, const char *device_id,
     stonith__register_messages(out);
 
     rc = pcmk__fence_list_targets(out, st, device_id, timeout);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif
@@ -487,7 +487,7 @@ pcmk_fence_metadata(xmlNodePtr *xml, stonith_t *st, const char *agent,
     stonith__register_messages(out);
 
     rc = pcmk__fence_metadata(out, st, agent, timeout);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif
@@ -536,7 +536,7 @@ pcmk_fence_registered(xmlNodePtr *xml, stonith_t *st, const char *target,
     stonith__register_messages(out);
 
     rc = pcmk__fence_registered(out, st, target, timeout);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif
@@ -603,7 +603,7 @@ pcmk_fence_validate(xmlNodePtr *xml, stonith_t *st, const char *agent,
     stonith__register_messages(out);
 
     rc = pcmk__fence_validate(out, st, agent, id, params, timeout);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 #endif

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -168,6 +168,6 @@ pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
     }
     pcmk__register_lib_messages(out);
     rc = pcmk__resource_digests(out, rsc, node, overrides);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_result_code.c
+++ b/lib/pacemaker/pcmk_result_code.c
@@ -73,7 +73,7 @@ pcmk_show_result_code(xmlNodePtr *xml, int code, enum pcmk_result_type type,
     pcmk__register_lib_messages(out);
 
     rc = pcmk__show_result_code(out, code, type, flags);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }
 
@@ -162,6 +162,6 @@ pcmk_list_result_codes(xmlNodePtr *xml, enum pcmk_result_type type,
     pcmk__register_lib_messages(out);
 
     rc = pcmk__list_result_codes(out, type, flags);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_rule.c
+++ b/lib/pacemaker/pcmk_rule.c
@@ -291,6 +291,6 @@ pcmk_check_rules(xmlNodePtr *xml, xmlNodePtr input, const crm_time_t *date,
     pcmk__register_lib_messages(out);
 
     rc = pcmk__check_rules(out, input, date, rule_ids);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -1001,6 +1001,6 @@ pcmk_simulate(xmlNodePtr *xml, pcmk_scheduler_t *scheduler,
 
     rc = pcmk__simulate(scheduler, out, injections, flags, section_opts,
                         use_date, input_file, graph_file, dot_file);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
     return rc;
 }

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -179,7 +179,7 @@ pcmk_status(xmlNodePtr *xml)
 
     rc = pcmk__status(out, cib, pcmk__fence_history_full, pcmk_section_all,
                       show_opts, NULL, NULL, NULL, false, 0);
-    pcmk__xml_output_finish(out, xml);
+    pcmk__xml_output_finish(out, pcmk_rc2exitc(rc), xml);
 
     cib_delete(cib);
     return rc;


### PR DESCRIPTION
…ode.

It previously did, but that was removed because the exit code was also being used to determine whether the function should do any output or not.

However, this means that the public libpacemaker API functions will write out an XML block with a <status code=""> wrapper that always looks successful.  This is because pcmk__xml_output_finish previously called out->finish with 0 for the exit code always.  The actual exit code of the process was not taken into account.