### PR TITLE
Convert crm_ticket to use formatted output

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -3294,14 +3294,15 @@ false
 * Passed: crm_ticket     - Query ticket granted state
 =#=#=#= Begin test: Query ticket granted state, outputting as xml =#=#=#=
 <pacemaker-result api-version="X" request="crm_ticket -t ticketA -G granted --output-as=xml">
+  <tickets>
+    <ticket id="ticketA">
+      <attribute name="granted" value="false"/>
+    </ticket>
+  </tickets>
   <status code="0" message="OK"/>
 </pacemaker-result>
-false
-/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
-false
-^
-=#=#=#= End test: Query ticket granted state, outputting as xml - Failed to validate (1) =#=#=#=
-* Failed (rc=001): crm_ticket     - Query ticket granted state, outputting as xml
+=#=#=#= End test: Query ticket granted state, outputting as xml - OK (0) =#=#=#=
+* Passed: crm_ticket     - Query ticket granted state, outputting as xml
 =#=#=#= Begin test: Delete ticket granted state =#=#=#=
 =#=#=#= Current cib after: Delete ticket granted state =#=#=#=
 <cib epoch="29" num_updates="2" admin_epoch="0">

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -3229,16 +3229,13 @@ State XML:
 * Passed: crm_ticket     - Query ticket state
 =#=#=#= Begin test: Query ticket state, outputting as xml =#=#=#=
 <pacemaker-result api-version="X" request="crm_ticket -t ticketA -q --output-as=xml">
+  <tickets>
+    <ticket id="ticketA" granted="false"/>
+  </tickets>
   <status code="0" message="OK"/>
 </pacemaker-result>
-State XML:
-
-<ticket_state id="ticketA" granted="false"/>
-/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
-State XML:
-^
-=#=#=#= End test: Query ticket state, outputting as xml - Failed to validate (1) =#=#=#=
-* Failed (rc=001): crm_ticket     - Query ticket state, outputting as xml
+=#=#=#= End test: Query ticket state, outputting as xml - OK (0) =#=#=#=
+* Passed: crm_ticket     - Query ticket state, outputting as xml
 =#=#=#= Begin test: Query ticket granted state =#=#=#=
 false
 =#=#=#= Current cib after: Query ticket granted state =#=#=#=
@@ -3853,16 +3850,20 @@ Constraints XML:
 * Passed: crm_ticket     - Query ticket constraints
 =#=#=#= Begin test: Query ticket constraints, outputting as xml =#=#=#=
 <pacemaker-result api-version="X" request="crm_ticket -t ticketA -c --output-as=xml">
+  <tickets>
+    <ticket id="ticketA">
+      <constraints>
+        <rsc_ticket id="dummy-dep-ticketA" rsc="dummy" rsc-role="Started" ticket="ticketA" loss-policy="freeze"/>
+      </constraints>
+    </ticket>
+  </tickets>
+  <resources>
+    <resource id="dummy"/>
+  </resources>
   <status code="0" message="OK"/>
 </pacemaker-result>
-Constraints XML:
-
-<rsc_ticket id="dummy-dep-ticketA" rsc="dummy" rsc-role="Started" ticket="ticketA" loss-policy="freeze"/>
-/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
-Constraints XML:
-^
-=#=#=#= End test: Query ticket constraints, outputting as xml - Failed to validate (1) =#=#=#=
-* Failed (rc=001): crm_ticket     - Query ticket constraints, outputting as xml
+=#=#=#= End test: Query ticket constraints, outputting as xml - OK (0) =#=#=#=
+* Passed: crm_ticket     - Query ticket constraints, outputting as xml
 =#=#=#= Begin test: Delete ticket constraint =#=#=#=
 =#=#=#= Current cib after: Delete ticket constraint =#=#=#=
 <cib epoch="31" num_updates="0" admin_epoch="0">

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -3207,6 +3207,38 @@ false
 </cib>
 =#=#=#= End test: Set ticket granted state - OK (0) =#=#=#=
 * Passed: crm_ticket     - Set ticket granted state
+=#=#=#= Begin test: List ticket IDs =#=#=#=
+ticketA
+=#=#=#= End test: List ticket IDs - OK (0) =#=#=#=
+* Passed: crm_ticket     - List ticket IDs
+=#=#=#= Begin test: List ticket IDs, outputting in XML =#=#=#=
+<pacemaker-result api-version="X" request="crm_ticket -w --output-as=xml">
+  <status code="0" message="OK"/>
+</pacemaker-result>
+ticketA
+/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
+ticketA
+^
+=#=#=#= End test: List ticket IDs, outputting in XML - Failed to validate (1) =#=#=#=
+* Failed (rc=001): crm_ticket     - List ticket IDs, outputting in XML
+=#=#=#= Begin test: Query ticket state =#=#=#=
+State XML:
+
+<ticket_state id="ticketA" granted="false"/>
+=#=#=#= End test: Query ticket state - OK (0) =#=#=#=
+* Passed: crm_ticket     - Query ticket state
+=#=#=#= Begin test: Query ticket state, outputting as xml =#=#=#=
+<pacemaker-result api-version="X" request="crm_ticket -t ticketA -q --output-as=xml">
+  <status code="0" message="OK"/>
+</pacemaker-result>
+State XML:
+
+<ticket_state id="ticketA" granted="false"/>
+/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
+State XML:
+^
+=#=#=#= End test: Query ticket state, outputting as xml - Failed to validate (1) =#=#=#=
+* Failed (rc=001): crm_ticket     - Query ticket state, outputting as xml
 =#=#=#= Begin test: Query ticket granted state =#=#=#=
 false
 =#=#=#= Current cib after: Query ticket granted state =#=#=#=
@@ -3264,6 +3296,16 @@ false
 </cib>
 =#=#=#= End test: Query ticket granted state - OK (0) =#=#=#=
 * Passed: crm_ticket     - Query ticket granted state
+=#=#=#= Begin test: Query ticket granted state, outputting as xml =#=#=#=
+<pacemaker-result api-version="X" request="crm_ticket -t ticketA -G granted --output-as=xml">
+  <status code="0" message="OK"/>
+</pacemaker-result>
+false
+/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
+false
+^
+=#=#=#= End test: Query ticket granted state, outputting as xml - Failed to validate (1) =#=#=#=
+* Failed (rc=001): crm_ticket     - Query ticket granted state, outputting as xml
 =#=#=#= Begin test: Delete ticket granted state =#=#=#=
 =#=#=#= Current cib after: Delete ticket granted state =#=#=#=
 <cib epoch="29" num_updates="2" admin_epoch="0">
@@ -3489,9 +3531,209 @@ true
 </cib>
 =#=#=#= End test: Activate a ticket - OK (0) =#=#=#=
 * Passed: crm_ticket     - Activate a ticket
