### PR TITLE
Formatted output for cluster options (part 1)

### DIFF
--- a/cts/cli/regression.acls.exp
+++ b/cts/cli/regression.acls.exp
@@ -30,8 +30,8 @@ A new shadow instance was created. To begin using it, enter the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -87,8 +87,8 @@ A new shadow instance was created. To begin using it, enter the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -145,8 +145,8 @@ A new shadow instance was created. To begin using it, enter the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -203,8 +203,8 @@ A new shadow instance was created. To begin using it, enter the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -264,8 +264,8 @@ A new shadow instance was created. To begin using it, enter the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -328,8 +328,8 @@ A new shadow instance was created. To begin using it, enter the following into y
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -433,8 +433,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -506,8 +506,8 @@ pcmk__apply_creation_acl 	trace: ACLs allow creation of <nvpair> with id="cib-bo
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -577,8 +577,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -643,8 +643,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -711,8 +711,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -801,8 +801,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -877,8 +877,8 @@ Stopped
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -951,8 +951,8 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1028,8 +1028,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1154,8 +1154,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1229,8 +1229,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1303,8 +1303,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1377,8 +1377,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1451,8 +1451,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1522,8 +1522,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1589,8 +1589,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1656,8 +1656,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1723,8 +1723,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1790,8 +1790,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1857,8 +1857,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1924,8 +1924,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -1991,8 +1991,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -2058,8 +2058,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -2127,8 +2127,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -2196,8 +2196,8 @@ Call failed: Permission denied
       </acl_user>
       <acl_role id="observer">
         <read id="observer-read-1" xpath="/cib"/>
-        <write id="observer-write-1" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <write id="observer-write-2" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <write id="observer-write-1" xpath="//nvpair[@name='stonith-enabled']"/>
+        <write id="observer-write-2" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <read id="admin-read-1" xpath="/cib"/>
@@ -2273,8 +2273,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2388,8 +2388,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2469,8 +2469,8 @@ crm_attribute: Error performing operation: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2549,8 +2549,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2624,8 +2624,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2701,8 +2701,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2800,8 +2800,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2885,8 +2885,8 @@ Stopped
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -2968,8 +2968,8 @@ Deleted 'dummy' option: id=dummy-meta_attributes-target-role name=target-role
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3054,8 +3054,8 @@ Set 'dummy' option: id=dummy-meta_attributes-target-role set=dummy-meta_attribut
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3189,8 +3189,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3273,8 +3273,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3356,8 +3356,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3439,8 +3439,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3522,8 +3522,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3602,8 +3602,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3678,8 +3678,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3754,8 +3754,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3830,8 +3830,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3906,8 +3906,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -3982,8 +3982,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -4058,8 +4058,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -4134,8 +4134,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -4210,8 +4210,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -4288,8 +4288,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>
@@ -4366,8 +4366,8 @@ Call failed: Permission denied
       </acl_target>
       <acl_role id="observer">
         <acl_permission id="observer-read-1" kind="read" xpath="/cib"/>
-        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name=&apos;stonith-enabled&apos;]"/>
-        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name=&apos;target-role&apos;]"/>
+        <acl_permission id="observer-write-1" kind="write" xpath="//nvpair[@name='stonith-enabled']"/>
+        <acl_permission id="observer-write-2" kind="write" xpath="//nvpair[@name='target-role']"/>
       </acl_role>
       <acl_role id="admin">
         <acl_permission id="admin-read-1" kind="read" xpath="/cib"/>

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -1,18 +1,31 @@
 =#=#=#= Begin test: Get CIB manager metadata =#=#=#=
-<?xml version=""?>
 <resource-agent name="pacemaker-based" version="">
-  <version>1.1</version>
-  <longdesc lang="en">Cluster options used by Pacemaker's Cluster Information Base manager</longdesc>
-  <shortdesc lang="en">Cluster Information Base manager options</shortdesc>
+  <version>
+    1.1
+  </version>
+  <longdesc lang="en">
+    Cluster options used by Pacemaker's Cluster Information Base manager
+  </longdesc>
+  <shortdesc lang="en">
+    Cluster Information Base manager options
+  </shortdesc>
   <parameters>
     <parameter name="enable-acl">
-      <longdesc lang="en">Enable Access Control Lists (ACLs) for the CIB</longdesc>
-      <shortdesc lang="en">Enable Access Control Lists (ACLs) for the CIB</shortdesc>
+      <longdesc lang="en">
+        Enable Access Control Lists (ACLs) for the CIB
+      </longdesc>
+      <shortdesc lang="en">
+        Enable Access Control Lists (ACLs) for the CIB
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="cluster-ipc-limit">
-      <longdesc lang="en">Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
-      <shortdesc lang="en">Maximum IPC message backlog before disconnecting a cluster daemon</shortdesc>
+      <longdesc lang="en">
+        Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
+      </longdesc>
+      <shortdesc lang="en">
+        Maximum IPC message backlog before disconnecting a cluster daemon
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
   </parameters>
@@ -20,88 +33,153 @@
 =#=#=#= End test: Get CIB manager metadata - OK (0) =#=#=#=
 * Passed: pacemaker-based - Get CIB manager metadata
 =#=#=#= Begin test: Get controller metadata =#=#=#=
-<?xml version=""?>
 <resource-agent name="pacemaker-controld" version="">
-  <version>1.1</version>
-  <longdesc lang="en">Cluster options used by Pacemaker's controller</longdesc>
-  <shortdesc lang="en">Pacemaker controller options</shortdesc>
+  <version>
+    1.1
+  </version>
+  <longdesc lang="en">
+    Cluster options used by Pacemaker's controller
+  </longdesc>
+  <shortdesc lang="en">
+    Pacemaker controller options
+  </shortdesc>
   <parameters>
     <parameter name="dc-version">
-      <longdesc lang="en">Includes a hash which identifies the exact revision the code was built from. Used for diagnostic purposes.</longdesc>
-      <shortdesc lang="en">Pacemaker version on cluster node elected Designated Controller (DC)</shortdesc>
+      <longdesc lang="en">
+        Includes a hash which identifies the exact revision the code was built from. Used for diagnostic purposes.
+      </longdesc>
+      <shortdesc lang="en">
+        Pacemaker version on cluster node elected Designated Controller (DC)
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="cluster-infrastructure">
-      <longdesc lang="en">Used for informational and diagnostic purposes.</longdesc>
-      <shortdesc lang="en">The messaging layer on which Pacemaker is currently running</shortdesc>
+      <longdesc lang="en">
+        Used for informational and diagnostic purposes.
+      </longdesc>
+      <shortdesc lang="en">
+        The messaging layer on which Pacemaker is currently running
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="cluster-name">
-      <longdesc lang="en">This optional value is mostly for users' convenience as desired in administration, but may also be used in Pacemaker configuration rules via the #cluster-name node attribute, and by higher-level tools and resource agents.</longdesc>
-      <shortdesc lang="en">An arbitrary name for the cluster</shortdesc>
+      <longdesc lang="en">
+        This optional value is mostly for users' convenience as desired in administration, but may also be used in Pacemaker configuration rules via the #cluster-name node attribute, and by higher-level tools and resource agents.
+      </longdesc>
+      <shortdesc lang="en">
+        An arbitrary name for the cluster
+      </shortdesc>
       <content type="string"/>
     </parameter>
     <parameter name="dc-deadtime">
-      <longdesc lang="en">The optimal value will depend on the speed and load of your network and the type of switches used.</longdesc>
-      <shortdesc lang="en">How long to wait for a response from other nodes during start-up</shortdesc>
+      <longdesc lang="en">
+        The optimal value will depend on the speed and load of your network and the type of switches used.
+      </longdesc>
+      <shortdesc lang="en">
+        How long to wait for a response from other nodes during start-up
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="cluster-recheck-interval">
-      <longdesc lang="en">Pacemaker is primarily event-driven, and looks ahead to know when to recheck cluster state for failure-timeout settings and most time-based rules. However, it will also recheck the cluster after this amount of inactivity, to evaluate rules with date specifications and serve as a fail-safe for certain types of scheduler bugs. A value of 0 disables polling. A positive value sets an interval in seconds, unless other units are specified (for example, "5min").</longdesc>
-      <shortdesc lang="en">Polling interval to recheck cluster state and evaluate rules with date specifications</shortdesc>
+      <longdesc lang="en">
+        Pacemaker is primarily event-driven, and looks ahead to know when to recheck cluster state for failure-timeout settings and most time-based rules. However, it will also recheck the cluster after this amount of inactivity, to evaluate rules with date specifications and serve as a fail-safe for certain types of scheduler bugs. A value of 0 disables polling. A positive value sets an interval in seconds, unless other units are specified (for example, "5min").
+      </longdesc>
+      <shortdesc lang="en">
+        Polling interval to recheck cluster state and evaluate rules with date specifications
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="fence-reaction">
-      <longdesc lang="en">A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure.</longdesc>
-      <shortdesc lang="en">How a cluster node should react if notified of its own fencing</shortdesc>
+      <longdesc lang="en">
+        A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure.
+      </longdesc>
+      <shortdesc lang="en">
+        How a cluster node should react if notified of its own fencing
+      </shortdesc>
       <content type="select" default="">
-        <option value="stop" />
-        <option value="panic" />
+        <option value="stop"/>
+        <option value="panic"/>
       </content>
     </parameter>
     <parameter name="election-timeout">
-      <longdesc lang="en">Declare an election failed if it is not decided within this much time. If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <longdesc lang="en">
+        Declare an election failed if it is not decided within this much time. If you need to adjust this value, it probably indicates the presence of a bug.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only ***
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="shutdown-escalation">
-      <longdesc lang="en">Exit immediately if shutdown does not complete within this much time. If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <longdesc lang="en">
+        Exit immediately if shutdown does not complete within this much time. If you need to adjust this value, it probably indicates the presence of a bug.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only ***
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="join-integration-timeout">
-      <longdesc lang="en">If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <longdesc lang="en">
+        If you need to adjust this value, it probably indicates the presence of a bug.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only ***
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="join-finalization-timeout">
-      <longdesc lang="en">If you need to adjust this value, it probably indicates the presence of a bug.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only ***</shortdesc>
+      <longdesc lang="en">
+        If you need to adjust this value, it probably indicates the presence of a bug.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only ***
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="transition-delay">
-      <longdesc lang="en">Delay cluster recovery for this much time to allow for additional events to occur. Useful if your configuration is sensitive to the order in which ping updates arrive.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Enabling this option will slow down cluster recovery under all conditions</shortdesc>
+      <longdesc lang="en">
+        Delay cluster recovery for this much time to allow for additional events to occur. Useful if your configuration is sensitive to the order in which ping updates arrive.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Enabling this option will slow down cluster recovery under all conditions
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="stonith-watchdog-timeout">
-      <longdesc lang="en">If this is set to a positive value, lost nodes are assumed to achieve self-fencing using watchdog-based SBD within this much time. This does not require a fencing resource to be explicitly configured, though a fence_watchdog resource can be configured, to limit use to specific nodes. If this is set to 0 (the default), the cluster will never assume watchdog-based self-fencing. If this is set to a negative value, the cluster will use twice the local value of the `SBD_WATCHDOG_TIMEOUT` environment variable if that is positive, or otherwise treat this as 0. WARNING: When used, this timeout must be larger than `SBD_WATCHDOG_TIMEOUT` on all nodes that use watchdog-based SBD, and Pacemaker will refuse to start on any of those nodes where this is not true for the local value or SBD is not active. When this is set to a negative value, `SBD_WATCHDOG_TIMEOUT` must be set to the same value on all nodes that use SBD, otherwise data corruption or loss could occur.</longdesc>
-      <shortdesc lang="en">How long before nodes can be assumed to be safely down when watchdog-based self-fencing via SBD is in use</shortdesc>
+      <longdesc lang="en">
+        If this is set to a positive value, lost nodes are assumed to achieve self-fencing using watchdog-based SBD within this much time. This does not require a fencing resource to be explicitly configured, though a fence_watchdog resource can be configured, to limit use to specific nodes. If this is set to 0 (the default), the cluster will never assume watchdog-based self-fencing. If this is set to a negative value, the cluster will use twice the local value of the `SBD_WATCHDOG_TIMEOUT` environment variable if that is positive, or otherwise treat this as 0. WARNING: When used, this timeout must be larger than `SBD_WATCHDOG_TIMEOUT` on all nodes that use watchdog-based SBD, and Pacemaker will refuse to start on any of those nodes where this is not true for the local value or SBD is not active. When this is set to a negative value, `SBD_WATCHDOG_TIMEOUT` must be set to the same value on all nodes that use SBD, otherwise data corruption or loss could occur.
+      </longdesc>
+      <shortdesc lang="en">
+        How long before nodes can be assumed to be safely down when watchdog-based self-fencing via SBD is in use
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="stonith-max-attempts">
-      <longdesc lang="en">How many times fencing can fail before it will no longer be immediately re-attempted on a target</longdesc>
-      <shortdesc lang="en">How many times fencing can fail before it will no longer be immediately re-attempted on a target</shortdesc>
+      <longdesc lang="en">
+        How many times fencing can fail before it will no longer be immediately re-attempted on a target
+      </longdesc>
+      <shortdesc lang="en">
+        How many times fencing can fail before it will no longer be immediately re-attempted on a target
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="load-threshold">
-      <longdesc lang="en">The cluster will slow down its recovery process when the amount of system resources used (currently CPU) approaches this limit</longdesc>
-      <shortdesc lang="en">Maximum amount of system load that should be used by cluster nodes</shortdesc>
+      <longdesc lang="en">
+        The cluster will slow down its recovery process when the amount of system resources used (currently CPU) approaches this limit
+      </longdesc>
+      <shortdesc lang="en">
+        Maximum amount of system load that should be used by cluster nodes
+      </shortdesc>
       <content type="percentage" default=""/>
     </parameter>
     <parameter name="node-action-limit">
-      <longdesc lang="en">Maximum number of jobs that can be scheduled per node (defaults to 2x cores)</longdesc>
-      <shortdesc lang="en">Maximum number of jobs that can be scheduled per node (defaults to 2x cores)</shortdesc>
+      <longdesc lang="en">
+        Maximum number of jobs that can be scheduled per node (defaults to 2x cores)
+      </longdesc>
+      <shortdesc lang="en">
+        Maximum number of jobs that can be scheduled per node (defaults to 2x cores)
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
   </parameters>
@@ -109,140 +187,245 @@
 =#=#=#= End test: Get controller metadata - OK (0) =#=#=#=
 * Passed: pacemaker-controld - Get controller metadata
 =#=#=#= Begin test: Get fencer metadata =#=#=#=
-<?xml version=""?>
 <resource-agent name="pacemaker-fenced" version="">
-  <version>1.1</version>
-  <longdesc lang="en">Instance attributes available for all "stonith"-class resources and used by Pacemaker's fence daemon, formerly known as stonithd</longdesc>
-  <shortdesc lang="en">Instance attributes available for all "stonith"-class resources</shortdesc>
+  <version>
+    1.1
+  </version>
+  <longdesc lang="en">
+    Instance attributes available for all "stonith"-class resources and used by Pacemaker's fence daemon, formerly known as stonithd
+  </longdesc>
+  <shortdesc lang="en">
+    Instance attributes available for all "stonith"-class resources
+  </shortdesc>
   <parameters>
     <parameter name="pcmk_host_argument">
-      <longdesc lang="en">Some devices do not support the standard 'port' parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of "none" can be used to tell the cluster not to supply any additional parameters.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate parameter to supply instead of 'port'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard 'port' parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of "none" can be used to tell the cluster not to supply any additional parameters.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate parameter to supply instead of 'port'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_map">
-      <longdesc lang="en">For example, "node1:1;node2:2,3" would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2.</longdesc>
-      <shortdesc lang="en">A mapping of node names to port numbers for devices that do not support node names.</shortdesc>
+      <longdesc lang="en">
+        For example, "node1:1;node2:2,3" would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2.
+      </longdesc>
+      <shortdesc lang="en">
+        A mapping of node names to port numbers for devices that do not support node names.
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_list">
-      <longdesc lang="en">For example, "node1,node2,node3".</longdesc>
-      <shortdesc lang="en">A list of nodes that can be targeted by this device (optional unless pcmk_host_list="static-list")</shortdesc>
+      <longdesc lang="en">
+        For example, "node1,node2,node3".
+      </longdesc>
+      <shortdesc lang="en">
+        A list of nodes that can be targeted by this device (optional unless pcmk_host_list="static-list")
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_check">
-      <longdesc lang="en">Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node.</longdesc>
-      <shortdesc lang="en">How to determine which nodes can be targeted by the device</shortdesc>
+      <longdesc lang="en">
+        Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node.
+      </longdesc>
+      <shortdesc lang="en">
+        How to determine which nodes can be targeted by the device
+      </shortdesc>
       <content type="select" default="">
-        <option value="dynamic-list" />
-        <option value="static-list" />
-        <option value="status" />
-        <option value="none" />
+        <option value="dynamic-list"/>
+        <option value="static-list"/>
+        <option value="status"/>
+        <option value="none"/>
       </content>
     </parameter>
     <parameter name="pcmk_delay_max">
-      <longdesc lang="en">Enable a delay of no more than the time specified before executing fencing actions. Pacemaker derives the overall delay by taking the value of pcmk_delay_base and adding a random delay value such that the sum is kept below this maximum.</longdesc>
-      <shortdesc lang="en">Enable a base delay for fencing actions and specify base delay value.</shortdesc>
+      <longdesc lang="en">
+        Enable a delay of no more than the time specified before executing fencing actions. Pacemaker derives the overall delay by taking the value of pcmk_delay_base and adding a random delay value such that the sum is kept below this maximum.
+      </longdesc>
+      <shortdesc lang="en">
+        Enable a base delay for fencing actions and specify base delay value.
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_delay_base">
-      <longdesc lang="en">This enables a static delay for fencing actions, which can help avoid "death matches" where two nodes try to fence each other at the same time. If pcmk_delay_max is also used, a random delay will be added such that the total delay is kept below that value. This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, "node1:1s;node2:5") to set a different value for each target.</longdesc>
-      <shortdesc lang="en">Enable a base delay for fencing actions and specify base delay value.</shortdesc>
+      <longdesc lang="en">
+        This enables a static delay for fencing actions, which can help avoid "death matches" where two nodes try to fence each other at the same time. If pcmk_delay_max is also used, a random delay will be added such that the total delay is kept below that value. This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, "node1:1s;node2:5") to set a different value for each target.
+      </longdesc>
+      <shortdesc lang="en">
+        Enable a base delay for fencing actions and specify base delay value.
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_action_limit">
-      <longdesc lang="en">Cluster property concurrent-fencing="true" needs to be configured first. Then use this to specify the maximum number of actions can be performed in parallel on this device. A value of -1 means an unlimited number of actions can be performed in parallel.</longdesc>
-      <shortdesc lang="en">The maximum number of actions can be performed in parallel on this device</shortdesc>
+      <longdesc lang="en">
+        Cluster property concurrent-fencing="true" needs to be configured first. Then use this to specify the maximum number of actions can be performed in parallel on this device. A value of -1 means an unlimited number of actions can be performed in parallel.
+      </longdesc>
+      <shortdesc lang="en">
+        The maximum number of actions can be performed in parallel on this device
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_reboot_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'reboot' action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'reboot'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'reboot' action.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate command to run instead of 'reboot'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_reboot_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'reboot' actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">
+        Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'reboot' actions.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_reboot_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'reboot' action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'reboot' command within the timeout period</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'reboot' action before giving up.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** The maximum number of times to try the 'reboot' command within the timeout period
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_off_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'off' action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'off'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'off' action.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate command to run instead of 'off'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_off_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'off' actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'off' actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">
+        Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'off' actions.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'off' actions instead of stonith-timeout
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_off_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'off' action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'off' command within the timeout period</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'off' action before giving up.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** The maximum number of times to try the 'off' command within the timeout period
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_on_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'on' action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'on'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'on' action.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate command to run instead of 'on'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_on_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'on' actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'on' actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">
+        Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'on' actions.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'on' actions instead of stonith-timeout
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_on_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'on' action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'on' command within the timeout period</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'on' action before giving up.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** The maximum number of times to try the 'on' command within the timeout period
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_list_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'list' action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'list'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'list' action.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate command to run instead of 'list'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_list_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'list' actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'list' actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">
+        Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'list' actions.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'list' actions instead of stonith-timeout
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_list_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'list' action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'list' command within the timeout period</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'list' action before giving up.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** The maximum number of times to try the 'list' command within the timeout period
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_monitor_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'monitor' action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'monitor'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'monitor' action.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate command to run instead of 'monitor'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_monitor_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'monitor' actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">
+        Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'monitor' actions.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_monitor_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'monitor' action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'monitor' command within the timeout period</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'monitor' action before giving up.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** The maximum number of times to try the 'monitor' command within the timeout period
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_status_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'status' action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'status'</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'status' action.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** An alternate command to run instead of 'status'
+      </shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_status_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'status' actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'status' actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">
+        Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'status' actions.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'status' actions instead of stonith-timeout
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_status_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'status' action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'status' command within the timeout period</shortdesc>
+      <longdesc lang="en">
+        Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'status' action before giving up.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** The maximum number of times to try the 'status' command within the timeout period
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
   </parameters>
