### PR TITLE
Fix: libcrmcommon: use uint32_t for 32-bit magic numbers

### DIFF
--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -38,12 +38,12 @@ typedef struct pcmk__deleted_xml_s {
 } pcmk__deleted_xml_t;
 
 typedef struct xml_node_private_s {
-        long check;
+        uint32_t check;
         uint32_t flags;
 } xml_node_private_t;
 
 typedef struct xml_doc_private_s {
-        long check;
+        uint32_t check;
         uint32_t flags;
         char *user;
         GList *acls;


### PR DESCRIPTION
So that they are correctly handled on 32-bit systems.

Previously unit test would fail on 32-bit systems:
```
  > lib/common/tests/xml/crm_xml_init_test
  TAP version 13
  1..8
  ok 1 - buffer_scheme_test
  not ok 2 - create_document_node
  # 0xffffffff81726354 != 0x81726354
  # crm_xml_init_test.c:61: error: Failure!
```