+=#=#=#= Begin test: List ticket details =#=#=#=
+ticketA	revoked           (standby=false)
+=#=#=#= End test: List ticket details - OK (0) =#=#=#=
+* Passed: crm_ticket     - List ticket details
+=#=#=#= Begin test: List ticket details, outputting as XML =#=#=#=
+<pacemaker-result api-version="X" request="crm_ticket -L -t ticketA --output-as=xml">
+  <status code="0" message="OK"/>
+</pacemaker-result>
+ticketA	revoked           (standby=false)
+/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
+ticketA	revoked           (standby=false)
+^
+=#=#=#= End test: List ticket details, outputting as XML - Failed to validate (1) =#=#=#=
+* Failed (rc=001): crm_ticket     - List ticket details, outputting as XML
+=#=#=#= Begin test: Add a second ticket =#=#=#=
+false
+=#=#=#= Current cib after: Add a second ticket =#=#=#=
+<cib epoch="29" num_updates="4" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+        <utilization id="nodes-node1-utilization">
+          <nvpair id="nodes-node1-utilization-cpu" name="cpu" value="1"/>
+        </utilization>
+      </node>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status>
+    <node_state id="node1" uname="node1" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="crm_simulate">
+      <transient_attributes id="node1">
+        <instance_attributes id="status-node1"/>
+      </transient_attributes>
+      <lrm id="node1">
+        <lrm_resources>
+          <lrm_resource id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="0830891652dabe627ca72b8e879199b1"/>
+          </lrm_resource>
+          <lrm_resource id="Fence" class="stonith" type="fence_true">
+            <lrm_rsc_op id="Fence_last_0" operation_key="Fence_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <tickets>
+      <ticket_state id="ticketA" standby="false"/>
+    </tickets>
+  </status>
+</cib>
+=#=#=#= End test: Add a second ticket - OK (0) =#=#=#=
+* Passed: crm_ticket     - Add a second ticket
+=#=#=#= Begin test: Set second ticket granted state =#=#=#=
+=#=#=#= Current cib after: Set second ticket granted state =#=#=#=
+<cib epoch="29" num_updates="5" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+        <utilization id="nodes-node1-utilization">
+          <nvpair id="nodes-node1-utilization-cpu" name="cpu" value="1"/>
+        </utilization>
+      </node>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status>
+    <node_state id="node1" uname="node1" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="crm_simulate">
+      <transient_attributes id="node1">
+        <instance_attributes id="status-node1"/>
+      </transient_attributes>
+      <lrm id="node1">
+        <lrm_resources>
+          <lrm_resource id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="0830891652dabe627ca72b8e879199b1"/>
+          </lrm_resource>
+          <lrm_resource id="Fence" class="stonith" type="fence_true">
+            <lrm_rsc_op id="Fence_last_0" operation_key="Fence_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <tickets>
+      <ticket_state id="ticketA" standby="false"/>
+      <ticket_state id="ticketB" granted="false"/>
+    </tickets>
+  </status>
+</cib>
+=#=#=#= End test: Set second ticket granted state - OK (0) =#=#=#=
+* Passed: crm_ticket     - Set second ticket granted state
+=#=#=#= Begin test: List tickets =#=#=#=
+ticketA	revoked          
+ticketB	revoked          
+=#=#=#= End test: List tickets - OK (0) =#=#=#=
+* Passed: crm_ticket     - List tickets
+=#=#=#= Begin test: List tickets, outputting as XML =#=#=#=
+<pacemaker-result api-version="X" request="crm_ticket -l --output-as=xml">
+  <status code="0" message="OK"/>
+</pacemaker-result>
+ticketA	revoked          
+ticketB	revoked          
+/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
+ticketA	revoked          
+^
+=#=#=#= End test: List tickets, outputting as XML - Failed to validate (1) =#=#=#=
+* Failed (rc=001): crm_ticket     - List tickets, outputting as XML
+=#=#=#= Begin test: Delete second ticket =#=#=#=
+=#=#=#= Current cib after: Delete second ticket =#=#=#=
+<cib epoch="29" num_updates="6" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+        <utilization id="nodes-node1-utilization">
+          <nvpair id="nodes-node1-utilization-cpu" name="cpu" value="1"/>
+        </utilization>
+      </node>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status>
+    <node_state id="node1" uname="node1" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="crm_simulate">
+      <transient_attributes id="node1">
+        <instance_attributes id="status-node1"/>
+      </transient_attributes>
+      <lrm id="node1">
+        <lrm_resources>
+          <lrm_resource id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="0830891652dabe627ca72b8e879199b1"/>
+          </lrm_resource>
+          <lrm_resource id="Fence" class="stonith" type="fence_true">
+            <lrm_rsc_op id="Fence_last_0" operation_key="Fence_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <tickets>
+      <ticket_state id="ticketA" standby="false"/>
+    </tickets>
+  </status>
+</cib>
+=#=#=#= End test: Delete second ticket - OK (0) =#=#=#=
+* Passed: cibadmin       - Delete second ticket
 =#=#=#= Begin test: Delete ticket standby state =#=#=#=
 =#=#=#= Current cib after: Delete ticket standby state =#=#=#=
-<cib epoch="29" num_updates="5" admin_epoch="0">
+<cib epoch="29" num_updates="7" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3545,11 +3787,143 @@ true
 </cib>
 =#=#=#= End test: Delete ticket standby state - OK (0) =#=#=#=
 * Passed: crm_ticket     - Delete ticket standby state
