### PR TITLE
Fix: libcrmservice: Revert single quotes to double quotes in metadata

### DIFF
--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -668,8 +668,8 @@ systemd_unit_exists(const char *name)
 #define METADATA_FORMAT                                                        \
     "<?xml " PCMK_XA_VERSION "=\"1.0\"?>\n"                                    \
     "<" PCMK_XE_RESOURCE_AGENT " "                                             \
-        PCMK_XA_NAME "='%s' "                                                  \
-        PCMK_XA_VERSION "='" PCMK_DEFAULT_AGENT_VERSION "'>\n"                 \
+        PCMK_XA_NAME "=\"%s\" "                                                \
+        PCMK_XA_VERSION "=\"" PCMK_DEFAULT_AGENT_VERSION "\">\n"               \
     "  <" PCMK_XE_VERSION ">1.1</" PCMK_XE_VERSION ">\n"                       \
     "  <" PCMK_XE_LONGDESC " " PCMK_XA_LANG "=\"" PCMK__VALUE_EN "\">\n"       \
     "    %s\n"                                                                 \

--- a/lib/services/upstart.c
+++ b/lib/services/upstart.c
@@ -375,8 +375,8 @@ parse_status_result(const char *name, const char *state, void *userdata)
 #define METADATA_FORMAT                                                       \
     "<?xml " PCMK_XA_VERSION "=\"1.0\"?>\n"                                   \
     "<" PCMK_XE_RESOURCE_AGENT " "                                            \
-        PCMK_XA_NAME "='%s' "                                                 \
-        PCMK_XA_VERSION "='" PCMK_DEFAULT_AGENT_VERSION "'>\n"                \
+        PCMK_XA_NAME "=\"%s\" "                                               \
+        PCMK_XA_VERSION "=\"" PCMK_DEFAULT_AGENT_VERSION "\">\n"              \
     "  <" PCMK_XE_VERSION ">1.1</" PCMK_XE_VERSION ">\n"                      \
     "  <" PCMK_XE_LONGDESC " " PCMK_XA_LANG "=\"" PCMK__VALUE_EN "\">\n"      \
     "    Upstart agent for controlling the system %s service\n"               \


### PR DESCRIPTION
078e007c changed a few double quotes to single quotes in the fake metadata for systemd and upstart agents. This causes a pattern match to fail in cts-lab.

A better fix is to create and dump real XML instead of substituting into a string. This gets the job done for now.