@@ -250,186 +433,315 @@
 =#=#=#= End test: Get fencer metadata - OK (0) =#=#=#=
 * Passed: pacemaker-fenced - Get fencer metadata
 =#=#=#= Begin test: Get scheduler metadata =#=#=#=
-<?xml version=""?>
 <resource-agent name="pacemaker-schedulerd" version="">
-  <version>1.1</version>
-  <longdesc lang="en">Cluster options used by Pacemaker's scheduler</longdesc>
-  <shortdesc lang="en">Pacemaker scheduler options</shortdesc>
+  <version>
+    1.1
+  </version>
+  <longdesc lang="en">
+    Cluster options used by Pacemaker's scheduler
+  </longdesc>
+  <shortdesc lang="en">
+    Pacemaker scheduler options
+  </shortdesc>
   <parameters>
     <parameter name="no-quorum-policy">
-      <longdesc lang="en">What to do when the cluster does not have quorum</longdesc>
-      <shortdesc lang="en">What to do when the cluster does not have quorum</shortdesc>
+      <longdesc lang="en">
+        What to do when the cluster does not have quorum
+      </longdesc>
+      <shortdesc lang="en">
+        What to do when the cluster does not have quorum
+      </shortdesc>
       <content type="select" default="">
-        <option value="stop" />
-        <option value="freeze" />
-        <option value="ignore" />
-        <option value="demote" />
-        <option value="suicide" />
+        <option value="stop"/>
+        <option value="freeze"/>
+        <option value="ignore"/>
+        <option value="demote"/>
+        <option value="suicide"/>
       </content>
     </parameter>
     <parameter name="shutdown-lock">
-      <longdesc lang="en">When true, resources active on a node when it is cleanly shut down are kept "locked" to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.</longdesc>
-      <shortdesc lang="en">Whether to lock resources to a cleanly shut down node</shortdesc>
+      <longdesc lang="en">
+        When true, resources active on a node when it is cleanly shut down are kept "locked" to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.
+      </longdesc>
+      <shortdesc lang="en">
+        Whether to lock resources to a cleanly shut down node
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="shutdown-lock-limit">
-      <longdesc lang="en">If shutdown-lock is true and this is set to a nonzero time duration, shutdown locks will expire after this much time has passed since the shutdown was initiated, even if the node has not rejoined.</longdesc>
-      <shortdesc lang="en">Do not lock resources to a cleanly shut down node longer than this</shortdesc>
+      <longdesc lang="en">
+        If shutdown-lock is true and this is set to a nonzero time duration, shutdown locks will expire after this much time has passed since the shutdown was initiated, even if the node has not rejoined.
+      </longdesc>
+      <shortdesc lang="en">
+        Do not lock resources to a cleanly shut down node longer than this
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="symmetric-cluster">
-      <longdesc lang="en">Whether resources can run on any node by default</longdesc>
-      <shortdesc lang="en">Whether resources can run on any node by default</shortdesc>
+      <longdesc lang="en">
+        Whether resources can run on any node by default
+      </longdesc>
+      <shortdesc lang="en">
+        Whether resources can run on any node by default
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="maintenance-mode">
-      <longdesc lang="en">Whether the cluster should refrain from monitoring, starting, and stopping resources</longdesc>
-      <shortdesc lang="en">Whether the cluster should refrain from monitoring, starting, and stopping resources</shortdesc>
+      <longdesc lang="en">
+        Whether the cluster should refrain from monitoring, starting, and stopping resources
+      </longdesc>
+      <shortdesc lang="en">
+        Whether the cluster should refrain from monitoring, starting, and stopping resources
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="start-failure-is-fatal">
-      <longdesc lang="en">When true, the cluster will immediately ban a resource from a node if it fails to start there. When false, the cluster will instead check the resource's fail count against its migration-threshold.</longdesc>
-      <shortdesc lang="en">Whether a start failure should prevent a resource from being recovered on the same node</shortdesc>
+      <longdesc lang="en">
+        When true, the cluster will immediately ban a resource from a node if it fails to start there. When false, the cluster will instead check the resource's fail count against its migration-threshold.
+      </longdesc>
+      <shortdesc lang="en">
+        Whether a start failure should prevent a resource from being recovered on the same node
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="enable-startup-probes">
-      <longdesc lang="en">Whether the cluster should check for active resources during start-up</longdesc>
-      <shortdesc lang="en">Whether the cluster should check for active resources during start-up</shortdesc>
+      <longdesc lang="en">
+        Whether the cluster should check for active resources during start-up
+      </longdesc>
+      <shortdesc lang="en">
+        Whether the cluster should check for active resources during start-up
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stonith-enabled">
-      <longdesc lang="en">If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Whether nodes may be fenced as part of recovery</shortdesc>
+      <longdesc lang="en">
+        If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Whether nodes may be fenced as part of recovery
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stonith-action">
-      <longdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")</longdesc>
-      <shortdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")</shortdesc>
+      <longdesc lang="en">
+        Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")
+      </longdesc>
+      <shortdesc lang="en">
+        Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")
+      </shortdesc>
       <content type="select" default="">
-        <option value="reboot" />
-        <option value="off" />
-        <option value="poweroff" />
+        <option value="reboot"/>
+        <option value="off"/>
+        <option value="poweroff"/>
       </content>
     </parameter>
     <parameter name="stonith-timeout">
-      <longdesc lang="en">How long to wait for on, off, and reboot fence actions to complete by default</longdesc>
-      <shortdesc lang="en">How long to wait for on, off, and reboot fence actions to complete by default</shortdesc>
+      <longdesc lang="en">
+        How long to wait for on, off, and reboot fence actions to complete by default
+      </longdesc>
+      <shortdesc lang="en">
+        How long to wait for on, off, and reboot fence actions to complete by default
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="have-watchdog">
-      <longdesc lang="en">This is set automatically by the cluster according to whether SBD is detected to be in use. User-configured values are ignored. The value `true` is meaningful if diskless SBD is used and `stonith-watchdog-timeout` is nonzero. In that case, if fencing is required, watchdog-based self-fencing will be performed via SBD without requiring a fencing resource explicitly configured.</longdesc>
-      <shortdesc lang="en">Whether watchdog integration is enabled</shortdesc>
+      <longdesc lang="en">
+        This is set automatically by the cluster according to whether SBD is detected to be in use. User-configured values are ignored. The value `true` is meaningful if diskless SBD is used and `stonith-watchdog-timeout` is nonzero. In that case, if fencing is required, watchdog-based self-fencing will be performed via SBD without requiring a fencing resource explicitly configured.
+      </longdesc>
+      <shortdesc lang="en">
+        Whether watchdog integration is enabled
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="concurrent-fencing">
-      <longdesc lang="en">Allow performing fencing operations in parallel</longdesc>
-      <shortdesc lang="en">Allow performing fencing operations in parallel</shortdesc>
+      <longdesc lang="en">
+        Allow performing fencing operations in parallel
+      </longdesc>
+      <shortdesc lang="en">
+        Allow performing fencing operations in parallel
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="startup-fencing">
-      <longdesc lang="en">Setting this to false may lead to a "split-brain" situation, potentially leading to data loss and/or service unavailability.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Whether to fence unseen nodes at start-up</shortdesc>
+      <longdesc lang="en">
+        Setting this to false may lead to a "split-brain" situation, potentially leading to data loss and/or service unavailability.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Whether to fence unseen nodes at start-up
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="priority-fencing-delay">
-      <longdesc lang="en">Apply specified delay for the fencings that are targeting the lost nodes with the highest total resource priority in case we don't have the majority of the nodes in our cluster partition, so that the more significant nodes potentially win any fencing match, which is especially meaningful under split-brain of 2-node cluster. A promoted resource instance takes the base priority + 1 on calculation if the base priority is not 0. Any static/random delays that are introduced by `pcmk_delay_base/max` configured for the corresponding fencing resources will be added to this delay. This delay should be significantly greater than, safely twice, the maximum `pcmk_delay_base/max`. By default, priority fencing delay is disabled.</longdesc>
-      <shortdesc lang="en">Apply fencing delay targeting the lost nodes with the highest total resource priority</shortdesc>
+      <longdesc lang="en">
+        Apply specified delay for the fencings that are targeting the lost nodes with the highest total resource priority in case we don't have the majority of the nodes in our cluster partition, so that the more significant nodes potentially win any fencing match, which is especially meaningful under split-brain of 2-node cluster. A promoted resource instance takes the base priority + 1 on calculation if the base priority is not 0. Any static/random delays that are introduced by `pcmk_delay_base/max` configured for the corresponding fencing resources will be added to this delay. This delay should be significantly greater than, safely twice, the maximum `pcmk_delay_base/max`. By default, priority fencing delay is disabled.
+      </longdesc>
+      <shortdesc lang="en">
+        Apply fencing delay targeting the lost nodes with the highest total resource priority
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="node-pending-timeout">
-      <longdesc lang="en">Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes. Setting the value to 2h means fence nodes after 2 hours.</longdesc>
-      <shortdesc lang="en">How long to wait for a node that has joined the cluster to join the controller process group</shortdesc>
+      <longdesc lang="en">
+        Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes. Setting the value to 2h means fence nodes after 2 hours.
+      </longdesc>
+      <shortdesc lang="en">
+        How long to wait for a node that has joined the cluster to join the controller process group
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="cluster-delay">
-      <longdesc lang="en">The node elected Designated Controller (DC) will consider an action failed if it does not get a response from the node executing the action within this time (after considering the action's own timeout). The "correct" value will depend on the speed and load of your network and cluster nodes.</longdesc>
-      <shortdesc lang="en">Maximum time for node-to-node communication</shortdesc>
+      <longdesc lang="en">
+        The node elected Designated Controller (DC) will consider an action failed if it does not get a response from the node executing the action within this time (after considering the action's own timeout). The "correct" value will depend on the speed and load of your network and cluster nodes.
+      </longdesc>
+      <shortdesc lang="en">
+        Maximum time for node-to-node communication
+      </shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="batch-limit">
-      <longdesc lang="en">The "correct" value will depend on the speed and load of your network and cluster nodes. If set to 0, the cluster will impose a dynamically calculated limit when any node has a high load.</longdesc>
-      <shortdesc lang="en">Maximum number of jobs that the cluster may execute in parallel across all nodes</shortdesc>
+      <longdesc lang="en">
+        The "correct" value will depend on the speed and load of your network and cluster nodes. If set to 0, the cluster will impose a dynamically calculated limit when any node has a high load.
+      </longdesc>
+      <shortdesc lang="en">
+        Maximum number of jobs that the cluster may execute in parallel across all nodes
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="migration-limit">
-      <longdesc lang="en">The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)</longdesc>
-      <shortdesc lang="en">The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)</shortdesc>
+      <longdesc lang="en">
+        The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)
+      </longdesc>
+      <shortdesc lang="en">
+        The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="stop-all-resources">
-      <longdesc lang="en">Whether the cluster should stop all active resources</longdesc>
-      <shortdesc lang="en">Whether the cluster should stop all active resources</shortdesc>
+      <longdesc lang="en">
+        Whether the cluster should stop all active resources
+      </longdesc>
+      <shortdesc lang="en">
+        Whether the cluster should stop all active resources
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stop-orphan-resources">
-      <longdesc lang="en">Whether to stop resources that were removed from the configuration</longdesc>
-      <shortdesc lang="en">Whether to stop resources that were removed from the configuration</shortdesc>
+      <longdesc lang="en">
+        Whether to stop resources that were removed from the configuration
+      </longdesc>
+      <shortdesc lang="en">
+        Whether to stop resources that were removed from the configuration
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stop-orphan-actions">
-      <longdesc lang="en">Whether to cancel recurring actions removed from the configuration</longdesc>
-      <shortdesc lang="en">Whether to cancel recurring actions removed from the configuration</shortdesc>
+      <longdesc lang="en">
+        Whether to cancel recurring actions removed from the configuration
+      </longdesc>
+      <shortdesc lang="en">
+        Whether to cancel recurring actions removed from the configuration
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="remove-after-stop">
-      <longdesc lang="en">Values other than default are poorly tested and potentially dangerous. This option will be removed in a future release.</longdesc>
-      <shortdesc lang="en">*** Deprecated *** Whether to remove stopped resources from the executor</shortdesc>
+      <longdesc lang="en">
+        Values other than default are poorly tested and potentially dangerous. This option will be removed in a future release.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Deprecated *** Whether to remove stopped resources from the executor
+      </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="pe-error-series-max">
-      <longdesc lang="en">Zero to disable, -1 to store unlimited.</longdesc>
-      <shortdesc lang="en">The number of scheduler inputs resulting in errors to save</shortdesc>
+      <longdesc lang="en">
+        Zero to disable, -1 to store unlimited.
+      </longdesc>
+      <shortdesc lang="en">
+        The number of scheduler inputs resulting in errors to save
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pe-warn-series-max">
-      <longdesc lang="en">Zero to disable, -1 to store unlimited.</longdesc>
-      <shortdesc lang="en">The number of scheduler inputs resulting in warnings to save</shortdesc>
+      <longdesc lang="en">
+        Zero to disable, -1 to store unlimited.
+      </longdesc>
+      <shortdesc lang="en">
+        The number of scheduler inputs resulting in warnings to save
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pe-input-series-max">
-      <longdesc lang="en">Zero to disable, -1 to store unlimited.</longdesc>
-      <shortdesc lang="en">The number of scheduler inputs without errors or warnings to save</shortdesc>
+      <longdesc lang="en">
+        Zero to disable, -1 to store unlimited.
+      </longdesc>
+      <shortdesc lang="en">
+        The number of scheduler inputs without errors or warnings to save
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-strategy">
-      <longdesc lang="en">Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green".</longdesc>
-      <shortdesc lang="en">How cluster should react to node health attributes</shortdesc>
+      <longdesc lang="en">
+        Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green".
+      </longdesc>
+      <shortdesc lang="en">
+        How cluster should react to node health attributes
+      </shortdesc>
       <content type="select" default="">
-        <option value="none" />
-        <option value="migrate-on-red" />
-        <option value="only-green" />
-        <option value="progressive" />
-        <option value="custom" />
+        <option value="none"/>
+        <option value="migrate-on-red"/>
+        <option value="only-green"/>
+        <option value="progressive"/>
+        <option value="custom"/>
       </content>
     </parameter>
     <parameter name="node-health-base">
-      <longdesc lang="en">Only used when "node-health-strategy" is set to "progressive".</longdesc>
-      <shortdesc lang="en">Base health score assigned to a node</shortdesc>
+      <longdesc lang="en">
+        Only used when "node-health-strategy" is set to "progressive".
+      </longdesc>
+      <shortdesc lang="en">
+        Base health score assigned to a node
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-green">
-      <longdesc lang="en">Only used when "node-health-strategy" is set to "custom" or "progressive".</longdesc>
-      <shortdesc lang="en">The score to use for a node health attribute whose value is "green"</shortdesc>
+      <longdesc lang="en">
+        Only used when "node-health-strategy" is set to "custom" or "progressive".
+      </longdesc>
+      <shortdesc lang="en">
+        The score to use for a node health attribute whose value is "green"
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-yellow">
-      <longdesc lang="en">Only used when "node-health-strategy" is set to "custom" or "progressive".</longdesc>
-      <shortdesc lang="en">The score to use for a node health attribute whose value is "yellow"</shortdesc>
+      <longdesc lang="en">
+        Only used when "node-health-strategy" is set to "custom" or "progressive".
+      </longdesc>
+      <shortdesc lang="en">
+        The score to use for a node health attribute whose value is "yellow"
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-red">
-      <longdesc lang="en">Only used when "node-health-strategy" is set to "custom" or "progressive".</longdesc>
-      <shortdesc lang="en">The score to use for a node health attribute whose value is "red"</shortdesc>
+      <longdesc lang="en">
+        Only used when "node-health-strategy" is set to "custom" or "progressive".
+      </longdesc>
+      <shortdesc lang="en">
+        The score to use for a node health attribute whose value is "red"
+      </shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="placement-strategy">
-      <longdesc lang="en">How the cluster should allocate resources to nodes</longdesc>
-      <shortdesc lang="en">How the cluster should allocate resources to nodes</shortdesc>
+      <longdesc lang="en">
+        How the cluster should allocate resources to nodes
+      </longdesc>
+      <shortdesc lang="en">
+        How the cluster should allocate resources to nodes
+      </shortdesc>
       <content type="select" default="">
-        <option value="default" />
-        <option value="utilization" />
-        <option value="minimal" />
-        <option value="balanced" />
+        <option value="default"/>
+        <option value="utilization"/>
+        <option value="minimal"/>
+        <option value="balanced"/>
       </content>
     </parameter>
   </parameters>

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -2,7 +2,7 @@
 <?xml version=""?>
 <resource-agent name="pacemaker-based" version="">
   <version>1.1</version>
-  <longdesc lang="en">Cluster options used by Pacemaker&apos;s Cluster Information Base manager</longdesc>
+  <longdesc lang="en">Cluster options used by Pacemaker's Cluster Information Base manager</longdesc>
   <shortdesc lang="en">Cluster Information Base manager options</shortdesc>
   <parameters>
     <parameter name="enable-acl">
@@ -11,7 +11,7 @@
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="cluster-ipc-limit">
-      <longdesc lang="en">Raise this if log has &quot;Evicting client&quot; messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
+      <longdesc lang="en">Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
       <shortdesc lang="en">Maximum IPC message backlog before disconnecting a cluster daemon</shortdesc>
       <content type="integer" default=""/>
     </parameter>
@@ -23,7 +23,7 @@
 <?xml version=""?>
 <resource-agent name="pacemaker-controld" version="">
   <version>1.1</version>
-  <longdesc lang="en">Cluster options used by Pacemaker&apos;s controller</longdesc>
+  <longdesc lang="en">Cluster options used by Pacemaker's controller</longdesc>
   <shortdesc lang="en">Pacemaker controller options</shortdesc>
   <parameters>
     <parameter name="dc-version">
@@ -37,7 +37,7 @@
       <content type="string" default=""/>
     </parameter>
     <parameter name="cluster-name">
-      <longdesc lang="en">This optional value is mostly for users&apos; convenience as desired in administration, but may also be used in Pacemaker configuration rules via the #cluster-name node attribute, and by higher-level tools and resource agents.</longdesc>
+      <longdesc lang="en">This optional value is mostly for users' convenience as desired in administration, but may also be used in Pacemaker configuration rules via the #cluster-name node attribute, and by higher-level tools and resource agents.</longdesc>
       <shortdesc lang="en">An arbitrary name for the cluster</shortdesc>
       <content type="string"/>
     </parameter>
