### PR TITLE
Fix: libcrmcommon: Escape XML non-printing characters correctly as hex

### DIFF
--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -121,7 +121,7 @@ static void
 escape_nonprinting(void **state)
 {
     const char *nonprinting = "\a\r\x7f\x1b";
-    const char *nonprinting_esc = "&#07;&#0d;&#7f;&#1b;";
+    const char *nonprinting_esc = "&#x07;&#x0d;&#x7f;&#x1b;";
     char *str = NULL;
 
     str = pcmk__xml_escape(nonprinting, false);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1558,7 +1558,7 @@ pcmk__xml_escape(const char *text, bool escape_quote)
             default:
                 if ((copy[index] < 0x20) || (copy[index] >= 0x7f)) {
                     // Escape non-printing characters
-                    snprintf(buf, sizeof(buf), "&#%.2x;", copy[index]);
+                    snprintf(buf, sizeof(buf), "&#x%.2x;", copy[index]);
                     copy = replace_text(copy, &index, &length, buf);
                 }
                 break;


### PR DESCRIPTION
Fixes regression introduced in c6d9cea9.

That commit introduced `pcmk__xml_escape()`, which (among other things) escapes non-printing characters as their hexadecimal character references. However, a prefix of `"#x"` (instead of only `"#"`) is required to indicate that the number is in hex rather than decimal.