### PR TITLE
Refactor: libraries: Call pcmk__output_xml_pop_parent.

### DIFF
--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -77,6 +77,8 @@ pacemakerd_features_xml(pcmk__output_t *out, va_list args) {
 
     out->end_list(out);
 
+    pcmk__output_xml_pop_parent(out);
+
     g_strfreev(feature_list);
     return pcmk_rc_ok;
 }

--- a/lib/lrmd/lrmd_output.c
+++ b/lib/lrmd/lrmd_output.c
@@ -47,10 +47,14 @@ lrmd__alternatives_list_xml(pcmk__output_t *out, va_list args) {
     lrmd_list_t *list = va_arg(args, lrmd_list_t *);
     const char *agent_spec = va_arg(args, const char *);
 
+    int rc = pcmk_rc_ok;
+
     pcmk__output_xml_create_parent(out, PCMK_XE_PROVIDERS,
                                    PCMK_XA_FOR, agent_spec,
                                    NULL);
-    return xml_list(out, list, PCMK_XE_PROVIDER);
+    rc = xml_list(out, list, PCMK_XE_PROVIDER);
+    pcmk__output_xml_pop_parent(out);
+    return rc;
 }
 
 PCMK__OUTPUT_ARGS("alternatives-list", "lrmd_list_t *", "const char *")
@@ -69,6 +73,7 @@ lrmd__agents_list_xml(pcmk__output_t *out, va_list args) {
     const char *agent_spec = va_arg(args, const char *);
     const char *provider = va_arg(args, const char *);
 
+    int rc = pcmk_rc_ok;
     xmlNodePtr node = NULL;
 
     node = pcmk__output_xml_create_parent(out, PCMK_XE_AGENTS,
@@ -79,7 +84,9 @@ lrmd__agents_list_xml(pcmk__output_t *out, va_list args) {
         crm_xml_add(node, PCMK_XA_PROVIDER, provider);
     }
 
-    return xml_list(out, list, PCMK_XE_AGENT);
+    rc = xml_list(out, list, PCMK_XE_AGENT);
+    pcmk__output_xml_pop_parent(out);
+    return rc;
 }
 
 PCMK__OUTPUT_ARGS("agents-list", "lrmd_list_t *", "const char *", "const char *")
@@ -103,6 +110,7 @@ lrmd__providers_list_xml(pcmk__output_t *out, va_list args) {
     lrmd_list_t *list = va_arg(args, lrmd_list_t *);
     const char *agent_spec = va_arg(args, const char *);
 
+    int rc = pcmk_rc_ok;
     xmlNodePtr node = pcmk__output_xml_create_parent(out, PCMK_XE_PROVIDERS,
                                                      PCMK_XA_STANDARD, "ocf",
                                                      NULL);
@@ -111,7 +119,9 @@ lrmd__providers_list_xml(pcmk__output_t *out, va_list args) {
         crm_xml_add(node, PCMK_XA_AGENT, agent_spec);
     }
 
-    return xml_list(out, list, PCMK_XE_PROVIDER);
+    rc = xml_list(out, list, PCMK_XE_PROVIDER);
+    pcmk__output_xml_pop_parent(out);
+    return rc;
 }
 
 PCMK__OUTPUT_ARGS("providers-list", "lrmd_list_t *", "const char *")

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1597,6 +1597,7 @@ inject_modify_config_xml(pcmk__output_t *out, va_list args)
         crm_xml_add(node, PCMK_XA_WATCHDOG, watchdog);
     }
 
+    pcmk__output_xml_pop_parent(out);
     return pcmk_rc_ok;
 }
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -593,6 +593,7 @@ resource_search_list_xml(pcmk__output_t *out, va_list args)
         }
     }
 
+    pcmk__output_xml_pop_parent(out);
     return pcmk_rc_ok;
 }
 
@@ -774,6 +775,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
         g_list_free(hosts);
     }
 
+    pcmk__output_xml_pop_parent(out);
     return pcmk_rc_ok;
 }
 


### PR DESCRIPTION
Any custom output message that calls pcmk__output_create_parent should later call pcmk__output_xml_pop_parent.  Without doing this, any other XML nodes created after the custom message will be created with an unexpected parent.

Big caveat:  The "node" custom message works this way on purpose, however.  It counts on the fact that it creates the parent and exits, then other things happen, and then the parent is popped.  I can't convince myself that the parent is correctly being popped in every instance but that looks like the intent.