@@ -52,7 +52,7 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="fence-reaction">
-      <longdesc lang="en">A cluster node may receive notification of a &quot;succeeded&quot; fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn&apos;t cut cluster communication. Use &quot;stop&quot; to attempt to immediately stop Pacemaker and stay stopped, or &quot;panic&quot; to attempt to immediately reboot the local node, falling back to stop on failure. Allowed values: stop, panic.</longdesc>
+      <longdesc lang="en">A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure. Allowed values: stop, panic.</longdesc>
       <shortdesc lang="en">How a cluster node should react if notified of its own fencing</shortdesc>
       <content type="select" default="">
         <option value="stop" />
@@ -112,26 +112,26 @@
 <?xml version=""?>
 <resource-agent name="pacemaker-fenced" version="">
   <version>1.1</version>
-  <longdesc lang="en">Instance attributes available for all &quot;stonith&quot;-class resources and used by Pacemaker&apos;s fence daemon, formerly known as stonithd</longdesc>
-  <shortdesc lang="en">Instance attributes available for all &quot;stonith&quot;-class resources</shortdesc>
+  <longdesc lang="en">Instance attributes available for all "stonith"-class resources and used by Pacemaker's fence daemon, formerly known as stonithd</longdesc>
+  <shortdesc lang="en">Instance attributes available for all "stonith"-class resources</shortdesc>
   <parameters>
     <parameter name="pcmk_host_argument">
-      <longdesc lang="en">Some devices do not support the standard &apos;port&apos; parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of &quot;none&quot; can be used to tell the cluster not to supply any additional parameters.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate parameter to supply instead of &apos;port&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard 'port' parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of "none" can be used to tell the cluster not to supply any additional parameters.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate parameter to supply instead of 'port'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_map">
-      <longdesc lang="en">For example, &quot;node1:1;node2:2,3&quot; would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2.</longdesc>
+      <longdesc lang="en">For example, "node1:1;node2:2,3" would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2.</longdesc>
       <shortdesc lang="en">A mapping of node names to port numbers for devices that do not support node names.</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_list">
-      <longdesc lang="en">For example, &quot;node1,node2,node3&quot;.</longdesc>
-      <shortdesc lang="en">A list of nodes that can be targeted by this device (optional unless pcmk_host_list=&quot;static-list&quot;)</shortdesc>
+      <longdesc lang="en">For example, "node1,node2,node3".</longdesc>
+      <shortdesc lang="en">A list of nodes that can be targeted by this device (optional unless pcmk_host_list="static-list")</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_check">
-      <longdesc lang="en">Use &quot;dynamic-list&quot; to query the device via the &apos;list&apos; command; &quot;static-list&quot; to check the pcmk_host_list attribute; &quot;status&quot; to query the device via the &apos;status&apos; command; or &quot;none&quot; to assume every device can fence every node. Allowed values: dynamic-list, static-list, status, none.</longdesc>
+      <longdesc lang="en">Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node. Allowed values: dynamic-list, static-list, status, none.</longdesc>
       <shortdesc lang="en">How to determine which nodes can be targeted by the device</shortdesc>
       <content type="select" default="">
         <option value="dynamic-list" />
@@ -146,103 +146,103 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_delay_base">
-      <longdesc lang="en">This enables a static delay for fencing actions, which can help avoid &quot;death matches&quot; where two nodes try to fence each other at the same time. If pcmk_delay_max is also used, a random delay will be added such that the total delay is kept below that value. This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, &quot;node1:1s;node2:5&quot;) to set a different value for each target.</longdesc>
+      <longdesc lang="en">This enables a static delay for fencing actions, which can help avoid "death matches" where two nodes try to fence each other at the same time. If pcmk_delay_max is also used, a random delay will be added such that the total delay is kept below that value. This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, "node1:1s;node2:5") to set a different value for each target.</longdesc>
       <shortdesc lang="en">Enable a base delay for fencing actions and specify base delay value.</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_action_limit">
-      <longdesc lang="en">Cluster property concurrent-fencing=&quot;true&quot; needs to be configured first. Then use this to specify the maximum number of actions can be performed in parallel on this device. A value of -1 means an unlimited number of actions can be performed in parallel.</longdesc>
+      <longdesc lang="en">Cluster property concurrent-fencing="true" needs to be configured first. Then use this to specify the maximum number of actions can be performed in parallel on this device. A value of -1 means an unlimited number of actions can be performed in parallel.</longdesc>
       <shortdesc lang="en">The maximum number of actions can be performed in parallel on this device</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_reboot_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the &apos;reboot&apos; action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of &apos;reboot&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'reboot' action.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'reboot'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_reboot_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for &apos;reboot&apos; actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for &apos;reboot&apos; actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'reboot' actions.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_reboot_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may &quot;fail&quot; if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a &apos;reboot&apos; action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the &apos;reboot&apos; command within the timeout period</shortdesc>
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'reboot' action before giving up.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'reboot' command within the timeout period</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_off_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the &apos;off&apos; action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of &apos;off&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'off' action.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'off'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_off_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for &apos;off&apos; actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for &apos;off&apos; actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'off' actions.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'off' actions instead of stonith-timeout</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_off_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may &quot;fail&quot; if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a &apos;off&apos; action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the &apos;off&apos; command within the timeout period</shortdesc>
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'off' action before giving up.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'off' command within the timeout period</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_on_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the &apos;on&apos; action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of &apos;on&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'on' action.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'on'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_on_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for &apos;on&apos; actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for &apos;on&apos; actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'on' actions.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'on' actions instead of stonith-timeout</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_on_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may &quot;fail&quot; if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a &apos;on&apos; action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the &apos;on&apos; command within the timeout period</shortdesc>
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'on' action before giving up.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'on' command within the timeout period</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_list_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the &apos;list&apos; action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of &apos;list&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'list' action.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'list'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_list_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for &apos;list&apos; actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for &apos;list&apos; actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'list' actions.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'list' actions instead of stonith-timeout</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_list_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may &quot;fail&quot; if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a &apos;list&apos; action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the &apos;list&apos; command within the timeout period</shortdesc>
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'list' action before giving up.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'list' command within the timeout period</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_monitor_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the &apos;monitor&apos; action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of &apos;monitor&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'monitor' action.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'monitor'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_monitor_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for &apos;monitor&apos; actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for &apos;monitor&apos; actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'monitor' actions.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_monitor_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may &quot;fail&quot; if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a &apos;monitor&apos; action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the &apos;monitor&apos; command within the timeout period</shortdesc>
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'monitor' action before giving up.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'monitor' command within the timeout period</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="pcmk_status_action">
-      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the &apos;status&apos; action.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of &apos;status&apos;</shortdesc>
+      <longdesc lang="en">Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'status' action.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** An alternate command to run instead of 'status'</shortdesc>
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_status_timeout">
-      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for &apos;status&apos; actions.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for &apos;status&apos; actions instead of stonith-timeout</shortdesc>
+      <longdesc lang="en">Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'status' actions.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** Specify an alternate timeout to use for 'status' actions instead of stonith-timeout</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="pcmk_status_retries">
-      <longdesc lang="en">Some devices do not support multiple connections. Operations may &quot;fail&quot; if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a &apos;status&apos; action before giving up.</longdesc>
-      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the &apos;status&apos; command within the timeout period</shortdesc>
+      <longdesc lang="en">Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'status' action before giving up.</longdesc>
+      <shortdesc lang="en">*** Advanced Use Only *** The maximum number of times to try the 'status' command within the timeout period</shortdesc>
       <content type="integer" default=""/>
     </parameter>
   </parameters>
@@ -253,7 +253,7 @@
 <?xml version=""?>
 <resource-agent name="pacemaker-schedulerd" version="">
   <version>1.1</version>
-  <longdesc lang="en">Cluster options used by Pacemaker&apos;s scheduler</longdesc>
+  <longdesc lang="en">Cluster options used by Pacemaker's scheduler</longdesc>
   <shortdesc lang="en">Pacemaker scheduler options</shortdesc>
   <parameters>
     <parameter name="no-quorum-policy">
@@ -268,7 +268,7 @@
       </content>
     </parameter>
     <parameter name="shutdown-lock">
-      <longdesc lang="en">When true, resources active on a node when it is cleanly shut down are kept &quot;locked&quot; to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.</longdesc>
+      <longdesc lang="en">When true, resources active on a node when it is cleanly shut down are kept "locked" to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.</longdesc>
       <shortdesc lang="en">Whether to lock resources to a cleanly shut down node</shortdesc>
       <content type="boolean" default=""/>
     </parameter>
@@ -288,7 +288,7 @@
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="start-failure-is-fatal">
-      <longdesc lang="en">When true, the cluster will immediately ban a resource from a node if it fails to start there. When false, the cluster will instead check the resource&apos;s fail count against its migration-threshold.</longdesc>
+      <longdesc lang="en">When true, the cluster will immediately ban a resource from a node if it fails to start there. When false, the cluster will instead check the resource's fail count against its migration-threshold.</longdesc>
       <shortdesc lang="en">Whether a start failure should prevent a resource from being recovered on the same node</shortdesc>
       <content type="boolean" default=""/>
     </parameter>
@@ -298,13 +298,13 @@
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stonith-enabled">
-      <longdesc lang="en">If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a &quot;split-brain&quot; situation, potentially leading to data loss and/or service unavailability.</longdesc>
+      <longdesc lang="en">If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.</longdesc>
       <shortdesc lang="en">*** Advanced Use Only *** Whether nodes may be fenced as part of recovery</shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stonith-action">
-      <longdesc lang="en">Action to send to fence device when a node needs to be fenced (&quot;poweroff&quot; is a deprecated alias for &quot;off&quot;). Allowed values: reboot, off, poweroff.</longdesc>
-      <shortdesc lang="en">Action to send to fence device when a node needs to be fenced (&quot;poweroff&quot; is a deprecated alias for &quot;off&quot;)</shortdesc>
+      <longdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off"). Allowed values: reboot, off, poweroff.</longdesc>
+      <shortdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")</shortdesc>
       <content type="select" default="">
         <option value="reboot" />
         <option value="off" />
@@ -327,12 +327,12 @@
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="startup-fencing">
-      <longdesc lang="en">Setting this to false may lead to a &quot;split-brain&quot; situation, potentially leading to data loss and/or service unavailability.</longdesc>
+      <longdesc lang="en">Setting this to false may lead to a "split-brain" situation, potentially leading to data loss and/or service unavailability.</longdesc>
       <shortdesc lang="en">*** Advanced Use Only *** Whether to fence unseen nodes at start-up</shortdesc>
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="priority-fencing-delay">
-      <longdesc lang="en">Apply specified delay for the fencings that are targeting the lost nodes with the highest total resource priority in case we don&apos;t have the majority of the nodes in our cluster partition, so that the more significant nodes potentially win any fencing match, which is especially meaningful under split-brain of 2-node cluster. A promoted resource instance takes the base priority + 1 on calculation if the base priority is not 0. Any static/random delays that are introduced by `pcmk_delay_base/max` configured for the corresponding fencing resources will be added to this delay. This delay should be significantly greater than, safely twice, the maximum `pcmk_delay_base/max`. By default, priority fencing delay is disabled.</longdesc>
+      <longdesc lang="en">Apply specified delay for the fencings that are targeting the lost nodes with the highest total resource priority in case we don't have the majority of the nodes in our cluster partition, so that the more significant nodes potentially win any fencing match, which is especially meaningful under split-brain of 2-node cluster. A promoted resource instance takes the base priority + 1 on calculation if the base priority is not 0. Any static/random delays that are introduced by `pcmk_delay_base/max` configured for the corresponding fencing resources will be added to this delay. This delay should be significantly greater than, safely twice, the maximum `pcmk_delay_base/max`. By default, priority fencing delay is disabled.</longdesc>
       <shortdesc lang="en">Apply fencing delay targeting the lost nodes with the highest total resource priority</shortdesc>
       <content type="time" default=""/>
     </parameter>
