### PR TITLE
Fix: cibsecret: Use 'ps axww' to avoid truncating issue

### DIFF
--- a/tools/cibsecret.in
+++ b/tools/cibsecret.in
@@ -171,7 +171,7 @@ check_env() {
     else
         fatal $CRM_EX_NOT_INSTALLED "please install pssh, pdsh, or ssh to run $PROG"
     fi
-    ps -ef | grep '[p]acemaker-controld' >/dev/null ||
+    ps axww | grep '[p]acemaker-controld' >/dev/null ||
         fatal $CRM_EX_UNAVAILABLE "pacemaker not running? $PROG needs pacemaker"
 }
 


### PR DESCRIPTION
When python program calling cibsecret with a small terminal width, the command `ps -ef | grep '[p]acemaker-controld'` will return 1, see
```
>>> cmd = "ps -ef | grep '[p]acemaker-controld' >/dev/null"
>>> # When terminal width is small
>>> subprocess.call(cmd, shell=True)
1
>>> # When terminal is big enough
>>> subprocess.call(cmd, shell=True)
0
```
Use 'ps axww' can avoid this issue, also for BSD environment