### PR TITLE
Build: libpe_rules: Remove unneeded build stuff for libpe_rules_test.

### DIFF
--- a/lib/pengine/Makefile.am
+++ b/lib/pengine/Makefile.am
@@ -68,18 +68,6 @@ libpe_status_la_SOURCES	+= utils.c
 
 include $(top_srcdir)/mk/tap.mk
 
-libpe_rules_test_la_SOURCES = $(libpe_rules_la_SOURCES)
-libpe_rules_test_la_LDFLAGS = $(libpe_rules_la_LDFLAGS)	\
-			      -rpath $(libdir) 		\
-			      $(LDFLAGS_WRAP)
-# See comments on libcrmcommon_test_la in lib/common/Makefile.am regarding these flags.
-libpe_rules_test_la_CFLAGS = $(libpe_rules_la_CFLAGS) 	\
-			     -DPCMK__UNIT_TESTING 	\
-			     -fno-builtin -fno-inline
-libpe_rules_test_la_LIBADD = $(top_builddir)/lib/common/libcrmcommon_test.la 	\
-			     -lcmocka 						\
-			     -lm
-
 libpe_status_test_la_SOURCES = $(libpe_status_la_SOURCES)
 libpe_status_test_la_LDFLAGS = $(libpe_status_la_LDFLAGS) 	\
 			       -rpath $(libdir) 		\


### PR DESCRIPTION
Now that the code being tested has moved into libcrmcommon, these variables are no longer needed and cause autotools to raise warnings.

This should have been done in 3af5699c7de52880e373815c0322875a2068ba75.