@@ -342,12 +342,12 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="cluster-delay">
-      <longdesc lang="en">The node elected Designated Controller (DC) will consider an action failed if it does not get a response from the node executing the action within this time (after considering the action&apos;s own timeout). The &quot;correct&quot; value will depend on the speed and load of your network and cluster nodes.</longdesc>
+      <longdesc lang="en">The node elected Designated Controller (DC) will consider an action failed if it does not get a response from the node executing the action within this time (after considering the action's own timeout). The "correct" value will depend on the speed and load of your network and cluster nodes.</longdesc>
       <shortdesc lang="en">Maximum time for node-to-node communication</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="batch-limit">
-      <longdesc lang="en">The &quot;correct&quot; value will depend on the speed and load of your network and cluster nodes. If set to 0, the cluster will impose a dynamically calculated limit when any node has a high load.</longdesc>
+      <longdesc lang="en">The "correct" value will depend on the speed and load of your network and cluster nodes. If set to 0, the cluster will impose a dynamically calculated limit when any node has a high load.</longdesc>
       <shortdesc lang="en">Maximum number of jobs that the cluster may execute in parallel across all nodes</shortdesc>
       <content type="integer" default=""/>
     </parameter>
@@ -392,7 +392,7 @@
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-strategy">
-      <longdesc lang="en">Requires external entities to create node attributes (named with the prefix &quot;#health&quot;) with values &quot;red&quot;, &quot;yellow&quot;, or &quot;green&quot;. Allowed values: none, migrate-on-red, only-green, progressive, custom.</longdesc>
+      <longdesc lang="en">Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green". Allowed values: none, migrate-on-red, only-green, progressive, custom.</longdesc>
       <shortdesc lang="en">How cluster should react to node health attributes</shortdesc>
       <content type="select" default="">
         <option value="none" />
@@ -403,23 +403,23 @@
       </content>
     </parameter>
     <parameter name="node-health-base">
-      <longdesc lang="en">Only used when &quot;node-health-strategy&quot; is set to &quot;progressive&quot;.</longdesc>
+      <longdesc lang="en">Only used when "node-health-strategy" is set to "progressive".</longdesc>
       <shortdesc lang="en">Base health score assigned to a node</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-green">
-      <longdesc lang="en">Only used when &quot;node-health-strategy&quot; is set to &quot;custom&quot; or &quot;progressive&quot;.</longdesc>
-      <shortdesc lang="en">The score to use for a node health attribute whose value is &quot;green&quot;</shortdesc>
+      <longdesc lang="en">Only used when "node-health-strategy" is set to "custom" or "progressive".</longdesc>
+      <shortdesc lang="en">The score to use for a node health attribute whose value is "green"</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-yellow">
-      <longdesc lang="en">Only used when &quot;node-health-strategy&quot; is set to &quot;custom&quot; or &quot;progressive&quot;.</longdesc>
-      <shortdesc lang="en">The score to use for a node health attribute whose value is &quot;yellow&quot;</shortdesc>
+      <longdesc lang="en">Only used when "node-health-strategy" is set to "custom" or "progressive".</longdesc>
+      <shortdesc lang="en">The score to use for a node health attribute whose value is "yellow"</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-red">
-      <longdesc lang="en">Only used when &quot;node-health-strategy&quot; is set to &quot;custom&quot; or &quot;progressive&quot;.</longdesc>
-      <shortdesc lang="en">The score to use for a node health attribute whose value is &quot;red&quot;</shortdesc>
+      <longdesc lang="en">Only used when "node-health-strategy" is set to "custom" or "progressive".</longdesc>
+      <shortdesc lang="en">The score to use for a node health attribute whose value is "red"</shortdesc>
       <content type="integer" default=""/>
     </parameter>
     <parameter name="placement-strategy">

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -47,12 +47,12 @@
       <content type="time" default=""/>
     </parameter>
     <parameter name="cluster-recheck-interval">
-      <longdesc lang="en">Pacemaker is primarily event-driven, and looks ahead to know when to recheck cluster state for failure-timeout settings and most time-based rules. However, it will also recheck the cluster after this amount of inactivity, to evaluate rules with date specifications and serve as a fail-safe for certain types of scheduler bugs. Allowed values: Zero disables polling, while positive values are an interval in seconds (unless other units are specified, for example "5min").</longdesc>
+      <longdesc lang="en">Pacemaker is primarily event-driven, and looks ahead to know when to recheck cluster state for failure-timeout settings and most time-based rules. However, it will also recheck the cluster after this amount of inactivity, to evaluate rules with date specifications and serve as a fail-safe for certain types of scheduler bugs. A value of 0 disables polling. A positive value sets an interval in seconds, unless other units are specified (for example, "5min").</longdesc>
       <shortdesc lang="en">Polling interval to recheck cluster state and evaluate rules with date specifications</shortdesc>
       <content type="time" default=""/>
     </parameter>
     <parameter name="fence-reaction">
-      <longdesc lang="en">A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure. Allowed values: stop, panic.</longdesc>
+      <longdesc lang="en">A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure.</longdesc>
       <shortdesc lang="en">How a cluster node should react if notified of its own fencing</shortdesc>
       <content type="select" default="">
         <option value="stop" />
@@ -131,7 +131,7 @@
       <content type="string" default=""/>
     </parameter>
     <parameter name="pcmk_host_check">
-      <longdesc lang="en">Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node. Allowed values: dynamic-list, static-list, status, none.</longdesc>
+      <longdesc lang="en">Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node.</longdesc>
       <shortdesc lang="en">How to determine which nodes can be targeted by the device</shortdesc>
       <content type="select" default="">
         <option value="dynamic-list" />
@@ -257,7 +257,7 @@
   <shortdesc lang="en">Pacemaker scheduler options</shortdesc>
   <parameters>
     <parameter name="no-quorum-policy">
-      <longdesc lang="en">What to do when the cluster does not have quorum. Allowed values: stop, freeze, ignore, demote, suicide.</longdesc>
+      <longdesc lang="en">What to do when the cluster does not have quorum</longdesc>
       <shortdesc lang="en">What to do when the cluster does not have quorum</shortdesc>
       <content type="select" default="">
         <option value="stop" />
@@ -303,7 +303,7 @@
       <content type="boolean" default=""/>
     </parameter>
     <parameter name="stonith-action">
-      <longdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off"). Allowed values: reboot, off, poweroff.</longdesc>
+      <longdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")</longdesc>
       <shortdesc lang="en">Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")</shortdesc>
       <content type="select" default="">
         <option value="reboot" />
@@ -392,7 +392,7 @@
       <content type="integer" default=""/>
     </parameter>
     <parameter name="node-health-strategy">
-      <longdesc lang="en">Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green". Allowed values: none, migrate-on-red, only-green, progressive, custom.</longdesc>
+      <longdesc lang="en">Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green".</longdesc>
       <shortdesc lang="en">How cluster should react to node health attributes</shortdesc>
       <content type="select" default="">
         <option value="none" />
@@ -423,7 +423,7 @@
       <content type="integer" default=""/>
     </parameter>
     <parameter name="placement-strategy">
-      <longdesc lang="en">How the cluster should allocate resources to nodes. Allowed values: default, utilization, minimal, balanced.</longdesc>
+      <longdesc lang="en">How the cluster should allocate resources to nodes</longdesc>
       <shortdesc lang="en">How the cluster should allocate resources to nodes</shortdesc>
       <content type="select" default="">
         <option value="default" />

--- a/cts/cli/regression.rules.exp
+++ b/cts/cli/regression.rules.exp
@@ -37,7 +37,6 @@ log_xmllib_err 	error: XML Error: Entity: line 1: parser error : Start tag expec
 log_xmllib_err 	error: XML Error: invalidxml
 log_xmllib_err 	error: XML Error: ^
 crm_rule: Couldn't parse input string: invalidxml
-
 =#=#=#= End test: crm_rule given invalid input XML - Invalid data given (65) =#=#=#=
 * Passed: crm_rule       - crm_rule given invalid input XML
 =#=#=#= Begin test: crm_rule given invalid input XML (XML) =#=#=#=
@@ -50,8 +49,7 @@ log_xmllib_err 	error: XML Error: ^
 <pacemaker-result api-version="X" request="crm_rule -c -r blahblah -X invalidxml --output-as=xml">
   <status code="65" message="Invalid data given">
     <errors>
-      <error>crm_rule: Couldn't parse input string: invalidxml
-</error>
+      <error>crm_rule: Couldn't parse input string: invalidxml</error>
     </errors>
   </status>
 </pacemaker-result>
@@ -65,7 +63,6 @@ log_xmllib_err 	error: XML Error: Entity: line 1: parser error : Start tag expec
 log_xmllib_err 	error: XML Error: invalidxml
 log_xmllib_err 	error: XML Error: ^
 crm_rule: Couldn't parse input from STDIN
-
 =#=#=#= End test: crm_rule given invalid input XML on stdin - Invalid data given (65) =#=#=#=
 * Passed: echo           - crm_rule given invalid input XML on stdin
 =#=#=#= Begin test: crm_rule given invalid input XML on stdin (XML) =#=#=#=
@@ -78,8 +75,7 @@ log_xmllib_err 	error: XML Error: ^
 <pacemaker-result api-version="X" request="crm_rule -c -r blahblah -X - --output-as=xml">
   <status code="65" message="Invalid data given">
     <errors>
-      <error>crm_rule: Couldn't parse input from STDIN
-</error>
+      <error>crm_rule: Couldn't parse input from STDIN</error>
     </errors>
   </status>
 </pacemaker-result>

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -4609,8 +4609,8 @@ Removing constraint: cli-prefer-dummy
   <change operation="delete" path="/cib/configuration/comment" position="0"/>
   <change operation="delete" path="/cib/configuration/comment" position="1"/>
   <change operation="delete" path="/cib/configuration/resources/comment" position="0"/>
-  <change operation="delete" path="/cib/configuration/resources/primitive[@id=&apos;Fencing&apos;]/operations/op[@id=&apos;Fencing-start-0&apos;]"/>
-  <change operation="modify" path="/cib/configuration/crm_config/cluster_property_set[@id=&apos;cib-bootstrap-options&apos;]/nvpair[@id=&apos;cib-bootstrap-options-cluster-name&apos;]">
+  <change operation="delete" path="/cib/configuration/resources/primitive[@id='Fencing']/operations/op[@id='Fencing-start-0']"/>
+  <change operation="modify" path="/cib/configuration/crm_config/cluster_property_set[@id='cib-bootstrap-options']/nvpair[@id='cib-bootstrap-options-cluster-name']">
     <change-list>
       <change-attr name="value" operation="set" value="mycluster"/>
       <change-attr name="name" operation="set" value="cluster-name"/>
@@ -4628,7 +4628,7 @@ Removing constraint: cli-prefer-dummy
   <change operation="create" path="/cib/configuration/resources" position="0">
     <!-- test: modify this comment to say something different -->
   </change>
-  <change operation="modify" path="/cib/configuration/resources/primitive[@id=&apos;Fencing&apos;]/instance_attributes[@id=&apos;Fencing-params&apos;]/nvpair[@id=&apos;Fencing-pcmk_host_list&apos;]">
+  <change operation="modify" path="/cib/configuration/resources/primitive[@id='Fencing']/instance_attributes[@id='Fencing-params']/nvpair[@id='Fencing-pcmk_host_list']">
     <change-list>
       <change-attr name="value" operation="set" value="node1 node2 node3 node4"/>
     </change-list>
@@ -4636,7 +4636,7 @@ Removing constraint: cli-prefer-dummy
       <nvpair id="Fencing-pcmk_host_list" name="pcmk_host_list" value="node1 node2 node3 node4"/>
     </change-result>
   </change>
-  <change operation="modify" path="/cib/configuration/resources/primitive[@id=&apos;Fencing&apos;]/operations/op[@id=&apos;Fencing-monitor-120s&apos;]">
+  <change operation="modify" path="/cib/configuration/resources/primitive[@id='Fencing']/operations/op[@id='Fencing-monitor-120s']">
     <change-list>
       <change-attr name="timeout" operation="set" value="120s"/>
       <change-attr name="name" operation="set" value="monitor"/>
@@ -4645,9 +4645,9 @@ Removing constraint: cli-prefer-dummy
       <op id="Fencing-monitor-120s" interval="120s" timeout="120s" name="monitor"/>
     </change-result>
   </change>
-  <change operation="move" path="/cib/configuration/resources/primitive[@id=&apos;dummy&apos;]/instance_attributes[@id=&apos;dummy-params&apos;]/nvpair[@id=&apos;dummy-op_sleep&apos;]" position="1"/>
-  <change operation="move" path="/cib/configuration/resources/primitive[@id=&apos;dummy&apos;]/instance_attributes[@id=&apos;dummy-params&apos;]/nvpair[@id=&apos;dummy-fake&apos;]" position="2"/>
-  <change operation="modify" path="/cib/configuration/resources/primitive[@id=&apos;dummy&apos;]/operations/op[@id=&apos;dummy-monitor-5s&apos;]">
+  <change operation="move" path="/cib/configuration/resources/primitive[@id='dummy']/instance_attributes[@id='dummy-params']/nvpair[@id='dummy-op_sleep']" position="1"/>
+  <change operation="move" path="/cib/configuration/resources/primitive[@id='dummy']/instance_attributes[@id='dummy-params']/nvpair[@id='dummy-fake']" position="2"/>
+  <change operation="modify" path="/cib/configuration/resources/primitive[@id='dummy']/operations/op[@id='dummy-monitor-5s']">
     <change-list>
       <change-attr name="name" operation="set" value="monitor"/>
       <change-attr name="timeout" operation="unset"/>
@@ -7048,7 +7048,7 @@ Diff: +++ 1.4.1 (null)
       <cib epoch="4" num_updates="1" admin_epoch="1"/>
     </change-result>
   </change>
-  <change operation="modify" path="/cib/configuration/resources/primitive[@id=&apos;dummy&apos;]">
+  <change operation="modify" path="/cib/configuration/resources/primitive[@id='dummy']">
     <change-list>
       <change-attr name="description" operation="set" value="desc"/>
     </change-list>
@@ -7679,26 +7679,26 @@ Diff: +++ 0.1.0 (null)
     <source admin_epoch="1" epoch="1" num_updates="173"/>
     <target admin_epoch="0" epoch="1" num_updates="0"/>
   </version>
-  <change operation="delete" path="/cib/configuration/crm_config/cluster_property_set[@id=&apos;cib-bootstrap-options&apos;]"/>
-  <change operation="delete" path="/cib/configuration/nodes/node[@id=&apos;1&apos;]"/>
-  <change operation="delete" path="/cib/configuration/nodes/node[@id=&apos;2&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/clone[@id=&apos;ping-clone&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/primitive[@id=&apos;Fencing&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/primitive[@id=&apos;dummy&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/clone[@id=&apos;inactive-clone&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/group[@id=&apos;inactive-group&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/bundle[@id=&apos;httpd-bundle&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/group[@id=&apos;exim-group&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/clone[@id=&apos;mysql-clone-group&apos;]"/>
-  <change operation="delete" path="/cib/configuration/resources/clone[@id=&apos;promotable-clone&apos;]"/>
-  <change operation="delete" path="/cib/configuration/constraints/rsc_location[@id=&apos;not-on-cluster1&apos;]"/>
-  <change operation="delete" path="/cib/configuration/constraints/rsc_location[@id=&apos;loc-promotable-clone&apos;]"/>
+  <change operation="delete" path="/cib/configuration/crm_config/cluster_property_set[@id='cib-bootstrap-options']"/>
+  <change operation="delete" path="/cib/configuration/nodes/node[@id='1']"/>
+  <change operation="delete" path="/cib/configuration/nodes/node[@id='2']"/>
+  <change operation="delete" path="/cib/configuration/resources/clone[@id='ping-clone']"/>
+  <change operation="delete" path="/cib/configuration/resources/primitive[@id='Fencing']"/>
+  <change operation="delete" path="/cib/configuration/resources/primitive[@id='dummy']"/>
+  <change operation="delete" path="/cib/configuration/resources/clone[@id='inactive-clone']"/>
+  <change operation="delete" path="/cib/configuration/resources/group[@id='inactive-group']"/>
+  <change operation="delete" path="/cib/configuration/resources/bundle[@id='httpd-bundle']"/>
+  <change operation="delete" path="/cib/configuration/resources/group[@id='exim-group']"/>
+  <change operation="delete" path="/cib/configuration/resources/clone[@id='mysql-clone-group']"/>
+  <change operation="delete" path="/cib/configuration/resources/clone[@id='promotable-clone']"/>
+  <change operation="delete" path="/cib/configuration/constraints/rsc_location[@id='not-on-cluster1']"/>
+  <change operation="delete" path="/cib/configuration/constraints/rsc_location[@id='loc-promotable-clone']"/>
   <change operation="delete" path="/cib/configuration/tags"/>
   <change operation="delete" path="/cib/configuration/op_defaults"/>
-  <change operation="delete" path="/cib/status/node_state[@id=&apos;2&apos;]"/>
-  <change operation="delete" path="/cib/status/node_state[@id=&apos;1&apos;]"/>
-  <change operation="delete" path="/cib/status/node_state[@id=&apos;httpd-bundle-0&apos;]"/>
-  <change operation="delete" path="/cib/status/node_state[@id=&apos;httpd-bundle-1&apos;]"/>
+  <change operation="delete" path="/cib/status/node_state[@id='2']"/>
+  <change operation="delete" path="/cib/status/node_state[@id='1']"/>
+  <change operation="delete" path="/cib/status/node_state[@id='httpd-bundle-0']"/>
+  <change operation="delete" path="/cib/status/node_state[@id='httpd-bundle-1']"/>
   <change operation="modify" path="/cib">
     <change-list>
       <change-attr name="crm_feature_set" operation="set" value=""/>

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -133,11 +133,11 @@ based_metadata(void)
     const char *desc_long = "Cluster options used by Pacemaker's Cluster "
                             "Information Base manager";
 
-    gchar *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
-                                             pcmk__opt_context_based);
+    char *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
+                                            pcmk__opt_context_based);
 
     printf("%s", s);
-    g_free(s);
+    free(s);
 }
 
 static GOptionEntry entries[] = {

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -53,11 +53,11 @@ controld_metadata(void)
     const char *desc_short = "Pacemaker controller options";
     const char *desc_long = "Cluster options used by Pacemaker's controller";
 
-    gchar *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
-                                             pcmk__opt_context_controld);
+    char *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
+                                            pcmk__opt_context_controld);
 
     printf("%s", s);
-    g_free(s);
+    free(s);
 }
 
 static GOptionContext *

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -821,12 +821,12 @@ fencer_metadata(void)
                                "Pacemaker's fence daemon, formerly known as "
                                "stonithd");
 
-    gchar *s = pcmk__format_option_metadata(name, desc_short, desc_long,
-                                            pcmk__opt_context_none,
-                                            fencer_options,
-                                            PCMK__NELEM(fencer_options));
+    char *s = pcmk__format_option_metadata(name, desc_short, desc_long,
+                                           pcmk__opt_context_none,
+                                           fencer_options,
+                                           PCMK__NELEM(fencer_options));
     printf("%s", s);
-    g_free(s);
+    free(s);
 }
 
 static GOptionEntry entries[] = {

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -53,11 +53,11 @@ scheduler_metadata(pcmk__output_t *out)
     const char *desc_short = "Pacemaker scheduler options";
     const char *desc_long = "Cluster options used by Pacemaker's scheduler";
 
-    gchar *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
-                                             pcmk__opt_context_schedulerd);
+    char *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
+                                            pcmk__opt_context_schedulerd);
 
     out->output_xml(out, PCMK_XE_METADATA, s);
-    g_free(s);
+    free(s);
 }
 
 static GOptionContext *

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -68,15 +68,15 @@ typedef struct pcmk__cluster_option_s {
 
 const char *pcmk__cluster_option(GHashTable *options, const char *name);
 
-gchar *pcmk__format_option_metadata(const char *name, const char *desc_short,
-                                    const char *desc_long,
-                                    enum pcmk__opt_context filter,
-                                    pcmk__cluster_option_t *option_list,
-                                    int len);
+char *pcmk__format_option_metadata(const char *name, const char *desc_short,
+                                   const char *desc_long,
+                                   enum pcmk__opt_context filter,
+                                   pcmk__cluster_option_t *option_list,
+                                   int len);
 
-gchar *pcmk__cluster_option_metadata(const char *name, const char *desc_short,
-                                     const char *desc_long,
-                                     enum pcmk__opt_context filter);
+char *pcmk__cluster_option_metadata(const char *name, const char *desc_short,
+                                    const char *desc_long,
+                                    enum pcmk__opt_context filter);
 
 void pcmk__validate_cluster_options(GHashTable *options);
 

--- a/include/crm/common/xml.h
+++ b/include/crm/common/xml.h
@@ -285,7 +285,6 @@ void patchset_process_digest(xmlNode *patch, xmlNode *source, xmlNode *target, b
 void save_xml_to_file(const xmlNode *xml, const char *desc,
                       const char *filename);
 
-char * crm_xml_escape(const char *text);
 void crm_xml_sanitize_id(char *id);
 void crm_xml_set_id(xmlNode *xml, const char *format, ...) G_GNUC_PRINTF(2, 3);
 

--- a/include/crm/common/xml_compat.h
+++ b/include/crm/common/xml_compat.h
@@ -71,6 +71,9 @@ crm_element_name(const xmlNode *xml)
     return (xml == NULL)? NULL : (const char *) xml->name;
 }
 
+//! \deprecated Do not use
+char *crm_xml_escape(const char *text);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -348,6 +348,8 @@ pcmk__xe_next(const xmlNode *child)
     return next;
 }
 
+void pcmk__xe_set_content(xmlNode *node, const char *content);
+
 /*!
  * \internal
  * \brief Like pcmk__xe_set_props, but takes a va_list instead of

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -217,6 +217,7 @@ void pcmk__xe_remove_matching_attrs(xmlNode *element,
 
 GString *pcmk__element_xpath(const xmlNode *xml);
 
+bool pcmk__xml_needs_escape(const char *text, bool escape_quote);
 char *pcmk__xml_escape(const char *text, bool escape_quote);
 
 /*!

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -217,6 +217,8 @@ void pcmk__xe_remove_matching_attrs(xmlNode *element,
 
 GString *pcmk__element_xpath(const xmlNode *xml);
 
+char *pcmk__xml_escape(const char *text, bool escape_quote);
+
 /*!
  * \internal
  * \brief Get the root directory to scan XML artefacts of given kind for

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -1078,11 +1078,11 @@ cib_metadata(void)
     const char *desc_long = "Cluster options used by Pacemaker's Cluster "
                             "Information Base manager";
 
-    gchar *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
-                                             pcmk__opt_context_based);
+    char *s = pcmk__cluster_option_metadata(name, desc_short, desc_long,
+                                            pcmk__opt_context_based);
 
     printf("%s", s);
-    g_free(s);
+    free(s);
 }
 
 // LCOV_EXCL_STOP

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -957,7 +957,7 @@ static void
 add_desc(GString *s, const char *tag, const char *desc, const char *values,
          const char *spaces)
 {
-    char *escaped_en = crm_xml_escape(desc);
+    char *escaped_en = pcmk__xml_escape(desc, false);
 
     if (spaces != NULL) {
         g_string_append(s, spaces);
@@ -983,7 +983,7 @@ add_desc(GString *s, const char *tag, const char *desc, const char *values,
     {
         static const char *locale = NULL;
 
-        char *localized = crm_xml_escape(_(desc));
+        char *localized = pcmk__xml_escape(_(desc), false);
 
         if (strcmp(escaped_en, localized) != 0) {
             if (locale == NULL) {

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -166,7 +166,7 @@ log_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
     priv = out->priv;
 
     node = create_xml_node(NULL, name);
-    xmlNodeSetContent(node, (pcmkXmlStr) buf);
+    pcmk__xe_set_content(node, buf);
     do_crm_log_xml(priv->log_level, name, node);
     free(node);
 }

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -516,7 +516,7 @@ pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name, const c
     CRM_CHECK(pcmk__str_any_of(out->fmt_name, "xml", "html", NULL), return NULL);
 
     node = pcmk__output_create_xml_node(out, name, NULL);
-    xmlNodeSetContent(node, (pcmkXmlStr) content);
+    pcmk__xe_set_content(node, content);
     return node;
 }
 

--- a/lib/common/tests/xml/Makefile.am
+++ b/lib/common/tests/xml/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2022-2023 the Pacemaker project contributors
+# Copyright 2022-2024 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -13,6 +13,7 @@ include $(top_srcdir)/mk/unittest.mk
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = crm_xml_init_test 		\
 		 pcmk__xe_foreach_child_test 	\
-		 pcmk__xe_match_test
+		 pcmk__xe_match_test		\
+		 pcmk__xml_escape_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/xml/Makefile.am
+++ b/lib/common/tests/xml/Makefile.am
@@ -14,6 +14,7 @@ include $(top_srcdir)/mk/unittest.mk
 check_PROGRAMS = crm_xml_init_test 		\
 		 pcmk__xe_foreach_child_test 	\
 		 pcmk__xe_match_test		\
-		 pcmk__xml_escape_test
+		 pcmk__xml_escape_test		\
+		 pcmk__xml_needs_escape_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/xml_internal.h>
+
+// @TODO Add tests for Unicode characters
+
+static void
+null_empty(void **state)
+{
+    char *str = NULL;
+
+    str = pcmk__xml_escape(NULL, false);
+    assert_null(str);
+
+    str = pcmk__xml_escape(NULL, true);
+    assert_null(str);
+
+    str = pcmk__xml_escape("", false);
+    assert_string_equal(str, "");
+    free(str);
+
+    str = pcmk__xml_escape("", true);
+    assert_string_equal(str, "");
+    free(str);
+}
+
+static void
+escape_unchanged(void **state)
+{
+    // No escaped characters (note: this string includes single quote at end)
+    const char *unchanged = "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "0123456789"
+                            "\n\t`~!@#$%^*()-_=+/|\\[]{}?.,'";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(unchanged, false);
+    assert_string_equal(str, unchanged);
+    free(str);
+
+    str = pcmk__xml_escape(unchanged, true);
+    assert_string_equal(str, unchanged);
+    free(str);
+}
+
+// Ensure special characters get escaped at start, middle, and end
+
+static void
+escape_left_angle(void **state)
+{
+    const char *l_angle = "<abc<def<";
+    const char *l_angle_esc = "&lt;abc&lt;def&lt;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(l_angle, false);
+    assert_string_equal(str, l_angle_esc);
+    free(str);
+
+    str = pcmk__xml_escape(l_angle, true);
+    assert_string_equal(str, l_angle_esc);
+    free(str);
+}
+
+static void
+escape_right_angle(void **state)
+{
+    const char *r_angle = ">abc>def>";
+    const char *r_angle_esc = "&gt;abc&gt;def&gt;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(r_angle, false);
+    assert_string_equal(str, r_angle_esc);
+    free(str);
+
+    str = pcmk__xml_escape(r_angle, true);
+    assert_string_equal(str, r_angle_esc);
+    free(str);
+}
+
+static void
+escape_ampersand(void **state)
+{
+    const char *ampersand = "&abc&def&";
+    const char *ampersand_esc = "&amp;abc&amp;def&amp;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(ampersand, false);
+    assert_string_equal(str, ampersand_esc);
+    free(str);
+
+    str = pcmk__xml_escape(ampersand, true);
+    assert_string_equal(str, ampersand_esc);
+    free(str);
+}
+
+static void
+escape_double_quote(void **state)
+{
+    const char *double_quote = "\"abc\"def\"";
+    const char *double_quote_esc = "&quot;abc&quot;def&quot;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(double_quote, false);
+    assert_string_equal(str, double_quote);
+    free(str);
+
+    str = pcmk__xml_escape(double_quote, true);
+    assert_string_equal(str, double_quote_esc);
+    free(str);
+}
+
+static void
+escape_nonprinting(void **state)
+{
+    const char *nonprinting = "\a\r\x7f\x1b";
+    const char *nonprinting_esc = "&#07;&#0d;&#7f;&#1b;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(nonprinting, false);
+    assert_string_equal(str, nonprinting_esc);
+    free(str);
+
+    str = pcmk__xml_escape(nonprinting, true);
+    assert_string_equal(str, nonprinting_esc);
+    free(str);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(null_empty),
+                cmocka_unit_test(escape_unchanged),
+                cmocka_unit_test(escape_left_angle),
+                cmocka_unit_test(escape_right_angle),
+                cmocka_unit_test(escape_ampersand),
+                cmocka_unit_test(escape_double_quote),
+                cmocka_unit_test(escape_nonprinting));

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -12,8 +12,6 @@
 #include <crm/common/unittest_internal.h>
 #include <crm/common/xml_internal.h>
 
-// @TODO Add tests for Unicode characters
-
 static void
 null_empty(void **state)
 {
@@ -135,6 +133,54 @@ escape_nonprinting(void **state)
     free(str);
 }
 
+static void
+escape_utf8(void **state)
+{
+    /* Non-ASCII UTF-8 characters may be two, three, or four 8-bit bytes wide
+     * and should not be escaped.
+     */
+    const char *chinese = "仅高级使用";
+    const char *two_byte = "abc""\xcf\xa6""d<ef";
+    const char *two_byte_esc = "abc""\xcf\xa6""d&lt;ef";
+    const char *three_byte = "abc""\xef\x98\x98""d<ef";
+    const char *three_byte_esc = "abc""\xef\x98\x98""d&lt;ef";
+    const char *four_byte = "abc""\xf0\x94\x81\x90""d<ef";
+    const char *four_byte_esc = "abc""\xf0\x94\x81\x90""d&lt;ef";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(chinese, false);
+    assert_string_equal(str, chinese);
+    free(str);
+
+    str = pcmk__xml_escape(chinese, true);
+    assert_string_equal(str, chinese);
+    free(str);
+
+    str = pcmk__xml_escape(two_byte, false);
+    assert_string_equal(str, two_byte_esc);
+    free(str);
+
+    str = pcmk__xml_escape(two_byte, true);
+    assert_string_equal(str, two_byte_esc);
+    free(str);
+
+    str = pcmk__xml_escape(three_byte, false);
+    assert_string_equal(str, three_byte_esc);
+    free(str);
+
+    str = pcmk__xml_escape(three_byte, true);
+    assert_string_equal(str, three_byte_esc);
+    free(str);
+
+    str = pcmk__xml_escape(four_byte, false);
+    assert_string_equal(str, four_byte_esc);
+    free(str);
+
+    str = pcmk__xml_escape(four_byte, true);
+    assert_string_equal(str, four_byte_esc);
+    free(str);
+}
+
 PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(null_empty),
                 cmocka_unit_test(escape_unchanged),