+=#=#=#= Begin test: Delete ticket standby state =#=#=#=
+=#=#=#= Current cib after: Delete ticket standby state =#=#=#=
+<cib epoch="30" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+        <utilization id="nodes-node1-utilization">
+          <nvpair id="nodes-node1-utilization-cpu" name="cpu" value="1"/>
+        </utilization>
+      </node>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+    </resources>
+    <constraints>
+      <rsc_ticket id="dummy-dep-ticketA" rsc="dummy" rsc-role="Started" ticket="ticketA" loss-policy="freeze"/>
+    </constraints>
+  </configuration>
+  <status>
+    <node_state id="node1" uname="node1" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="crm_simulate">
+      <transient_attributes id="node1">
+        <instance_attributes id="status-node1"/>
+      </transient_attributes>
+      <lrm id="node1">
+        <lrm_resources>
+          <lrm_resource id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="0830891652dabe627ca72b8e879199b1"/>
+          </lrm_resource>
+          <lrm_resource id="Fence" class="stonith" type="fence_true">
+            <lrm_rsc_op id="Fence_last_0" operation_key="Fence_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <tickets>
+      <ticket_state id="ticketA"/>
+    </tickets>
+  </status>
+</cib>
+=#=#=#= End test: Delete ticket standby state - OK (0) =#=#=#=
+* Passed: cibadmin       - Delete ticket standby state
+=#=#=#= Begin test: Query ticket constraints =#=#=#=
+Constraints XML:
+
+<rsc_ticket id="dummy-dep-ticketA" rsc="dummy" rsc-role="Started" ticket="ticketA" loss-policy="freeze"/>
+=#=#=#= End test: Query ticket constraints - OK (0) =#=#=#=
+* Passed: crm_ticket     - Query ticket constraints
+=#=#=#= Begin test: Query ticket constraints, outputting as xml =#=#=#=
+<pacemaker-result api-version="X" request="crm_ticket -t ticketA -c --output-as=xml">
+  <status code="0" message="OK"/>
+</pacemaker-result>
+Constraints XML:
+
+<rsc_ticket id="dummy-dep-ticketA" rsc="dummy" rsc-role="Started" ticket="ticketA" loss-policy="freeze"/>
+/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
+Constraints XML:
+^
+=#=#=#= End test: Query ticket constraints, outputting as xml - Failed to validate (1) =#=#=#=
+* Failed (rc=001): crm_ticket     - Query ticket constraints, outputting as xml
+=#=#=#= Begin test: Delete ticket constraint =#=#=#=
+=#=#=#= Current cib after: Delete ticket constraint =#=#=#=
+<cib epoch="31" num_updates="0" admin_epoch="0">
+  <configuration>
+    <crm_config>
+      <cluster_property_set id="cib-bootstrap-options">
+        <nvpair id="cib-bootstrap-options-no-quorum-policy" name="no-quorum-policy" value="ignore"/>
+      </cluster_property_set>
+      <cluster_property_set id="duplicate">
+        <nvpair id="duplicate-cluster-delay" name="cluster-delay" value="30s"/>
+      </cluster_property_set>
+    </crm_config>
+    <nodes>
+      <node id="node1" uname="node1">
+        <instance_attributes id="nodes-node1">
+          <nvpair id="nodes-node1-ram" name="ram" value="1024M"/>
+        </instance_attributes>
+        <utilization id="nodes-node1-utilization">
+          <nvpair id="nodes-node1-utilization-cpu" name="cpu" value="1"/>
+        </utilization>
+      </node>
+    </nodes>
+    <resources>
+      <primitive id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+        <meta_attributes id="dummy-meta_attributes"/>
+        <instance_attributes id="dummy-instance_attributes">
+          <nvpair id="dummy-instance_attributes-delay" name="delay" value="10s"/>
+        </instance_attributes>
+      </primitive>
+      <primitive id="Fence" class="stonith" type="fence_true"/>
+    </resources>
+    <constraints/>
+  </configuration>
+  <status>
+    <node_state id="node1" uname="node1" in_ccm="true" crmd="online" join="member" expected="member" crm-debug-origin="crm_simulate">
+      <transient_attributes id="node1">
+        <instance_attributes id="status-node1"/>
+      </transient_attributes>
+      <lrm id="node1">
+        <lrm_resources>
+          <lrm_resource id="dummy" class="ocf" provider="pacemaker" type="Dummy">
+            <lrm_rsc_op id="dummy_last_0" operation_key="dummy_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="0830891652dabe627ca72b8e879199b1"/>
+          </lrm_resource>
+          <lrm_resource id="Fence" class="stonith" type="fence_true">
+            <lrm_rsc_op id="Fence_last_0" operation_key="Fence_start_0" operation="start" crm-debug-origin="crm_simulate" transition-key="2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" transition-magic="0:0;2:-1:0:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" exit-reason="" call-id="2" rc-code="0" op-status="0" interval="0" exec-time="0" queue-time="0" op-digest="f2317cad3d54cec5d7d7aa7d0bf35cf8"/>
+          </lrm_resource>
+        </lrm_resources>
+      </lrm>
+    </node_state>
+    <tickets>
+      <ticket_state id="ticketA"/>
+    </tickets>
+  </status>
+</cib>
+=#=#=#= End test: Delete ticket constraint - OK (0) =#=#=#=
+* Passed: cibadmin       - Delete ticket constraint
 =#=#=#= Begin test: Ban a resource on unknown node =#=#=#=
 crm_resource: Node 'host1' not found
 Error performing operation: No such object
 =#=#=#= Current cib after: Ban a resource on unknown node =#=#=#=
-<cib epoch="29" num_updates="5" admin_epoch="0">
+<cib epoch="31" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3635,7 +4009,7 @@ Revised Cluster Status:
     * dummy	(ocf:pacemaker:Dummy):	 Started node1
     * Fence	(stonith:fence_true):	 Started node2
 =#=#=#= Current cib after: Create two more nodes and bring them online =#=#=#=
-<cib epoch="31" num_updates="8" admin_epoch="0">
+<cib epoch="33" num_updates="8" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3720,7 +4094,7 @@ WARNING: Creating rsc_location constraint 'cli-ban-dummy-on-node1' with a score 
 	This will prevent dummy from running on node1 until the constraint is removed using the clear option or by editing the CIB with an appropriate tool.
 	This will be the case even if node1 is the last node in the cluster
 =#=#=#= Current cib after: Ban dummy from node1 =#=#=#=
-<cib epoch="32" num_updates="0" admin_epoch="0">
+<cib epoch="34" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3816,7 +4190,7 @@ Locations:
   <status code="0" message="OK"/>
 </pacemaker-result>
 =#=#=#= Current cib after: Ban dummy from node2 =#=#=#=
-<cib epoch="33" num_updates="0" admin_epoch="0">
+<cib epoch="35" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -3923,7 +4297,7 @@ Revised Cluster Status:
     * dummy	(ocf:pacemaker:Dummy):	 Started node3
     * Fence	(stonith:fence_true):	 Started node2
 =#=#=#= Current cib after: Relocate resources due to ban =#=#=#=
-<cib epoch="33" num_updates="2" admin_epoch="0">
+<cib epoch="35" num_updates="2" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4011,7 +4385,7 @@ Revised Cluster Status:
   <status code="0" message="OK"/>
 </pacemaker-result>
 =#=#=#= Current cib after: Move dummy to node1 =#=#=#=
-<cib epoch="35" num_updates="0" admin_epoch="0">
+<cib epoch="37" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4097,7 +4471,7 @@ Revised Cluster Status:
 =#=#=#= Begin test: Clear implicit constraints for dummy on node2 =#=#=#=
 Removing constraint: cli-ban-dummy-on-node2
 =#=#=#= Current cib after: Clear implicit constraints for dummy on node2 =#=#=#=
-<cib epoch="36" num_updates="0" admin_epoch="0">
+<cib epoch="38" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4189,7 +4563,7 @@ Removing constraint: cli-ban-dummy-on-node2
 Performing update of 'is-managed' on 'test-clone', the parent of 'test-primitive'
 Set 'test-clone' option: id=test-clone-meta_attributes-is-managed set=test-clone-meta_attributes name=is-managed value=false
 =#=#=#= Current cib after: Create a resource meta attribute =#=#=#=
-<cib epoch="38" num_updates="0" admin_epoch="0">
+<cib epoch="40" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4237,7 +4611,7 @@ Set 'test-clone' option: id=test-clone-meta_attributes-is-managed set=test-clone
 =#=#=#= Begin test: Create a resource meta attribute in the primitive =#=#=#=
 Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed set=test-primitive-meta_attributes name=is-managed value=false
 =#=#=#= Current cib after: Create a resource meta attribute in the primitive =#=#=#=
-<cib epoch="39" num_updates="0" admin_epoch="0">
+<cib epoch="41" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4294,7 +4668,7 @@ Multiple attributes match name=is-managed
 A value for 'is-managed' already exists in child 'test-primitive', performing update on that instead of 'test-clone'
 Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=is-managed value=true
 =#=#=#= Current cib after: Update resource meta attribute with duplicates =#=#=#=
