### PR TITLE
Doc: Pacemaker Explained: Fix CIB_user default

### DIFF
--- a/doc/sphinx/Clusters_from_Scratch/cluster-setup.rst
+++ b/doc/sphinx/Clusters_from_Scratch/cluster-setup.rst
@@ -114,14 +114,14 @@ Start and enable the daemon by issuing the following commands on each node:
     # systemctl enable pcsd.service
     Created symlink from /etc/systemd/system/multi-user.target.wants/pcsd.service to /usr/lib/systemd/system/pcsd.service.
 
-The installed packages will create an ``hacluster`` user with a disabled password.
-While this is fine for running ``pcs`` commands locally,
+The installed packages will create an |CRM_DAEMON_USER| user with a disabled
+password. While this is fine for running ``pcs`` commands locally,
 the account needs a login password in order to perform such tasks as syncing
 the Corosync configuration, or starting and stopping the cluster on other nodes.
 
 This tutorial will make use of such commands,
-so now we will set a password for the ``hacluster`` user, using the same password
-on both nodes:
+so now we will set a password for the |CRM_DAEMON_USER| user, using the same
+password on both nodes:
 
 .. code-block:: console
 

--- a/doc/sphinx/Pacemaker_Administration/alerts.rst
+++ b/doc/sphinx/Pacemaker_Administration/alerts.rst
@@ -287,7 +287,7 @@ Special concerns when writing alert agents:
   this into consideration, for example by queueing resource-intensive actions
   into some other instance, instead of directly executing them.
    
-* Alert agents are run as the ``hacluster`` user, which has a minimal set
+* Alert agents are run as the |CRM_DAEMON_USER| user, which has a minimal set
   of permissions. If an agent requires additional privileges, it is
   recommended to configure ``sudo`` to allow the agent to run the necessary
   commands as another user with the appropriate privileges.
@@ -297,7 +297,7 @@ Special concerns when writing alert agents:
   user-configured ``timestamp-format``), ``CRM_alert_recipient,`` and all
   instance attributes. Mostly this is needed simply to protect against
   configuration errors, but if some user can modify the CIB without having
-  ``hacluster``-level access to the cluster nodes, it is a potential security
+  |CRM_DAEMON_USER| access to the cluster nodes, it is a potential security
   concern as well, to avoid the possibility of code injection.
    
 .. note:: **ocf:pacemaker:ClusterMon compatibility**
@@ -308,4 +308,4 @@ Special concerns when writing alert agents:
    passed to alert agents are available prepended with ``CRM_notify_``
    as well as ``CRM_alert_``. One break in compatibility is that ``ClusterMon``
    ran external scripts as the ``root`` user, while alert agents are run as the
-   ``hacluster`` user.
+   |CRM_DAEMON_USER| user.

--- a/doc/sphinx/Pacemaker_Administration/configuring.rst
+++ b/doc/sphinx/Pacemaker_Administration/configuring.rst
@@ -203,8 +203,8 @@ when working on a cluster node.
 
        CIB_user
      - |CRM_DAEMON_USER_RAW|
-     - The user to connect as. Needs to be part of the ``haclient`` group on
-       the target host.
+     - The user to connect as. Needs to be part of the |CRM_DAEMON_GROUP| group
+       on the target host.
    * - .. index::
           single: CIB_passwd
           single: environment variable; CIB_passwd
@@ -235,7 +235,7 @@ when working on a cluster node.
      - Whether to encrypt network traffic
 
 So, if **c001n01** is an active cluster node and is listening on port 1234
-for connections, and **someuser** is a member of the **haclient** group,
+for connections, and **someuser** is a member of the |CRM_DAEMON_GROUP| group,
 then the following would prompt for **someuser**'s password and return
 the cluster's current configuration:
 

--- a/doc/sphinx/Pacemaker_Administration/configuring.rst
+++ b/doc/sphinx/Pacemaker_Administration/configuring.rst
@@ -202,7 +202,7 @@ when working on a cluster node.
           single: environment variable; CIB_user
 
        CIB_user
-     - $USER
+     - |CRM_DAEMON_USER_RAW|
      - The user to connect as. Needs to be part of the ``haclient`` group on
        the target host.
    * - .. index::