@@ -142,4 +188,5 @@ PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(escape_right_angle),
                 cmocka_unit_test(escape_ampersand),
                 cmocka_unit_test(escape_double_quote),
-                cmocka_unit_test(escape_nonprinting));
+                cmocka_unit_test(escape_nonprinting),
+                cmocka_unit_test(escape_utf8));

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/xml_internal.h>
+
+// @TODO Add tests for Unicode characters
+
+static void
+null_empty(void **state)
+{
+    assert_false(pcmk__xml_needs_escape(NULL, false));
+    assert_false(pcmk__xml_needs_escape(NULL, true));
+
+    assert_false(pcmk__xml_needs_escape("", false));
+    assert_false(pcmk__xml_needs_escape("", true));
+}
+
+static void
+escape_unchanged(void **state)
+{
+    // No escaped characters (note: this string includes single quote at end)
+    const char *unchanged = "abcdefghijklmnopqrstuvwxyz"
+                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "0123456789"
+                            "\n\t`~!@#$%^*()-_=+/|\\[]{}?.,'";
+
+    assert_false(pcmk__xml_needs_escape(unchanged, false));
+    assert_false(pcmk__xml_needs_escape(unchanged, true));
+}
+
+// Ensure special characters get escaped at start, middle, and end
+
+static void
+escape_left_angle(void **state)
+{
+    const char *l_angle_left = "<abcdef";
+    const char *l_angle_mid = "abc<def";
+    const char *l_angle_right = "abcdef<";
+
+    assert_true(pcmk__xml_needs_escape(l_angle_left, false));
+    assert_true(pcmk__xml_needs_escape(l_angle_mid, false));
+    assert_true(pcmk__xml_needs_escape(l_angle_right, false));
+
+    assert_true(pcmk__xml_needs_escape(l_angle_left, true));
+    assert_true(pcmk__xml_needs_escape(l_angle_mid, true));
+    assert_true(pcmk__xml_needs_escape(l_angle_right, true));
+}
+
+static void
+escape_right_angle(void **state)
+{
+    const char *r_angle_left = ">abcdef";
+    const char *r_angle_mid = "abc>def";
+    const char *r_angle_right = "abcdef>";
+
+    assert_true(pcmk__xml_needs_escape(r_angle_left, false));
+    assert_true(pcmk__xml_needs_escape(r_angle_mid, false));
+    assert_true(pcmk__xml_needs_escape(r_angle_right, false));
+
+    assert_true(pcmk__xml_needs_escape(r_angle_left, true));
+    assert_true(pcmk__xml_needs_escape(r_angle_mid, true));
+    assert_true(pcmk__xml_needs_escape(r_angle_right, true));
+}
+
+static void
+escape_ampersand(void **state)
+{
+    const char *ampersand_left = "&abcdef";
+    const char *ampersand_mid = "abc&def";
+    const char *ampersand_right = "abcdef&";
+
+    assert_true(pcmk__xml_needs_escape(ampersand_left, false));
+    assert_true(pcmk__xml_needs_escape(ampersand_mid, false));
+    assert_true(pcmk__xml_needs_escape(ampersand_right, false));
+
+    assert_true(pcmk__xml_needs_escape(ampersand_left, true));
+    assert_true(pcmk__xml_needs_escape(ampersand_mid, true));
+    assert_true(pcmk__xml_needs_escape(ampersand_right, true));
+}
+
+static void
+escape_double_quote(void **state)
+{
+    const char *double_quote_left = "\"abcdef";
+    const char *double_quote_mid = "abc\"def";
+    const char *double_quote_right = "abcdef\"";
+
+    assert_false(pcmk__xml_needs_escape(double_quote_left, false));
+    assert_false(pcmk__xml_needs_escape(double_quote_mid, false));
+    assert_false(pcmk__xml_needs_escape(double_quote_right, false));
+
+    assert_true(pcmk__xml_needs_escape(double_quote_left, true));
+    assert_true(pcmk__xml_needs_escape(double_quote_mid, true));
+    assert_true(pcmk__xml_needs_escape(double_quote_right, true));
+}
+
+static void
+escape_nonprinting(void **state)
+{
+    const char *alert_left = "\aabcdef";
+    const char *alert_mid = "abc\adef";
+    const char *alert_right = "abcdef\a";
+
+    const char *delete_left = "\x7f""abcdef";
+    const char *delete_mid = "abc\x7f""def";
+    const char *delete_right = "abcdef\x7f";
+
+    const char *nonprinting_all = "\a\r\x7f\x1b";
+
+    assert_true(pcmk__xml_needs_escape(alert_left, false));
+    assert_true(pcmk__xml_needs_escape(alert_mid, false));
+    assert_true(pcmk__xml_needs_escape(alert_right, false));
+
+    assert_true(pcmk__xml_needs_escape(alert_left, true));
+    assert_true(pcmk__xml_needs_escape(alert_mid, true));
+    assert_true(pcmk__xml_needs_escape(alert_right, true));
+
+    assert_true(pcmk__xml_needs_escape(delete_left, false));
+    assert_true(pcmk__xml_needs_escape(delete_mid, false));
+    assert_true(pcmk__xml_needs_escape(delete_right, false));
+
+    assert_true(pcmk__xml_needs_escape(delete_left, true));
+    assert_true(pcmk__xml_needs_escape(delete_mid, true));
+    assert_true(pcmk__xml_needs_escape(delete_right, true));
+
+    assert_true(pcmk__xml_needs_escape(nonprinting_all, false));
+    assert_true(pcmk__xml_needs_escape(nonprinting_all, true));
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(null_empty),
+                cmocka_unit_test(escape_unchanged),
+                cmocka_unit_test(escape_left_angle),
+                cmocka_unit_test(escape_right_angle),
+                cmocka_unit_test(escape_ampersand),
+                cmocka_unit_test(escape_double_quote),
+                cmocka_unit_test(escape_nonprinting));

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -12,8 +12,6 @@
 #include <crm/common/unittest_internal.h>
 #include <crm/common/xml_internal.h>
 
-// @TODO Add tests for Unicode characters
-
 static void
 null_empty(void **state)
 {
@@ -136,6 +134,39 @@ escape_nonprinting(void **state)
     assert_true(pcmk__xml_needs_escape(nonprinting_all, true));
 }
 
+static void
+escape_utf8(void **state)
+{
+    /* Non-ASCII UTF-8 characters may be two, three, or four 8-bit bytes wide
+     * and should not be escaped.
+     */
+    const char *chinese = "仅高级使用";
+    const char *two_byte = "abc""\xcf\xa6""def";
+    const char *two_byte_special = "abc""\xcf\xa6""d<ef";
+    const char *three_byte = "abc""\xef\x98\x98""def";
+    const char *three_byte_special = "abc""\xef\x98\x98""d<ef";
+    const char *four_byte = "abc""\xf0\x94\x81\x90""def";
+    const char *four_byte_special = "abc""\xf0\x94\x81\x90""d<ef";
+
+    assert_false(pcmk__xml_needs_escape(chinese, false));
+    assert_false(pcmk__xml_needs_escape(chinese, true));
+
+    assert_false(pcmk__xml_needs_escape(two_byte, false));
+    assert_false(pcmk__xml_needs_escape(two_byte, true));
+    assert_true(pcmk__xml_needs_escape(two_byte_special, false));
+    assert_true(pcmk__xml_needs_escape(two_byte_special, true));
+
+    assert_false(pcmk__xml_needs_escape(three_byte, false));
+    assert_false(pcmk__xml_needs_escape(three_byte, true));
+    assert_true(pcmk__xml_needs_escape(three_byte_special, false));
+    assert_true(pcmk__xml_needs_escape(three_byte_special, true));
+
+    assert_false(pcmk__xml_needs_escape(four_byte, false));
+    assert_false(pcmk__xml_needs_escape(four_byte, true));
+    assert_true(pcmk__xml_needs_escape(four_byte_special, false));
+    assert_true(pcmk__xml_needs_escape(four_byte_special, true));
+}
+
 PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(null_empty),
                 cmocka_unit_test(escape_unchanged),
@@ -143,4 +174,5 @@ PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(escape_right_angle),
                 cmocka_unit_test(escape_ampersand),
                 cmocka_unit_test(escape_double_quote),
-                cmocka_unit_test(escape_nonprinting));
+                cmocka_unit_test(escape_nonprinting),
+                cmocka_unit_test(escape_utf8));

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1507,21 +1507,20 @@ static void
 dump_xml_text(const xmlNode *data, uint32_t options, GString *buffer,
               int depth)
 {
-    /* @COMPAT: Remove when log_data_element() is removed. There are no internal
-     * code paths to this, except through the deprecated log_data_element().
-     */
     bool pretty = pcmk_is_set(options, pcmk__xml_fmt_pretty);
     int spaces = pretty? (2 * depth) : 0;
+    char *content = pcmk__xml_escape((const char *) data->content, false);
 
     for (int lpc = 0; lpc < spaces; lpc++) {
         g_string_append_c(buffer, ' ');
     }
 
-    g_string_append(buffer, (const gchar *) data->content);
+    g_string_append(buffer, content);
 
     if (pretty) {
         g_string_append_c(buffer, '\n');
     }
+    free(content);
 }
 
 /*!

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1371,8 +1371,9 @@ crm_xml_escape(const char *text)
     CRM_ASSERT(copy != NULL);
     for (size_t index = 0; index <= length; index++) {
         if(copy[index] & 0x80 && copy[index+1] & 0x80){
+            // @TODO Is this a valid test for Unicode characters?
             index++;
-            break;
+            continue;
         }
         switch (copy[index]) {
             case 0:

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -667,15 +667,32 @@ create_xml_node(xmlNode * parent, const char *name)
     return node;
 }
 
+/*!
+ * \internal
+ * \brief Set a given string as an XML node's content
+ *
+ * \param[in,out] node     Node whose content to set
+ * \param[in]     content  String to set as the content
+ *
+ * \note \c xmlNodeSetContent() does not escape special characters.
+ */
+void
+pcmk__xe_set_content(xmlNode *node, const char *content)
+{
+    if (node != NULL) {
+        char *escaped = pcmk__xml_escape(content, false);
+
+        xmlNodeSetContent(node, (pcmkXmlStr) escaped);
+        free(escaped);
+    }
+}
+
 xmlNode *
 pcmk_create_xml_text_node(xmlNode * parent, const char *name, const char *content)
 {
     xmlNode *node = create_xml_node(parent, name);
 
-    if (node != NULL) {
-        xmlNodeSetContent(node, (pcmkXmlStr) content);
-    }
-
+    pcmk__xe_set_content(node, content);
     return node;
 }
 

--- a/lib/common/xml_attr.c
+++ b/lib/common/xml_attr.c
@@ -61,8 +61,9 @@ pcmk__marked_as_deleted(xmlAttrPtr a, void *user_data)
 void
 pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
 {
-    char *p_value = NULL;
-    const char *p_name = NULL;
+    const char *name = NULL;
+    const char *value = NULL;
+    char *value_esc = NULL;
     xml_node_private_t *nodepriv = NULL;
 
     if (attr == NULL || attr->children == NULL) {
@@ -74,10 +75,15 @@ pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
         return;
     }
 
-    p_name = (const char *) attr->name;
-    p_value = pcmk__xml_escape((const char *) attr->children->content, true);
-    pcmk__g_strcat(buffer, " ", p_name, "=\"", pcmk__s(p_value, "<null>"), "\"",
+    name = (const char *) attr->name;
+    value = (const char *) attr->children->content;
+    if (pcmk__xml_needs_escape(value, true)) {
+        value_esc = pcmk__xml_escape(value, true);
+        value = value_esc;
+    }
+
+    pcmk__g_strcat(buffer, " ", name, "=\"", pcmk__s(value, "<null>"), "\"",
                    NULL);
 
-    free(p_value);
+    free(value_esc);
 }

--- a/lib/common/xml_attr.c
+++ b/lib/common/xml_attr.c
@@ -75,7 +75,7 @@ pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
     }
 
     p_name = (const char *) attr->name;
-    p_value = crm_xml_escape((const char *)attr->children->content);
+    p_value = pcmk__xml_escape((const char *) attr->children->content, true);
     pcmk__g_strcat(buffer, " ", p_name, "=\"", pcmk__s(p_value, "<null>"), "\"",
                    NULL);
 

--- a/lib/common/xml_attr.c
+++ b/lib/common/xml_attr.c
@@ -77,13 +77,19 @@ pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
 
     name = (const char *) attr->name;
     value = (const char *) attr->children->content;
+    if (value == NULL) {
+        /* Don't print anything for unset attribute. Any null-indicator value,
+         * including the empty string, could also be a real value that needs to
+         * be treated differently from "unset".
+         */
+        return;
+    }
+
     if (pcmk__xml_needs_escape(value, true)) {
         value_esc = pcmk__xml_escape(value, true);
         value = value_esc;
     }
 
-    pcmk__g_strcat(buffer, " ", name, "=\"", pcmk__s(value, "<null>"), "\"",
-                   NULL);
-
+    pcmk__g_strcat(buffer, " ", name, "=\"", value, "\"", NULL);
     free(value_esc);
 }

--- a/lib/common/xml_display.c
+++ b/lib/common/xml_display.c
@@ -125,14 +125,16 @@ show_xml_element(pcmk__output_t *out, GString *buffer, const char *prefix,
 
             if ((hidden != NULL) && (p_name[0] != '\0')
                 && (strstr(hidden, p_name) != NULL)) {
-                pcmk__str_update(&p_copy, "*****");
+
+                p_value = "*****";
 
             } else {
                 p_copy = pcmk__xml_escape(p_value, true);
+                p_value = p_copy;
             }
 
             pcmk__g_strcat(buffer, " ", p_name, "=\"",
-                           pcmk__s(p_copy, "<null>"), "\"", NULL);
+                           pcmk__s(p_value, "<null>"), "\"", NULL);
             free(p_copy);
         }
 

--- a/lib/common/xml_display.c
+++ b/lib/common/xml_display.c
@@ -128,7 +128,7 @@ show_xml_element(pcmk__output_t *out, GString *buffer, const char *prefix,
                 pcmk__str_update(&p_copy, "*****");
 
             } else {
-                p_copy = crm_xml_escape(p_value);
+                p_copy = pcmk__xml_escape(p_value, true);
             }
 
             pcmk__g_strcat(buffer, " ", p_name, "=\"",

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -203,8 +203,8 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
     }
 
     if (lha_agents_lib && st_new_fn && st_del_fn && st_info_fn && st_log_fn) {
-        char *xml_meta_longdesc = NULL;
-        char *xml_meta_shortdesc = NULL;
+        char *meta_longdesc_escaped = NULL;
+        char *meta_shortdesc_escaped = NULL;
 
         char *meta_param = NULL;
         char *meta_longdesc = NULL;
@@ -241,25 +241,22 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
             return -EINVAL;
         }
 
-        xml_meta_longdesc =
-            (char *)xmlEncodeEntitiesReentrant(NULL, (const unsigned char *)meta_longdesc);
-        xml_meta_shortdesc =
-            (char *)xmlEncodeEntitiesReentrant(NULL, (const unsigned char *)meta_shortdesc);
+        meta_longdesc_escaped = pcmk__xml_escape(meta_longdesc, false);
+        meta_shortdesc_escaped = pcmk__xml_escape(meta_shortdesc, false);
 
         /* @TODO This needs a string that's parsable by crm_get_msec(). In
          * general, pcmk__readable_interval() doesn't provide that. It works
          * here because PCMK_DEFAULT_ACTION_TIMEOUT_MS is 20000 -> "20s".
          */
         timeout_str = pcmk__readable_interval(PCMK_DEFAULT_ACTION_TIMEOUT_MS);
-        buffer = crm_strdup_printf(META_TEMPLATE, agent, xml_meta_longdesc,
-                                   xml_meta_shortdesc, meta_param,
+        buffer = crm_strdup_printf(META_TEMPLATE, agent, meta_longdesc_escaped,
+                                   meta_shortdesc_escaped, meta_param,
                                    timeout_str, timeout_str, timeout_str);
 
-        xmlFree(xml_meta_longdesc);
-        xmlFree(xml_meta_shortdesc);
-
-        free(meta_shortdesc);
+        free(meta_longdesc_escaped);
+        free(meta_shortdesc_escaped);
         free(meta_longdesc);
+        free(meta_shortdesc);
         free(meta_param);
     }
     if (output) {

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -203,9 +203,6 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
     }
 
     if (lha_agents_lib && st_new_fn && st_del_fn && st_info_fn && st_log_fn) {
-        char *meta_longdesc_escaped = NULL;
-        char *meta_shortdesc_escaped = NULL;
-
         char *meta_param = NULL;
         char *meta_longdesc = NULL;
         char *meta_shortdesc = NULL;
@@ -241,20 +238,28 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
             return -EINVAL;
         }
 
-        meta_longdesc_escaped = pcmk__xml_escape(meta_longdesc, false);
-        meta_shortdesc_escaped = pcmk__xml_escape(meta_shortdesc, false);
+        if (pcmk__xml_needs_escape(meta_longdesc, false)) {
+            char *escaped = pcmk__xml_escape(meta_longdesc, false);
+
+            free(meta_longdesc);
+            meta_longdesc = escaped;
+        }
+        if (pcmk__xml_needs_escape(meta_shortdesc, false)) {
+            char *escaped = pcmk__xml_escape(meta_shortdesc, false);
+
+            free(meta_shortdesc);
+            meta_shortdesc = escaped;
+        }
 
         /* @TODO This needs a string that's parsable by crm_get_msec(). In
          * general, pcmk__readable_interval() doesn't provide that. It works
          * here because PCMK_DEFAULT_ACTION_TIMEOUT_MS is 20000 -> "20s".
          */
         timeout_str = pcmk__readable_interval(PCMK_DEFAULT_ACTION_TIMEOUT_MS);
