### PR TITLE
Fix: attrd: Regression in transient attr deletions

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -373,7 +373,8 @@ static int
 add_unset_attr_update(const attribute_t *attr, const char *attr_id,
                       const char *node_id, const char *set_id)
 {
-    char *xpath = crm_strdup_printf("/" XML_CIB_TAG_STATUS
+    char *xpath = crm_strdup_printf("/" XML_TAG_CIB
+                                    "/" XML_CIB_TAG_STATUS
                                     "/" XML_CIB_TAG_STATE
                                         "[@" XML_ATTR_ID "='%s']"
                                     "/" XML_TAG_TRANSIENT_NODEATTRS


### PR DESCRIPTION
Already in 2.1 branch

73b8c033 modified attrd to use a CIB transaction in attrd_write_attribute(). However, attribute-delete requests had no effect because "/cib" was missing from the CIB delete request's XPath.

Ref T732