-<cib epoch="40" num_updates="0" admin_epoch="0">
+<cib epoch="42" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4346,7 +4720,7 @@ Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=i
 =#=#=#= Begin test: Update resource meta attribute with duplicates (force clone) =#=#=#=
 Set 'test-clone' option: id=test-clone-meta_attributes-is-managed name=is-managed value=true
 =#=#=#= Current cib after: Update resource meta attribute with duplicates (force clone) =#=#=#=
-<cib epoch="41" num_updates="0" admin_epoch="0">
+<cib epoch="43" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4402,7 +4776,7 @@ Multiple attributes match name=is-managed
 
 Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=is-managed value=false
 =#=#=#= Current cib after: Update child resource meta attribute with duplicates =#=#=#=
-<cib epoch="42" num_updates="0" admin_epoch="0">
+<cib epoch="44" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4459,7 +4833,7 @@ Multiple attributes match name=is-managed
 A value for 'is-managed' already exists in child 'test-primitive', performing delete on that instead of 'test-clone'
 Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=is-managed
 =#=#=#= Current cib after: Delete resource meta attribute with duplicates =#=#=#=
-<cib epoch="43" num_updates="0" admin_epoch="0">
+<cib epoch="45" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4510,7 +4884,7 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 Performing delete of 'is-managed' on 'test-clone', the parent of 'test-primitive'
 Deleted 'test-clone' option: id=test-clone-meta_attributes-is-managed name=is-managed
 =#=#=#= Current cib after: Delete resource meta attribute in parent =#=#=#=
-<cib epoch="44" num_updates="0" admin_epoch="0">
+<cib epoch="46" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4558,7 +4932,7 @@ Deleted 'test-clone' option: id=test-clone-meta_attributes-is-managed name=is-ma
 =#=#=#= Begin test: Create a resource meta attribute in the primitive =#=#=#=
 Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed set=test-primitive-meta_attributes name=is-managed value=false
 =#=#=#= Current cib after: Create a resource meta attribute in the primitive =#=#=#=
-<cib epoch="45" num_updates="0" admin_epoch="0">
+<cib epoch="47" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4609,7 +4983,7 @@ Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed set=te
 A value for 'is-managed' already exists in child 'test-primitive', performing update on that instead of 'test-clone'
 Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=is-managed value=true
 =#=#=#= Current cib after: Update existing resource meta attribute =#=#=#=
-<cib epoch="46" num_updates="0" admin_epoch="0">
+<cib epoch="48" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4659,7 +5033,7 @@ Set 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=i
 =#=#=#= Begin test: Create a resource meta attribute in the parent =#=#=#=
 Set 'test-clone' option: id=test-clone-meta_attributes-is-managed set=test-clone-meta_attributes name=is-managed value=true
 =#=#=#= Current cib after: Create a resource meta attribute in the parent =#=#=#=
-<cib epoch="47" num_updates="0" admin_epoch="0">
+<cib epoch="49" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4714,7 +5088,7 @@ Set 'test-clone' option: id=test-clone-meta_attributes-is-managed set=test-clone
 =#=#=#= Begin test: Delete resource parent meta attribute (force) =#=#=#=
 Deleted 'test-clone' option: id=test-clone-meta_attributes-is-managed name=is-managed
 =#=#=#= Current cib after: Delete resource parent meta attribute (force) =#=#=#=
-<cib epoch="48" num_updates="0" admin_epoch="0">
+<cib epoch="50" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4763,7 +5137,7 @@ Deleted 'test-clone' option: id=test-clone-meta_attributes-is-managed name=is-ma
 * Passed: crm_resource   - Delete resource parent meta attribute (force)
 =#=#=#= Begin test: Restore duplicates =#=#=#=
 =#=#=#= Current cib after: Restore duplicates =#=#=#=
-<cib epoch="49" num_updates="0" admin_epoch="0">
+<cib epoch="51" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4819,7 +5193,7 @@ Multiple attributes match name=is-managed
 
 Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed name=is-managed
 =#=#=#= Current cib after: Delete resource child meta attribute =#=#=#=
-<cib epoch="50" num_updates="0" admin_epoch="0">
+<cib epoch="52" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4868,7 +5242,7 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 * Passed: crm_resource   - Delete resource child meta attribute
 =#=#=#= Begin test: Create the dummy-group resource group =#=#=#=
 =#=#=#= Current cib after: Create the dummy-group resource group =#=#=#=
-<cib epoch="51" num_updates="0" admin_epoch="0">
+<cib epoch="53" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4922,7 +5296,7 @@ Deleted 'test-primitive' option: id=test-primitive-meta_attributes-is-managed na
 =#=#=#= Begin test: Create a resource meta attribute in dummy1 =#=#=#=
 Set 'dummy1' option: id=dummy1-meta_attributes-is-managed set=dummy1-meta_attributes name=is-managed value=true
 =#=#=#= Current cib after: Create a resource meta attribute in dummy1 =#=#=#=
-<cib epoch="52" num_updates="0" admin_epoch="0">
+<cib epoch="54" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -4981,7 +5355,7 @@ Set 'dummy1' option: id=dummy1-meta_attributes-is-managed set=dummy1-meta_attrib
 Set 'dummy1' option: id=dummy1-meta_attributes-is-managed name=is-managed value=false
 Set 'dummy-group' option: id=dummy-group-meta_attributes-is-managed set=dummy-group-meta_attributes name=is-managed value=false
 =#=#=#= Current cib after: Create a resource meta attribute in dummy-group =#=#=#=
-<cib epoch="54" num_updates="0" admin_epoch="0">
+<cib epoch="56" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5041,7 +5415,7 @@ Set 'dummy-group' option: id=dummy-group-meta_attributes-is-managed set=dummy-gr
 * Passed: crm_resource   - Create a resource meta attribute in dummy-group
 =#=#=#= Begin test: Delete the dummy-group resource group =#=#=#=
 =#=#=#= Current cib after: Delete the dummy-group resource group =#=#=#=
-<cib epoch="55" num_updates="0" admin_epoch="0">
+<cib epoch="57" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5091,7 +5465,7 @@ Set 'dummy-group' option: id=dummy-group-meta_attributes-is-managed set=dummy-gr
 =#=#=#= Begin test: Specify a lifetime when moving a resource =#=#=#=
 Migration will take effect until:
 =#=#=#= Current cib after: Specify a lifetime when moving a resource =#=#=#=
-<cib epoch="57" num_updates="0" admin_epoch="0">
+<cib epoch="59" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5145,7 +5519,7 @@ Migration will take effect until:
 * Passed: crm_resource   - Specify a lifetime when moving a resource
 =#=#=#= Begin test: Try to move a resource previously moved with a lifetime =#=#=#=
 =#=#=#= Current cib after: Try to move a resource previously moved with a lifetime =#=#=#=
-<cib epoch="59" num_updates="0" admin_epoch="0">
+<cib epoch="61" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5198,7 +5572,7 @@ WARNING: Creating rsc_location constraint 'cli-ban-dummy-on-node1' with a score 
 	This will prevent dummy from running on node1 until the constraint is removed using the clear option or by editing the CIB with an appropriate tool.
 	This will be the case even if node1 is the last node in the cluster
 =#=#=#= Current cib after: Ban dummy from node1 for a short time =#=#=#=