-        buffer = crm_strdup_printf(META_TEMPLATE, agent, meta_longdesc_escaped,
-                                   meta_shortdesc_escaped, meta_param,
+        buffer = crm_strdup_printf(META_TEMPLATE, agent, meta_longdesc,
+                                   meta_shortdesc, meta_param,
                                    timeout_str, timeout_str, timeout_str);
 
-        free(meta_longdesc_escaped);
-        free(meta_shortdesc_escaped);
         free(meta_longdesc);
         free(meta_shortdesc);
         free(meta_param);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1545,14 +1545,13 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
     const char *call_id = crm_element_value(xml_op, PCMK__XA_CALL_ID);
     const char *exitstatus = NULL;
     const char *exit_reason = crm_element_value(xml_op, PCMK_XA_EXIT_REASON);
+    char *exit_reason_esc = pcmk__xml_escape(pcmk__s(exit_reason, "none"),
+                                             true);
     const char *status_s = NULL;
 
     time_t epoch = 0;
     char *rc_s = NULL;
-    char *reason_s = crm_xml_escape(exit_reason ? exit_reason : "none");
     xmlNodePtr node = NULL;
-
-    exit_reason = pcmk__s(reason_s, "");
 
     pcmk__scan_min_int(crm_element_value(xml_op, PCMK__XA_RC_CODE), &rc, 0);
     pcmk__scan_min_int(crm_element_value(xml_op, PCMK__XA_OP_STATUS), &status,
@@ -1568,7 +1567,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
                                         op_key_name, op_key,
                                         PCMK_XA_NODE, uname,
                                         PCMK_XA_EXITSTATUS, exitstatus,
-                                        PCMK_XA_EXITREASON, exit_reason,
+                                        PCMK_XA_EXITREASON, exit_reason_esc,
                                         PCMK_XA_EXITCODE, rc_s,
                                         PCMK_XA_CALL, call_id,
                                         PCMK_XA_STATUS, status_s,
@@ -1603,7 +1602,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
         free(rc_change);
     }
 
-    free(reason_s);
+    free(exit_reason_esc);
     return pcmk_rc_ok;
 }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1544,15 +1544,20 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
     const char *uname = crm_element_value(xml_op, PCMK_XA_UNAME);
     const char *call_id = crm_element_value(xml_op, PCMK__XA_CALL_ID);
     const char *exitstatus = NULL;
-    const char *exit_reason = crm_element_value(xml_op, PCMK_XA_EXIT_REASON);
-    char *exit_reason_esc = pcmk__xml_escape(pcmk__s(exit_reason, "none"),
-                                             true);
+    const char *exit_reason = pcmk__s(crm_element_value(xml_op,
+                                                        PCMK_XA_EXIT_REASON),
+                                      "none");
     const char *status_s = NULL;
 
     time_t epoch = 0;
+    char *exit_reason_esc = NULL;
     char *rc_s = NULL;
     xmlNodePtr node = NULL;
 
+    if (pcmk__xml_needs_escape(exit_reason, true)) {
+        exit_reason_esc = pcmk__xml_escape(exit_reason, true);
+        exit_reason = exit_reason_esc;
+    }
     pcmk__scan_min_int(crm_element_value(xml_op, PCMK__XA_RC_CODE), &rc, 0);
     pcmk__scan_min_int(crm_element_value(xml_op, PCMK__XA_OP_STATUS), &status,
                        0);
@@ -1567,7 +1572,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
                                         op_key_name, op_key,
                                         PCMK_XA_NODE, uname,
                                         PCMK_XA_EXITSTATUS, exitstatus,
-                                        PCMK_XA_EXITREASON, exit_reason_esc,
+                                        PCMK_XA_EXITREASON, exit_reason,
                                         PCMK_XA_EXITCODE, rc_s,
                                         PCMK_XA_CALL, call_id,
                                         PCMK_XA_STATUS, status_s,

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -80,14 +80,6 @@
 #define SHORT_DESC                      "# Short-Description:"
 #define DESCRIPTION                     "# Description:"
 
-#define lsb_meta_helper_free_value(m)           \
-    do {                                        \
-        if ((m) != NULL) {                      \
-            xmlFree(m);                         \
-            (m) = NULL;                         \
-        }                                       \
-    } while(0)
-
 /*!
  * \internal
  * \brief Grab an LSB header value
@@ -102,7 +94,7 @@ static inline gboolean
 lsb_meta_helper_get_value(const char *line, char **value, const char *prefix)
 {
     if (!*value && pcmk__starts_with(line, prefix)) {
-        *value = (char *)xmlEncodeEntitiesReentrant(NULL, BAD_CAST line+strlen(prefix));
+        *value = pcmk__xml_escape(line + strlen(prefix), false);
         return TRUE;
     }
     return FALSE;
@@ -205,9 +197,7 @@ services__get_lsb_metadata(const char *type, char **output)
             }
 
             // Make long description safe to use in XML
-            long_desc =
-                (char *) xmlEncodeEntitiesReentrant(NULL,
-                                                    (pcmkXmlStr) desc->str);
+            long_desc = pcmk__xml_escape(desc->str, false);
             g_string_free(desc, TRUE);
 
             if (processed_line) {
@@ -237,15 +227,15 @@ services__get_lsb_metadata(const char *type, char **output)
                                 pcmk__s(default_start, ""),
                                 pcmk__s(default_stop, ""));
 
-    lsb_meta_helper_free_value(long_desc);
-    lsb_meta_helper_free_value(short_desc);
-    lsb_meta_helper_free_value(provides);
-    lsb_meta_helper_free_value(required_start);
-    lsb_meta_helper_free_value(required_stop);
-    lsb_meta_helper_free_value(should_start);
-    lsb_meta_helper_free_value(should_stop);
-    lsb_meta_helper_free_value(default_start);
-    lsb_meta_helper_free_value(default_stop);
+    free(long_desc);
+    free(short_desc);
+    free(provides);
+    free(required_start);
+    free(required_stop);
+    free(should_start);
+    free(should_stop);
+    free(default_start);
+    free(default_stop);
     return pcmk_ok;
 }
 

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -93,6 +93,9 @@
 static inline gboolean
 lsb_meta_helper_get_value(const char *line, char **value, const char *prefix)
 {
+    /* @TODO Perhaps update later to use pcmk__xml_needs_escape(). Involves many
+     * extra variables in the caller.
+     */
     if (!*value && pcmk__starts_with(line, prefix)) {
         *value = pcmk__xml_escape(line + strlen(prefix), false);
         return TRUE;

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -711,7 +711,7 @@ systemd_unit_metadata(const char *name, int timeout)
         desc = crm_strdup_printf("Systemd unit file for %s", name);
     }
 
-    escaped = crm_xml_escape(desc);
+    escaped = pcmk__xml_escape(desc, false);
 
     meta = crm_strdup_printf(METADATA_FORMAT, name, escaped, name);
     free(desc);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -701,8 +701,6 @@ systemd_unit_metadata(const char *name, int timeout)
     char *desc = NULL;
     char *path = NULL;
 
-    char *escaped = NULL;
-
     if (invoke_unit_by_name(name, NULL, &path) == pcmk_rc_ok) {
         /* TODO: Worth a making blocking call for? Probably not. Possibly if cached. */
         desc = systemd_get_property(path, "Description", NULL, NULL, NULL,
@@ -711,12 +709,16 @@ systemd_unit_metadata(const char *name, int timeout)
         desc = crm_strdup_printf("Systemd unit file for %s", name);
     }
 
-    escaped = pcmk__xml_escape(desc, false);
+    if (pcmk__xml_needs_escape(desc, false)) {
+        char *escaped = pcmk__xml_escape(desc, false);
 
-    meta = crm_strdup_printf(METADATA_FORMAT, name, escaped, name);
+        free(desc);
+        desc = escaped;
+    }
+
+    meta = crm_strdup_printf(METADATA_FORMAT, name, desc, name);
     free(desc);
     free(path);
-    free(escaped);
     return meta;
 }
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,5 +1,5 @@
 #
-# Copyright 2003-2022 the Pacemaker project contributors
+# Copyright 2003-2024 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pacemaker 2\n"
 "Report-Msgid-Bugs-To: developers@clusterlabs.org\n"
-"POT-Creation-Date: 2024-01-11 11:22-0800\n"
+"POT-Creation-Date: 2024-02-01 16:24-0800\n"
 "PO-Revision-Date: 2021-11-08 11:04+0800\n"
 "Last-Translator: Vivi <developers@clusterlabs.org>\n"
 "Language-Team: CHINESE <wangluwei@uniontech.org>\n"
@@ -20,13 +20,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: daemons/fenced/pacemaker-fenced.c:537
+#: daemons/fenced/pacemaker-fenced.c:534
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** An alternate parameter to supply instead of 'port'"
 msgstr "仅高级使用：使用替代的参数名，而不是'port'"
 
-#: daemons/fenced/pacemaker-fenced.c:539
+#: daemons/fenced/pacemaker-fenced.c:536
 #, fuzzy
 msgid ""
 "Some devices do not support the standard 'port' parameter or may provide "
@@ -38,14 +38,14 @@ msgstr ""
 "设备专用的参数名，该参数用于标识需要fence的机器。值none可以用于告诉集群不要提"
 "供任何其他的参数。"
 
-#: daemons/fenced/pacemaker-fenced.c:549
+#: daemons/fenced/pacemaker-fenced.c:546
 #, fuzzy
 msgid ""
 "A mapping of node names to port numbers for devices that do not support node "
 "names."
 msgstr "为不支持主机名的设备提供主机名到端口号的映射。"
 
-#: daemons/fenced/pacemaker-fenced.c:551
+#: daemons/fenced/pacemaker-fenced.c:548
 #, fuzzy
 msgid ""
 "For example, \"node1:1;node2:2,3\" would tell the cluster to use port 1 for "
@@ -53,24 +53,24 @@ msgid ""
 msgstr ""
 "例如 node1:1;node2:2,3，将会告诉集群对node1使用端口1,对node2使用端口2和3 "
 
-#: daemons/fenced/pacemaker-fenced.c:558
+#: daemons/fenced/pacemaker-fenced.c:555
 #, fuzzy
 msgid ""
 "A list of nodes that can be targeted by this device (optional unless "
 "pcmk_host_list=\"static-list\")"
 msgstr "该设备控制的机器列表(可选参数，除非 pcmk_host_list 设置为 static-list)"
 
-#: daemons/fenced/pacemaker-fenced.c:560
+#: daemons/fenced/pacemaker-fenced.c:557
 #, fuzzy
 msgid "For example, \"node1,node2,node3\"."
 msgstr "例如 node1,node2,node3"
 
-#: daemons/fenced/pacemaker-fenced.c:567
+#: daemons/fenced/pacemaker-fenced.c:564
 #, fuzzy
 msgid "How to determine which nodes can be targeted by the device"
 msgstr "如何确定设备控制哪些机器。"
 
-#: daemons/fenced/pacemaker-fenced.c:568
+#: daemons/fenced/pacemaker-fenced.c:565
 #, fuzzy
 msgid ""
 "Use \"dynamic-list\" to query the device via the 'list' command; \"static-"
@@ -82,11 +82,11 @@ msgstr ""
 "pcmk_host_list属性），status（通过'status'命令查询设备），none（假设每个设备"
 "都可fence 每台机器 ）"
 
-#: daemons/fenced/pacemaker-fenced.c:577 daemons/fenced/pacemaker-fenced.c:588
+#: daemons/fenced/pacemaker-fenced.c:574 daemons/fenced/pacemaker-fenced.c:585
 msgid "Enable a base delay for fencing actions and specify base delay value."
 msgstr "在执行 fencing 操作前启用不超过指定时间的延迟。"
 
-#: daemons/fenced/pacemaker-fenced.c:579
+#: daemons/fenced/pacemaker-fenced.c:576
 msgid ""
 "Enable a delay of no more than the time specified before executing fencing "
 "actions. Pacemaker derives the overall delay by taking the value of "
@@ -97,7 +97,7 @@ msgstr ""
 "pcmk_delay_base的值并添加随机延迟值来得出总体延迟,从而使总和保持在此最大值以"
 "下。"
 
-#: daemons/fenced/pacemaker-fenced.c:590
+#: daemons/fenced/pacemaker-fenced.c:587
 #, fuzzy
 msgid ""
 "This enables a static delay for fencing actions, which can help avoid "
@@ -114,12 +114,12 @@ msgstr ""
 "目标分别配置了各自的设备的情况）， 或着设置为一个节点映射 （例如，\"node1:1s;"
 "node2:5\"）从而为每个目标设置不同值。"
 
-#: daemons/fenced/pacemaker-fenced.c:603
+#: daemons/fenced/pacemaker-fenced.c:600
 msgid ""
 "The maximum number of actions can be performed in parallel on this device"
 msgstr "可以在该设备上并发执行的最多操作数量"
 
-#: daemons/fenced/pacemaker-fenced.c:605
+#: daemons/fenced/pacemaker-fenced.c:602
 #, fuzzy
 msgid ""
 "Cluster property concurrent-fencing=\"true\" needs to be configured first. "
@@ -130,13 +130,13 @@ msgstr ""
 "需要首先配置集群属性 concurrent-fencing=true 。然后使用此参数指定可以在该设备"
 "上并发执行的最多操作数量。 -1 代表没有限制"
 
-#: daemons/fenced/pacemaker-fenced.c:615
+#: daemons/fenced/pacemaker-fenced.c:612
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** An alternate command to run instead of 'reboot'"
 msgstr "仅高级使用：运行替代命令，而不是'reboot'"
 
-#: daemons/fenced/pacemaker-fenced.c:617
+#: daemons/fenced/pacemaker-fenced.c:614
 #, fuzzy
 msgid ""
 "Some devices do not support the standard commands or may provide additional "
@@ -146,14 +146,14 @@ msgstr ""
 "一些设备不支持标准命令或可能提供其他命令，使用此选项可以指定一个该设备特定的"
 "替代命令，用来实现'reboot'操作。"
 
-#: daemons/fenced/pacemaker-fenced.c:625
+#: daemons/fenced/pacemaker-fenced.c:622
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** Specify an alternate timeout to use for 'reboot' "
 "actions instead of stonith-timeout"
 msgstr "仅高级使用：指定用于'reboot' 操作的替代超时，而不是stonith-timeout"
 
-#: daemons/fenced/pacemaker-fenced.c:628
+#: daemons/fenced/pacemaker-fenced.c:625
 #, fuzzy
 msgid ""
 "Some devices need much more/less time to complete than normal. Use this to "
@@ -162,14 +162,14 @@ msgstr ""
 "一些设备需要比正常情况下更多或更少的时间来完成操作，使用此选项指定一个用"
 "于'reboot'操作的该设备特定的替代超时。"
 
-#: daemons/fenced/pacemaker-fenced.c:636
+#: daemons/fenced/pacemaker-fenced.c:633
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** The maximum number of times to try the 'reboot' "
 "command within the timeout period"
 msgstr "仅高级使用：在超时前重试'reboot'命令的最大次数"
 
-#: daemons/fenced/pacemaker-fenced.c:639
+#: daemons/fenced/pacemaker-fenced.c:636
 #, fuzzy
 msgid ""
 "Some devices do not support multiple connections. Operations may \"fail\" if "
@@ -182,12 +182,12 @@ msgstr ""
 "Pacemaker将自动重试（如果时间允许）。 使用此选项更改Pacemaker在放弃之前重"
 "试'reboot' 操作的次数."
 
-#: daemons/fenced/pacemaker-fenced.c:649
+#: daemons/fenced/pacemaker-fenced.c:646
 #, fuzzy
 msgid "*** Advanced Use Only *** An alternate command to run instead of 'off'"
 msgstr "仅高级使用：运行替代命令，而不是'off'"
 
-#: daemons/fenced/pacemaker-fenced.c:651
+#: daemons/fenced/pacemaker-fenced.c:648
 #, fuzzy
 msgid ""
 "Some devices do not support the standard commands or may provide additional "
@@ -197,14 +197,14 @@ msgstr ""
 "一些设备不支持标准命令或可能提供其他命令,使用此选项可指定一个该设备专用的替代"
 "命令，用来实现'off'操作。"
 
-#: daemons/fenced/pacemaker-fenced.c:659
+#: daemons/fenced/pacemaker-fenced.c:656
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** Specify an alternate timeout to use for 'off' "
 "actions instead of stonith-timeout"
 msgstr "仅高级使用：指定用于off 操作的替代超时，而不是stonith-timeout"
 
-#: daemons/fenced/pacemaker-fenced.c:662
+#: daemons/fenced/pacemaker-fenced.c:659
 #, fuzzy
 msgid ""
 "Some devices need much more/less time to complete than normal. Use this to "
@@ -213,14 +213,14 @@ msgstr ""
 "一些设备需要比正常情况下更多或更少的时间来完成操作，使用此选项指定一个用"
 "于'off'操作的该设备特定的替代超时。"
 
-#: daemons/fenced/pacemaker-fenced.c:670
+#: daemons/fenced/pacemaker-fenced.c:667
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** The maximum number of times to try the 'off' "
 "command within the timeout period"
 msgstr "仅高级使用：在超时前重试'off'命令的最大次数"
 
-#: daemons/fenced/pacemaker-fenced.c:673
+#: daemons/fenced/pacemaker-fenced.c:670
 #, fuzzy
 msgid ""
 "Some devices do not support multiple connections. Operations may \"fail\" if "
@@ -233,12 +233,12 @@ msgstr ""
 "Pacemaker将自动重试（如果时间允许）。 使用此选项更改Pacemaker在放弃之前重"
 "试'off' 操作的次数."
 
-#: daemons/fenced/pacemaker-fenced.c:683
+#: daemons/fenced/pacemaker-fenced.c:680
 #, fuzzy
 msgid "*** Advanced Use Only *** An alternate command to run instead of 'on'"
 msgstr "仅高级使用：运行替代命令，而不是'on'"
 
-#: daemons/fenced/pacemaker-fenced.c:685
+#: daemons/fenced/pacemaker-fenced.c:682
 #, fuzzy
 msgid ""
 "Some devices do not support the standard commands or may provide additional "
@@ -248,14 +248,14 @@ msgstr ""
 "一些设备不支持标准命令或可能提供其他命令，使用此选项可指定一个该设备特定的替"
 "代命令，用来实现'on'操作。"
 
-#: daemons/fenced/pacemaker-fenced.c:693
+#: daemons/fenced/pacemaker-fenced.c:690
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** Specify an alternate timeout to use for 'on' "
 "actions instead of stonith-timeout"
 msgstr "仅高级使用：指定用于on 操作的替代超时，而不是stonith-timeout"
 
-#: daemons/fenced/pacemaker-fenced.c:696
+#: daemons/fenced/pacemaker-fenced.c:693
 #, fuzzy
 msgid ""
 "Some devices need much more/less time to complete than normal. Use this to "
@@ -264,14 +264,14 @@ msgstr ""
 "一些设备需要比正常情况下更多或更少的时间来完成操作，使用此选项指定一个用"
 "于'on'操作的该设备特定的替代超时。"
 
-#: daemons/fenced/pacemaker-fenced.c:704
+#: daemons/fenced/pacemaker-fenced.c:701
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** The maximum number of times to try the 'on' "
 "command within the timeout period"
 msgstr "仅高级使用：在超时前重试'on'命令的最大次数"
 
-#: daemons/fenced/pacemaker-fenced.c:707
+#: daemons/fenced/pacemaker-fenced.c:704
 #, fuzzy
 msgid ""
 "Some devices do not support multiple connections. Operations may \"fail\" if "
@@ -284,12 +284,12 @@ msgstr ""
 "Pacemaker将自动重试（如果时间允许）。 使用此选项更改Pacemaker在放弃之前重"
 "试'on' 操作的次数."
 