--- a/doc/sphinx/Pacemaker_Administration/configuring.rst
+++ b/doc/sphinx/Pacemaker_Administration/configuring.rst
@@ -189,45 +189,50 @@ cluster even if the machine itself is not in the same cluster. To do this, one
 simply sets up a number of environment variables and runs the same commands as
 when working on a cluster node.
 
-.. table:: **Environment Variables Used to Connect to Remote Instances of the CIB**
+.. list-table:: **Environment Variables Used to Connect to Remote Instances of the CIB**
+   :class: longtable
+   :widths: 2 2 5
+   :header-rows: 1
 
-   +----------------------+-----------+------------------------------------------------+
-   | Environment Variable | Default   | Description                                    |
-   +======================+===========+================================================+
-   | CIB_user             | $USER     | .. index::                                     |
-   |                      |           |    single: CIB_user                            |
-   |                      |           |    single: environment variable; CIB_user      |
-   |                      |           |                                                |
-   |                      |           | The user to connect as. Needs to be            |
-   |                      |           | part of the ``haclient`` group on              |
-   |                      |           | the target host.                               |
-   +----------------------+-----------+------------------------------------------------+
-   | CIB_passwd           |           | .. index::                                     |
-   |                      |           |    single: CIB_passwd                          |
-   |                      |           |    single: environment variable; CIB_passwd    |
-   |                      |           |                                                |
-   |                      |           | The user's password. Read from the             |
-   |                      |           | command line if unset.                         |
-   +----------------------+-----------+------------------------------------------------+
-   | CIB_server           | localhost | .. index::                                     |
-   |                      |           |    single: CIB_server                          |
-   |                      |           |    single: environment variable; CIB_server    |
-   |                      |           |                                                |
-   |                      |           | The host to contact                            |
-   +----------------------+-----------+------------------------------------------------+
-   | CIB_port             |           | .. index::                                     |
-   |                      |           |    single: CIB_port                            |
-   |                      |           |    single: environment variable; CIB_port      |
-   |                      |           |                                                |
-   |                      |           | The port on which to contact the server;       |
-   |                      |           | required.                                      |
-   +----------------------+-----------+------------------------------------------------+
-   | CIB_encrypted        | TRUE      | .. index::                                     |
-   |                      |           |    single: CIB_encrypted                       |
-   |                      |           |    single: environment variable; CIB_encrypted |
-   |                      |           |                                                |
-   |                      |           | Whether to encrypt network traffic             |
-   +----------------------+-----------+------------------------------------------------+
+   * - Environment Variable
+     - Default
+     - Description
+   * - .. index::
+          single: CIB_user
+          single: environment variable; CIB_user
+
+       CIB_user
+     - $USER
+     - The user to connect as. Needs to be part of the ``haclient`` group on
+       the target host.
+   * - .. index::
+          single: CIB_passwd
+          single: environment variable; CIB_passwd
+
+       CIB_passwd
+     -
+     - The user's password. Read from the command line if unset.
+   * - .. index::
+          single: CIB_server
+          single: environment variable; CIB_server
+
+       CIB_server
+     - localhost
+     - The host to contact
+   * - .. index::
+          single: CIB_port
+          single: environment variable; CIB_port
+
+       CIB_port
+     -
+     - The port on which to contact the server; required
+   * - .. index::
+          single: CIB_encrypted
+          single: environment variable; CIB_encrypted
+
+       CIB_encrypted
+     - true
+     - Whether to encrypt network traffic
 
 So, if **c001n01** is an active cluster node and is listening on port 1234
 for connections, and **someuser** is a member of the **haclient** group,

--- a/doc/sphinx/Pacemaker_Explained/acls.rst
+++ b/doc/sphinx/Pacemaker_Explained/acls.rst
@@ -275,9 +275,9 @@ elements.
 
 .. important::
 
