### PR TITLE
Some crm_get_msec() best practices

### DIFF
--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1668,7 +1668,9 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
 
         op_timeout = g_hash_table_lookup(params, "pcmk_monitor_timeout");
         if (op_timeout != NULL) {
-            op->timeout = crm_get_msec(op_timeout);
+            long long timeout_ms = crm_get_msec(op_timeout);
+
+            op->timeout = (int) QB_MIN(timeout_ms, INT_MAX);
         }
     }
 

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -1006,7 +1006,7 @@ controld_execute_fence_action(pcmk__graph_t *graph,
 bool
 controld_verify_stonith_watchdog_timeout(const char *value)
 {
-    long st_timeout = value? crm_get_msec(value) : 0;
+    long long st_timeout = (value != NULL)? crm_get_msec(value) : 0;
     const char *our_nodename = controld_globals.our_nodename;
 
     if (st_timeout == 0

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -212,7 +212,7 @@ update_stonith_watchdog_timeout_ms(xmlNode *cib)
         timeout_ms = pcmk__auto_stonith_watchdog_timeout();
     }
 
-    stonith_watchdog_timeout_ms = (long) QB_MIN(timeout_ms, LONG_MAX);
+    stonith_watchdog_timeout_ms = timeout_ms;
 }
 
 /*!
@@ -601,7 +601,7 @@ update_fencing_topology(const char *event, xmlNode * msg)
 static void
 update_cib_cache_cb(const char *event, xmlNode * msg)
 {
-    long timeout_ms_saved = stonith_watchdog_timeout_ms;
+    long long timeout_ms_saved = stonith_watchdog_timeout_ms;
     bool need_full_refresh = false;
 
     if(!have_cib_devices) {

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -195,7 +195,7 @@ remove_cib_device(xmlXPathObjectPtr xpathObj)
 static void
 update_stonith_watchdog_timeout_ms(xmlNode *cib)
 {
-    long timeout_ms = 0;
+    long long timeout_ms = 0;
     xmlNode *stonith_watchdog_xml = NULL;
     const char *value = NULL;
 
@@ -212,7 +212,7 @@ update_stonith_watchdog_timeout_ms(xmlNode *cib)
         timeout_ms = pcmk__auto_stonith_watchdog_timeout();
     }
 
-    stonith_watchdog_timeout_ms = timeout_ms;
+    stonith_watchdog_timeout_ms = (long) QB_MIN(timeout_ms, LONG_MAX);
 }
 
 /*!

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -42,7 +42,7 @@
 #define SUMMARY "daemon for executing fencing devices in a Pacemaker cluster"
 
 char *stonith_our_uname = NULL;
-long stonith_watchdog_timeout_ms = 0;
+long long stonith_watchdog_timeout_ms = 0;
 GList *stonith_watchdog_targets = NULL;
 
 static GMainLoop *mainloop = NULL;

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -327,7 +327,7 @@ extern char *stonith_our_uname;
 extern gboolean stand_alone;
 extern GHashTable *device_list;
 extern GHashTable *topology;
-extern long stonith_watchdog_timeout_ms;
+extern long long stonith_watchdog_timeout_ms;
 extern GList *stonith_watchdog_targets;
 extern GHashTable *stonith_remote_op_list;
 extern crm_exit_t exit_code;

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -400,8 +400,12 @@ pcmk_shutdown_worker(gpointer user_data)
     {
         const char *delay = pcmk__env_option(PCMK__ENV_SHUTDOWN_DELAY);
         if(delay) {
+            long long delay_ms = crm_get_msec(delay);
+
             sync();
-            pcmk__sleep_ms(crm_get_msec(delay));
+            if (delay_ms > 0) {
+                pcmk__sleep_ms((unsigned int) QB_MIN(delay_ms, UINT_MAX));
+            }
         }
     }
 

--- a/lib/common/tests/strings/crm_get_msec_test.c
+++ b/lib/common/tests/strings/crm_get_msec_test.c
@@ -33,6 +33,7 @@ good_input(void **state) {
     assert_int_equal(crm_get_msec("\t100\n"), 100000);
 
     assert_int_equal(crm_get_msec("100ms"), 100);
+    assert_int_equal(crm_get_msec(" 100 ms "), 100);
     assert_int_equal(crm_get_msec("100 MSEC"), 100);
     assert_int_equal(crm_get_msec("1000US"), 1);
     assert_int_equal(crm_get_msec("1000usec"), 1);
@@ -55,6 +56,15 @@ good_input(void **state) {
     assert_int_equal(crm_get_msec("  3.14.159  "), 3000);
     assert_int_equal(crm_get_msec("3.14.159ms"), 3);
     assert_int_equal(crm_get_msec("  3.14.159  ms  "), 3);
+
+    // Questionable
+    assert_int_equal(crm_get_msec(" 100 mshr "), 100);
+    assert_int_equal(crm_get_msec(" 100 ms hr "), 100);
+    assert_int_equal(crm_get_msec(" 100 sasdf "), 100000);
+    assert_int_equal(crm_get_msec(" 100 s asdf "), 100000);
+    assert_int_equal(crm_get_msec(" 3.14 shour "), 3000);
+    assert_int_equal(crm_get_msec(" 3.14 s hour "), 3000);
+    assert_int_equal(crm_get_msec(" 3.14 ms!@#$ "), 3);
 }
 
 static void

--- a/lib/common/tests/strings/crm_get_msec_test.c
+++ b/lib/common/tests/strings/crm_get_msec_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the Pacemaker project contributors
+ * Copyright 2021-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,6 +19,11 @@ bad_input(void **state) {
     assert_int_equal(crm_get_msec("100xs"), PCMK__PARSE_INT_DEFAULT);
     assert_int_equal(crm_get_msec(" 100 xs "), PCMK__PARSE_INT_DEFAULT);
     assert_int_equal(crm_get_msec("-100ms"), PCMK__PARSE_INT_DEFAULT);
+
+    assert_int_equal(crm_get_msec("3.xs"), PCMK__PARSE_INT_DEFAULT);
+    assert_int_equal(crm_get_msec("  3.   xs  "), PCMK__PARSE_INT_DEFAULT);
+    assert_int_equal(crm_get_msec("3.14xs"), PCMK__PARSE_INT_DEFAULT);
+    assert_int_equal(crm_get_msec("  3.14  xs  "), PCMK__PARSE_INT_DEFAULT);
 }
 
 static void
@@ -37,6 +42,19 @@ good_input(void **state) {
     assert_int_equal(crm_get_msec("13 min"), 780000);
     assert_int_equal(crm_get_msec("2\th"), 7200000);
     assert_int_equal(crm_get_msec("1 hr"), 3600000);
+
+    assert_int_equal(crm_get_msec("3."), 3000);
+    assert_int_equal(crm_get_msec("  3.  ms  "), 3);
+    assert_int_equal(crm_get_msec("3.14"), 3000);
+    assert_int_equal(crm_get_msec("  3.14  ms  "), 3);
+
+    // Questionable
+    assert_int_equal(crm_get_msec("3.14."), 3000);
+    assert_int_equal(crm_get_msec("  3.14.  ms  "), 3);
+    assert_int_equal(crm_get_msec("3.14.159"), 3000);
+    assert_int_equal(crm_get_msec("  3.14.159  "), 3000);
+    assert_int_equal(crm_get_msec("3.14.159ms"), 3);
+    assert_int_equal(crm_get_msec("  3.14.159  ms  "), 3);
 }
 
 static void

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -47,7 +47,9 @@ get_meta_attrs_from_cib(xmlNode *basenode, pcmk__alert_t *entry,
 
     value = g_hash_table_lookup(config_hash, PCMK_META_TIMEOUT);
     if (value) {
-        entry->timeout = crm_get_msec(value);
+        long long timeout_ms = crm_get_msec(value);
+
+        entry->timeout = (int) QB_MIN(timeout_ms, INT_MAX);
         if (entry->timeout <= 0) {
             if (entry->timeout == 0) {
                 crm_trace("Alert %s uses default timeout of %dmsec",

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -97,7 +97,7 @@ struct {
     char *prop_name;              // Attribute name
     gchar *prop_set;              // --set-name (attribute block XML ID)
     gchar *prop_value;            // --parameter-value (attribute value)
-    int timeout_ms;               // Parsed from --timeout value
+    long long timeout_ms;         // Parsed from --timeout value
     char *agent_spec;             // Standard and/or provider and/or agent
     gchar *xml_file;              // Value of (deprecated) --xml-file
     int check_level;              // Optional value of --validate or --force-check
@@ -898,6 +898,13 @@ set_prop_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError
 gboolean
 timeout_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
     options.timeout_ms = crm_get_msec(optarg);
+
+    if (options.timeout_ms < 0) {
+        crm_warn("Ignoring invalid timeout '%s'", optarg);
+        options.timeout_ms = 0;
+    } else {
+        options.timeout_ms = QB_MIN(options.timeout_ms, INT_MAX);
+    }
     return TRUE;
 }
 


### PR DESCRIPTION
This has two main parts:
* Bounds-check the return value in callers, ensuring we don't overflow the data type where we want to store it.
* Make the body more maintainable.

In service of maintainability, I added a dynamically allocated buffer. It's not technically necessary, but it's MUCH easier to reason about what's happening this way.

We could use a fixed-size buffer based on the length of a long long if we assume it's always 64 bits -- which is not guaranteed by the standard. I don't want to have to think about edge cases involving truncation of the number or the units in an overly long input string.

I got rid of the pointer to where the number starts and how long the number is, as well as the check of the particular kind of whitespace character at the end of the string. I replaced all that with a function that makes a copy into a buffer, stripping out all the whitespace (from both ends and from the middle) and truncating decimals. 

I'm also using `scan_ll()`'s `end_text` argument to get the units now. The effect is the same.

As noted in the comments and the new tests, there is some questionable behavior:
* The number part can have an unbounded number of decimal points. We ignore all decimal points and digits between the first decimal point and the next non-decimal point, non-digit character. So "3.14.159 ms" is perfectly valid and gets treated as "3ms".
* If the units start with "s", "ms", "us", "m", or "hr", we accept them. It makes no difference what comes after that. We can have garbage (e.g., "3 ms!@#$" == "3ms") or multiple units (e.g., "3 ms hour" == "3mshour" == "3ms).

---

I started this work to prepare to add a new function that's like `crm_get_msec()` but accepts negative timeouts. There's no longer a use case for that currently, but I felt this was still worthwhile.