-#: daemons/fenced/pacemaker-fenced.c:717
+#: daemons/fenced/pacemaker-fenced.c:714
 #, fuzzy
 msgid "*** Advanced Use Only *** An alternate command to run instead of 'list'"
 msgstr "仅高级使用：运行替代命令，而不是'list'"
 
-#: daemons/fenced/pacemaker-fenced.c:719
+#: daemons/fenced/pacemaker-fenced.c:716
 #, fuzzy
 msgid ""
 "Some devices do not support the standard commands or may provide additional "
@@ -299,14 +299,14 @@ msgstr ""
 "一些设备不支持标准命令或可能提供其他命令，使用此选项可指定一个该设备特定的替"
 "代命令，用来实现'list'操作。"
 
-#: daemons/fenced/pacemaker-fenced.c:727
+#: daemons/fenced/pacemaker-fenced.c:724
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** Specify an alternate timeout to use for 'list' "
 "actions instead of stonith-timeout"
 msgstr "仅高级使用：指定用于list 操作的替代超时，而不是stonith-timeout"
 
-#: daemons/fenced/pacemaker-fenced.c:730
+#: daemons/fenced/pacemaker-fenced.c:727
 #, fuzzy
 msgid ""
 "Some devices need much more/less time to complete than normal. Use this to "
@@ -315,14 +315,14 @@ msgstr ""
 "一些设备需要比正常情况下更多或更少的时间来完成操作，使用此选项指定一个用"
 "于'list'操作的该设备特定的替代超时。"
 
-#: daemons/fenced/pacemaker-fenced.c:738
+#: daemons/fenced/pacemaker-fenced.c:735
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** The maximum number of times to try the 'list' "
 "command within the timeout period"
 msgstr "仅高级使用：在超时前重试'list'命令的最大次数"
 
-#: daemons/fenced/pacemaker-fenced.c:741
+#: daemons/fenced/pacemaker-fenced.c:738
 #, fuzzy
 msgid ""
 "Some devices do not support multiple connections. Operations may \"fail\" if "
@@ -335,13 +335,13 @@ msgstr ""
 "Pacemaker将自动重试（如果时间允许）。 使用此选项更改Pacemaker在放弃之前重"
 "试'list' 操作的次数."
 
-#: daemons/fenced/pacemaker-fenced.c:751
+#: daemons/fenced/pacemaker-fenced.c:748
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** An alternate command to run instead of 'monitor'"
 msgstr "仅高级使用：运行替代命令，而不是'monitor'"
 
-#: daemons/fenced/pacemaker-fenced.c:753
+#: daemons/fenced/pacemaker-fenced.c:750
 #, fuzzy
 msgid ""
 "Some devices do not support the standard commands or may provide additional "
@@ -351,14 +351,14 @@ msgstr ""
 "一些设备不支持标准命令或可能提供其他命令，使用此选项可指定一个该设备特定的替"
 "代命令，用来实现'monitor'操作。"
 
-#: daemons/fenced/pacemaker-fenced.c:761
+#: daemons/fenced/pacemaker-fenced.c:758
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** Specify an alternate timeout to use for 'monitor' "
 "actions instead of stonith-timeout"
 msgstr "仅高级使用：指定用于monitor 操作的替代超时，而不是stonith-timeout"
 
-#: daemons/fenced/pacemaker-fenced.c:764
+#: daemons/fenced/pacemaker-fenced.c:761
 #, fuzzy
 msgid ""
 "Some devices need much more/less time to complete than normal. Use this to "
@@ -367,14 +367,14 @@ msgstr ""
 "一些设备需要比正常情况下更多或更少的时间来完成操作，使用此选项指定一个用"
 "于'monitor'操作的该设备特定的替代超时。"
 
-#: daemons/fenced/pacemaker-fenced.c:772
+#: daemons/fenced/pacemaker-fenced.c:769
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** The maximum number of times to try the 'monitor' "
 "command within the timeout period"
 msgstr "仅高级使用：在超时前重试'monitor'命令的最大次数"
 
-#: daemons/fenced/pacemaker-fenced.c:775
+#: daemons/fenced/pacemaker-fenced.c:772
 #, fuzzy
 msgid ""
 "Some devices do not support multiple connections. Operations may \"fail\" if "
@@ -387,13 +387,13 @@ msgstr ""
 "Pacemaker将自动重试（如果时间允许）。 使用此选项更改Pacemaker在放弃之前重"
 "试'monitor' 操作的次数."
 
-#: daemons/fenced/pacemaker-fenced.c:785
+#: daemons/fenced/pacemaker-fenced.c:782
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** An alternate command to run instead of 'status'"
 msgstr "仅高级使用：运行替代命令，而不是'status'"
 
-#: daemons/fenced/pacemaker-fenced.c:787
+#: daemons/fenced/pacemaker-fenced.c:784
 #, fuzzy
 msgid ""
 "Some devices do not support the standard commands or may provide additional "
@@ -403,14 +403,14 @@ msgstr ""
 "一些设备不支持标准命令或可能提供其他命令，使用此选项可指定一个该设备特定的替"
 "代命令，用来实现'status'操作。"
 
-#: daemons/fenced/pacemaker-fenced.c:795
+#: daemons/fenced/pacemaker-fenced.c:792
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** Specify an alternate timeout to use for 'status' "
 "actions instead of stonith-timeout"
 msgstr "仅高级使用：指定用于status 操作的替代超时，而不是stonith-timeout"
 
-#: daemons/fenced/pacemaker-fenced.c:798
+#: daemons/fenced/pacemaker-fenced.c:795
 #, fuzzy
 msgid ""
 "Some devices need much more/less time to complete than normal. Use this to "
@@ -419,14 +419,14 @@ msgstr ""
 "一些设备需要比正常情况下更多或更少的时间来完成操作，使用此选项指定一个用"
 "于'status'操作的该设备特定的替代超时"
 
-#: daemons/fenced/pacemaker-fenced.c:806
+#: daemons/fenced/pacemaker-fenced.c:803
 #, fuzzy
 msgid ""
 "*** Advanced Use Only *** The maximum number of times to try the 'status' "
 "command within the timeout period"
 msgstr "仅高级使用：在超时前重试'status'命令的最大次数"
 
-#: daemons/fenced/pacemaker-fenced.c:809
+#: daemons/fenced/pacemaker-fenced.c:806
 #, fuzzy
 msgid ""
 "Some devices do not support multiple connections. Operations may \"fail\" if "
@@ -439,11 +439,11 @@ msgstr ""
 "Pacemaker将自动重试（如果时间允许）。 使用此选项更改Pacemaker在放弃之前重"
 "试'status' 操作的次数."
 
-#: daemons/fenced/pacemaker-fenced.c:821
+#: daemons/fenced/pacemaker-fenced.c:818
 msgid "Instance attributes available for all \"stonith\"-class resources"
 msgstr " 可用于所有stonith类资源的实例属性"
 
-#: daemons/fenced/pacemaker-fenced.c:823
+#: daemons/fenced/pacemaker-fenced.c:820
 msgid ""
 "Instance attributes available for all \"stonith\"-class resources and used "
 "by Pacemaker's fence daemon, formerly known as stonithd"
@@ -451,15 +451,15 @@ msgstr ""
 " 可用于所有stonith类资源的实例属性，并由Pacemaker的fence守护程序使用（以前称"
 "为stonithd)"
 
-#: daemons/fenced/pacemaker-fenced.c:838
+#: daemons/fenced/pacemaker-fenced.c:835
 msgid "Deprecated (will be removed in a future release)"
 msgstr "已弃用(将在未来版本中删除)"
 
-#: daemons/fenced/pacemaker-fenced.c:841
+#: daemons/fenced/pacemaker-fenced.c:838
 msgid "Intended for use in regression testing only"
 msgstr "仅适用于回归测试"
 
-#: daemons/fenced/pacemaker-fenced.c:844
+#: daemons/fenced/pacemaker-fenced.c:841
 msgid "Send logs to the additional named logfile"
 msgstr "将日志发送到其他命名日志文件"
 
@@ -468,13 +468,15 @@ msgid "Pacemaker version on cluster node elected Designated Controller (DC)"
 msgstr "集群选定的控制器节点(DC)的 Pacemaker 版本"
 
 #: lib/common/options.c:59
+#, fuzzy
 msgid ""
-"Includes a hash which identifies the exact changeset the code was built "
-"from. Used for diagnostic purposes."
+"Includes a hash which identifies the exact revision the code was built from. "
+"Used for diagnostic purposes."
 msgstr "它包含一个标识所构建代码变更版本的哈希值，其可用于诊断。"
 
 #: lib/common/options.c:66
-msgid "The messaging stack on which Pacemaker is currently running"
+#, fuzzy
+msgid "The messaging layer on which Pacemaker is currently running"
 msgstr "Pacemaker 正在使用的消息传输引擎"
 
 #: lib/common/options.c:67
@@ -505,59 +507,53 @@ msgid ""
 "type of switches used."
 msgstr "其最佳值将取决于你的网络速度和负载以及所用交换机的类型。"
 
-#: lib/common/options.c:89
-#, fuzzy
-msgid ""
-"Zero disables polling, while positive values are an interval in seconds "
-"(unless other units are specified, for example \"5min\")"
-msgstr ""
-"设置为0将禁用轮询，设置为正数将是以秒为单位的时间间隔（除非使用了其他单位，比"
-"如\"5min\"表示5分钟）"
-
-#: lib/common/options.c:93
+#: lib/common/options.c:91
 msgid ""
 "Polling interval to recheck cluster state and evaluate rules with date "
 "specifications"
 msgstr "重新检查集群状态并且评估具有日期规格的配置规则的轮询间隔"
 
-#: lib/common/options.c:95
+#: lib/common/options.c:93
+#, fuzzy
 msgid ""
 "Pacemaker is primarily event-driven, and looks ahead to know when to recheck "
-"cluster state for failure timeouts and most time-based rules. However, it "
-"will also recheck the cluster after this amount of inactivity, to evaluate "
-"rules with date specifications and serve as a fail-safe for certain types of "
-"scheduler bugs."
+"cluster state for failure-timeout settings and most time-based rules. "
+"However, it will also recheck the cluster after this amount of inactivity, "
+"to evaluate rules with date specifications and serve as a fail-safe for "
+"certain types of scheduler bugs. A value of 0 disables polling. A positive "
+"value sets an interval in seconds, unless other units are specified (for "
+"example, \"5min\")."
 msgstr ""
 "Pacemaker 主要是通过事件驱动的，并能预期重新检查集群状态以评估大多数基于时间"
 "的规则以及过期的错误。然而无论如何，在集群经过该时间间隔的不活动状态后，它还"
 "将重新检查集群，以评估具有日期规格的规则，并为某些类型的调度程序缺陷提供故障"
 "保护。"
 
-#: lib/common/options.c:105
+#: lib/common/options.c:107
 msgid "How a cluster node should react if notified of its own fencing"
 msgstr "集群节点在收到针对自己的 fence 操作结果通知时应如何反应"
 
-#: lib/common/options.c:106
+#: lib/common/options.c:108
 #, fuzzy
 msgid ""
-"A cluster node may receive notification of its own fencing if fencing is "
-"misconfigured, or if fabric fencing is in use that doesn't cut cluster "
-"communication. Use \"stop\" to attempt to immediately stop Pacemaker and "
-"stay stopped, or \"panic\" to attempt to immediately reboot the local node, "
-"falling back to stop on failure."
+"A cluster node may receive notification of a \"succeeded\" fencing that "
+"targeted it if fencing is misconfigured, or if fabric fencing is in use that "
+"doesn't cut cluster communication. Use \"stop\" to attempt to immediately "
+"stop Pacemaker and stay stopped, or \"panic\" to attempt to immediately "
+"reboot the local node, falling back to stop on failure."
 msgstr ""
 "如果有错误的 fence 配置，或者在使用 fabric fence 机制 (并不会切断集群通信），"
 "则集群节点可能会收到针对自己的 fence 结果通知。允许的值为 \"stop\" 尝试立即停"
 "止 pacemaker 并保持停用状态,或者 \"panic\" 尝试立即重新启动本地节点，并在失败"
 "时返回执行stop。"
 
-#: lib/common/options.c:117 lib/common/options.c:126 lib/common/options.c:136
-#: lib/common/options.c:145
+#: lib/common/options.c:119 lib/common/options.c:128 lib/common/options.c:138
+#: lib/common/options.c:147
 #, fuzzy
 msgid "*** Advanced Use Only ***"
 msgstr "*** Advanced Use Only *** pacemaker未使用"
 
-#: lib/common/options.c:118
+#: lib/common/options.c:120
 msgid ""
 "Declare an election failed if it is not decided within this much time. If "
 "you need to adjust this value, it probably indicates the presence of a bug."
@@ -565,7 +561,7 @@ msgstr ""
 "如果集群在本项设置时间内没有作出决定则宣布选举失败。如果您需要调整该值，这可"
 "能代表存在某些缺陷。"
 
-#: lib/common/options.c:127
+#: lib/common/options.c:129
 msgid ""
 "Exit immediately if shutdown does not complete within this much time. If you "
 "need to adjust this value, it probably indicates the presence of a bug."
@@ -573,19 +569,19 @@ msgstr ""
 "如果在这段时间内关机仍未完成，则立即退出。如果您需要调整该值，这可能代表存在"
 "某些缺陷。"
 
-#: lib/common/options.c:137 lib/common/options.c:146
+#: lib/common/options.c:139 lib/common/options.c:148
 msgid ""
 "If you need to adjust this value, it probably indicates the presence of a "
 "bug."
 msgstr "如果您需要调整该值，这可能代表存在某些缺陷。"
 
-#: lib/common/options.c:153
+#: lib/common/options.c:155
 msgid ""
 "*** Advanced Use Only *** Enabling this option will slow down cluster "
 "recovery under all conditions"
 msgstr "*** Advanced Use Only *** 启用此选项将在所有情况下减慢集群恢复的速度"
 
-#: lib/common/options.c:156
+#: lib/common/options.c:158
 msgid ""
 "Delay cluster recovery for this much time to allow for additional events to "
 "occur. Useful if your configuration is sensitive to the order in which ping "
@@ -594,15 +590,15 @@ msgstr ""
 "集群恢复将被推迟指定的时间间隔，以等待更多事件发生。如果您的配置对 ping 更新"
 "到达的顺序很敏感，这就很有用"
 
-#: lib/common/options.c:165
+#: lib/common/options.c:168
 msgid "What to do when the cluster does not have quorum"
 msgstr "当集群没有必需票数时该如何作"
 
-#: lib/common/options.c:172
+#: lib/common/options.c:175
 msgid "Whether to lock resources to a cleanly shut down node"
 msgstr "是否锁定资源到完全关闭的节点"
 
-#: lib/common/options.c:173
+#: lib/common/options.c:176
 msgid ""
 "When true, resources active on a node when it is cleanly shut down are kept "
 "\"locked\" to that node (not allowed to run elsewhere) until they start "
@@ -616,11 +612,11 @@ msgstr ""
 "设置）。 Stonith资源和Pacemaker Remote连接永远不会被锁定。 克隆和捆绑实例以及"
 "可升级克隆的主角色目前从未锁定，尽管可以在将来的发行版中添加支持。"
 
-#: lib/common/options.c:186
+#: lib/common/options.c:189
 msgid "Do not lock resources to a cleanly shut down node longer than this"
 msgstr "资源会被锁定到完全关闭的节点的最长时间"
 
-#: lib/common/options.c:188
+#: lib/common/options.c:191
 msgid ""
 "If shutdown-lock is true and this is set to a nonzero time duration, "
 "shutdown locks will expire after this much time has passed since the "
@@ -629,27 +625,27 @@ msgstr ""
 "如果shutdown-lock为true，并且将此选项设置为非零持续时间，则自从开始shutdown以"
 "来经过了这么长的时间后，shutdown锁将过期，即使该节点尚未重新加入。"
 
-#: lib/common/options.c:197
+#: lib/common/options.c:200
 msgid "Enable Access Control Lists (ACLs) for the CIB"
 msgstr "为CIB启用访问控制列表(ACL)"
 
-#: lib/common/options.c:204
+#: lib/common/options.c:207
 msgid "Whether resources can run on any node by default"
 msgstr "资源是否默认可以在任何节点上运行"
 
-#: lib/common/options.c:211
+#: lib/common/options.c:214
 msgid ""
 "Whether the cluster should refrain from monitoring, starting, and stopping "
 "resources"
 msgstr "集群是否应避免监视，启动和停止资源"
 
-#: lib/common/options.c:219
+#: lib/common/options.c:222
 msgid ""
 "Whether a start failure should prevent a resource from being recovered on "
 "the same node"
 msgstr "是否避免在同一节点上重启启动失败的资源"
 
-#: lib/common/options.c:221
+#: lib/common/options.c:224
 msgid ""
 "When true, the cluster will immediately ban a resource from a node if it "
 "fails to start there. When false, the cluster will instead check the "
@@ -658,16 +654,16 @@ msgstr ""
 "当为true，如果资源启动失败，集群将立即禁止节点启动该资源，当为false，集群将根"
 "据其迁移阈值来检查资源的失败计数。"
 
-#: lib/common/options.c:229
+#: lib/common/options.c:232
 msgid "Whether the cluster should check for active resources during start-up"
 msgstr "集群是否在启动期间检查运行资源"
 
-#: lib/common/options.c:239
+#: lib/common/options.c:242
 msgid ""
 "*** Advanced Use Only *** Whether nodes may be fenced as part of recovery"
 msgstr "*** Advanced Use Only *** 节点是否可以被 fence 以作为集群恢复的一部分"
 
-#: lib/common/options.c:241
+#: lib/common/options.c:244
 msgid ""
 "If false, unresponsive nodes are immediately assumed to be harmless, and "
 "resources that were active on them may be recovered elsewhere. This can "
@@ -677,22 +673,22 @@ msgstr ""
 "如果为false，则立即假定无响应的节点是无害的，并且可以在其他位置恢复在其上活动"
 "的资源。 这可能会导致 \"split-brain\" 情况，可能导致数据丢失和/或服务不可用。"
 
-#: lib/common/options.c:250
+#: lib/common/options.c:253
 msgid ""
 "Action to send to fence device when a node needs to be fenced (\"poweroff\" "
 "is a deprecated alias for \"off\")"
 msgstr "发送到 fence 设备的操作（ \"poweroff\" 是 \"off \"的别名,不建议使用)"
 
-#: lib/common/options.c:258
+#: lib/common/options.c:261
 msgid ""
 "How long to wait for on, off, and reboot fence actions to complete by default"
 msgstr ""
 
-#: lib/common/options.c:266
+#: lib/common/options.c:269
 msgid "Whether watchdog integration is enabled"
 msgstr "是否启用watchdog集成设置"
 
-#: lib/common/options.c:267
+#: lib/common/options.c:270
 msgid ""
 "This is set automatically by the cluster according to whether SBD is "
 "detected to be in use. User-configured values are ignored. The value `true` "
@@ -706,7 +702,7 @@ msgstr ""
 "这种情况下，无需明确配置fence资源，如果需要fence时，基于watchdog的自我fence会"
 "通过SBD执行。"
 
-#: lib/common/options.c:288
+#: lib/common/options.c:291
 #, fuzzy
 msgid ""
 "How long before nodes can be assumed to be safely down when watchdog-based "
@@ -715,21 +711,23 @@ msgstr ""
 "当基于 watchdog 的自我 fence 机制通过SBD 被执行时，我们可以假设节点安全关闭之"
 "前需要等待多长时间"
 
-#: lib/common/options.c:290
+#: lib/common/options.c:293
+#, fuzzy
 msgid ""