-   The ``root`` and ``hacluster`` user accounts always have full access to the
-   CIB, regardless of ACLs. For all other user accounts, when ``enable-acl`` is
-   true, permission to all parts of the CIB is denied by default (permissions
+   The ``root`` and |CRM_DAEMON_USER| user accounts always have full access to
+   the CIB, regardless of ACLs. For all other user accounts, when ``enable-acl``
+   is true, permission to all parts of the CIB is denied by default (permissions
    must be explicitly granted).
    
 ACL Examples

--- a/doc/sphinx/Pacemaker_Explained/acls.rst
+++ b/doc/sphinx/Pacemaker_Explained/acls.rst
@@ -6,9 +6,9 @@
 Access Control Lists (ACLs)
 ---------------------------
 
-By default, the ``root`` user or any user in the ``haclient`` group can modify
-Pacemaker's CIB without restriction. Pacemaker offers *access control lists
-(ACLs)* to provide more fine-grained authorization.
+By default, the ``root`` user or any user in the |CRM_DAEMON_GROUP| group can
+modify Pacemaker's CIB without restriction. Pacemaker offers *access control
+lists (ACLs)* to provide more fine-grained authorization.
    
 .. important::
 
@@ -24,7 +24,7 @@ In order to use ACLs:
 * The ``enable-acl`` :ref:`cluster option <cluster_options>` must be set to
   true.
 
-* Desired users must have user accounts in the ``haclient`` group on all
+* Desired users must have user accounts in the |CRM_DAEMON_GROUP| group on all
   cluster nodes in the cluster.
 
 * If your CIB was created before Pacemaker 1.1.12, it might need to be updated
@@ -436,8 +436,8 @@ the CIB, such as ``crm_attribute`` when managing permanent node attributes,
 ``crm_mon``, and ``cibadmin``.
 
 However, command-line tools that communicate directly with Pacemaker daemons
-via IPC are not affected by ACLs. For example, users in the ``haclient`` group
-may still do the following, regardless of ACLs:
+via IPC are not affected by ACLs. For example, users in the |CRM_DAEMON_GROUP|
+group may still do the following, regardless of ACLs:
 
 * Query transient node attribute values using ``crm_attribute`` and
   ``attrd_updater``.

--- a/doc/sphinx/Pacemaker_Remote/baremetal-tutorial.rst
+++ b/doc/sphinx/Pacemaker_Remote/baremetal-tutorial.rst
@@ -109,7 +109,7 @@ Start and enable the ``pcsd`` daemon on the remote node.
     [root@remote1 ~]# systemctl enable pcsd
     Created symlink /etc/systemd/system/multi-user.target.wants/pcsd.service → /usr/lib/systemd/system/pcsd.service.
 
-Next, set a password for the ``hacluster`` user on the remote node
+Next, set a password for the |CRM_DAEMON_USER| user on the remote node
 
 .. code-block:: none
 

--- a/doc/sphinx/Pacemaker_Remote/kvm-tutorial.rst
+++ b/doc/sphinx/Pacemaker_Remote/kvm-tutorial.rst
@@ -254,7 +254,7 @@ Start and enable the ``pcsd`` daemon on the guest.
     [root@guest1 ~]# systemctl enable pcsd
     Created symlink /etc/systemd/system/multi-user.target.wants/pcsd.service → /usr/lib/systemd/system/pcsd.service.
 
-Next, set a password for the ``hacluster`` user on the guest.
+Next, set a password for the |CRM_DAEMON_USER| user on the guest.
 
 .. code-block:: none
 

--- a/doc/sphinx/conf.py.in
+++ b/doc/sphinx/conf.py.in
@@ -33,6 +33,7 @@ rst_prolog="""
 .. |CRM_BLACKBOX_DIR| replace:: ``%CRM_BLACKBOX_DIR%``
 .. |CRM_DAEMON_GROUP| replace:: ``%CRM_DAEMON_GROUP%``
 .. |CRM_DAEMON_USER| replace:: ``%CRM_DAEMON_USER%``
+.. |CRM_DAEMON_USER_RAW| replace:: %CRM_DAEMON_USER%
 .. |CRM_SCHEMA_DIRECTORY| replace:: %CRM_SCHEMA_DIRECTORY%
 .. |PCMK_AUTHKEY_FILE| replace:: %PACEMAKER_CONFIG_DIR%/authkey
 .. |PCMK_CONFIG_FILE| replace:: ``%CONFIGDIR%/pacemaker``


### PR DESCRIPTION
And use substitutions where possible for hacluster and haclient.