### PR TITLE
Build: Remove the rpmlintrc file.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,8 +34,8 @@ build: init
 # Pass option depending on whether automake has been run or not
 USE_FILE = $(shell test -e rpm/Makefile || echo "-f Makefile.am")
 
-.PHONY: $(PACKAGE).spec chroot dirty export mock rc release rpm rpmlint srpm
-$(PACKAGE).spec chroot dirty export mock rc release rpm rpmlint srpm:
+.PHONY: $(PACKAGE).spec chroot dirty export mock rc release rpm srpm
+$(PACKAGE).spec chroot dirty export mock rc release rpm srpm:
 	$(MAKE) $(AM_MAKEFLAGS) -C rpm $(USE_FILE) "$@"
 
 mock-% rpm-% spec-% srpm-%: FORCE

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -162,7 +162,12 @@ $(RPM_SPEC_DIR)/$(PACKAGE).spec: spec-clean pacemaker.spec.in
 	    -e 's/^\(%global commit_abbrev \).*/\1$(SPEC_ABBREV)/'	\
 	    -e "s/PACKAGE_DATE/$$(date +'%a %b %d %Y')/"		\
 	    -e 's/PACKAGE_VERSION/$(SPEC_RELEASE_NO)-$(SPECVERSION)/'	\
-	    > "$@"
+	    > "$@"; 							\
+	if echo "$$(rpmlint --help 2>&1)" | grep -q "ignore-unused-rpmlintrc"; then 	\
+		rpmlint --ignore-unused-rpmlintrc --file rpmlintrc "$@"; 		\
+	else 										\
+		rpmlint --file rpmlintrc "$@"; 						\
+	fi
 
 .PHONY: spec $(PACKAGE).spec
 spec $(PACKAGE).spec: $(RPM_SPEC_DIR)/$(PACKAGE).spec
@@ -190,10 +195,6 @@ rpm:	srpm
 .PHONY: rpm-clean
 rpm-clean: spec-clean srpm-clean
 	-if [ -n "$(RPM_CLEAN)" ]; then rm -rf $(RPM_CLEAN); fi
-
-.PHONY: rpmlint
-rpmlint: $(RPM_SPEC_DIR)/$(PACKAGE).spec
-	rpmlint -f rpmlintrc "$<"
 
 .PHONY: rpm-dep
 rpm-dep: $(RPM_SPEC_DIR)/$(PACKAGE).spec

--- a/rpm/rpmlintrc
+++ b/rpm/rpmlintrc
@@ -6,18 +6,9 @@ addFilter("E: hardcoded-library-path in /usr/lib/os-release")
 
 # When building developer packages
 addFilter("W: invalid-url Source0:")
-addFilter("W: unstripped-binary-or-object")
-addFilter("W: incoherent-version-in-changelog")
-addFilter("E: changelog-time-in-future")
 
 # rpmlint doesn't like logrotate script being in pacemaker-cli package
 addFilter("E: incoherent-logrotate-file /etc/logrotate.d/pacemaker")
 
 # pacemaker_remote scriptlets use a state file
 addFilter("W: dangerous-command-in-%(pre|postun|posttrans) rm")
-
-# We should really use "pacemaker-remote", but we don't
-addFilter("W: incoherent-init-script-name pacemaker_remote")
-
-# Some scriptlets have code for systemd systems only
-addFilter("W: empty-%(post|pre|preun|postun|posttrans)")


### PR DESCRIPTION
First, we were using the wrong command line option.  It should be "-r rpmlintrc".  Second, everything we have in the rpmlintrc file at the moment is not even necessary, causing rpmlint to throw errors about unused filters.

We can later bring the file back if it's necessary, but just removing it causes rpmlint to pass.

Fixes T760