-"If this is set to a positive value, lost nodes are assumed to self-fence "
-"using watchdog-based SBD within this much time. This does not require a "
-"fencing resource to be explicitly configured, though a fence_watchdog "
-"resource can be configured, to limit use to specific nodes. If this is set "
-"to 0 (the default), the cluster will never assume watchdog-based self-"
-"fencing. If this is set to a negative value, the cluster will use twice the "
-"local value of the `SBD_WATCHDOG_TIMEOUT` environment variable if that is "
-"positive, or otherwise treat this as 0. WARNING: When used, this timeout "
-"must be larger than `SBD_WATCHDOG_TIMEOUT` on all nodes that use watchdog-"
-"based SBD, and Pacemaker will refuse to start on any of those nodes where "
-"this is not true for the local value or SBD is not active. When this is set "
-"to a negative value, `SBD_WATCHDOG_TIMEOUT` must be set to the same value on "
-"all nodes that use SBD, otherwise data corruption or loss could occur."
+"If this is set to a positive value, lost nodes are assumed to achieve self-"
+"fencing using watchdog-based SBD within this much time. This does not "
+"require a fencing resource to be explicitly configured, though a "
+"fence_watchdog resource can be configured, to limit use to specific nodes. "
+"If this is set to 0 (the default), the cluster will never assume watchdog-"
+"based self-fencing. If this is set to a negative value, the cluster will use "
+"twice the local value of the `SBD_WATCHDOG_TIMEOUT` environment variable if "
+"that is positive, or otherwise treat this as 0. WARNING: When used, this "
+"timeout must be larger than `SBD_WATCHDOG_TIMEOUT` on all nodes that use "
+"watchdog-based SBD, and Pacemaker will refuse to start on any of those nodes "
+"where this is not true for the local value or SBD is not active. When this "
+"is set to a negative value, `SBD_WATCHDOG_TIMEOUT` must be set to the same "
+"value on all nodes that use SBD, otherwise data corruption or loss could "
+"occur."
 msgstr ""
 "如果设置为正值，则假定丢失的节点在这段时间内使用基于watchdog的SBD进行自我防"
 "护。这不需要明确配置fence资源，但可以配置一个fence_watchdog资源，以限制特定节"
@@ -740,21 +738,21 @@ msgstr ""
 "Pacemaker将拒绝在任何节点上启动。如果设置为负值，则在使用SBD的所有节点上，"
 "`SBD_WATCHDOG_TIMEOUT`必须设置为相同的值，否则可能会发生数据损坏或丢失。"
 
-#: lib/common/options.c:310
+#: lib/common/options.c:313
 msgid ""
 "How many times fencing can fail before it will no longer be immediately re-"
 "attempted on a target"
 msgstr "fence操作失败多少次会停止立即尝试"
 
-#: lib/common/options.c:318
+#: lib/common/options.c:321
 msgid "Allow performing fencing operations in parallel"
 msgstr "允许并行执行 fencing 操作"
 
-#: lib/common/options.c:325
+#: lib/common/options.c:328
 msgid "*** Advanced Use Only *** Whether to fence unseen nodes at start-up"
 msgstr "*** 仅高级使用 *** 是否在启动时fence不可见节点"
 
-#: lib/common/options.c:327
+#: lib/common/options.c:330
 #, fuzzy
 msgid ""
 "Setting this to false may lead to a \"split-brain\" situation, potentially "
@@ -763,13 +761,13 @@ msgstr ""
 "将此设置为 false 可能会导致 \"split-brain\" 的情况，可能导致数据丢失和/或服务"
 "不可用。"
 
-#: lib/common/options.c:334
+#: lib/common/options.c:337
 msgid ""
 "Apply fencing delay targeting the lost nodes with the highest total resource "
 "priority"
 msgstr "针对具有最高总资源优先级的丢失节点应用fencing延迟"
 
-#: lib/common/options.c:336
+#: lib/common/options.c:339
 msgid ""
 "Apply specified delay for the fencings that are targeting the lost nodes "
 "with the highest total resource priority in case we don't have the majority "
@@ -789,13 +787,13 @@ msgstr ""
 "加到此延迟。为了安全, 这个延迟应该明显大于 pcmk_delay_base/max 的最大设置值，"
 "例如两倍。默认情况下，优先级fencing延迟已禁用。"
 
-#: lib/common/options.c:353
+#: lib/common/options.c:356
 msgid ""
 "How long to wait for a node that has joined the cluster to join the "
 "controller process group"
 msgstr "等待已加入集群的节点加入控制器进程组的时间"
 
-#: lib/common/options.c:355
+#: lib/common/options.c:358
 msgid ""
 "Fence nodes that do not join the controller process group within this much "
 "time after joining the cluster, to allow the cluster to continue managing "
@@ -806,11 +804,11 @@ msgstr ""
 "资源。值为0表示永远不 fence 待定节点。将值设置为2h表示2小时后 fence 待定节"
 "点。"
 
-#: lib/common/options.c:365
+#: lib/common/options.c:368
 msgid "Maximum time for node-to-node communication"
 msgstr "最大节点间通信时间"
 
-#: lib/common/options.c:366
+#: lib/common/options.c:369
 msgid ""
 "The node elected Designated Controller (DC) will consider an action failed "
 "if it does not get a response from the node executing the action within this "
@@ -821,29 +819,29 @@ msgstr ""
 "响应，则会被选为指定控制器（DC）的节点认定为失败。\"正确\" 值将取决于速度和您"
 "的网络和集群节点的负载。"
 
-#: lib/common/options.c:378
+#: lib/common/options.c:381
 msgid "Maximum amount of system load that should be used by cluster nodes"
 msgstr "集群节点应该使用的最大系统负载量"
 
-#: lib/common/options.c:380
+#: lib/common/options.c:383
 msgid ""
 "The cluster will slow down its recovery process when the amount of system "
 "resources used (currently CPU) approaches this limit"
 msgstr "当使用的系统资源量（当前为CPU）接近此限制时，集群将减慢其恢复过程"
 
-#: lib/common/options.c:387
+#: lib/common/options.c:390
 msgid ""
 "Maximum number of jobs that can be scheduled per node (defaults to 2x cores)"
 msgstr "每个节点可以调度的最大作业数（默认为2x内核数）"
 
-#: lib/common/options.c:395
+#: lib/common/options.c:398
 #, fuzzy
 msgid ""
 "Maximum number of jobs that the cluster may execute in parallel across all "
 "nodes"
 msgstr "集群可以在所有节点上并发执行的最大作业数"
 
-#: lib/common/options.c:397
+#: lib/common/options.c:400
 msgid ""
 "The \"correct\" value will depend on the speed and load of your network and "
 "cluster nodes. If set to 0, the cluster will impose a dynamically calculated "
@@ -852,17 +850,17 @@ msgstr ""
 "\"正确\" 值将取决于速度和您的网络与集群节点的负载。如果设置为0，当任何节点具"
 "有高负载时，集群将施加一个动态计算的限制。"
 
-#: lib/common/options.c:406
+#: lib/common/options.c:409
 msgid ""
 "The number of live migration actions that the cluster is allowed to execute "
 "in parallel on a node (-1 means no limit)"
 msgstr "允许集群在一个节点上并行执行的实时迁移操作的数量(-1表示没有限制)"
 
-#: lib/common/options.c:414
+#: lib/common/options.c:417
 msgid "Maximum IPC message backlog before disconnecting a cluster daemon"
 msgstr "断开集群守护程序之前的最大IPC消息积压"
 
-#: lib/common/options.c:415
+#: lib/common/options.c:418
 msgid ""
 "Raise this if log has \"Evicting client\" messages for cluster daemon PIDs "
 "(a good value is the number of resources in the cluster multiplied by the "
@@ -871,92 +869,88 @@ msgstr ""
 "如果日志中有针对集群守护程序PID的消息“Evicting client”，（则建议将值设为集群"
 "中的资源数量乘以节点数量）"
 
-#: lib/common/options.c:425
+#: lib/common/options.c:428
 #, fuzzy
 msgid "Whether the cluster should stop all active resources"
 msgstr "集群是否在启动期间检查运行资源"
 
-#: lib/common/options.c:432
+#: lib/common/options.c:435
 msgid "Whether to stop resources that were removed from the configuration"
 msgstr "是否停止配置已被删除的资源"
 
-#: lib/common/options.c:440
+#: lib/common/options.c:443
 msgid "Whether to cancel recurring actions removed from the configuration"
 msgstr "是否取消配置已被删除的的重复操作"
 
-#: lib/common/options.c:448
+#: lib/common/options.c:451
 msgid ""
 "*** Deprecated *** Whether to remove stopped resources from the executor"
 msgstr "***不推荐***是否从pacemaker-execd 守护进程中清除已停止的资源"
 
-#: lib/common/options.c:450
+#: lib/common/options.c:453
 msgid ""
 "Values other than default are poorly tested and potentially dangerous. This "
 "option will be removed in a future release."
 msgstr "非默认值未经过充分的测试，有潜在的风险。该选项将在未来的版本中删除。"
 
-#: lib/common/options.c:459
+#: lib/common/options.c:462
 msgid "The number of scheduler inputs resulting in errors to save"
 msgstr "保存导致错误的调度程序输入的数量"
 
-#: lib/common/options.c:460 lib/common/options.c:467 lib/common/options.c:474
+#: lib/common/options.c:463 lib/common/options.c:470 lib/common/options.c:477
 msgid "Zero to disable, -1 to store unlimited."
 msgstr "零表示禁用，-1表示存储不受限制。"
 
-#: lib/common/options.c:466
+#: lib/common/options.c:469
 msgid "The number of scheduler inputs resulting in warnings to save"
 msgstr "保存导致警告的调度程序输入的数量"
 
-#: lib/common/options.c:473
+#: lib/common/options.c:476
 msgid "The number of scheduler inputs without errors or warnings to save"
 msgstr "保存没有错误或警告的调度程序输入的数量"
 
-#: lib/common/options.c:485
+#: lib/common/options.c:488
 #, fuzzy
 msgid "How cluster should react to node health attributes"
 msgstr "集群节点对节点健康属性如何反应"
 
-#: lib/common/options.c:486
+#: lib/common/options.c:489
 msgid ""
 "Requires external entities to create node attributes (named with the prefix "
 "\"#health\") with values \"red\", \"yellow\", or \"green\"."
 msgstr ""
 "需要外部实体创建具有“red”,“yellow”或“green”值的节点属性(前缀为“#health”)"
 
-#: lib/common/options.c:494
+#: lib/common/options.c:497
 msgid "Base health score assigned to a node"
 msgstr "分配给节点的基本健康分数"
 
-#: lib/common/options.c:495
+#: lib/common/options.c:498
 msgid "Only used when \"node-health-strategy\" is set to \"progressive\"."
 msgstr "仅在“node-health-strategy”设置为“progressive”时使用。"
 
-#: lib/common/options.c:502
+#: lib/common/options.c:505
 msgid "The score to use for a node health attribute whose value is \"green\""
 msgstr "为节点健康属性值为“green”所使用的分数"
 
-#: lib/common/options.c:504 lib/common/options.c:513 lib/common/options.c:522
+#: lib/common/options.c:507 lib/common/options.c:516 lib/common/options.c:525
 msgid ""
 "Only used when \"node-health-strategy\" is set to \"custom\" or "
 "\"progressive\"."
 msgstr "仅在“node-health-strategy”设置为“custom”或“progressive”时使用。"
 
-#: lib/common/options.c:511
+#: lib/common/options.c:514
 msgid "The score to use for a node health attribute whose value is \"yellow\""
 msgstr "为节点健康属性值为“yellow”所使用的分数"
 
-#: lib/common/options.c:520
+#: lib/common/options.c:523
 msgid "The score to use for a node health attribute whose value is \"red\""
 msgstr "为节点健康属性值为“red”所使用的分数"
 
-#: lib/common/options.c:532
+#: lib/common/options.c:536
 #, fuzzy
 msgid "How the cluster should allocate resources to nodes"
 msgstr "集群应该如何分配资源到节点"
-
-#: lib/common/options.c:995
-msgid "  Allowed values: "
-msgstr " 允许的值: "
 
 #: lib/common/cmdline.c:70
 msgid "Display software version and exit"
@@ -991,12 +985,12 @@ msgstr "显示输出帮助"
 msgid "Aborting because no messages received in %d seconds"
 msgstr "中止，因为在%d秒内没有接收到消息"
 
-#: tools/crm_resource.c:921
+#: tools/crm_resource.c:928
 #, c-format
 msgid "Invalid check level setting: %s"
 msgstr "无效的检查级别设置：%s"
 
-#: tools/crm_resource.c:1008
+#: tools/crm_resource.c:1015
 #, c-format
 msgid ""
 "Resource '%s' not moved: active in %d locations (promoted in %d).\n"
@@ -1008,7 +1002,7 @@ msgstr ""
 "若要阻止'%s'在特定位置运行，请指定一个节点。若要防止'%s'在指定位置升级，指定"
 "一个节点并使用--promoted选项"
 
-#: tools/crm_resource.c:1019
+#: tools/crm_resource.c:1026
 #, c-format
 msgid ""
 "Resource '%s' not moved: active in %d locations.\n"
@@ -1017,140 +1011,151 @@ msgstr ""
 "资源%s未移动:在%d个位置运行\n"
 "若要防止'%s'运行在特定位置，指定一个节点"
 
-#: tools/crm_resource.c:1096
+#: tools/crm_resource.c:1103
 #, c-format
 msgid "Could not get modified CIB: %s\n"
 msgstr "无法获得修改的CIB：%s\n"
 
-#: tools/crm_resource.c:1174
+#: tools/crm_resource.c:1181
 #, c-format
 msgid "No cluster connection to Pacemaker Remote node %s detected"
 msgstr "未检测到至pacemaker远程节点%s的集群连接"
 
-#: tools/crm_resource.c:1235
+#: tools/crm_resource.c:1242
 msgid "Must specify -t with resource type"
 msgstr "需要使用-t指定资源类型"
 
-#: tools/crm_resource.c:1241
+#: tools/crm_resource.c:1248
 msgid "Must supply -v with new value"
 msgstr "必须使用-v指定新值"
 
-#: tools/crm_resource.c:1273
+#: tools/crm_resource.c:1280
 msgid "Could not create executor connection"
 msgstr "无法创建到pacemaker-execd守护进程的连接"
 
-#: tools/crm_resource.c:1298
+#: tools/crm_resource.c:1305
 #, fuzzy, c-format
 msgid "Metadata query for %s failed: %s"
 msgstr "，查询%s的元数据失败: %s\n"
 
-#: tools/crm_resource.c:1304
+#: tools/crm_resource.c:1311
 #, c-format
 msgid "'%s' is not a valid agent specification"
 msgstr "'%s' 是一个无效的代理"
 
-#: tools/crm_resource.c:1317
+#: tools/crm_resource.c:1324
 msgid "--resource cannot be used with --class, --agent, and --provider"
 msgstr "--resource 不能与 --class, --agent, --provider一起使用"
 
-#: tools/crm_resource.c:1322
+#: tools/crm_resource.c:1329
 msgid ""
 "--class, --agent, and --provider can only be used with --validate and --"
 "force-*"
 msgstr "--class, --agent和--provider只能被用于--validate和--force-*"
 
-#: tools/crm_resource.c:1331
+#: tools/crm_resource.c:1338
 msgid "stonith does not support providers"
 msgstr "stonith 不支持提供者"
 
-#: tools/crm_resource.c:1335
+#: tools/crm_resource.c:1342
 #, c-format
 msgid "%s is not a known stonith agent"
 msgstr "%s 不是一个已知stonith代理"
 
-#: tools/crm_resource.c:1340
+#: tools/crm_resource.c:1347
 #, c-format
 msgid "%s:%s:%s is not a known resource"
 msgstr "%s:%s:%s 不是一个已知资源"
 
-#: tools/crm_resource.c:1454
+#: tools/crm_resource.c:1461
 #, c-format
 msgid "Error creating output format %s: %s"
 msgstr "创建输出格式错误 %s:%s"
 
-#: tools/crm_resource.c:1481
+#: tools/crm_resource.c:1488
 msgid "--expired requires --clear or -U"
 msgstr "--expired需要和--clear或-U一起使用"
 
-#: tools/crm_resource.c:1498
+#: tools/crm_resource.c:1505
 #, c-format
 msgid "Error parsing '%s' as a name=value pair"
 msgstr "'%s'解析错误，格式为name=value"
 
-#: tools/crm_resource.c:1595
+#: tools/crm_resource.c:1602
 msgid "Must supply a resource id with -r"
 msgstr "必须使用-r指定资源id"
 
-#: tools/crm_resource.c:1601
+#: tools/crm_resource.c:1608
 msgid "Must supply a node name with -N"
 msgstr "必须使用-N指定节点名称"
 
-#: tools/crm_resource.c:1619
+#: tools/crm_resource.c:1626
 msgid "Could not create CIB connection"
 msgstr "无法创建到CIB的连接"
 
-#: tools/crm_resource.c:1627
+#: tools/crm_resource.c:1634
 #, c-format
 msgid "Could not connect to the CIB: %s"
 msgstr "不能连接到CIB：%s"
 
-#: tools/crm_resource.c:1648
+#: tools/crm_resource.c:1655
 #, c-format
 msgid "Resource '%s' not found"
 msgstr "没有发现'%s'资源"
 
-#: tools/crm_resource.c:1660
+#: tools/crm_resource.c:1669
 #, c-format
 msgid "Cannot operate on clone resource instance '%s'"
 msgstr "不能操作克隆资源实例'%s'"
 
-#: tools/crm_resource.c:1672
+#: tools/crm_resource.c:1681
 #, c-format
 msgid "Node '%s' not found"
 msgstr "没有发现%s节点"
 
-#: tools/crm_resource.c:1683
+#: tools/crm_resource.c:1692
 #, c-format
 msgid "Error connecting to the controller: %s"
 msgstr "连接到控制器错误：%s"
 
-#: tools/crm_resource.c:1692
+#: tools/crm_resource.c:1701
 #, fuzzy, c-format
 msgid "Error connecting to %s: %s"
 msgstr "连接到控制器错误：%s"
 
-#: tools/crm_resource.c:1952
+#: tools/crm_resource.c:1962
 msgid "You need to supply a value with the -v option"
 msgstr "需要使用-v选项提供一个值"
 
-#: tools/crm_resource.c:2008
+#: tools/crm_resource.c:2018
 msgid "You need to specify a resource type with -t"
 msgstr "需要使用-t指定资源类型"
 
-#: tools/crm_resource.c:2015
+#: tools/crm_resource.c:2025
 #, fuzzy, c-format
 msgid "Could not delete resource %s: %s"
 msgstr "无法删除资源：%s：%s"
 
-#: tools/crm_resource.c:2025
+#: tools/crm_resource.c:2035
 #, c-format
 msgid "Unimplemented command: %d"
 msgstr "无效的命令：%d"
 
-#: tools/crm_resource.c:2055
+#: tools/crm_resource.c:2065
 #, c-format
 msgid "Error performing operation: %s"
 msgstr "执行操作错误：%s"
+
+#, fuzzy
+#~ msgid ""
+#~ "Zero disables polling, while positive values are an interval in seconds "
+#~ "(unless other units are specified, for example \"5min\")"
+#~ msgstr ""
+#~ "设置为0将禁用轮询，设置为正数将是以秒为单位的时间间隔（除非使用了其他单"
+#~ "位，比如\"5min\"表示5分钟）"
+
+#~ msgid "  Allowed values: "
+#~ msgstr " 允许的值: "
 
 #~ msgid ""
 #~ "This value is not used by Pacemaker, but is kept for backward "

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -179,7 +179,8 @@ main(int argc, char **argv)
 
         if (input == NULL) {
             exit_code = CRM_EX_DATAERR;
-            g_set_error(&error, PCMK__EXITC_ERROR, exit_code, "Couldn't parse input from STDIN\n");
+            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                        "Couldn't parse input from STDIN");
             goto done;
         }
     } else if (options.input_xml != NULL) {
@@ -188,7 +189,7 @@ main(int argc, char **argv)
         if (input == NULL) {
             exit_code = CRM_EX_DATAERR;
             g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                        "Couldn't parse input string: %s\n", options.input_xml);
+                        "Couldn't parse input string: %s", options.input_xml);
             goto done;
         }
     }


### PR DESCRIPTION
This part can stand on its own before we continue moving toward proper `pcmk__output_t` formatted output.