-<cib epoch="60" num_updates="0" admin_epoch="0">
+<cib epoch="62" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5254,7 +5628,7 @@ WARNING: Creating rsc_location constraint 'cli-ban-dummy-on-node1' with a score 
 =#=#=#= Begin test: Remove expired constraints =#=#=#=
 Removing constraint: cli-ban-dummy-on-node1
 =#=#=#= Current cib after: Remove expired constraints =#=#=#=
-<cib epoch="61" num_updates="0" admin_epoch="0">
+<cib epoch="63" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5304,7 +5678,7 @@ Removing constraint: cli-ban-dummy-on-node1
 =#=#=#= Begin test: Clear all implicit constraints for dummy =#=#=#=
 Removing constraint: cli-prefer-dummy
 =#=#=#= Current cib after: Clear all implicit constraints for dummy =#=#=#=
-<cib epoch="62" num_updates="0" admin_epoch="0">
+<cib epoch="64" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5351,7 +5725,7 @@ Removing constraint: cli-prefer-dummy
 * Passed: crm_resource   - Clear all implicit constraints for dummy
 =#=#=#= Begin test: Set a node health strategy =#=#=#=
 =#=#=#= Current cib after: Set a node health strategy =#=#=#=
-<cib epoch="63" num_updates="0" admin_epoch="0">
+<cib epoch="65" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5399,7 +5773,7 @@ Removing constraint: cli-prefer-dummy
 * Passed: crm_attribute  - Set a node health strategy
 =#=#=#= Begin test: Set a node health attribute =#=#=#=
 =#=#=#= Current cib after: Set a node health attribute =#=#=#=
-<cib epoch="64" num_updates="0" admin_epoch="0">
+<cib epoch="66" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -5460,7 +5834,7 @@ Removing constraint: cli-prefer-dummy
 * Passed: crm_resource   - Show why a resource is not running on an unhealthy node
 =#=#=#= Begin test: Delete a resource =#=#=#=
 =#=#=#= Current cib after: Delete a resource =#=#=#=
-<cib epoch="65" num_updates="0" admin_epoch="0">
+<cib epoch="67" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">

--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -3213,14 +3213,13 @@ ticketA
 * Passed: crm_ticket     - List ticket IDs
 =#=#=#= Begin test: List ticket IDs, outputting in XML =#=#=#=
 <pacemaker-result api-version="X" request="crm_ticket -w --output-as=xml">
+  <tickets>
+    <ticket id="ticketA" status="revoked" standby="false"/>
+  </tickets>
   <status code="0" message="OK"/>
 </pacemaker-result>
-ticketA
-/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
-ticketA
-^
-=#=#=#= End test: List ticket IDs, outputting in XML - Failed to validate (1) =#=#=#=
-* Failed (rc=001): crm_ticket     - List ticket IDs, outputting in XML
+=#=#=#= End test: List ticket IDs, outputting in XML - OK (0) =#=#=#=
+* Passed: crm_ticket     - List ticket IDs, outputting in XML
 =#=#=#= Begin test: Query ticket state =#=#=#=
 State XML:
 
@@ -3529,19 +3528,18 @@ true
 =#=#=#= End test: Activate a ticket - OK (0) =#=#=#=
 * Passed: crm_ticket     - Activate a ticket
 =#=#=#= Begin test: List ticket details =#=#=#=
-ticketA	revoked           (standby=false)
+ticketA	revoked	(standby=false)
 =#=#=#= End test: List ticket details - OK (0) =#=#=#=
 * Passed: crm_ticket     - List ticket details
 =#=#=#= Begin test: List ticket details, outputting as XML =#=#=#=
 <pacemaker-result api-version="X" request="crm_ticket -L -t ticketA --output-as=xml">
+  <tickets>
+    <ticket id="ticketA" status="revoked" standby="false"/>
+  </tickets>
   <status code="0" message="OK"/>
 </pacemaker-result>
-ticketA	revoked           (standby=false)
-/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
-ticketA	revoked           (standby=false)
-^
-=#=#=#= End test: List ticket details, outputting as XML - Failed to validate (1) =#=#=#=
-* Failed (rc=001): crm_ticket     - List ticket details, outputting as XML
+=#=#=#= End test: List ticket details, outputting as XML - OK (0) =#=#=#=
+* Passed: crm_ticket     - List ticket details, outputting as XML
 =#=#=#= Begin test: Add a second ticket =#=#=#=
 false
 =#=#=#= Current cib after: Add a second ticket =#=#=#=
@@ -3657,21 +3655,20 @@ false
 =#=#=#= End test: Set second ticket granted state - OK (0) =#=#=#=
 * Passed: crm_ticket     - Set second ticket granted state
 =#=#=#= Begin test: List tickets =#=#=#=
-ticketA	revoked          
-ticketB	revoked          
+ticketA	revoked
+ticketB	revoked
 =#=#=#= End test: List tickets - OK (0) =#=#=#=
 * Passed: crm_ticket     - List tickets
 =#=#=#= Begin test: List tickets, outputting as XML =#=#=#=
 <pacemaker-result api-version="X" request="crm_ticket -l --output-as=xml">
+  <tickets>
+    <ticket id="ticketA" status="revoked" standby="false"/>
+    <ticket id="ticketB" status="revoked" standby="false"/>
+  </tickets>
   <status code="0" message="OK"/>
 </pacemaker-result>
-ticketA	revoked          
-ticketB	revoked          
-/tmp/cts-cli.ta_outfile:4: parser error : Extra content at the end of the document
-ticketA	revoked          
-^
-=#=#=#= End test: List tickets, outputting as XML - Failed to validate (1) =#=#=#=
-* Failed (rc=001): crm_ticket     - List tickets, outputting as XML
+=#=#=#= End test: List tickets, outputting as XML - OK (0) =#=#=#=
+* Passed: crm_ticket     - List tickets, outputting as XML
 =#=#=#= Begin test: Delete second ticket =#=#=#=
 =#=#=#= Current cib after: Delete second ticket =#=#=#=
 <cib epoch="29" num_updates="6" admin_epoch="0">

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1161,9 +1161,29 @@ function test_tools() {
     cmd="crm_ticket -t ticketA -r --force"
     test_assert $CRM_EX_OK
 
+    desc="List ticket IDs"
+    cmd="crm_ticket -w"
+    test_assert $CRM_EX_OK 0
+
+    desc="List ticket IDs, outputting in XML"
+    cmd="crm_ticket -w --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
+    desc="Query ticket state"
+    cmd="crm_ticket -t ticketA -q"
+    test_assert $CRM_EX_OK 0
+
+    desc="Query ticket state, outputting as xml"
+    cmd="crm_ticket -t ticketA -q --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
     desc="Query ticket granted state"
     cmd="crm_ticket -t ticketA -G granted"
     test_assert $CRM_EX_OK
+
+    desc="Query ticket granted state, outputting as xml"
+    cmd="crm_ticket -t ticketA -G granted --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
 
     desc="Delete ticket granted state"
     cmd="crm_ticket -t ticketA -D granted --force"
@@ -1181,8 +1201,52 @@ function test_tools() {
     cmd="crm_ticket -t ticketA -a"
     test_assert $CRM_EX_OK
 
+    desc="List ticket details"
+    cmd="crm_ticket -L -t ticketA"
+    test_assert $CRM_EX_OK 0
+
+    desc="List ticket details, outputting as XML"
+    cmd="crm_ticket -L -t ticketA --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
+    desc="Add a second ticket"
+    cmd="crm_ticket -t ticketB -G granted -d false"
+    test_assert $CRM_EX_OK
+
+    desc="Set second ticket granted state"
+    cmd="crm_ticket -t ticketB -r --force"
+    test_assert $CRM_EX_OK
+
+    desc="List tickets"
+    cmd="crm_ticket -l"
+    test_assert $CRM_EX_OK 0
+
+    desc="List tickets, outputting as XML"
+    cmd="crm_ticket -l --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
+    desc="Delete second ticket"
+    cmd="cibadmin --delete --xml-text '<ticket_state id=\"ticketB\"/>'"
+    test_assert $CRM_EX_OK
+
     desc="Delete ticket standby state"
     cmd="crm_ticket -t ticketA -D standby"
+    test_assert $CRM_EX_OK
+
+    esc="Add a constraint to a ticket"
+    cmd="cibadmin -C -o constraints --xml-text '<rsc_ticket id=\"dummy-dep-ticketA\" rsc=\"dummy\" rsc-role=\"Started\" ticket=\"ticketA\" loss-policy=\"freeze\"/>'"
+    test_assert $CRM_EX_OK
+
+    desc="Query ticket constraints"
+    cmd="crm_ticket -t ticketA -c"
+    test_assert $CRM_EX_OK 0
+
+    desc="Query ticket constraints, outputting as xml"
+    cmd="crm_ticket -t ticketA -c --output-as=xml"
+    test_assert_validate $CRM_EX_OK 0
+
+    desc="Delete ticket constraint"
+    cmd="cibadmin --delete --xml-text '<rsc_ticket id=\"dummy-dep-ticketA\"/>'"
     test_assert $CRM_EX_OK
 
     desc="Ban a resource on unknown node"

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -3400,6 +3400,9 @@ for t in $tests; do
         -e 's|^/tmp/cts-cli\.shadow\.[^/]*/|/tmp/cts-cli.shadow/|' \
         -e 's|"/tmp/cts-cli\.shadow\.[^/]*/|"/tmp/cts-cli.shadow/|' \
         -e 's|^/tmp/cts-cli\.validity\.bad.xml\.[^:]*:|validity.bad.xml:|'\
+        -e 's|^/tmp/cts-cli\.ta_outfile\.[^:]*:|/tmp/cts-cli.ta_outfile:|' \
+        -e 's|^/tmp/cts-cli\.ta_outfile\.[^ ]* fails to validate|/tmp/cts-cli.ta_outfile fails to validate|' \
+        -e 's|^/tmp/cts-cli\.xmllint_outfile\.[^:]*:|/tmp/cts-cli.xmllint_outfile:|' \
         -e 's/^Entity: line [0-9][0-9]*: //'\
         -e 's/\(validation ([0-9][0-9]* of \)[0-9][0-9]*\().*\)/\1X\2/' \
         -e 's/^Migration will take effect until: .*/Migration will take effect until:/' \

--- a/include/crm/common/xml_names.h
+++ b/include/crm/common/xml_names.h
@@ -268,6 +268,7 @@ extern "C" {
 #define PCMK_XA_EXITSTATUS                  "exitstatus"
 #define PCMK_XA_EXPECTED                    "expected"
 #define PCMK_XA_EXPECTED_UP                 "expected_up"
+#define PCMK_XA_EXPIRES                     "expires"
 #define PCMK_XA_EXTENDED_STATUS             "extended-status"
 #define PCMK_XA_FAIL_COUNT                  "fail-count"
 #define PCMK_XA_FAILED                      "failed"

--- a/include/crm/common/xml_names.h
+++ b/include/crm/common/xml_names.h
@@ -81,6 +81,7 @@ extern "C" {
 #define PCMK_XE_CLUSTER_STATUS              "cluster_status"
 #define PCMK_XE_COMMAND                     "command"
 #define PCMK_XE_CONFIGURATION               "configuration"
+#define PCMK_XE_CONSTRAINT                  "constraint"
 #define PCMK_XE_CONSTRAINTS                 "constraints"
 #define PCMK_XE_CONTENT                     "content"
 #define PCMK_XE_CRM_CONFIG                  "crm_config"

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -69,7 +69,7 @@ extern "C" {
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  * >=3.19.0: DC supports PCMK__CIB_REQUEST_COMMIT_TRANSACT
  */
-#  define CRM_FEATURE_SET		"3.19.1"
+#  define CRM_FEATURE_SET		"3.19.2"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1870,7 +1870,7 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
 
     /* Print tickets if requested */
     if (pcmk_is_set(section_opts, pcmk_section_tickets)) {
-        CHECK_RC(rc, out->message(out, "ticket-list", scheduler,
+        CHECK_RC(rc, out->message(out, "ticket-list", scheduler->tickets,
                                   (rc == pcmk_rc_ok)));
     }
 
@@ -1989,7 +1989,7 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
 
     /* Print tickets if requested */
     if (pcmk_is_set(section_opts, pcmk_section_tickets)) {
-        out->message(out, "ticket-list", scheduler, false);
+        out->message(out, "ticket-list", scheduler->tickets, false);
     }
 
     /* Print negative location constraints if requested */
@@ -2116,7 +2116,7 @@ cluster_status_html(pcmk__output_t *out, va_list args)
 
     /* Print tickets if requested */
     if (pcmk_is_set(section_opts, pcmk_section_tickets)) {
-        out->message(out, "ticket-list", scheduler, false);
+        out->message(out, "ticket-list", scheduler->tickets, false);
     }
 
     /* Print negative location constraints if requested */

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1871,7 +1871,7 @@ pcmk__cluster_status_text(pcmk__output_t *out, va_list args)
     /* Print tickets if requested */
     if (pcmk_is_set(section_opts, pcmk_section_tickets)) {
         CHECK_RC(rc, out->message(out, "ticket-list", scheduler->tickets,
-                                  (rc == pcmk_rc_ok)));
+                                  (rc == pcmk_rc_ok), false, false));
     }
 
     /* Print negative location constraints if requested */
@@ -1989,7 +1989,7 @@ cluster_status_xml(pcmk__output_t *out, va_list args)
 
     /* Print tickets if requested */
     if (pcmk_is_set(section_opts, pcmk_section_tickets)) {
-        out->message(out, "ticket-list", scheduler->tickets, false);
+        out->message(out, "ticket-list", scheduler->tickets, false, false, false);
     }
 
     /* Print negative location constraints if requested */
@@ -2116,7 +2116,7 @@ cluster_status_html(pcmk__output_t *out, va_list args)
 
     /* Print tickets if requested */
     if (pcmk_is_set(section_opts, pcmk_section_tickets)) {
-        out->message(out, "ticket-list", scheduler->tickets, false);
+        out->message(out, "ticket-list", scheduler->tickets, false, false, false);
     }
 
     /* Print negative location constraints if requested */

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -3199,16 +3199,16 @@ ticket_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ticket-list", "pcmk_scheduler_t *", "bool")
+PCMK__OUTPUT_ARGS("ticket-list", "GHashTable *", "bool")
 static int
 ticket_list(pcmk__output_t *out, va_list args) {
-    pcmk_scheduler_t *scheduler = va_arg(args, pcmk_scheduler_t *);
+    GHashTable *tickets = va_arg(args, GHashTable *);
     bool print_spacer = va_arg(args, int);
 
     GHashTableIter iter;
-    gpointer key, value;
+    gpointer value;
 
-    if (g_hash_table_size(scheduler->tickets) == 0) {
+    if (g_hash_table_size(tickets) == 0) {
         return pcmk_rc_no_output;
     }
 
@@ -3218,8 +3218,8 @@ ticket_list(pcmk__output_t *out, va_list args) {
     out->begin_list(out, NULL, NULL, "Tickets");
 
     /* Print each ticket */
-    g_hash_table_iter_init(&iter, scheduler->tickets);
-    while (g_hash_table_iter_next(&iter, &key, &value)) {
+    g_hash_table_iter_init(&iter, tickets);
+    while (g_hash_table_iter_next(&iter, NULL, &value)) {
         pcmk_ticket_t *ticket = (pcmk_ticket_t *) value;
         out->message(out, "ticket", ticket);
     }

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -3268,11 +3268,13 @@ ticket_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("ticket-list", "GHashTable *", "bool")
+PCMK__OUTPUT_ARGS("ticket-list", "GHashTable *", "bool", "bool", "bool")
 static int
 ticket_list(pcmk__output_t *out, va_list args) {
     GHashTable *tickets = va_arg(args, GHashTable *);
     bool print_spacer = va_arg(args, int);
+    bool raw = va_arg(args, int);
+    bool details = va_arg(args, int);
 
     GHashTableIter iter;
     gpointer value;
@@ -3290,7 +3292,7 @@ ticket_list(pcmk__output_t *out, va_list args) {
     g_hash_table_iter_init(&iter, tickets);
     while (g_hash_table_iter_next(&iter, NULL, &value)) {
         pcmk_ticket_t *ticket = (pcmk_ticket_t *) value;
-        out->message(out, "ticket", ticket, false, false);
+        out->message(out, "ticket", ticket, raw, details);
     }
 
     /* Close section */

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -402,10 +402,7 @@ find_ticket_constraints(cib_t * the_cib, gchar *ticket_id, xmlNode ** ticket_con
     *ticket_cons_xml = NULL;
 
     xpath_base = pcmk_cib_xpath_for(PCMK_XE_CONSTRAINTS);
-    if (xpath_base == NULL) {
-        crm_err(PCMK_XE_CONSTRAINTS " CIB element not known (bug?)");
-        return -ENOMSG;
-    }
+    CRM_ASSERT(xpath_base != NULL);
 
     xpath = g_string_sized_new(1024);
     pcmk__g_strcat(xpath, xpath_base, "/" PCMK_XE_RSC_TICKET, NULL);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -300,9 +300,8 @@ find_ticket_state(cib_t * the_cib, gchar *ticket_id, xmlNode ** ticket_state_xml
     crm_log_xml_debug(xml_search, "Match");
     if (xml_search->children != NULL) {
         if (ticket_id) {
-            fprintf(stdout,
-                    "Multiple " PCMK__XE_TICKET_STATE "s match ticket_id=%s\n",
-                    ticket_id);
+            out->info(out, "Multiple " PCMK__XE_TICKET_STATE "s match ticket=%s",
+                      ticket_id);
         }
         *ticket_state_xml = xml_search;
     } else {
@@ -747,7 +746,7 @@ delete_ticket_state(gchar *ticket_id, cib_t * cib)
     rc = pcmk_legacy2rc(rc);
 
     if (rc == pcmk_rc_ok) {
-        fprintf(stdout, "Cleaned up %s\n", ticket_id);
+        out->info(out, "Cleaned up %s", ticket_id);
     }
 
     free_xml(ticket_state_xml);

--- a/xml/Makefile.am
+++ b/xml/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2004-2023 the Pacemaker project contributors
+# Copyright 2004-2024 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -63,6 +63,7 @@ API_request_base	= command-output	\
 			  crm_rule 		\
 			  crm_shadow		\
 			  crm_simulate		\
+			  crm_ticket 		\
 			  crmadmin		\
 			  digests		\
 			  pacemakerd 		\
@@ -95,7 +96,8 @@ API_base		= $(API_request_base)	\
 			  patchset		\
 			  resources		\
 			  status		\
-			  subprocess-output
+			  subprocess-output 	\
+			  ticket
 
 CIB_base		= cib 			\
 			  $(CIB_cfg_base) 	\

--- a/xml/api/crm_mon-2.35.rng
+++ b/xml/api/crm_mon-2.35.rng
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm-mon"/>
+    </start>
+
+    <define name="element-crm-mon">
+        <choice>
+            <ref name="element-crm-mon-disconnected" />
+            <group>
+                <optional>
+                    <externalRef href="pacemakerd-health-2.25.rng" />
+                </optional>
+                <optional>
+                    <ref name="element-summary" />
+                </optional>
+                <optional>
+                    <ref name="nodes-list" />
+                </optional>
+                <optional>
+                    <ref name="resources-list" />
+                </optional>
+                <optional>
+                    <ref name="node-attributes-list" />
+                </optional>
+                <optional>
+                    <externalRef href="node-history-2.12.rng"/>
+                </optional>
+                <optional>
+                    <ref name="failures-list" />
+                </optional>
+                <optional>
+                    <ref name="fence-event-list" />
+                </optional>
+                <optional>
+                    <ref name="tickets-list" />
+                </optional>
+                <optional>
+                    <ref name="bans-list" />
+                </optional>
+            </group>
+        </choice>
+    </define>
+
+    <define name="element-crm-mon-disconnected">
+        <element name="crm-mon-disconnected">
+            <optional>
+                <attribute name="description"> <text /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="pacemakerd-state"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-summary">
+        <element name="summary">
+            <optional>
+                <element name="stack">
+                    <attribute name="type"> <text /> </attribute>
+                    <optional>
+                        <attribute name="pacemakerd-state">
+                            <text />
+                        </attribute>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="current_dc">
+                    <attribute name="present"> <data type="boolean" /> </attribute>
+                    <optional>
+                        <group>
+                            <attribute name="version"> <text /> </attribute>
+                            <attribute name="name"> <text /> </attribute>
+                            <attribute name="id"> <text /> </attribute>
+                            <attribute name="with_quorum"> <data type="boolean" /> </attribute>
+                        </group>
+                    </optional>
+                    <optional>
+                        <attribute name="mixed_version"> <data type="boolean" /> </attribute>
+                    </optional>
+                </element>
+            </optional>
+            <optional>
+                <element name="last_update">
+                    <attribute name="time"> <text /> </attribute>
+                    <optional>
+                        <attribute name="origin"> <text /> </attribute>
+                    </optional>
+                </element>
+                <element name="last_change">
+                    <attribute name="time"> <text /> </attribute>
+                    <attribute name="user"> <text /> </attribute>
+                    <attribute name="client"> <text /> </attribute>
+                    <attribute name="origin"> <text /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="nodes_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+                <element name="resources_configured">
+                    <attribute name="number"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="disabled"> <data type="nonNegativeInteger" /> </attribute>
+                    <attribute name="blocked"> <data type="nonNegativeInteger" /> </attribute>
+                </element>
+            </optional>
+            <optional>
+                <element name="cluster_options">
+                    <attribute name="stonith-enabled"> <data type="boolean" /> </attribute>
+                    <attribute name="symmetric-cluster"> <data type="boolean" /> </attribute>
+                    <attribute name="no-quorum-policy"> <text /> </attribute>
+                    <attribute name="maintenance-mode"> <data type="boolean" /> </attribute>
+                    <attribute name="stop-all-resources"> <data type="boolean" /> </attribute>
+                    <attribute name="stonith-timeout-ms"> <data type="integer" /> </attribute>
+                    <attribute name="priority-fencing-delay-ms"> <data type="integer" /> </attribute>
+                </element>
+            </optional>
+        </element>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <externalRef href="resources-2.29.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="nodes-list">
+        <element name="nodes">
+            <zeroOrMore>
+                <externalRef href="nodes-2.29.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="node-attributes-list">
+        <element name="node_attributes">
+            <zeroOrMore>
+                <externalRef href="node-attrs-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="failures-list">
+        <element name="failures">
+            <zeroOrMore>
+                <externalRef href="failure-2.8.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="fence-event-list">
+        <element name="fence_history">
+            <optional>
+                <attribute name="status"> <data type="integer" /> </attribute>
+            </optional>
+            <zeroOrMore>
+                <externalRef href="fence-event-2.15.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="tickets-list">
+        <element name="tickets">
+            <zeroOrMore>
+                <ref name="element-ticket" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="bans-list">
+        <element name="bans">
+            <zeroOrMore>
+                <ref name="element-ban" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="element-ticket">
+        <element name="ticket">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="status">
+                <choice>
+                    <value>granted</value>
+                    <value>revoked</value>
+                </choice>
+            </attribute>
+            <attribute name="standby"> <data type="boolean" /> </attribute>
+            <optional>
+                <attribute name="last-granted"> <text /> </attribute>
+            </optional>
+        </element>
+    </define>
+
+    <define name="element-ban">
+        <element name="ban">
+            <attribute name="id"> <text /> </attribute>
+            <attribute name="resource"> <text /> </attribute>
+            <attribute name="node"> <text /> </attribute>
+            <attribute name="weight"> <data type="integer" /> </attribute>
+            <attribute name="promoted-only"> <data type="boolean" /> </attribute>
+            <!-- DEPRECATED: master_only is a duplicate of promoted-only that is
+                 provided solely for API backward compatibility. It will be
+                 removed in a future release. Check promoted-only instead.
+              -->
+            <attribute name="master_only"> <data type="boolean" /> </attribute>
+        </element>
+    </define>
+</grammar>

--- a/xml/api/crm_mon-2.35.rng
+++ b/xml/api/crm_mon-2.35.rng
@@ -167,7 +167,7 @@
     <define name="tickets-list">
         <element name="tickets">
             <zeroOrMore>
-                <ref name="element-ticket" />
+                <externalRef href="ticket-2.35.rng" />
             </zeroOrMore>
         </element>
     </define>
@@ -177,22 +177,6 @@
             <zeroOrMore>
                 <ref name="element-ban" />
             </zeroOrMore>
-        </element>
-    </define>
-
-    <define name="element-ticket">
-        <element name="ticket">
-            <attribute name="id"> <text /> </attribute>
-            <attribute name="status">
-                <choice>
-                    <value>granted</value>
-                    <value>revoked</value>
-                </choice>
-            </attribute>
-            <attribute name="standby"> <data type="boolean" /> </attribute>
-            <optional>
-                <attribute name="last-granted"> <text /> </attribute>
-            </optional>
         </element>
     </define>
 

--- a/xml/api/crm_ticket-2.35.rng
+++ b/xml/api/crm_ticket-2.35.rng
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <start>
+        <ref name="element-crm_ticket"/>
+    </start>
+
+    <define name="element-crm_ticket">
+        <ref name="tickets-list" />
+        <optional>
+            <ref name="resources-list" />
+        </optional>
+    </define>
+
+    <define name="resources-list">
+        <element name="resources">
+            <zeroOrMore>
+                <element name="resource">
+                    <attribute name="id"> <data type="ID" /> </attribute>
+                </element>
+            </zeroOrMore>
+        </element>
+    </define>
+
+    <define name="tickets-list">
+        <element name="tickets">
+            <zeroOrMore>
+                <externalRef href="ticket-2.35.rng" />
+            </zeroOrMore>
+        </element>
+    </define>
+
+</grammar>

--- a/xml/api/ticket-2.35.rng
+++ b/xml/api/ticket-2.35.rng
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+    <include href="../constraints-3.9.rng">
+        <start>
+            <ref name="element-ticket"/>
+        </start>
+
+        <!-- This redefines the constraints element from constraints-X.X.rng
+             so it can only contain the element-rsc_ticket element.  This allows
+             us to restrict it so only those kinds of constraints are allowed
+             in ticket XML.
+          -->
+        <define name="element-constraints">
+            <element name="constraints">
+                <zeroOrMore>
+                    <ref name="element-rsc_ticket"/>
+                </zeroOrMore>
+            </element>
+        </define>
+    </include>
+
+    <define name="element-ticket">
+        <element name="ticket">
+            <attribute name="id"> <data type="ID" /> </attribute>
+            <optional>
+                <attribute name="status">
+                    <choice>
+                        <value>granted</value>
+                        <value>revoked</value>
+                    </choice>
+                </attribute>
+            </optional>
+            <optional>
+                <attribute name="standby"> <data type="boolean" /> </attribute>
+            </optional>
+            <optional>
+                <attribute name="last-granted"> <text /> </attribute>
+            </optional>
+            <optional>
+                <element name="attribute">
+                    <attribute name="name"> <text /> </attribute>
+                    <attribute name="value"> <text /> </attribute>
+                </element>
+            </optional>
+            <zeroOrMore>
+                <attribute>
+                    <anyName>
+                        <except>
+                            <name>attribute</name>
+                            <name>constraints</name>
+                            <name>id</name>
+                            <name>last-granted</name>
+                            <name>standby</name>
+                            <name>status</name>
+                        </except>
+                    </anyName>
+                    <text />
+                </attribute>
+            </zeroOrMore>
+            <optional>
+                <ref name="element-constraints" />
+            </optional>
+        </element>
+    </define>
+
+</grammar>


### PR DESCRIPTION
This also includes the patch from #3356, but I assume I'll have to rebase this a couple times so I'm not worried about that.

One significant thing to note is that I don't think the new ticket schema is complete.  There's a block in the ticket_xml function that adds arbitrary key/value pairs as attributes to the ticket's XML node.  I'm not sure what all could be in those pairs, so at the moment I've just left it out of the schema.  I'll have to add something, though, and if they can be potentially anything, the schema is a little less useful.