### PR TITLE
Assert on more memory allocation errors

### DIFF
--- a/daemons/attrd/attrd_attributes.c
+++ b/daemons/attrd/attrd_attributes.c
@@ -49,17 +49,15 @@ attrd_create_attribute(xmlNode *xml)
 
     a = pcmk__assert_alloc(1, sizeof(attribute_t));
 
+    a->id = pcmk__str_copy(name);
+    a->set_type = pcmk__str_copy(set_type);
+    a->set_id = crm_element_value_copy(xml, PCMK__XA_ATTR_SET);
+    a->user = crm_element_value_copy(xml, PCMK__XA_ATTR_USER);
+    a->values = pcmk__strikey_table(NULL, attrd_free_attribute_value);
+
     if (is_private) {
         attrd_set_attr_flags(a, attrd_attr_is_private);
     }
-
-    pcmk__str_update(&a->id, name);
-    pcmk__str_update(&a->set_type, set_type);
-
-    a->set_id = crm_element_value_copy(xml, PCMK__XA_ATTR_SET);
-    a->values = pcmk__strikey_table(NULL, attrd_free_attribute_value);
-
-    a->user = crm_element_value_copy(xml, PCMK__XA_ATTR_USER);
 
     if (dampen_s != NULL) {
         dampen = crm_get_msec(dampen_s);
@@ -245,7 +243,7 @@ attrd_set_id(const attribute_t *attr, const char *node_state_id)
          * attribute, which would break backward compatibility, pose design
          * challenges, and potentially cause problems in rolling upgrades.
          */
-        pcmk__str_update(&set_id, attr->set_id);
+        set_id = pcmk__str_copy(attr->set_id);
     }
     crm_xml_sanitize_id(set_id);
     return set_id;

--- a/daemons/attrd/attrd_attributes.c
+++ b/daemons/attrd/attrd_attributes.c
@@ -48,7 +48,7 @@ attrd_create_attribute(xmlNode *xml)
     }
 
     a = calloc(1, sizeof(attribute_t));
-    CRM_ASSERT(a != NULL);
+    pcmk__mem_assert(a);
 
     if (is_private) {
         attrd_set_attr_flags(a, attrd_attr_is_private);

--- a/daemons/attrd/attrd_attributes.c
+++ b/daemons/attrd/attrd_attributes.c
@@ -47,8 +47,7 @@ attrd_create_attribute(xmlNode *xml)
         return NULL;
     }
 
-    a = calloc(1, sizeof(attribute_t));
-    pcmk__mem_assert(a);
+    a = pcmk__assert_alloc(1, sizeof(attribute_t));
 
     if (is_private) {
         attrd_set_attr_flags(a, attrd_attr_is_private);

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -196,10 +196,10 @@ attrd_cib_erase_transient_attrs(const char *node)
     call_id = the_cib->cmds->remove(the_cib, xpath, NULL, cib_xpath);
     free(xpath);
 
-    // strdup() is just for logging here, so ignore failure
     the_cib->cmds->register_callback_full(the_cib, call_id, 120, FALSE,
-                                          strdup(node), "attrd_erase_cb",
-                                          attrd_erase_cb, free);
+                                          pcmk__str_copy(node),
+                                          "attrd_erase_cb", attrd_erase_cb,
+                                          free);
 }
 
 /*!

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -469,8 +469,8 @@ set_alert_attribute_value(GHashTable *t, attribute_value_t *v)
     attribute_value_t *a_v = pcmk__assert_alloc(1, sizeof(attribute_value_t));
 
     a_v->nodeid = v->nodeid;
-    a_v->nodename = strdup(v->nodename);
-    pcmk__str_update(&a_v->current, v->current);
+    a_v->nodename = pcmk__str_copy(v->nodename);
+    a_v->current = pcmk__str_copy(v->current);
 
     g_hash_table_replace(t, a_v->nodename, a_v);
 }
@@ -614,7 +614,7 @@ write_attribute(attribute_t *a, bool ignore_delay)
                  a->id, pcmk__s(a->set_id, "unspecified"));
     }
     if (cib_updates > 0) {
-        char *id = NULL;
+        char *id = pcmk__str_copy(a->id);
 
         // Commit transaction
         a->update = the_cib->cmds->end_transaction(the_cib, true, cib_none);
@@ -623,7 +623,6 @@ write_attribute(attribute_t *a, bool ignore_delay)
                  a->update, cib_updates, pcmk__plural_s(cib_updates),
                  a->id, pcmk__s(a->set_id, "unspecified"));
 
-        pcmk__str_update(&id, a->id);
         if (the_cib->cmds->register_callback_full(the_cib, a->update,
                                                   CIB_OP_TIMEOUT_S, FALSE, id,
                                                   "attrd_cib_callback",

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -468,7 +468,7 @@ set_alert_attribute_value(GHashTable *t, attribute_value_t *v)
 {
     attribute_value_t *a_v = NULL;
     a_v = calloc(1, sizeof(attribute_value_t));
-    CRM_ASSERT(a_v != NULL);
+    pcmk__mem_assert(a_v);
 
     a_v->nodeid = v->nodeid;
     a_v->nodename = strdup(v->nodename);

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -466,9 +466,7 @@ send_alert_attributes_value(attribute_t *a, GHashTable *t)
 static void
 set_alert_attribute_value(GHashTable *t, attribute_value_t *v)
 {
-    attribute_value_t *a_v = NULL;
-    a_v = calloc(1, sizeof(attribute_value_t));
-    pcmk__mem_assert(a_v);
+    attribute_value_t *a_v = pcmk__assert_alloc(1, sizeof(attribute_value_t));
 
     a_v->nodeid = v->nodeid;
     a_v->nodename = strdup(v->nodename);

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -240,7 +240,7 @@ update_attr_on_host(attribute_t *a, const crm_node_t *peer, const xmlNode *xml,
     v = g_hash_table_lookup(a->values, host);
     if (v == NULL) {
         v = calloc(1, sizeof(attribute_value_t));
-        CRM_ASSERT(v != NULL);
+        pcmk__mem_assert(v);
 
         pcmk__str_update(&v->nodename, host);
         g_hash_table_replace(a->values, v->nodename, v);

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -241,7 +241,7 @@ update_attr_on_host(attribute_t *a, const crm_node_t *peer, const xmlNode *xml,
     if (v == NULL) {
         v = pcmk__assert_alloc(1, sizeof(attribute_value_t));
 
-        pcmk__str_update(&v->nodename, host);
+        v->nodename = pcmk__str_copy(host);
         g_hash_table_replace(a->values, v->nodename, v);
     }
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -239,8 +239,7 @@ update_attr_on_host(attribute_t *a, const crm_node_t *peer, const xmlNode *xml,
     // Create entry for value if not already existing
     v = g_hash_table_lookup(a->values, host);
     if (v == NULL) {
-        v = calloc(1, sizeof(attribute_value_t));
-        pcmk__mem_assert(v);
+        v = pcmk__assert_alloc(1, sizeof(attribute_value_t));
 
         pcmk__str_update(&v->nodename, host);
         g_hash_table_replace(a->values, v->nodename, v);

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -146,12 +146,9 @@ attrd_add_client_to_waitlist(pcmk__request_t *request)
     }
 
     wl = calloc(sizeof(struct waitlist_node), 1);
+    pcmk__mem_assert(wl);
 
-    CRM_ASSERT(wl != NULL);
-
-    wl->client_id = strdup(request->ipc_client->id);
-
-    CRM_ASSERT(wl->client_id);
+    pcmk__str_update(&(wl->client_id), request->ipc_client->id);
 
     if (pcmk__str_eq(sync_point, PCMK__VALUE_LOCAL, pcmk__str_none)) {
         wl->sync_point = attrd_sync_point_local;
@@ -502,22 +499,21 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
     g_hash_table_iter_init(&iter, peer_protocol_vers);
     while (g_hash_table_iter_next(&iter, &host, &ver)) {
         if (ATTRD_SUPPORTS_CONFIRMATION(GPOINTER_TO_INT(ver))) {
-            char *s = strdup((char *) host);
+            char *s = NULL;
 
-            CRM_ASSERT(s != NULL);
+            pcmk__str_update(&s, (char *) host);
             respondents = g_list_prepend(respondents, s);
         }
     }
 
     action = calloc(1, sizeof(struct confirmation_action));
-    CRM_ASSERT(action != NULL);
+    pcmk__mem_assert(action);
 
     action->respondents = respondents;
     action->fn = fn;
     action->xml = pcmk__xml_copy(NULL, request->xml);
 
-    action->client_id = strdup(request->ipc_client->id);
-    CRM_ASSERT(action->client_id != NULL);
+    pcmk__str_update(&(action->client_id), request->ipc_client->id);
 
     action->ipc_id = request->ipc_id;
     action->flags = request->flags;

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -145,8 +145,7 @@ attrd_add_client_to_waitlist(pcmk__request_t *request)
         waitlist = pcmk__intkey_table(free_waitlist_node);
     }
 
-    wl = calloc(sizeof(struct waitlist_node), 1);
-    pcmk__mem_assert(wl);
+    wl = pcmk__assert_alloc(1, sizeof(struct waitlist_node));
 
     pcmk__str_update(&(wl->client_id), request->ipc_client->id);
 
@@ -506,8 +505,7 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
         }
     }
 
-    action = calloc(1, sizeof(struct confirmation_action));
-    pcmk__mem_assert(action);
+    action = pcmk__assert_alloc(1, sizeof(struct confirmation_action));
 
     action->respondents = respondents;
     action->fn = fn;

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -147,8 +147,6 @@ attrd_add_client_to_waitlist(pcmk__request_t *request)
 
     wl = pcmk__assert_alloc(1, sizeof(struct waitlist_node));
 
-    pcmk__str_update(&(wl->client_id), request->ipc_client->id);
-
     if (pcmk__str_eq(sync_point, PCMK__VALUE_LOCAL, pcmk__str_none)) {
         wl->sync_point = attrd_sync_point_local;
     } else if (pcmk__str_eq(sync_point, PCMK__VALUE_CLUSTER, pcmk__str_none)) {
@@ -158,6 +156,7 @@ attrd_add_client_to_waitlist(pcmk__request_t *request)
         return;
     }
 
+    wl->client_id = pcmk__str_copy(request->ipc_client->id);
     wl->ipc_id = request->ipc_id;
     wl->flags = request->flags;
 
@@ -498,10 +497,8 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
     g_hash_table_iter_init(&iter, peer_protocol_vers);
     while (g_hash_table_iter_next(&iter, &host, &ver)) {
         if (ATTRD_SUPPORTS_CONFIRMATION(GPOINTER_TO_INT(ver))) {
-            char *s = NULL;
-
-            pcmk__str_update(&s, (char *) host);
-            respondents = g_list_prepend(respondents, s);
+            respondents = g_list_prepend(respondents,
+                                         pcmk__str_copy((char *) host));
         }
     }
 
@@ -510,9 +507,7 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
     action->respondents = respondents;
     action->fn = fn;
     action->xml = pcmk__xml_copy(NULL, request->xml);
-
-    pcmk__str_update(&(action->client_id), request->ipc_client->id);
-
+    action->client_id = pcmk__str_copy(request->ipc_client->id);
     action->ipc_id = request->ipc_id;
     action->flags = request->flags;
 

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -288,10 +288,10 @@ attrd_update_minimum_protocol_ver(const char *host, const char *value)
     pcmk__scan_min_int(value, &ver, 0);
 
     if (ver > 0) {
-        char *host_name = strdup(host);
+        char *host_name = NULL;
 
         /* Record the peer attrd's protocol version. */
-        CRM_ASSERT(host_name != NULL);
+        pcmk__str_update(&host_name, host);
         g_hash_table_insert(peer_protocol_vers, host_name, GINT_TO_POINTER(ver));
 
         /* If the protocol version is a new minimum, record it as such. */

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -205,7 +205,7 @@ attrd_failure_regex(regex_t *regex, const char *rsc, const char *op,
     /* Create a pattern that matches desired attributes */
 
     if (rsc == NULL) {
-        pattern = strdup(ATTRD_RE_CLEAR_ALL);
+        pattern = pcmk__str_copy(ATTRD_RE_CLEAR_ALL);
     } else if (op == NULL) {
         pattern = crm_strdup_printf(ATTRD_RE_CLEAR_ONE, rsc);
     } else {

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -288,11 +288,9 @@ attrd_update_minimum_protocol_ver(const char *host, const char *value)
     pcmk__scan_min_int(value, &ver, 0);
 
     if (ver > 0) {
-        char *host_name = NULL;
-
         /* Record the peer attrd's protocol version. */
-        pcmk__str_update(&host_name, host);
-        g_hash_table_insert(peer_protocol_vers, host_name, GINT_TO_POINTER(ver));
+        g_hash_table_insert(peer_protocol_vers, pcmk__str_copy(host),
+                            GINT_TO_POINTER(ver));
 
         /* If the protocol version is a new minimum, record it as such. */
         if (minimum_protocol_version == -1 || ver < minimum_protocol_version) {

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -160,7 +160,7 @@ create_cib_reply(const char *op, const char *call_id, const char *client_id,
 {
     xmlNode *reply = create_xml_node(NULL, PCMK__XE_CIB_REPLY);
 
-    CRM_ASSERT(reply != NULL);
+    pcmk__mem_assert(reply);
 
     crm_xml_add(reply, PCMK__XA_T, PCMK__VALUE_CIB);
     crm_xml_add(reply, PCMK__XA_CIB_OP, op);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -360,7 +360,7 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
         if (value == NULL) {
             cib_client->name = pcmk__itoa(cib_client->pid);
         } else {
-            cib_client->name = strdup(value);
+            cib_client->name = pcmk__str_copy(value);
             if (crm_is_daemon_name(value)) {
                 pcmk__set_client_flags(cib_client, cib_is_daemon);
             }
@@ -534,7 +534,7 @@ queue_local_notify(xmlNode * notify_src, const char *client_id, gboolean sync_re
                                                     sizeof(cib_local_notify_t));
 
     notify->notify_src = notify_src;
-    notify->client_id = strdup(client_id);
+    notify->client_id = pcmk__str_copy(client_id);
     notify->sync_reply = sync_reply;
     notify->from_peer = from_peer;
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -530,7 +530,8 @@ static void
 queue_local_notify(xmlNode * notify_src, const char *client_id, gboolean sync_reply,
                    gboolean from_peer)
 {
-    cib_local_notify_t *notify = calloc(1, sizeof(cib_local_notify_t));
+    cib_local_notify_t *notify = pcmk__assert_alloc(1,
+                                                    sizeof(cib_local_notify_t));
 
     notify->notify_src = notify_src;
     notify->client_id = strdup(client_id);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -399,7 +399,7 @@ cib_msg_copy(xmlNode *msg)
 
     xmlNode *copy = create_xml_node(NULL, PCMK__XE_COPY);
 
-    CRM_ASSERT(copy != NULL);
+    pcmk__mem_assert(copy);
 
     for (int lpc = 0; lpc < PCMK__NELEM(field_list); lpc++) {
         const char *field = field_list[lpc];

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -552,7 +552,7 @@ construct_pam_passwd(int num_msg, const struct pam_message **msg,
     CRM_CHECK(num_msg == 1, return PAM_CONV_ERR);       /* We only want to handle one message */
 
     reply = calloc(1, sizeof(struct pam_response));
-    CRM_ASSERT(reply != NULL);
+    pcmk__mem_assert(reply);
 
     for (count = 0; count < num_msg; ++count) {
         switch (msg[count]->msg_style) {

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -416,7 +416,7 @@ cib_handle_remote_msg(pcmk__client_t *client, xmlNode *command)
     }
 
     if (client->name == NULL) {
-        client->name = strdup(client->id);
+        client->name = pcmk__str_copy(client->id);
     }
 
     /* unset dangerous options */
@@ -511,7 +511,7 @@ cib_remote_msg(gpointer data)
 
         user = crm_element_value(command, PCMK_XA_USER);
         if (user) {
-            client->user = strdup(user);
+            client->user = pcmk__str_copy(user);
         }
 
         /* send ACK */
@@ -625,7 +625,7 @@ authenticate_user(const char *user, const char *passwd)
     }
 
     p_conv.conv = construct_pam_passwd;
-    p_conv.appdata_ptr = strdup(passwd);
+    p_conv.appdata_ptr = pcmk__str_copy(passwd);
 
     rc = pam_start(pam_name, user, &p_conv, &pam_h);
     if (rc != PAM_SUCCESS) {

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -316,7 +316,7 @@ cib_remote_listen(gpointer data)
     num_clients++;
 
     new_client = pcmk__new_unauth_client(NULL);
-    new_client->remote = calloc(1, sizeof(pcmk__remote_t));
+    new_client->remote = pcmk__assert_alloc(1, sizeof(pcmk__remote_t));
 
     if (ssock == remote_tls_fd) {
 #ifdef HAVE_GNUTLS_GNUTLS_H
@@ -551,8 +551,7 @@ construct_pam_passwd(int num_msg, const struct pam_message **msg,
     CRM_CHECK(data, return PAM_CONV_ERR);
     CRM_CHECK(num_msg == 1, return PAM_CONV_ERR);       /* We only want to handle one message */
 
-    reply = calloc(1, sizeof(struct pam_response));
-    pcmk__mem_assert(reply);
+    reply = pcmk__assert_alloc(1, sizeof(struct pam_response));
 
     for (count = 0; count < num_msg; ++count) {
         switch (msg[count]->msg_style) {

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -38,10 +38,9 @@ based_transaction_source_str(const pcmk__client_t *client, const char *origin)
                                    pcmk__s(origin, ""));
 
     } else {
-        source = strdup((origin != NULL)? origin : "unknown source");
+        pcmk__str_update(&source, pcmk__s(origin, "unknown source"));
     }
 
-    CRM_ASSERT(source != NULL);
     return source;
 }
 

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -28,20 +28,15 @@
 char *
 based_transaction_source_str(const pcmk__client_t *client, const char *origin)
 {
-    char *source = NULL;
-
     if (client != NULL) {
-        source = crm_strdup_printf("client %s (%s)%s%s",
-                                   pcmk__client_name(client),
-                                   pcmk__s(client->id, "unidentified"),
-                                   ((origin != NULL)? " on " : ""),
-                                   pcmk__s(origin, ""));
-
+        return crm_strdup_printf("client %s (%s)%s%s",
+                                 pcmk__client_name(client),
+                                 pcmk__s(client->id, "unidentified"),
+                                 ((origin != NULL)? " on " : ""),
+                                 pcmk__s(origin, ""));
     } else {
-        pcmk__str_update(&source, pcmk__s(origin, "unknown source"));
+        return pcmk__str_copy(pcmk__s(origin, "unknown source"));
     }
-
-    return source;
 }
 
 /*!

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -174,7 +174,7 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
 
     entry = g_hash_table_lookup(lrm_state->resource_history, op->rsc_id);
     if (entry == NULL && rsc) {
-        entry = calloc(1, sizeof(rsc_history_t));
+        entry = pcmk__assert_alloc(1, sizeof(rsc_history_t));
         entry->id = strdup(op->rsc_id);
         g_hash_table_insert(lrm_state->resource_history, entry->id, entry);
 
@@ -983,7 +983,7 @@ delete_resource(lrm_state_t *lrm_state, const char *id, lrmd_rsc_info_t *rsc,
             struct pending_deletion_op_s *op = NULL;
             char *ref = crm_element_value_copy(request->msg, PCMK_XA_REFERENCE);
 
-            op = calloc(1, sizeof(struct pending_deletion_op_s));
+            op = pcmk__assert_alloc(1, sizeof(struct pending_deletion_op_s));
             op->rsc = strdup(rsc->id);
             op->input = copy_ha_msg_input(request);
             g_hash_table_insert(lrm_state->deletion_ops, ref, op);
@@ -1365,8 +1365,7 @@ new_metadata_cb_data(lrmd_rsc_info_t *rsc, xmlNode *input_xml)
 {
     struct metadata_cb_data *data = NULL;
 
-    data = calloc(1, sizeof(struct metadata_cb_data));
-    pcmk__mem_assert(data);
+    data = pcmk__assert_alloc(1, sizeof(struct metadata_cb_data));
     data->input_xml = pcmk__xml_copy(NULL, input_xml);
     data->rsc = lrmd_copy_rsc_info(rsc);
     return data;
@@ -2023,7 +2022,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
         char *call_id_s = make_stop_id(rsc->id, call_id);
         active_op_t *pending = NULL;
 
-        pending = calloc(1, sizeof(active_op_t));
+        pending = pcmk__assert_alloc(1, sizeof(active_op_t));
         crm_trace("Recording pending op: %d - %s %s", call_id, op_id, call_id_s);
 
         pending->call_id = call_id;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1366,7 +1366,7 @@ new_metadata_cb_data(lrmd_rsc_info_t *rsc, xmlNode *input_xml)
     struct metadata_cb_data *data = NULL;
 
     data = calloc(1, sizeof(struct metadata_cb_data));
-    CRM_ASSERT(data != NULL);
+    pcmk__mem_assert(data);
     data->input_xml = pcmk__xml_copy(NULL, input_xml);
     data->rsc = lrmd_copy_rsc_info(rsc);
     return data;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1753,6 +1753,7 @@ controld_ack_event_directly(const char *to_host, const char *to_sys,
 
     CRM_CHECK(op != NULL, return);
     if (op->rsc_id == NULL) {
+        // op->rsc_id is a (const char *) but lrmd_free_event() frees it
         CRM_ASSERT(rsc_id != NULL);
         op->rsc_id = strdup(rsc_id);
     }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -181,7 +181,7 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
         entry->rsc.id = entry->id;
         entry->rsc.type = strdup(rsc->type);
         entry->rsc.standard = strdup(rsc->standard);
-        pcmk__str_update(&entry->rsc.provider, rsc->provider);
+        entry->rsc.provider = pcmk__str_copy(rsc->provider);
 
     } else if (entry == NULL) {
         crm_info("Resource %s no longer exists, not updating cache", op->rsc_id);
@@ -2031,7 +2031,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
         pending->op_key = strdup(op_id);
         pending->rsc_id = strdup(rsc->id);
         pending->start_time = time(NULL);
-        pcmk__str_update(&pending->user_data, op->user_data);
+        pending->user_data = pcmk__str_copy(op->user_data);
         if (crm_element_value_epoch(msg, PCMK_OPT_SHUTDOWN_LOCK,
                                     &(pending->lock_time)) != pcmk_ok) {
             pending->lock_time = 0;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -175,12 +175,12 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
     entry = g_hash_table_lookup(lrm_state->resource_history, op->rsc_id);
     if (entry == NULL && rsc) {
         entry = pcmk__assert_alloc(1, sizeof(rsc_history_t));
-        entry->id = strdup(op->rsc_id);
+        entry->id = pcmk__str_copy(op->rsc_id);
         g_hash_table_insert(lrm_state->resource_history, entry->id, entry);
 
         entry->rsc.id = entry->id;
-        entry->rsc.type = strdup(rsc->type);
-        entry->rsc.standard = strdup(rsc->standard);
+        entry->rsc.type = pcmk__str_copy(rsc->type);
+        entry->rsc.standard = pcmk__str_copy(rsc->standard);
         entry->rsc.provider = pcmk__str_copy(rsc->provider);
 
     } else if (entry == NULL) {
@@ -713,7 +713,7 @@ delete_rsc_entry(lrm_state_t *lrm_state, ha_msg_input_t *input,
     CRM_CHECK(rsc_id != NULL, return);
 
     if (rc == pcmk_ok) {
-        char *rsc_id_copy = strdup(rsc_id);
+        char *rsc_id_copy = pcmk__str_copy(rsc_id);
 
         if (rsc_iter) {
             g_hash_table_iter_remove(rsc_iter);
@@ -984,7 +984,7 @@ delete_resource(lrm_state_t *lrm_state, const char *id, lrmd_rsc_info_t *rsc,
             char *ref = crm_element_value_copy(request->msg, PCMK_XA_REFERENCE);
 
             op = pcmk__assert_alloc(1, sizeof(struct pending_deletion_op_s));
-            op->rsc = strdup(rsc->id);
+            op->rsc = pcmk__str_copy(rsc->id);
             op->input = copy_ha_msg_input(request);
             g_hash_table_insert(lrm_state->deletion_ops, ref, op);
         }
@@ -1711,7 +1711,7 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
     transition = crm_element_value(rsc_op, PCMK__XA_TRANSITION_KEY);
     CRM_CHECK(transition != NULL, return op);
 
-    op->user_data = strdup(transition);
+    op->user_data = pcmk__str_copy(transition);
 
     if (op->interval_ms != 0) {
         if (pcmk__strcase_any_of(operation, PCMK_ACTION_START, PCMK_ACTION_STOP,
@@ -1754,7 +1754,7 @@ controld_ack_event_directly(const char *to_host, const char *to_sys,
     if (op->rsc_id == NULL) {
         // op->rsc_id is a (const char *) but lrmd_free_event() frees it
         CRM_ASSERT(rsc_id != NULL);
-        op->rsc_id = strdup(rsc_id);
+        op->rsc_id = pcmk__str_copy(rsc_id);
     }
     if (to_sys == NULL) {
         to_sys = CRM_SYSTEM_TENGINE;
@@ -2027,9 +2027,9 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
 
         pending->call_id = call_id;
         pending->interval_ms = op->interval_ms;
-        pending->op_type = strdup(operation);
-        pending->op_key = strdup(op_id);
-        pending->rsc_id = strdup(rsc->id);
+        pending->op_type = pcmk__str_copy(operation);
+        pending->op_key = pcmk__str_copy(op_id);
+        pending->rsc_id = pcmk__str_copy(rsc->id);
         pending->start_time = time(NULL);
         pending->user_data = pcmk__str_copy(op->user_data);
         if (crm_element_value_epoch(msg, PCMK_OPT_SHUTDOWN_LOCK,
@@ -2091,7 +2091,7 @@ unescape_newlines(const char *string)
         return NULL;
     }
 
-    ret = strdup(string);
+    ret = pcmk__str_copy(string);
     pch = strstr(ret, escaped_newline);
     while (pch != NULL) {
         /* Replace newline escape pattern with actual newline (and a space so we

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -116,10 +116,7 @@ lrm_state_create(const char *node_name)
         return NULL;
     }
 
-    state = calloc(1, sizeof(lrm_state_t));
-    if (!state) {
-        return NULL;
-    }
+    state = pcmk__assert_alloc(1, sizeof(lrm_state_t));
 
     state->node_name = strdup(node_name);
     state->rsc_info_cache = pcmk__strkey_table(NULL, free_rsc_info);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -118,7 +118,7 @@ lrm_state_create(const char *node_name)
 
     state = pcmk__assert_alloc(1, sizeof(lrm_state_t));
 
-    state->node_name = strdup(node_name);
+    state->node_name = pcmk__str_copy(node_name);
     state->rsc_info_cache = pcmk__strkey_table(NULL, free_rsc_info);
     state->deletion_ops = pcmk__strkey_table(free, free_deletion_op);
     state->active_ops = pcmk__strkey_table(free, free_recurring_op);

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -175,7 +175,7 @@ st_fail_count_increment(const char *target)
         }
 
         rec->count = 1;
-        g_hash_table_insert(stonith_failures, strdup(target), rec);
+        g_hash_table_insert(stonith_failures, pcmk__str_copy(target), rec);
     }
 }
 
@@ -235,7 +235,7 @@ send_stonith_update(pcmk__graph_action_t *action, const char *target,
 
     if (peer->uuid == NULL) {
         crm_info("Recording uuid '%s' for node '%s'", uuid, target);
-        peer->uuid = strdup(uuid);
+        peer->uuid = pcmk__str_copy(uuid);
     }
 
     crmd_peer_down(peer, TRUE);
@@ -261,7 +261,7 @@ send_stonith_update(pcmk__graph_action_t *action, const char *target,
 
     /* Delay processing the trigger until the update completes */
     crm_debug("Sending fencing update %d for %s", rc, target);
-    fsa_register_cib_callback(rc, strdup(target), cib_fencing_updated);
+    fsa_register_cib_callback(rc, pcmk__str_copy(target), cib_fencing_updated);
 
     // Make sure it sticks
     /* controld_globals.cib_conn->cmds->bump_epoch(controld_globals.cib_conn,
@@ -315,7 +315,8 @@ static GList *stonith_cleanup_list = NULL;
  */
 void
 add_stonith_cleanup(const char *target) {
-    stonith_cleanup_list = g_list_append(stonith_cleanup_list, strdup(target));
+    stonith_cleanup_list = g_list_append(stonith_cleanup_list,
+                                         pcmk__str_copy(target));
 }
 
 /*!

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -197,7 +197,7 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
     if ((controld_globals.fsa_message_queue == NULL)
         && (controld_globals.fsa_actions != A_NOTHING)) {
         /* fake the first message so we can get into the loop */
-        fsa_data = calloc(1, sizeof(fsa_data_t));
+        fsa_data = pcmk__assert_alloc(1, sizeof(fsa_data_t));
         fsa_data->fsa_input = I_NULL;
         fsa_data->fsa_cause = C_FSA_INTERNAL;
         fsa_data->origin = __func__;

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -134,7 +134,7 @@ do_cl_join_offer_respond(long long action,
 
     query_call_id = cib_conn->cmds->query(cib_conn, NULL, NULL,
                                           cib_scope_local|cib_no_children);
-    fsa_register_cib_callback(query_call_id, strdup(join_id),
+    fsa_register_cib_callback(query_call_id, pcmk__str_copy(join_id),
                               join_query_callback);
     crm_trace("Registered join query callback: %d", query_call_id);
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -598,7 +598,7 @@ do_dc_join_finalize(long long action,
 
     if (pcmk_is_set(controld_globals.fsa_input_register, R_HAVE_CIB)) {
         // Send our CIB out to everyone
-        pcmk__str_update(&sync_from, controld_globals.our_nodename);
+        sync_from = pcmk__str_copy(controld_globals.our_nodename);
         crm_debug("Finalizing join-%d for %d node%s (sync'ing from local CIB)",
                   current_join_id, count_finalizable,
                   pcmk__plural_s(count_finalizable));
@@ -606,7 +606,7 @@ do_dc_join_finalize(long long action,
 
     } else {
         // Ask for the agreed best CIB
-        pcmk__str_update(&sync_from, max_generation_from);
+        sync_from = pcmk__str_copy(max_generation_from);
         crm_notice("Finalizing join-%d for %d node%s (sync'ing CIB from %s)",
                    current_join_id, count_finalizable,
                    pcmk__plural_s(count_finalizable), sync_from);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -264,7 +264,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
 
             delete_call_id = cib_conn->cmds->remove(cib_conn, PCMK_XE_NODES,
                                                     node_xml, cib_scope_local);
-            fsa_register_cib_callback(delete_call_id, strdup(node_uuid),
+            fsa_register_cib_callback(delete_call_id, pcmk__str_copy(node_uuid),
                                       remove_conflicting_node_callback);
 
             node_state_xml = create_xml_node(NULL, PCMK__XE_NODE_STATE);
@@ -274,7 +274,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
             delete_call_id = cib_conn->cmds->remove(cib_conn, PCMK_XE_STATUS,
                                                     node_state_xml,
                                                     cib_scope_local);
-            fsa_register_cib_callback(delete_call_id, strdup(node_uuid),
+            fsa_register_cib_callback(delete_call_id, pcmk__str_copy(node_uuid),
                                       remove_conflicting_node_callback);
             free_xml(node_state_xml);
         }
@@ -346,7 +346,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
                                                 (const char *) xpath->str,
                                                 NULL,
                                                 cib_scope_local|cib_xpath);
-                fsa_register_cib_callback(call_id, strdup(node->uuid),
+                fsa_register_cib_callback(call_id, pcmk__str_copy(node->uuid),
                                           search_conflicting_node_callback);
             }
         }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -99,7 +99,7 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
               fsa_input2string(input), fsa_cause2string(cause),
               (data? "with" : "without"));
 
-    fsa_data = calloc(1, sizeof(fsa_data_t));
+    fsa_data = pcmk__assert_alloc(1, sizeof(fsa_data_t));
     fsa_data->id = last_data_id;
     fsa_data->fsa_input = input;
     fsa_data->fsa_cause = cause;
@@ -188,9 +188,8 @@ fsa_dump_queue(int log_level)
 ha_msg_input_t *
 copy_ha_msg_input(ha_msg_input_t * orig)
 {
-    ha_msg_input_t *copy = calloc(1, sizeof(ha_msg_input_t));
+    ha_msg_input_t *copy = pcmk__assert_alloc(1, sizeof(ha_msg_input_t));
 
-    pcmk__mem_assert(copy);
     copy->msg = (orig != NULL)? pcmk__xml_copy(NULL, orig->msg) : NULL;
     copy->xml = get_message_xml(copy->msg, PCMK__XE_CRM_XML);
     return copy;

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -190,7 +190,7 @@ copy_ha_msg_input(ha_msg_input_t * orig)
 {
     ha_msg_input_t *copy = calloc(1, sizeof(ha_msg_input_t));
 
-    CRM_ASSERT(copy != NULL);
+    pcmk__mem_assert(copy);
     copy->msg = (orig != NULL)? pcmk__xml_copy(NULL, orig->msg) : NULL;
     copy->xml = get_message_xml(copy->msg, PCMK__XE_CRM_XML);
     return copy;

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -576,7 +576,7 @@ controld_authorize_ipc_message(const xmlNode *client_msg, pcmk__client_t *curr_c
     crm_trace("Validated IPC hello from client %s", client_name);
     crm_log_xml_trace(client_msg, "hello");
     if (curr_client) {
-        curr_client->userdata = strdup(client_name);
+        curr_client->userdata = pcmk__str_copy(client_name);
     }
     controld_trigger_fsa();
     return false;
@@ -737,7 +737,7 @@ handle_lrm_delete(xmlNode *stored_msg)
                      ((rc == pcmk_rc_ok)? "" : " not"));
             op = lrmd_new_event(rsc_id, PCMK_ACTION_DELETE, 0);
             op->type = lrmd_event_exec_complete;
-            op->user_data = strdup(transition? transition : FAKE_TE_ID);
+            op->user_data = pcmk__str_copy(pcmk__s(transition, FAKE_TE_ID));
             op->params = pcmk__strkey_table(free, free);
             pcmk__insert_dup(op->params, PCMK_XA_CRM_FEATURE_SET,
                              CRM_FEATURE_SET);

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -75,11 +75,7 @@ ra_param_from_xml(xmlNode *param_xml)
 
     p = pcmk__assert_alloc(1, sizeof(struct ra_param_s));
 
-    p->rap_name = strdup(param_name);
-    if (p->rap_name == NULL) {
-        free(p);
-        return NULL;
-    }
+    p->rap_name = pcmk__str_copy(param_name);
 
     if (pcmk__xe_attr_is_true(param_xml, PCMK_XA_RELOADABLE)) {
         controld_set_ra_param_flags(p, ra_param_reloadable);

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -73,10 +73,7 @@ ra_param_from_xml(xmlNode *param_xml)
     const char *param_name = crm_element_value(param_xml, PCMK_XA_NAME);
     struct ra_param_s *p;
 
-    p = calloc(1, sizeof(struct ra_param_s));
-    if (p == NULL) {
-        return NULL;
-    }
+    p = pcmk__assert_alloc(1, sizeof(struct ra_param_s));
 
     p->rap_name = strdup(param_name);
     if (p->rap_name == NULL) {
@@ -145,11 +142,7 @@ controld_cache_metadata(GHashTable *mdc, const lrmd_rsc_info_t *rsc,
         goto err;
     }
 
-    md = calloc(1, sizeof(struct ra_metadata_s));
-    if (md == NULL) {
-        reason = "Could not allocate memory";
-        goto err;
-    }
+    md = pcmk__assert_alloc(1, sizeof(struct ra_metadata_s));
 
     if (strcmp(rsc->standard, PCMK_RESOURCE_CLASS_OCF) == 0) {
         xmlChar *content = NULL;

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1001,7 +1001,7 @@ remote_ra_data_init(lrm_state_t * lrm_state)
         return;
     }
 
-    ra_data = calloc(1, sizeof(remote_ra_data_t));
+    ra_data = pcmk__assert_alloc(1, sizeof(remote_ra_data_t));
     ra_data->work = mainloop_add_trigger(G_PRIORITY_HIGH, handle_remote_ra_exec, lrm_state);
     lrm_state->remote_ra_data = ra_data;
 }
@@ -1047,7 +1047,7 @@ remote_ra_get_rsc_info(lrm_state_t * lrm_state, const char *rsc_id)
     lrmd_rsc_info_t *info = NULL;
 
     if ((lrm_state_find(rsc_id))) {
-        info = calloc(1, sizeof(lrmd_rsc_info_t));
+        info = pcmk__assert_alloc(1, sizeof(lrmd_rsc_info_t));
 
         info->id = strdup(rsc_id);
         info->type = strdup(REMOTE_LRMD_RA);
@@ -1286,12 +1286,7 @@ controld_execute_remote_agent(const lrm_state_t *lrm_state, const char *rsc_id,
         return pcmk_rc_ok;
     }
 
-    cmd = calloc(1, sizeof(remote_ra_cmd_t));
-    if (cmd == NULL) {
-        lrmd_key_value_freeall(params);
-        return ENOMEM;
-    }
-
+    cmd = pcmk__assert_alloc(1, sizeof(remote_ra_cmd_t));
     cmd->owner = strdup(lrm_state->node_name);
     cmd->rsc_id = strdup(rsc_id);
     cmd->action = strdup(action);

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1049,10 +1049,10 @@ remote_ra_get_rsc_info(lrm_state_t * lrm_state, const char *rsc_id)
     if ((lrm_state_find(rsc_id))) {
         info = pcmk__assert_alloc(1, sizeof(lrmd_rsc_info_t));
 
-        info->id = strdup(rsc_id);
-        info->type = strdup(REMOTE_LRMD_RA);
-        info->standard = strdup(PCMK_RESOURCE_CLASS_OCF);
-        info->provider = strdup("pacemaker");
+        info->id = pcmk__str_copy(rsc_id);
+        info->type = pcmk__str_copy(REMOTE_LRMD_RA);
+        info->standard = pcmk__str_copy(PCMK_RESOURCE_CLASS_OCF);
+        info->provider = pcmk__str_copy("pacemaker");
     }
 
     return info;
@@ -1208,7 +1208,7 @@ handle_dup:
     /* update the userdata */
     if (userdata) {
        free(cmd->userdata);
-       cmd->userdata = strdup(userdata);
+       cmd->userdata = pcmk__str_copy(userdata);
     }
 
     /* if we've already reported success, generate a new call id */
@@ -1287,17 +1287,11 @@ controld_execute_remote_agent(const lrm_state_t *lrm_state, const char *rsc_id,
     }
 
     cmd = pcmk__assert_alloc(1, sizeof(remote_ra_cmd_t));
-    cmd->owner = strdup(lrm_state->node_name);
-    cmd->rsc_id = strdup(rsc_id);
-    cmd->action = strdup(action);
-    cmd->userdata = strdup(userdata);
-    if ((cmd->owner == NULL) || (cmd->rsc_id == NULL) || (cmd->action == NULL)
-        || (cmd->userdata == NULL)) {
-        free_cmd(cmd);
-        lrmd_key_value_freeall(params);
-        return ENOMEM;
-    }
 
+    cmd->owner = pcmk__str_copy(lrm_state->node_name);
+    cmd->rsc_id = pcmk__str_copy(rsc_id);
+    cmd->action = pcmk__str_copy(action);
+    cmd->userdata = pcmk__str_copy(userdata);
     cmd->interval_ms = interval_ms;
     cmd->timeout = timeout_ms;
     cmd->start_delay = start_delay_ms;

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -508,7 +508,7 @@ te_update_job_count_on(const char *target, int offset, bool migrate)
     r = g_hash_table_lookup(te_targets, target);
     if(r == NULL) {
         r = pcmk__assert_alloc(1, sizeof(struct te_peer_s));
-        r->name = strdup(target);
+        r->name = pcmk__str_copy(target);
         g_hash_table_insert(te_targets, r->name, r);
     }
 
@@ -587,7 +587,7 @@ allowed_on_node(const pcmk__graph_t *graph, const pcmk__graph_action_t *action,
 
     if(r == NULL) {
         r = pcmk__assert_alloc(1, sizeof(struct te_peer_s));
-        r->name = strdup(target);
+        r->name = pcmk__str_copy(target);
         g_hash_table_insert(te_targets, r->name, r);
     }
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -507,7 +507,7 @@ te_update_job_count_on(const char *target, int offset, bool migrate)
 
     r = g_hash_table_lookup(te_targets, target);
     if(r == NULL) {
-        r = calloc(1, sizeof(struct te_peer_s));
+        r = pcmk__assert_alloc(1, sizeof(struct te_peer_s));
         r->name = strdup(target);
         g_hash_table_insert(te_targets, r->name, r);
     }
@@ -586,7 +586,7 @@ allowed_on_node(const pcmk__graph_t *graph, const pcmk__graph_action_t *action,
     limit = throttle_get_job_limit(target);
 
     if(r == NULL) {
-        r = calloc(1, sizeof(struct te_peer_s));
+        r = pcmk__assert_alloc(1, sizeof(struct te_peer_s));
         r->name = strdup(target);
         g_hash_table_insert(te_targets, r->name, r);
     }

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -270,7 +270,7 @@ process_resource_updates(const char *node, xmlNode *xml, xmlNode *change,
 
 static char *extract_node_uuid(const char *xpath) 
 {
-    char *mutable_path = strdup(xpath);
+    char *mutable_path = pcmk__str_copy(xpath);
     char *node_uuid = NULL;
     char *search = NULL;
     char *match = NULL;
@@ -289,7 +289,7 @@ static char *extract_node_uuid(const char *xpath)
     }
     search[0] = 0;
 
-    node_uuid = strdup(match);
+    node_uuid = pcmk__str_copy(match);
     free(mutable_path);
     return node_uuid;
 }
@@ -329,7 +329,7 @@ abort_unless_down(const char *xpath, const char *op, xmlNode *change,
 static void
 process_op_deletion(const char *xpath, xmlNode *change)
 {
-    char *mutable_key = strdup(xpath);
+    char *mutable_key = pcmk__str_copy(xpath);
     char *key;
     char *node_uuid;
 

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -245,8 +245,7 @@ update_failcount(const xmlNode *event, const char *event_node_uuid, int rc,
 
         /* Update the fail count, if we're not ignoring failures */
         if (!ignore_failures) {
-            fail_pair = calloc(1, sizeof(pcmk__attrd_query_pair_t));
-            pcmk__mem_assert(fail_pair);
+            fail_pair = pcmk__assert_alloc(1, sizeof(pcmk__attrd_query_pair_t));
 
             fail_name = pcmk__failcount_name(rsc_id, task, interval_ms);
             fail_pair->name = fail_name;
@@ -259,8 +258,7 @@ update_failcount(const xmlNode *event, const char *event_node_uuid, int rc,
         /* Update the last failure time (even if we're ignoring failures,
          * so that failure can still be detected and shown, e.g. by crm_mon)
          */
-        last_pair = calloc(1, sizeof(pcmk__attrd_query_pair_t));
-        pcmk__mem_assert(last_pair);
+        last_pair = pcmk__assert_alloc(1, sizeof(pcmk__attrd_query_pair_t));
 
         last_name = pcmk__lastfailure_name(rsc_id, task, interval_ms);
         last_pair->name = last_name;

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -246,7 +246,7 @@ update_failcount(const xmlNode *event, const char *event_node_uuid, int rc,
         /* Update the fail count, if we're not ignoring failures */
         if (!ignore_failures) {
             fail_pair = calloc(1, sizeof(pcmk__attrd_query_pair_t));
-            CRM_ASSERT(fail_pair != NULL);
+            pcmk__mem_assert(fail_pair);
 
             fail_name = pcmk__failcount_name(rsc_id, task, interval_ms);
             fail_pair->name = fail_name;
@@ -260,7 +260,7 @@ update_failcount(const xmlNode *event, const char *event_node_uuid, int rc,
          * so that failure can still be detected and shown, e.g. by crm_mon)
          */
         last_pair = calloc(1, sizeof(pcmk__attrd_query_pair_t));
-        CRM_ASSERT(last_pair != NULL);
+        pcmk__mem_assert(last_pair);
 
         last_name = pcmk__lastfailure_name(rsc_id, task, interval_ms);
         last_pair->name = last_name;

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -228,14 +228,13 @@ init_node_pending_timer(const crm_node_t *node, guint timeout)
                node->uname ? node->uname : "node", node->uuid,
                controld_globals.node_pending_timeout);
 
+    key = pcmk__str_copy(node->uuid);
     node_pending_timer = pcmk__assert_alloc(1, sizeof(struct abort_timer_s));
 
     node_pending_timer->aborted = FALSE;
     node_pending_timer->priority = PCMK_SCORE_INFINITY;
     node_pending_timer->action = pcmk__graph_restart;
     node_pending_timer->text = "Node pending timed out";
-
-    pcmk__str_update(&key, node->uuid);
 
     g_hash_table_replace(node_pending_timers, key, node_pending_timer);
 

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -229,15 +229,14 @@ init_node_pending_timer(const crm_node_t *node, guint timeout)
                controld_globals.node_pending_timeout);
 
     node_pending_timer = calloc(1, sizeof(struct abort_timer_s));
-    CRM_ASSERT(node_pending_timer != NULL);
+    pcmk__mem_assert(node_pending_timer);
 
     node_pending_timer->aborted = FALSE;
     node_pending_timer->priority = PCMK_SCORE_INFINITY;
     node_pending_timer->action = pcmk__graph_restart;
     node_pending_timer->text = "Node pending timed out";
 
-    key = strdup(node->uuid);
-    CRM_ASSERT(key != NULL);
+    pcmk__str_update(&key, node->uuid);
 
     g_hash_table_replace(node_pending_timers, key, node_pending_timer);
 

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -228,8 +228,7 @@ init_node_pending_timer(const crm_node_t *node, guint timeout)
                node->uname ? node->uname : "node", node->uuid,
                controld_globals.node_pending_timeout);
 
-    node_pending_timer = calloc(1, sizeof(struct abort_timer_s));
-    pcmk__mem_assert(node_pending_timer);
+    node_pending_timer = pcmk__assert_alloc(1, sizeof(struct abort_timer_s));
 
     node_pending_timer->aborted = FALSE;
     node_pending_timer->priority = PCMK_SCORE_INFINITY;

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -517,7 +517,7 @@ throttle_get_job_limit(const char *node)
     r = g_hash_table_lookup(throttle_records, node);
     if(r == NULL) {
         r = pcmk__assert_alloc(1, sizeof(struct throttle_record_s));
-        r->node = strdup(node);
+        r->node = pcmk__str_copy(node);
         r->mode = throttle_low;
         r->max = throttle_job_max;
         crm_trace("Defaulting to local values for unknown node %s", node);
@@ -561,7 +561,7 @@ throttle_update(xmlNode *xml)
 
     if(r == NULL) {
         r = pcmk__assert_alloc(1, sizeof(struct throttle_record_s));
-        r->node = strdup(from);
+        r->node = pcmk__str_copy(from);
         g_hash_table_insert(throttle_records, r->node, r);
     }
 

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -160,7 +160,7 @@ throttle_cib_load(float *load)
     }
 
     if(fgets(buffer, sizeof(buffer), stream)) {
-        char *comm = calloc(1, 256);
+        char *comm = pcmk__assert_alloc(1, 256);
         char state = 0;
         int rc = 0, pid = 0, ppid = 0, pgrp = 0, session = 0, tty_nr = 0, tpgid = 0;
         unsigned long flags = 0, minflt = 0, cminflt = 0, majflt = 0, cmajflt = 0, utime = 0, stime = 0;
@@ -516,7 +516,7 @@ throttle_get_job_limit(const char *node)
 
     r = g_hash_table_lookup(throttle_records, node);
     if(r == NULL) {
-        r = calloc(1, sizeof(struct throttle_record_s));
+        r = pcmk__assert_alloc(1, sizeof(struct throttle_record_s));
         r->node = strdup(node);
         r->mode = throttle_low;
         r->max = throttle_job_max;
@@ -560,7 +560,7 @@ throttle_update(xmlNode *xml)
     r = g_hash_table_lookup(throttle_records, from);
 
     if(r == NULL) {
-        r = calloc(1, sizeof(struct throttle_record_s));
+        r = pcmk__assert_alloc(1, sizeof(struct throttle_record_s));
         r->node = strdup(from);
         g_hash_table_insert(throttle_records, r->node, r);
     }

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -229,40 +229,13 @@ crm_timer_popped(gpointer data)
 bool
 controld_init_fsa_timers(void)
 {
-    transition_timer = calloc(1, sizeof(fsa_timer_t));
-    if (transition_timer == NULL) {
-        return FALSE;
-    }
-
-    integration_timer = calloc(1, sizeof(fsa_timer_t));
-    if (integration_timer == NULL) {
-        return FALSE;
-    }
-
-    finalization_timer = calloc(1, sizeof(fsa_timer_t));
-    if (finalization_timer == NULL) {
-        return FALSE;
-    }
-
-    election_timer = calloc(1, sizeof(fsa_timer_t));
-    if (election_timer == NULL) {
-        return FALSE;
-    }
-
-    shutdown_escalation_timer = calloc(1, sizeof(fsa_timer_t));
-    if (shutdown_escalation_timer == NULL) {
-        return FALSE;
-    }
-
-    wait_timer = calloc(1, sizeof(fsa_timer_t));
-    if (wait_timer == NULL) {
-        return FALSE;
-    }
-
-    recheck_timer = calloc(1, sizeof(fsa_timer_t));
-    if (recheck_timer == NULL) {
-        return FALSE;
-    }
+    transition_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
+    integration_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
+    finalization_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
+    election_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
+    shutdown_escalation_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
+    wait_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
+    recheck_timer = pcmk__assert_alloc(1, sizeof(fsa_timer_t));
 
     election_timer->source_id = 0;
     election_timer->period_ms = 0;

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -132,11 +132,7 @@ process_lrmd_alert_exec(pcmk__client_t *client, uint32_t id, xmlNode *request)
     pcmk__add_alert_key_int(params, PCMK__alert_key_node_sequence,
                             ++alert_sequence_no);
 
-    cb_data = calloc(1, sizeof(struct alert_cb_s));
-    if (cb_data == NULL) {
-        rc = -errno;
-        goto err;
-    }
+    cb_data = pcmk__assert_alloc(1, sizeof(struct alert_cb_s));
 
     /* coverity[deref_ptr] False Positive */
     cb_data->client_id = strdup(client->id);

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -118,7 +118,8 @@ process_lrmd_alert_exec(pcmk__client_t *client, uint32_t id, xmlNode *request)
 
     if ((alert_id == NULL) || (alert_path == NULL) ||
         (client == NULL) || (client->id == NULL)) { /* hint static analyzer */
-        return -EINVAL;
+        rc = -EINVAL;
+        goto err;
     }
     if (draining_alerts) {
         return pcmk_ok;
@@ -134,12 +135,7 @@ process_lrmd_alert_exec(pcmk__client_t *client, uint32_t id, xmlNode *request)
 
     cb_data = pcmk__assert_alloc(1, sizeof(struct alert_cb_s));
 
-    /* coverity[deref_ptr] False Positive */
-    cb_data->client_id = strdup(client->id);
-    if (cb_data->client_id == NULL) {
-        rc = -errno;
-        goto err;
-    }
+    cb_data->client_id = pcmk__str_copy(client->id);
 
     crm_element_value_int(request, PCMK__XA_LRMD_CALLID, &(cb_data->call_id));
 
@@ -163,9 +159,7 @@ process_lrmd_alert_exec(pcmk__client_t *client, uint32_t id, xmlNode *request)
 
 err:
     if (cb_data) {
-        if (cb_data->client_id) {
-            free(cb_data->client_id);
-        }
+        free(cb_data->client_id);
         free(cb_data);
     }
     services_action_free(action);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -277,7 +277,7 @@ build_rsc_from_xml(xmlNode * msg)
     xmlNode *rsc_xml = get_xpath_object("//" PCMK__XE_LRMD_RSC, msg, LOG_ERR);
     lrmd_rsc_t *rsc = NULL;
 
-    rsc = calloc(1, sizeof(lrmd_rsc_t));
+    rsc = pcmk__assert_alloc(1, sizeof(lrmd_rsc_t));
 
     crm_element_value_int(msg, PCMK__XA_LRMD_CALLOPT, &rsc->call_opts);
 
@@ -301,7 +301,7 @@ create_lrmd_cmd(xmlNode *msg, pcmk__client_t *client)
     xmlNode *rsc_xml = get_xpath_object("//" PCMK__XE_LRMD_RSC, msg, LOG_ERR);
     lrmd_cmd_t *cmd = NULL;
 
-    cmd = calloc(1, sizeof(lrmd_cmd_t));
+    cmd = pcmk__assert_alloc(1, sizeof(lrmd_cmd_t));
 
     crm_element_value_int(msg, PCMK__XA_LRMD_CALLOPT, &call_options);
     cmd->call_opts = call_options;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -305,7 +305,7 @@ create_lrmd_cmd(xmlNode *msg, pcmk__client_t *client)
 
     crm_element_value_int(msg, PCMK__XA_LRMD_CALLOPT, &call_options);
     cmd->call_opts = call_options;
-    cmd->client_id = strdup(client->id);
+    cmd->client_id = pcmk__str_copy(client->id);
 
     crm_element_value_int(msg, PCMK__XA_LRMD_CALLID, &cmd->call_id);
     crm_element_value_ms(rsc_xml, PCMK__XA_LRMD_RSC_INTERVAL,
@@ -861,7 +861,7 @@ action_complete(svc_action_t * action)
              */
             goagain = true;
             cmd->real_action = cmd->action;
-            cmd->action = strdup(PCMK_ACTION_MONITOR);
+            cmd->action = pcmk__str_copy(PCMK_ACTION_MONITOR);
 
         } else if (cmd->real_action != NULL) {
             // This is follow-up monitor to check whether start/stop completed

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -149,7 +149,7 @@ lrmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         if (value == NULL) {
             client->name = pcmk__itoa(pcmk__client_pid(c));
         } else {
-            client->name = strdup(value);
+            client->name = pcmk__str_copy(value);
         }
     }
 

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -86,7 +86,7 @@ ipc_proxy_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid, const char *ipc
 
     /* This ipc client is bound to a single ipc provider. If the
      * provider goes away, this client is disconnected */
-    client->userdata = strdup(ipc_proxy->id);
+    client->userdata = pcmk__str_copy(ipc_proxy->id);
     client->name = crm_strdup_printf("proxy-%s-%d-%.8s", ipc_channel, client->pid, client->id);
 
     /* Allow remote executor to distinguish between proxied local clients and

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -228,7 +228,7 @@ lrmd_remote_listen(gpointer data)
     }
 
     new_client = pcmk__new_unauth_client(NULL);
-    new_client->remote = calloc(1, sizeof(pcmk__remote_t));
+    new_client->remote = pcmk__assert_alloc(1, sizeof(pcmk__remote_t));
     pcmk__set_client_flags(new_client, pcmk__client_tls);
     new_client->remote->tls_session = session;
 

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -112,12 +112,8 @@ lrmd_remote_client_msg(gpointer data)
         crm_element_value_int(request, PCMK__XA_LRMD_REMOTE_MSG_ID, &id);
         crm_trace("Processing remote client request %d", id);
         if (!client->name) {
-            const char *value = crm_element_value(request,
+            client->name = crm_element_value_copy(request,
                                                   PCMK__XA_LRMD_CLIENTNAME);
-
-            if (value) {
-                client->name = strdup(value);
-            }
         }
 
         lrmd_call_id++;

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -351,8 +351,7 @@ create_async_command(xmlNode *msg)
         return NULL;
     }
 
-    cmd = calloc(1, sizeof(async_command_t));
-    pcmk__mem_assert(cmd);
+    cmd = pcmk__assert_alloc(1, sizeof(async_command_t));
 
     // All messages must include these
     cmd->action = crm_element_value_copy(op, PCMK__XA_ST_DEVICE_ACTION);
@@ -787,7 +786,7 @@ build_port_aliases(const char *hostmap, GList ** targets)
             case ':':
                 if (lpc > last) {
                     free(name);
-                    name = calloc(1, 1 + lpc - last);
+                    name = pcmk__assert_alloc(1, 1 + lpc - last);
                     memcpy(name, hostmap + last, lpc - last);
                 }
                 last = lpc + 1;
@@ -803,7 +802,7 @@ build_port_aliases(const char *hostmap, GList ** targets)
                     char *value = NULL;
                     int k = 0;
 
-                    value = calloc(1, 1 + lpc - last);
+                    value = pcmk__assert_alloc(1, 1 + lpc - last);
                     memcpy(value, hostmap + last, lpc - last);
 
                     for (int i = 0; value[i] != '\0'; i++) {
@@ -1085,9 +1084,7 @@ build_device_from_xml(xmlNode *dev)
 
     CRM_CHECK(agent != NULL, return device);
 
-    device = calloc(1, sizeof(stonith_device_t));
-
-    CRM_CHECK(device != NULL, {free(agent); return device;});
+    device = pcmk__assert_alloc(1, sizeof(stonith_device_t));
 
     device->id = crm_element_value_copy(dev, PCMK_XA_ID);
     device->agent = agent;
@@ -1170,7 +1167,7 @@ schedule_internal_command(const char *origin,
 {
     async_command_t *cmd = NULL;
 
-    cmd = calloc(1, sizeof(async_command_t));
+    cmd = pcmk__assert_alloc(1, sizeof(async_command_t));
 
     cmd->id = -1;
     cmd->default_timeout = timeout ? timeout : 60;
@@ -1784,13 +1781,8 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
     /* Find or create topology table entry */
     tp = g_hash_table_lookup(topology, target);
     if (tp == NULL) {
-        tp = calloc(1, sizeof(stonith_topology_t));
-        if (tp == NULL) {
-            pcmk__set_result(result, CRM_EX_ERROR, PCMK_EXEC_ERROR,
-                             strerror(ENOMEM));
-            free(target);
-            return;
-        }
+        tp = pcmk__assert_alloc(1, sizeof(stonith_topology_t));
+
         tp->kind = mode;
         tp->target = target;
         tp->target_value = crm_element_value_copy(level, PCMK_XA_TARGET_VALUE);
@@ -1915,26 +1907,29 @@ list_to_string(GList *list, const char *delim, gboolean terminate_with_delim)
     char *rv;
     GList *gIter;
 
+    char *pos = NULL;
+    const char *lead_delim = "";
+
     for (gIter = list; gIter != NULL; gIter = gIter->next) {
         const char *value = (const char *) gIter->data;
 
         alloc_size += strlen(value);
     }
-    rv = calloc(alloc_size, sizeof(char));
-    if (rv) {
-        char *pos = rv;
-        const char *lead_delim = "";
 
-        for (gIter = list; gIter != NULL; gIter = gIter->next) {
-            const char *value = (const char *) gIter->data;
+    rv = pcmk__assert_alloc(alloc_size, sizeof(char));
+    pos = rv;
 
-            pos = &pos[sprintf(pos, "%s%s", lead_delim, value)];
-            lead_delim = delim;
-        }
-        if (max && terminate_with_delim) {
-            sprintf(pos, "%s", delim);
-        }
+    for (gIter = list; gIter != NULL; gIter = gIter->next) {
+        const char *value = (const char *) gIter->data;
+
+        pos = &pos[sprintf(pos, "%s%s", lead_delim, value)];
+        lead_delim = delim;
     }
+
+    if (max && terminate_with_delim) {
+        sprintf(pos, "%s", delim);
+    }
+
     return rv;
 }
 
@@ -2260,13 +2255,7 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
         return;
     }
 
-    search = calloc(1, sizeof(struct device_search_s));
-    if (!search) {
-        crm_crit("Cannot search for capable fence devices: %s",
-                 strerror(ENOMEM));
-        callback(NULL, user_data);
-        return;
-    }
+    search = pcmk__assert_alloc(1, sizeof(struct device_search_s));
 
     pcmk__str_update(&search->host, host);
     pcmk__str_update(&search->action, action);
@@ -3261,8 +3250,7 @@ handle_query_request(pcmk__request_t *request)
 
     crm_log_xml_trace(request->xml, "Query");
 
-    query = calloc(1, sizeof(struct st_query_data));
-    pcmk__mem_assert(query);
+    query = pcmk__assert_alloc(1, sizeof(struct st_query_data));
 
     query->reply = fenced_construct_reply(request->xml, NULL, &request->result);
     pcmk__str_update(&query->remote_peer, request->peer);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -157,10 +157,10 @@ get_action_delay_base(const stonith_device_t *device, const char *action,
     hash_value = g_hash_table_lookup(device->params, PCMK_STONITH_DELAY_BASE);
 
     if (hash_value) {
-        char *value = strdup(hash_value);
+        char *value = NULL;
         char *valptr = value;
 
-        CRM_ASSERT(value != NULL);
+        pcmk__str_update(&value, hash_value);
 
         if (target != NULL) {
             for (char *val = strtok(value, "; \t"); val != NULL; val = strtok(NULL, "; \t")) {
@@ -352,7 +352,7 @@ create_async_command(xmlNode *msg)
     }
 
     cmd = calloc(1, sizeof(async_command_t));
-    CRM_ASSERT(cmd != NULL);
+    pcmk__mem_assert(cmd);
 
     // All messages must include these
     cmd->action = crm_element_value_copy(op, PCMK__XA_ST_DEVICE_ACTION);
@@ -3262,7 +3262,7 @@ handle_query_request(pcmk__request_t *request)
     crm_log_xml_trace(request->xml, "Query");
 
     query = calloc(1, sizeof(struct st_query_data));
-    CRM_ASSERT(query != NULL);
+    pcmk__mem_assert(query);
 
     query->reply = fenced_construct_reply(request->xml, NULL, &request->result);
     pcmk__str_update(&query->remote_peer, request->peer);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -649,7 +649,7 @@ schedule_stonith_command(async_command_t * cmd, stonith_device_t * device)
         cmd->target_nodeid = node->id;
     }
 
-    cmd->device = strdup(device->id);
+    cmd->device = pcmk__str_copy(device->id);
     cmd->timeout = get_action_timeout(device, cmd->action, cmd->default_timeout);
 
     if (cmd->remote_op_id) {
@@ -813,7 +813,7 @@ build_port_aliases(const char *hostmap, GList ** targets)
                     crm_debug("Adding alias '%s'='%s'", name, value);
                     g_hash_table_replace(aliases, name, value);
                     if (targets) {
-                        *targets = g_list_append(*targets, strdup(value));
+                        *targets = g_list_append(*targets, pcmk__str_copy(value));
                     }
                     value = NULL;
                     name = NULL;
@@ -887,7 +887,7 @@ get_agent_metadata(const char *agent, xmlNode ** metadata)
             crm_err("Could not retrieve metadata for fencing agent %s", agent);
             return EAGAIN;
         }
-        g_hash_table_replace(metadata_cache, strdup(agent), buffer);
+        g_hash_table_replace(metadata_cache, pcmk__str_copy(agent), buffer);
     }
 
     *metadata = pcmk__xml_parse(buffer);
@@ -1000,7 +1000,7 @@ map_action(GHashTable *params, const char *action, const char *value)
     } else {
         crm_warn("Mapping %s='%s' to %s='%s'",
                  STONITH_ATTR_ACTION_OP, value, key, value);
-        g_hash_table_insert(params, key, strdup(value));
+        g_hash_table_insert(params, key, pcmk__str_copy(value));
     }
 }
 
@@ -1170,12 +1170,12 @@ schedule_internal_command(const char *origin,
     cmd->id = -1;
     cmd->default_timeout = timeout ? timeout : 60;
     cmd->timeout = cmd->default_timeout;
-    cmd->action = strdup(action);
+    cmd->action = pcmk__str_copy(action);
     cmd->target = pcmk__str_copy(target);
-    cmd->device = strdup(device->id);
-    cmd->origin = strdup(origin);
-    cmd->client = strdup(crm_system_name);
-    cmd->client_name = strdup(crm_system_name);
+    cmd->device = pcmk__str_copy(device->id);
+    cmd->origin = pcmk__str_copy(origin);
+    cmd->client = pcmk__str_copy(crm_system_name);
+    cmd->client_name = pcmk__str_copy(crm_system_name);
 
     cmd->internal_user_data = internal_user_data;
     cmd->done_cb = done_cb; /* cmd, not internal_user_data, is passed to 'done_cb' as the userdata */
@@ -1806,7 +1806,7 @@ fenced_register_level(xmlNode *msg, char **desc, pcmk__action_result_t *result)
         const char *device = dIter->value;
 
         crm_trace("Adding device '%s' for %s[%d]", device, tp->target, id);
-        tp->levels[id] = g_list_append(tp->levels[id], strdup(device));
+        tp->levels[id] = g_list_append(tp->levels[id], pcmk__str_copy(device));
     }
     stonith_key_value_freeall(devices, 1, 1);
 
@@ -2026,7 +2026,8 @@ search_devices_record_result(struct device_search_s *search, const char *device,
                 return;
             }
         }
-        search->capable = g_list_append(search->capable, strdup(device));
+        search->capable = g_list_append(search->capable,
+                                        pcmk__str_copy(device));
     }
 
     if (search->replies_needed == search->replies_received) {

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -157,10 +157,8 @@ get_action_delay_base(const stonith_device_t *device, const char *action,
     hash_value = g_hash_table_lookup(device->params, PCMK_STONITH_DELAY_BASE);
 
     if (hash_value) {
-        char *value = NULL;
+        char *value = pcmk__str_copy(hash_value);
         char *valptr = value;
-
-        pcmk__str_update(&value, hash_value);
 
         if (target != NULL) {
             for (char *val = strtok(value, "; \t"); val != NULL; val = strtok(NULL, "; \t")) {
@@ -1173,7 +1171,7 @@ schedule_internal_command(const char *origin,
     cmd->default_timeout = timeout ? timeout : 60;
     cmd->timeout = cmd->default_timeout;
     cmd->action = strdup(action);
-    pcmk__str_update(&cmd->target, target);
+    cmd->target = pcmk__str_copy(target);
     cmd->device = strdup(device->id);
     cmd->origin = strdup(origin);
     cmd->client = strdup(crm_system_name);
@@ -2257,8 +2255,8 @@ get_capable_devices(const char *host, const char *action, int timeout, bool suic
 
     search = pcmk__assert_alloc(1, sizeof(struct device_search_s));
 
-    pcmk__str_update(&search->host, host);
-    pcmk__str_update(&search->action, action);
+    search->host = pcmk__str_copy(host);
+    search->action = pcmk__str_copy(action);
     search->per_device_timeout = timeout;
     search->allow_suicide = suicide;
     search->callback = callback;
@@ -3253,10 +3251,10 @@ handle_query_request(pcmk__request_t *request)
     query = pcmk__assert_alloc(1, sizeof(struct st_query_data));
 
     query->reply = fenced_construct_reply(request->xml, NULL, &request->result);
-    pcmk__str_update(&query->remote_peer, request->peer);
-    pcmk__str_update(&query->client_id, client_id);
-    pcmk__str_update(&query->target, target);
-    pcmk__str_update(&query->action, action);
+    query->remote_peer = pcmk__str_copy(request->peer);
+    query->client_id = pcmk__str_copy(client_id);
+    query->target = pcmk__str_copy(target);
+    query->action = pcmk__str_copy(action);
     query->call_options = request->call_options;
 
     crm_element_value_int(request->xml, PCMK__XA_ST_TIMEOUT, &timeout);

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -243,7 +243,7 @@ stonith_xml_history_to_list(const xmlNode *history)
 
         crm_trace("Attaching op %s to hashtable", id);
 
-        op = calloc(1, sizeof(remote_fencing_op_t));
+        op = pcmk__assert_alloc(1, sizeof(remote_fencing_op_t));
 
         op->id = id;
         op->target = crm_element_value_copy(xml_op, PCMK__XA_ST_TARGET);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1161,8 +1161,7 @@ create_remote_stonith_op(const char *client, xmlNode *request, gboolean peer)
         }
     }
 
-    op = calloc(1, sizeof(remote_fencing_op_t));
-    pcmk__mem_assert(op);
+    op = pcmk__assert_alloc(1, sizeof(remote_fencing_op_t));
 
     crm_element_value_int(request, PCMK__XA_ST_TIMEOUT, &(op->base_timeout));
     // Value -1 means disable any static/random fencing delays
@@ -2165,11 +2164,11 @@ add_device_properties(const xmlNode *xml, remote_fencing_op_t *op,
 {
     xmlNode *child;
     int verified = 0;
-    device_properties_t *props = calloc(1, sizeof(device_properties_t));
+    device_properties_t *props =
+        pcmk__assert_alloc(1, sizeof(device_properties_t));
     int flags = st_device_supports_on; /* Old nodes that don't set the flag assume they support the on action */
 
     /* Add a new entry to this peer's devices list */
-    pcmk__mem_assert(props);
     g_hash_table_insert(peer->devices, strdup(device), props);
 
     /* Peers with verified (monitored) access will be preferred */
@@ -2219,12 +2218,10 @@ static peer_device_info_t *
 add_result(remote_fencing_op_t *op, const char *host, int ndevices,
            const xmlNode *xml)
 {
-    peer_device_info_t *peer = calloc(1, sizeof(peer_device_info_t));
+    peer_device_info_t *peer = pcmk__assert_alloc(1,
+                                                  sizeof(peer_device_info_t));
     xmlNode *child;
 
-    // cppcheck seems not to understand the abort logic in CRM_CHECK
-    // cppcheck-suppress memleak
-    CRM_CHECK(peer != NULL, return NULL);
     peer->host = strdup(host);
     peer->devices = pcmk__strkey_table(free, free);
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1162,7 +1162,7 @@ create_remote_stonith_op(const char *client, xmlNode *request, gboolean peer)
     }
 
     op = calloc(1, sizeof(remote_fencing_op_t));
-    CRM_ASSERT(op != NULL);
+    pcmk__mem_assert(op);
 
     crm_element_value_int(request, PCMK__XA_ST_TIMEOUT, &(op->base_timeout));
     // Value -1 means disable any static/random fencing delays
@@ -2169,7 +2169,7 @@ add_device_properties(const xmlNode *xml, remote_fencing_op_t *op,
     int flags = st_device_supports_on; /* Old nodes that don't set the flag assume they support the on action */
 
     /* Add a new entry to this peer's devices list */
-    CRM_ASSERT(props != NULL);
+    pcmk__mem_assert(props);
     g_hash_table_insert(peer->devices, strdup(device), props);
 
     /* Peers with verified (monitored) access will be preferred */

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -801,7 +801,8 @@ add_required_device(remote_fencing_op_t *op, const char *device)
                                          sort_strings);
 
     if (!match) {
-        op->automatic_list = g_list_prepend(op->automatic_list, strdup(device));
+        op->automatic_list = g_list_prepend(op->automatic_list,
+                                            pcmk__str_copy(device));
     }
 }
 
@@ -834,7 +835,10 @@ set_op_device_list(remote_fencing_op_t * op, GList *devices)
         op->devices_list = NULL;
     }
     for (lpc = devices; lpc != NULL; lpc = lpc->next) {
-        op->devices_list = g_list_append(op->devices_list, strdup(lpc->data));
+        const char *device = lpc->data;
+
+        op->devices_list = g_list_append(op->devices_list,
+                                         pcmk__str_copy(device));
     }
     op->devices = op->devices_list;
 }
@@ -1112,7 +1116,7 @@ fenced_handle_manual_confirmation(const pcmk__client_t *client, xmlNode *msg)
     }
     op->state = st_done;
     set_fencing_completed(op);
-    op->delegate = strdup("a human");
+    op->delegate = pcmk__str_copy("a human");
 
     // For the fencer's purposes, the fencing operation is done
     pcmk__set_result(&op->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
@@ -1186,21 +1190,17 @@ create_remote_stonith_op(const char *client, xmlNode *request, gboolean peer)
      * Or may be the name of the function that created the operation.
      */
     op->originator = crm_element_value_copy(dev, PCMK__XA_ST_ORIGIN);
+    if (op->originator == NULL) {
+        /* Local or relayed request */
+        op->originator = pcmk__str_copy(stonith_our_uname);
+    }
 
     // Delegate may not be set
     op->delegate = crm_element_value_copy(dev, PCMK__XA_ST_DELEGATE);
     op->created = time(NULL);
 
-    if (op->originator == NULL) {
-        /* Local or relayed request */
-        op->originator = strdup(stonith_our_uname);
-    }
-
     CRM_LOG_ASSERT(client != NULL);
-    if (client) {
-        op->client_id = strdup(client);
-    }
-
+    op->client_id = pcmk__str_copy(client);
 
     /* For a RELAY operation, set fenced on the client. */
     operation = crm_element_value(request, PCMK__XA_ST_OP);
@@ -1242,8 +1242,7 @@ create_remote_stonith_op(const char *client, xmlNode *request, gboolean peer)
         stonith__clear_call_options(op->call_options, op->id, st_opt_cs_nodeid);
 
         if (node && node->uname) {
-            free(op->target);
-            op->target = strdup(node->uname);
+            pcmk__str_update(&(op->target), node->uname);
 
         } else {
             crm_warn("Could not expand nodeid '%s' into a host name", op->target);
@@ -2169,7 +2168,7 @@ add_device_properties(const xmlNode *xml, remote_fencing_op_t *op,
     int flags = st_device_supports_on; /* Old nodes that don't set the flag assume they support the on action */
 
     /* Add a new entry to this peer's devices list */
-    g_hash_table_insert(peer->devices, strdup(device), props);
+    g_hash_table_insert(peer->devices, pcmk__str_copy(device), props);
 
     /* Peers with verified (monitored) access will be preferred */
     crm_element_value_int(xml, PCMK__XA_ST_MONITOR_VERIFIED, &verified);
@@ -2222,7 +2221,7 @@ add_result(remote_fencing_op_t *op, const char *host, int ndevices,
                                                   sizeof(peer_device_info_t));
     xmlNode *child;
 
-    peer->host = strdup(host);
+    peer->host = pcmk__str_copy(host);
     peer->devices = pcmk__strkey_table(free, free);
 
     /* Each child element describes one capable device available to the peer */

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -492,19 +492,20 @@ start_child(pcmk_child_t * child)
         (void)setsid();
 
         /* Setup the two alternate arg arrays */
-        opts_vgrind[0] = strdup(VALGRIND_BIN);
+        opts_vgrind[0] = pcmk__str_copy(VALGRIND_BIN);
         if (use_callgrind) {
-            opts_vgrind[1] = strdup("--tool=callgrind");
-            opts_vgrind[2] = strdup("--callgrind-out-file=" CRM_STATE_DIR "/callgrind.out.%p");
-            opts_vgrind[3] = strdup(child->command);
+            opts_vgrind[1] = pcmk__str_copy("--tool=callgrind");
+            opts_vgrind[2] = pcmk__str_copy("--callgrind-out-file="
+                                            CRM_STATE_DIR "/callgrind.out.%p");
+            opts_vgrind[3] = pcmk__str_copy(child->command);
             opts_vgrind[4] = NULL;
         } else {
-            opts_vgrind[1] = strdup(child->command);
+            opts_vgrind[1] = pcmk__str_copy(child->command);
             opts_vgrind[2] = NULL;
             opts_vgrind[3] = NULL;
             opts_vgrind[4] = NULL;
         }
-        opts_default[0] = strdup(child->command);
+        opts_default[0] = pcmk__str_copy(child->command);
 
         if(gid) {
             // Drop root group access if not needed

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -27,7 +27,7 @@ init_working_set(void)
 {
     pcmk_scheduler_t *scheduler = pe_new_working_set();
 
-    CRM_ASSERT(scheduler != NULL);
+    pcmk__mem_assert(scheduler);
 
     crm_config_error = FALSE;
     crm_config_warning = FALSE;

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -267,6 +267,48 @@ extern int pcmk__score_yellow;
 
 /*!
  * \internal
+ * \brief Allocate new zero-initialized memory, asserting on failure
+ *
+ * \param[in] file      File where \p function is located
+ * \param[in] function  Calling function
+ * \param[in] line      Line within \p file
+ * \param[in] nmemb     Number of elements to allocate memory for
+ * \param[in] size      Size of each element
+ *
+ * \return Newly allocated memory of of size <tt>nmemb * size</tt> (guaranteed
+ *         not to be \c NULL)
+ *
+ * \note The caller is responsible for freeing the return value using \c free().
+ */
+static inline void *
+pcmk__assert_alloc_as(const char *file, const char *function, uint32_t line,
+                      size_t nmemb, size_t size)
+{
+    void *ptr = calloc(nmemb, size);
+
+    if (ptr == NULL) {
+        crm_abort(file, function, line, "Out of memory", FALSE, FALSE);
+    }
+    return ptr;
+}
+
+/*!
+ * \internal
+ * \brief Allocate new zero-initialized memory, asserting on failure
+ *
+ * \param[in] nmemb  Number of elements to allocate memory for
+ * \param[in] size   Size of each element
+ *
+ * \return Newly allocated memory of of size <tt>nmemb * size</tt> (guaranteed
+ *         not to be \c NULL)
+ *
+ * \note The caller is responsible for freeing the return value using \c free().
+ */
+#define pcmk__assert_alloc(nmemb, size) \
+    pcmk__assert_alloc_as(__FILE__, __func__, __LINE__, nmemb, size)
+
+/*!
+ * \internal
  * \brief Resize a dynamically allocated memory block
  *
  * \param[in] ptr   Memory block to resize (or NULL to allocate new memory)

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -335,6 +335,45 @@ pcmk__realloc(void *ptr, size_t size)
     return new_ptr;
 }
 
+/*!
+ * \internal
+ * \brief Copy a string, asserting on failure
+ *
+ * \param[in] file      File where \p function is located
+ * \param[in] function  Calling function
+ * \param[in] line      Line within \p file
+ * \param[in] str       String to copy (can be \c NULL)
+ *
+ * \return Newly allocated copy of \p str, or \c NULL if \p str is \c NULL
+ *
+ * \note The caller is responsible for freeing the return value using \c free().
+ */
+static inline char *
+pcmk__str_copy_as(const char *file, const char *function, uint32_t line,
+                  const char *str)
+{
+    if (str != NULL) {
+        char *result = strdup(str);
+
+        if (result == NULL) {
+            crm_abort(file, function, line, "Out of memory", FALSE, FALSE);
+        }
+        return result;
+    }
+    return NULL;
+}
+
+/*!
+ * \internal
+ * \brief Copy a string, asserting on failure
+ *
+ * \param[in] str  String to copy (can be \c NULL)
+ *
+ * \return Newly allocated copy of \p str, or \c NULL if \p str is \c NULL
+ *
+ * \note The caller is responsible for freeing the return value using \c free().
+ */
+#define pcmk__str_copy(str) pcmk__str_copy_as(__FILE__, __func__, __LINE__, str)
 
 static inline char *
 pcmk__getpid_s(void)

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the Pacemaker project contributors
+ * Copyright 2015-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -59,6 +59,22 @@ void pcmk__set_config_warning_handler(pcmk__config_warning_func warning_handler,
         } else {                                                    \
             pcmk__config_warning_handler(pcmk__config_warning_context, fmt);   \
         }                                                           \
+    } while (0)
+
+/*!
+ * \internal
+ * \brief Abort without dumping core if a pointer is \c NULL
+ *
+ * This is intended to check for memory allocation failure, rather than for null
+ * pointers in general.
+ *
+ * \param[in] ptr  Pointer to check
+ */
+#define pcmk__mem_assert(ptr) do {                                          \
+        if ((ptr) == NULL) {                                                \
+            crm_abort(__FILE__, __func__, __LINE__, "Out of memory", FALSE, \
+                      FALSE);                                               \
+        }                                                                   \
     } while (0)
 
 /*!

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -187,8 +187,7 @@ cib__update_node_attr(pcmk__output_t *out, cib_t *cib, int call_options, const c
             free_xml(xml_search);
             return ENOTUNIQ;
         } else {
-            pcmk__str_update(&local_attr_id,
-                             crm_element_value(xml_search, PCMK_XA_ID));
+            local_attr_id = crm_element_value_copy(xml_search, PCMK_XA_ID);
             attr_id = local_attr_id;
             free_xml(xml_search);
             goto do_modify;
@@ -384,8 +383,7 @@ cib__delete_node_attr(pcmk__output_t *out, cib_t *cib, int options, const char *
             free_xml(xml_search);
             return rc;
         } else {
-            pcmk__str_update(&local_attr_id,
-                             crm_element_value(xml_search, PCMK_XA_ID));
+            local_attr_id = crm_element_value_copy(xml_search, PCMK_XA_ID);
             attr_id = local_attr_id;
             free_xml(xml_search);
         }

--- a/lib/cib/cib_attrs.c
+++ b/lib/cib/cib_attrs.c
@@ -244,7 +244,8 @@ cib__update_node_attr(pcmk__output_t *out, cib_t *cib, int call_options, const c
 
         if (set_name == NULL) {
             if (pcmk__str_eq(section, PCMK_XE_CRM_CONFIG, pcmk__str_casei)) {
-                local_set_name = strdup(PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS);
+                local_set_name =
+                    pcmk__str_copy(PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS);
 
             } else if (pcmk__str_eq(node_type, PCMK_XE_TICKETS,
                                     pcmk__str_casei)) {

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -88,7 +88,7 @@ cib_client_add_notify_callback(cib_t * cib, const char *event,
     crm_trace("Adding callback for %s events (%d)",
               event, g_list_length(cib->notify_list));
 
-    new_client = calloc(1, sizeof(cib_notify_client_t));
+    new_client = pcmk__assert_alloc(1, sizeof(cib_notify_client_t));
     new_client->event = event;
     new_client->callback = callback;
 
@@ -146,7 +146,7 @@ cib_client_del_notify_callback(cib_t *cib, const char *event,
 
     crm_debug("Removing callback for %s events", event);
 
-    new_client = calloc(1, sizeof(cib_notify_client_t));
+    new_client = pcmk__assert_alloc(1, sizeof(cib_notify_client_t));
     new_client->event = event;
     new_client->callback = callback;
 
@@ -208,7 +208,7 @@ cib_client_register_callback_full(cib_t *cib, int call_id, int timeout,
         return FALSE;
     }
 
-    blob = calloc(1, sizeof(cib_callback_client_t));
+    blob = pcmk__assert_alloc(1, sizeof(cib_callback_client_t));
     blob->id = callback_name;
     blob->only_success = only_success;
     blob->user_data = user_data;
@@ -216,9 +216,9 @@ cib_client_register_callback_full(cib_t *cib, int call_id, int timeout,
     blob->free_func = free_func;
 
     if (timeout > 0) {
-        struct timer_rec_s *async_timer = NULL;
+        struct timer_rec_s *async_timer =
+            pcmk__assert_alloc(1, sizeof(struct timer_rec_s));
 
-        async_timer = calloc(1, sizeof(struct timer_rec_s));
         blob->timer = async_timer;
 
         async_timer->cib = cib;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -933,9 +933,6 @@ cib_file_write_with_digest(xmlNode *cib_root, const char *cib_dirname,
     char *tmp_cib = crm_strdup_printf("%s/cib.XXXXXX", cib_dirname);
     char *tmp_digest = crm_strdup_printf("%s/cib.XXXXXX", cib_dirname);
 
-    CRM_ASSERT((cib_path != NULL) && (digest_path != NULL)
-               && (tmp_cib != NULL) && (tmp_digest != NULL));
-
     /* Ensure the admin didn't modify the existing CIB underneath us */
     crm_trace("Reading cluster configuration file %s", cib_path);
     rc = cib_file_read_and_verify(cib_path, NULL, NULL);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -224,7 +224,7 @@ update_counter(xmlNode *xml_obj, const char *field, bool reset)
         int_value = atoi(old_value);
         new_value = pcmk__itoa(++int_value);
     } else {
-        pcmk__str_update(&new_value, "1");
+        new_value = pcmk__str_copy("1");
     }
 
     crm_trace("Update %s from %s to %s",

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -224,8 +224,7 @@ update_counter(xmlNode *xml_obj, const char *field, bool reset)
         int_value = atoi(old_value);
         new_value = pcmk__itoa(++int_value);
     } else {
-        new_value = strdup("1");
-        CRM_ASSERT(new_value != NULL);
+        pcmk__str_update(&new_value, "1");
     }
 
     crm_trace("Update %s from %s to %s",

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -611,10 +611,9 @@ cib_remote_new(const char *server, const char *user, const char *passwd, int por
     cib->variant = cib_remote;
     cib->variant_opaque = private;
 
-    pcmk__str_update(&private->server, server);
-    pcmk__str_update(&private->user, user);
-    pcmk__str_update(&private->passwd, passwd);
-
+    private->server = pcmk__str_copy(server);
+    private->user = pcmk__str_copy(user);
+    private->passwd = pcmk__str_copy(passwd);
     private->port = port;
     private->encrypted = encrypted;
 

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -119,17 +119,14 @@ crm_cluster_disconnect(crm_cluster_t *cluster)
 /*!
  * \brief Allocate a new \p crm_cluster_t object
  *
- * \return A newly allocated \p crm_cluster_t object (guaranteed not \p NULL)
+ * \return A newly allocated \p crm_cluster_t object (guaranteed not \c NULL)
  * \note The caller is responsible for freeing the return value using
  *       \p pcmk_cluster_free().
  */
 crm_cluster_t *
 pcmk_cluster_new(void)
 {
-    crm_cluster_t *cluster = calloc(1, sizeof(crm_cluster_t));
-
-    pcmk__mem_assert(cluster);
-    return cluster;
+    return (crm_cluster_t *) pcmk__assert_alloc(1, sizeof(crm_cluster_t));
 }
 
 /*!

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -128,7 +128,7 @@ pcmk_cluster_new(void)
 {
     crm_cluster_t *cluster = calloc(1, sizeof(crm_cluster_t));
 
-    CRM_ASSERT(cluster != NULL);
+    pcmk__mem_assert(cluster);
     return cluster;
 }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -973,7 +973,7 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
 
     if (node) {
         if (node->uname) {
-            target = strdup(node->uname);
+            target = pcmk__str_copy(node->uname);
             msg->host.size = strlen(node->uname);
             memset(msg->host.uname, 0, MAX_NAME);
             memcpy(msg->host.uname, node->uname, msg->host.size);
@@ -982,7 +982,7 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
         }
         msg->host.id = node->id;
     } else {
-        target = strdup("all");
+        target = pcmk__str_copy("all");
     }
 
     msg->sender.id = 0;
@@ -1004,10 +1004,9 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
     } else {
         char *compressed = NULL;
         unsigned int new_size = 0;
-        char *uncompressed = strdup(data);
 
-        if (pcmk__compress(uncompressed, (unsigned int) msg->size, 0,
-                           &compressed, &new_size) == pcmk_rc_ok) {
+        if (pcmk__compress(data, (unsigned int) msg->size, 0, &compressed,
+                           &new_size) == pcmk_rc_ok) {
 
             msg->header.size = sizeof(pcmk__cpg_msg_t) + new_size;
             msg = pcmk__realloc(msg, msg->header.size);
@@ -1023,7 +1022,6 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
             memcpy(msg->data, data, msg->size);
         }
 
-        free(uncompressed);
         free(compressed);
     }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -504,7 +504,7 @@ pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void 
         }
 
         crm_trace("Decompressing message data");
-        uncompressed = calloc(1, new_size);
+        uncompressed = pcmk__assert_alloc(1, new_size);
         rc = BZ2_bzBuffToBuffDecompress(uncompressed, &new_size, msg->data, msg->compressed_size, 1, 0);
 
         rc = pcmk__bzlib2rc(rc);
@@ -698,8 +698,8 @@ pcmk_cpg_membership(cpg_handle_t handle,
     uint32_t local_nodeid = get_local_nodeid(handle);
     const struct cpg_address **sorted;
 
-    sorted = calloc(member_list_entries, sizeof(const struct cpg_address *));
-    pcmk__mem_assert(sorted);
+    sorted = pcmk__assert_alloc(member_list_entries,
+                                sizeof(const struct cpg_address *));
 
     for (size_t iter = 0; iter < member_list_entries; iter++) {
         sorted[iter] = member_list + iter;
@@ -961,7 +961,7 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
         sender = local_pid;
     }
 
-    msg = calloc(1, sizeof(pcmk__cpg_msg_t));
+    msg = pcmk__assert_alloc(1, sizeof(pcmk__cpg_msg_t));
 
     msg_id++;
     msg->id = msg_id;
@@ -1027,7 +1027,7 @@ send_cluster_text(enum crm_ais_msg_class msg_class, const char *data,
         free(compressed);
     }
 
-    iov = calloc(1, sizeof(struct iovec));
+    iov = pcmk__assert_alloc(1, sizeof(struct iovec));
     iov->iov_base = msg;
     iov->iov_len = msg->header.size;
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -698,8 +698,8 @@ pcmk_cpg_membership(cpg_handle_t handle,
     uint32_t local_nodeid = get_local_nodeid(handle);
     const struct cpg_address **sorted;
 
-    sorted = malloc(member_list_entries * sizeof(const struct cpg_address *));
-    CRM_ASSERT(sorted != NULL);
+    sorted = calloc(member_list_entries, sizeof(const struct cpg_address *));
+    pcmk__mem_assert(sorted);
 
     for (size_t iter = 0; iter < member_list_entries; iter++) {
         sorted[iter] = member_list + iter;

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -488,19 +488,12 @@ parse_election_message(const election_t *e, const xmlNode *message,
 static void
 record_vote(election_t *e, struct vote *vote)
 {
-    char *voter_copy = NULL;
-    char *vote_copy = NULL;
-
     CRM_ASSERT(e && vote && vote->from && vote->op);
+
     if (e->voted == NULL) {
         e->voted = pcmk__strkey_table(free, free);
     }
-
-    voter_copy = strdup(vote->from);
-    vote_copy = strdup(vote->op);
-    CRM_ASSERT(voter_copy && vote_copy);
-
-    g_hash_table_replace(e->voted, voter_copy, vote_copy);
+    pcmk__insert_dup(e->voted, vote->from, vote->op);
 }
 
 static void

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -603,8 +603,7 @@ pcmk__purge_node_from_cache(const char *node_name, uint32_t node_id)
         /* node_name could be a pointer into the cache entry being purged,
          * so reassign it to a copy before the original gets freed
          */
-        node_name_copy = strdup(node_name);
-        CRM_ASSERT(node_name_copy != NULL);
+        pcmk__str_update(&node_name_copy, node_name);
         node_name = node_name_copy;
 
         crm_trace("Purging %s from Pacemaker Remote node cache", node_name);
@@ -1317,13 +1316,10 @@ known_node_cache_refresh_helper(xmlNode *xml_node, void *user_data)
         char *uniqueid = crm_generate_uuid();
 
         node = calloc(1, sizeof(crm_node_t));
-        CRM_ASSERT(node != NULL);
+        pcmk__mem_assert(node);
 
-        node->uname = strdup(uname);
-        CRM_ASSERT(node->uname != NULL);
-
-        node->uuid = strdup(id);
-        CRM_ASSERT(node->uuid != NULL);
+        pcmk__str_update(&(node->uname), uname);
+        pcmk__str_update(&(node->uuid), id);
 
         g_hash_table_replace(known_node_cache, uniqueid, node);
 

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -823,8 +823,7 @@ pcmk__get_node(unsigned int id, const char *uname, const char *uuid,
     if (node == NULL) {
         char *uniqueid = crm_generate_uuid();
 
-        node = calloc(1, sizeof(crm_node_t));
-        CRM_ASSERT(node);
+        node = pcmk__assert_alloc(1, sizeof(crm_node_t));
 
         crm_info("Created entry %s/%p for node %s/%u (%d total)",
                  uniqueid, node, uname, id, 1 + g_hash_table_size(crm_peer_cache));
@@ -1315,8 +1314,7 @@ known_node_cache_refresh_helper(xmlNode *xml_node, void *user_data)
     if (node == NULL) {
         char *uniqueid = crm_generate_uuid();
 
-        node = calloc(1, sizeof(crm_node_t));
-        pcmk__mem_assert(node);
+        node = pcmk__assert_alloc(1, sizeof(crm_node_t));
 
         pcmk__str_update(&(node->uname), uname);
         pcmk__str_update(&(node->uuid), id);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -385,7 +385,7 @@ reap_crm_member(uint32_t id, const char *name)
     }
 
     search.id = id;
-    pcmk__str_update(&search.uname, name);
+    search.uname = pcmk__str_copy(name);
     matches = g_hash_table_foreach_remove(crm_peer_cache, crm_reap_dead_member, &search);
     if(matches) {
         crm_notice("Purged %d peer%s with " PCMK_XA_ID
@@ -603,7 +603,7 @@ pcmk__purge_node_from_cache(const char *node_name, uint32_t node_id)
         /* node_name could be a pointer into the cache entry being purged,
          * so reassign it to a copy before the original gets freed
          */
-        pcmk__str_update(&node_name_copy, node_name);
+        node_name_copy = pcmk__str_copy(node_name);
         node_name = node_name_copy;
 
         crm_trace("Purging %s from Pacemaker Remote node cache", node_name);
@@ -1316,8 +1316,8 @@ known_node_cache_refresh_helper(xmlNode *xml_node, void *user_data)
 
         node = pcmk__assert_alloc(1, sizeof(crm_node_t));
 
-        pcmk__str_update(&(node->uname), uname);
-        pcmk__str_update(&(node->uuid), id);
+        node->uname = pcmk__str_copy(uname);
+        node->uuid = pcmk__str_copy(id);
 
         g_hash_table_replace(known_node_cache, uniqueid, node);
 

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -71,8 +71,7 @@ create_acl(const xmlNode *xml, GList *acls, enum xml_private_flags mode)
         return NULL;
     }
 
-    acl = calloc(1, sizeof (xml_acl_t));
-    pcmk__mem_assert(acl);
+    acl = pcmk__assert_alloc(1, sizeof (xml_acl_t));
 
     acl->mode = mode;
     if (xpath) {

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -804,8 +804,7 @@ pcmk__update_acl_user(xmlNode *request, const char *field,
     if (effective_user == NULL) {
         effective_user = pcmk__uid2username(geteuid());
         if (effective_user == NULL) {
-            effective_user = strdup("#unprivileged");
-            CRM_CHECK(effective_user != NULL, return NULL);
+            effective_user = pcmk__str_copy("#unprivileged");
             crm_err("Unable to determine effective user, assuming unprivileged for ACLs");
         }
     }

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -766,15 +766,13 @@ pcmk_acl_required(const char *user)
 char *
 pcmk__uid2username(uid_t uid)
 {
-    char *result = NULL;
     struct passwd *pwent = getpwuid(uid);
 
     if (pwent == NULL) {
         crm_perror(LOG_INFO, "Cannot get user details for user ID %d", uid);
         return NULL;
     }
-    pcmk__str_update(&result, pwent->pw_name);
-    return result;
+    return pcmk__str_copy(pwent->pw_name);
 }
 
 /*!

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -72,7 +72,7 @@ create_acl(const xmlNode *xml, GList *acls, enum xml_private_flags mode)
     }
 
     acl = calloc(1, sizeof (xml_acl_t));
-    CRM_ASSERT(acl != NULL);
+    pcmk__mem_assert(acl);
 
     acl->mode = mode;
     if (xpath) {

--- a/lib/common/actions.c
+++ b/lib/common/actions.c
@@ -455,8 +455,7 @@ decode_transition_key(const char *key, char **uuid, int *transition_id, int *act
         crm_warn("Invalid UUID '%s' in transition key '%s'", local_uuid, key);
     }
     if (uuid) {
-        *uuid = strdup(local_uuid);
-        CRM_ASSERT(*uuid);
+        *uuid = pcmk__str_copy(local_uuid);
     }
     if (transition_id) {
         *transition_id = local_transition_id;

--- a/lib/common/actions.c
+++ b/lib/common/actions.c
@@ -374,8 +374,8 @@ decode_transition_magic(const char *magic, char **uuid, int *transition_id, int 
 #ifdef HAVE_SSCANF_M
     res = sscanf(magic, "%d:%d;%ms", &local_op_status, &local_op_rc, &key);
 #else
-    key = calloc(1, strlen(magic) - 3); // magic must have >=4 other characters
-    CRM_ASSERT(key);
+    // magic must have >=4 other characters
+    key = pcmk__assert_alloc(1, strlen(magic) - 3);
     res = sscanf(magic, "%d:%d;%s", &local_op_status, &local_op_rc, key);
 #endif
     if (res == EOF) {

--- a/lib/common/actions.c
+++ b/lib/common/actions.c
@@ -320,12 +320,12 @@ parse_op_key(const char *key, char **rsc_id, char **op_type, guint *interval_ms)
     // Set output variables
     if (rsc_id != NULL) {
         *rsc_id = strndup(key, action_underbar);
-        CRM_ASSERT(*rsc_id != NULL);
+        pcmk__mem_assert(*rsc_id);
     }
     if (op_type != NULL) {
         *op_type = strndup(key + action_underbar + 1,
                            interval_underbar - action_underbar - 1);
-        CRM_ASSERT(*op_type != NULL);
+        pcmk__mem_assert(*op_type);
     }
     if (interval_ms != NULL) {
         *interval_ms = local_interval_ms;

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -97,8 +97,8 @@ pcmk__alert_new(const char *id, const char *path)
     pcmk__alert_t *entry = pcmk__assert_alloc(1, sizeof(pcmk__alert_t));
 
     CRM_ASSERT((id != NULL) && (path != NULL));
-    entry->id = strdup(id);
-    entry->path = strdup(path);
+    entry->id = pcmk__str_copy(id);
+    entry->path = pcmk__str_copy(path);
     entry->timeout = PCMK__ALERT_DEFAULT_TIMEOUT_MS;
     entry->flags = pcmk__alert_default;
     return entry;
@@ -165,6 +165,6 @@ pcmk__add_alert_key_int(GHashTable *table, enum pcmk__alert_keys_e name,
 {
     for (const char **key = pcmk__alert_keys[name]; *key; key++) {
         crm_trace("Inserting alert key %s = %d", *key, value);
-        g_hash_table_insert(table, strdup(*key), pcmk__itoa(value));
+        g_hash_table_insert(table, pcmk__str_copy(*key), pcmk__itoa(value));
     }
 }

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -94,9 +94,9 @@ const char *pcmk__alert_keys[PCMK__ALERT_INTERNAL_KEY_MAX][3] =
 pcmk__alert_t *
 pcmk__alert_new(const char *id, const char *path)
 {
-    pcmk__alert_t *entry = calloc(1, sizeof(pcmk__alert_t));
+    pcmk__alert_t *entry = pcmk__assert_alloc(1, sizeof(pcmk__alert_t));
 
-    CRM_ASSERT(entry && id && path);
+    CRM_ASSERT((id != NULL) && (path != NULL));
     entry->id = strdup(id);
     entry->path = strdup(path);
     entry->timeout = PCMK__ALERT_DEFAULT_TIMEOUT_MS;

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -137,8 +137,8 @@ pcmk__dup_alert(const pcmk__alert_t *entry)
     new_entry->timeout = entry->timeout;
     new_entry->flags = entry->flags;
     new_entry->envvars = pcmk__str_table_dup(entry->envvars);
-    pcmk__str_update(&new_entry->tstamp_format, entry->tstamp_format);
-    pcmk__str_update(&new_entry->recipient, entry->recipient);
+    new_entry->tstamp_format = pcmk__str_copy(entry->tstamp_format);
+    new_entry->recipient = pcmk__str_copy(entry->recipient);
     if (entry->select_attribute_name) {
         new_entry->select_attribute_name = g_strdupv(entry->select_attribute_name);
     }

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -638,8 +638,7 @@ pcmk__full_path(const char *filename, const char *dirname)
     CRM_ASSERT(filename != NULL);
 
     if (filename[0] == '/') {
-        path = strdup(filename);
-        CRM_ASSERT(path != NULL);
+        pcmk__str_update(&path, filename);
 
     } else {
         CRM_ASSERT(dirname != NULL);

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -633,19 +633,13 @@ pcmk__close_fds_in_child(bool all)
 char *
 pcmk__full_path(const char *filename, const char *dirname)
 {
-    char *path = NULL;
-
     CRM_ASSERT(filename != NULL);
 
     if (filename[0] == '/') {
-        pcmk__str_update(&path, filename);
-
-    } else {
-        CRM_ASSERT(dirname != NULL);
-        path = crm_strdup_printf("%s/%s", dirname, filename);
+        return pcmk__str_copy(filename);
     }
-
-    return path;
+    CRM_ASSERT(dirname != NULL);
+    return crm_strdup_printf("%s/%s", dirname, filename);
 }
 
 // Deprecated functions kept only for backward API compatibility

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -32,9 +32,7 @@ set_pairs_data(pcmk__attrd_api_reply_t *data, xmlNode *msg_data)
 
     for (xmlNode *node = first_named_child(msg_data, PCMK_XE_NODE);
          node != NULL; node = crm_next_same_xml(node)) {
-        pair = calloc(1, sizeof(pcmk__attrd_query_pair_t));
-
-        pcmk__mem_assert(pair);
+        pair = pcmk__assert_alloc(1, sizeof(pcmk__attrd_query_pair_t));
 
         pair->node = crm_element_value(node, PCMK__XA_ATTR_HOST);
         pair->name = name;

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -34,7 +34,7 @@ set_pairs_data(pcmk__attrd_api_reply_t *data, xmlNode *msg_data)
          node != NULL; node = crm_next_same_xml(node)) {
         pair = calloc(1, sizeof(pcmk__attrd_query_pair_t));
 
-        CRM_ASSERT(pair != NULL);
+        pcmk__mem_assert(pair);
 
         pair->node = crm_element_value(node, PCMK__XA_ATTR_HOST);
         pair->name = name;

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1123,7 +1123,7 @@ crm_ipc_decompress(crm_ipc_t * client)
         unsigned int size_u = 1 + header->size_uncompressed;
         /* never let buf size fall below our max size required for ipc reads. */
         unsigned int new_buf_size = QB_MAX((sizeof(pcmk__ipc_header_t) + size_u), client->max_buf_size);
-        char *uncompressed = calloc(1, new_buf_size);
+        char *uncompressed = pcmk__assert_alloc(1, new_buf_size);
 
         crm_trace("Decompressing message data %u bytes into %u bytes",
                  header->size_compressed, size_u);

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -164,7 +164,7 @@ set_nodes_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
 
         long long id_ll = 0;
 
-        node_info = calloc(1, sizeof(pcmk_controld_api_node_t));
+        node_info = pcmk__assert_alloc(1, sizeof(pcmk_controld_api_node_t));
         crm_element_value_ll(node, PCMK_XA_ID, &id_ll);
         if (id_ll > 0) {
             node_info->id = id_ll;

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -615,7 +615,7 @@ pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
     total = iov[0].iov_len + header->size_uncompressed;
 
     if (total < max_send_size) {
-        pcmk__str_update((char **) &(iov[1].iov_base), buffer->str);
+        iov[1].iov_base = pcmk__str_copy(buffer->str);
         iov[1].iov_len = header->size_uncompressed;
 
     } else {

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -259,10 +259,7 @@ pcmk__new_client(qb_ipcs_connection_t *c, uid_t uid_client, gid_t gid_client)
 static struct iovec *
 pcmk__new_ipc_event(void)
 {
-    struct iovec *iov = calloc(2, sizeof(struct iovec));
-
-    pcmk__mem_assert(iov);
-    return iov;
+    return (struct iovec *) pcmk__assert_alloc(2, sizeof(struct iovec));
 }
 
 /*!
@@ -413,7 +410,7 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
     if (header->size_compressed) {
         int rc = 0;
         unsigned int size_u = 1 + header->size_uncompressed;
-        uncompressed = calloc(1, size_u);
+        uncompressed = pcmk__assert_alloc(1, size_u);
 
         crm_trace("Decompressing message data %u bytes into %u bytes",
                   header->size_compressed, size_u);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -261,7 +261,7 @@ pcmk__new_ipc_event(void)
 {
     struct iovec *iov = calloc(2, sizeof(struct iovec));
 
-    CRM_ASSERT(iov != NULL);
+    pcmk__mem_assert(iov);
     return iov;
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -174,7 +174,10 @@ client_from_connection(qb_ipcs_connection_t *c, void *key, uid_t uid_client)
         client->user = pcmk__uid2username(uid_client);
         if (client->user == NULL) {
             client->user = strdup("#unprivileged");
-            CRM_CHECK(client->user != NULL, free(client); return NULL);
+            if (client->user == NULL) {
+                free(client);
+                return NULL;
+            }
             crm_err("Unable to enforce ACLs for user ID %d, assuming unprivileged",
                     uid_client);
         }

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -128,10 +128,7 @@ crm_time_new(const char *date_time)
 crm_time_t *
 crm_time_new_undefined(void)
 {
-    crm_time_t *result = calloc(1, sizeof(crm_time_t));
-
-    pcmk__mem_assert(result);
-    return result;
+    return (crm_time_t *) pcmk__assert_alloc(1, sizeof(crm_time_t));
 }
 
 /*!
@@ -1217,8 +1214,7 @@ crm_time_parse_period(const char *period_str)
     }
 
     tzset();
-    period = calloc(1, sizeof(crm_time_period_t));
-    pcmk__mem_assert(period);
+    period = pcmk__assert_alloc(1, sizeof(crm_time_period_t));
 
     if (period_str[0] == 'P') {
         period->diff = crm_time_parse_duration(period_str);
@@ -1834,8 +1830,11 @@ pcmk__time_hr_convert(pcmk__time_hr_t *target, const crm_time_t *dt)
     pcmk__time_hr_t *hr_dt = NULL;
 
     if (dt) {
-        hr_dt = target?target:calloc(1, sizeof(pcmk__time_hr_t));
-        pcmk__mem_assert(hr_dt);
+        hr_dt = target;
+        if (hr_dt == NULL) {
+            hr_dt = pcmk__assert_alloc(1, sizeof(pcmk__time_hr_t));
+        }
+
         *hr_dt = (pcmk__time_hr_t) {
             .years = dt->years,
             .months = dt->months,

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -694,12 +694,9 @@ char *
 crm_time_as_string(const crm_time_t *dt, int flags)
 {
     char result[DATE_MAX] = { '\0', };
-    char *result_copy = NULL;
 
     time_as_string_common(dt, 0, flags, result);
-
-    pcmk__str_update(&result_copy, result);
-    return result_copy;
+    return pcmk__str_copy(result);
 }
 
 /*!
@@ -2001,21 +1998,15 @@ char *
 pcmk__epoch2str(const time_t *source, uint32_t flags)
 {
     time_t epoch_time = (source == NULL)? time(NULL) : *source;
-    char *result = NULL;
 
     if (flags == 0) {
-        const char *buf = pcmk__trim(ctime(&epoch_time));
-
-        if (buf != NULL) {
-            pcmk__str_update(&result, buf);
-        }
+        return pcmk__str_copy(pcmk__trim(ctime(&epoch_time)));
     } else {
         crm_time_t dt;
 
         crm_time_set_timet(&dt, &epoch_time);
-        result = crm_time_as_string(&dt, flags);
+        return crm_time_as_string(&dt, flags);
     }
-    return result;
 }
 
 /*!
@@ -2041,7 +2032,6 @@ pcmk__timespec2str(const struct timespec *ts, uint32_t flags)
     struct timespec tmp_ts;
     crm_time_t dt;
     char result[DATE_MAX] = { 0 };
-    char *result_copy = NULL;
 
     if (ts == NULL) {
         qb_util_timespec_from_epoch_get(&tmp_ts);
@@ -2049,8 +2039,7 @@ pcmk__timespec2str(const struct timespec *ts, uint32_t flags)
     }
     crm_time_set_timet(&dt, &ts->tv_sec);
     time_as_string_common(&dt, ts->tv_nsec / QB_TIME_NS_IN_USEC, flags, result);
-    pcmk__str_update(&result_copy, result);
-    return result_copy;
+    return pcmk__str_copy(result);
 }
 
 /*!

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -130,7 +130,7 @@ crm_time_new_undefined(void)
 {
     crm_time_t *result = calloc(1, sizeof(crm_time_t));
 
-    CRM_ASSERT(result != NULL);
+    pcmk__mem_assert(result);
     return result;
 }
 
@@ -1218,7 +1218,7 @@ crm_time_parse_period(const char *period_str)
 
     tzset();
     period = calloc(1, sizeof(crm_time_period_t));
-    CRM_ASSERT(period != NULL);
+    pcmk__mem_assert(period);
 
     if (period_str[0] == 'P') {
         period->diff = crm_time_parse_duration(period_str);
@@ -1835,7 +1835,7 @@ pcmk__time_hr_convert(pcmk__time_hr_t *target, const crm_time_t *dt)
 
     if (dt) {
         hr_dt = target?target:calloc(1, sizeof(pcmk__time_hr_t));
-        CRM_ASSERT(hr_dt != NULL);
+        pcmk__mem_assert(hr_dt);
         *hr_dt = (pcmk__time_hr_t) {
             .years = dt->years,
             .months = dt->months,
@@ -2008,8 +2008,7 @@ pcmk__epoch2str(const time_t *source, uint32_t flags)
         const char *buf = pcmk__trim(ctime(&epoch_time));
 
         if (buf != NULL) {
-            result = strdup(buf);
-            CRM_ASSERT(result != NULL);
+            pcmk__str_update(&result, buf);
         }
     } else {
         crm_time_t dt;

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -785,7 +785,7 @@ set_identity(const char *entity, int argc, char *const *argv)
     }
 
     if (entity != NULL) {
-        crm_system_name = strdup(entity);
+        pcmk__str_update(&crm_system_name, entity);
 
     } else if ((argc > 0) && (argv != NULL)) {
         char *mutable = strdup(argv[0]);
@@ -794,14 +794,12 @@ set_identity(const char *entity, int argc, char *const *argv)
         if (strstr(modified, "lt-") == modified) {
             modified += 3;
         }
-        crm_system_name = strdup(modified);
+        pcmk__str_update(&crm_system_name, modified);
         free(mutable);
 
     } else {
-        crm_system_name = strdup("Unknown");
+        pcmk__str_update(&crm_system_name, "Unknown");
     }
-
-    CRM_ASSERT(crm_system_name != NULL);
 
     // Used by fencing.py.py (in fence-agents)
     pcmk__set_env_option(PCMK__ENV_SERVICE, crm_system_name, false);

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -785,7 +785,7 @@ set_identity(const char *entity, int argc, char *const *argv)
     }
 
     if (entity != NULL) {
-        pcmk__str_update(&crm_system_name, entity);
+        crm_system_name = pcmk__str_copy(entity);
 
     } else if ((argc > 0) && (argv != NULL)) {
         char *mutable = strdup(argv[0]);
@@ -794,11 +794,11 @@ set_identity(const char *entity, int argc, char *const *argv)
         if (strstr(modified, "lt-") == modified) {
             modified += 3;
         }
-        pcmk__str_update(&crm_system_name, modified);
+        crm_system_name = pcmk__str_copy(modified);
         free(mutable);
 
     } else {
-        pcmk__str_update(&crm_system_name, "Unknown");
+        crm_system_name = pcmk__str_copy("Unknown");
     }
 
     // Used by fencing.py.py (in fence-agents)

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -191,7 +191,6 @@ mainloop_add_trigger(int priority, int (*dispatch) (gpointer user_data),
 
     CRM_ASSERT(sizeof(crm_trigger_t) > sizeof(GSource));
     source = g_source_new(&crm_trigger_funcs, sizeof(crm_trigger_t));
-    CRM_ASSERT(source != NULL);
 
     return mainloop_setup_trigger(source, priority, dispatch, userdata);
 }

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -1263,7 +1263,7 @@ mainloop_child_add_with_flags(pid_t pid, int timeout, const char *desc, void *pr
     child->privatedata = privatedata;
     child->callback = callback;
     child->flags = flags;
-    pcmk__str_update(&child->desc, desc);
+    child->desc = pcmk__str_copy(desc);
 
     if (timeout) {
         child->timerid = g_timeout_add(timeout, child_timeout_callback, child);

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -1255,7 +1255,7 @@ mainloop_child_add_with_flags(pid_t pid, int timeout, const char *desc, void *pr
                    void (*callback) (mainloop_child_t * p, pid_t pid, int core, int signo, int exitcode))
 {
     static bool need_init = TRUE;
-    mainloop_child_t *child = calloc(1, sizeof(mainloop_child_t));
+    mainloop_child_t *child = pcmk__assert_alloc(1, sizeof(mainloop_child_t));
 
     child->pid = pid;
     child->timerid = 0;
@@ -1367,7 +1367,7 @@ mainloop_timer_set_period(mainloop_timer_t *t, guint period_ms)
 mainloop_timer_t *
 mainloop_timer_add(const char *name, guint period_ms, bool repeat, GSourceFunc cb, void *userdata)
 {
-    mainloop_timer_t *t = calloc(1, sizeof(mainloop_timer_t));
+    mainloop_timer_t *t = pcmk__assert_alloc(1, sizeof(mainloop_timer_t));
 
     if(t) {
         if(name) {

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -52,8 +52,8 @@ pcmk__new_nvpair(const char *name, const char *value)
 
     nvpair = pcmk__assert_alloc(1, sizeof(pcmk_nvpair_t));
 
-    pcmk__str_update(&nvpair->name, name);
-    pcmk__str_update(&nvpair->value, value);
+    nvpair->name = pcmk__str_copy(name);
+    nvpair->value = pcmk__str_copy(value);
     return nvpair;
 }
 
@@ -673,10 +673,7 @@ pcmk__xe_get_datetime(const xmlNode *xml, const char *attr, crm_time_t **t)
 char *
 crm_element_value_copy(const xmlNode *data, const char *name)
 {
-    char *value_copy = NULL;
-
-    pcmk__str_update(&value_copy, crm_element_value(data, name));
-    return value_copy;
+    return pcmk__str_copy(crm_element_value(data, name));
 }
 
 /*!

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -50,8 +50,7 @@ pcmk__new_nvpair(const char *name, const char *value)
 
     CRM_ASSERT(name);
 
-    nvpair = calloc(1, sizeof(pcmk_nvpair_t));
-    CRM_ASSERT(nvpair);
+    nvpair = pcmk__assert_alloc(1, sizeof(pcmk_nvpair_t));
 
     pcmk__str_update(&nvpair->name, name);
     pcmk__str_update(&nvpair->value, value);

--- a/lib/common/options_display.c
+++ b/lib/common/options_display.c
@@ -35,10 +35,8 @@ add_possible_values_default(pcmk__output_t *out,
 
     if ((option->values != NULL) && (strcmp(option->type, "select") == 0)) {
         const char *delim = ", ";
-        char *str = NULL;
         bool found_default = (option->default_value == NULL);
-
-        pcmk__str_update(&str, option->values);
+        char *str = pcmk__str_copy(option->values);
 
         for (const char *value = strtok(str, delim); value != NULL;
              value = strtok(NULL, delim)) {
@@ -265,11 +263,8 @@ add_possible_values_xml(pcmk__output_t *out,
 {
     if ((option->values != NULL) && (strcmp(option->type, "select") == 0)) {
         const char *delim = ", ";
-        char *str = NULL;
-        char *ptr = NULL;
-
-        pcmk__str_update(&str, option->values);
-        ptr = strtok(str, delim);
+        char *str = pcmk__str_copy(option->values);
+        const char *ptr = strtok(str, delim);
 
         while (ptr != NULL) {
             pcmk__output_create_xml_node(out, PCMK_XE_OPTION,

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -223,8 +223,8 @@ text_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plur
 
     new_list = pcmk__assert_alloc(1, sizeof(text_list_data_t));
     new_list->len = 0;
-    pcmk__str_update(&new_list->singular_noun, singular_noun);
-    pcmk__str_update(&new_list->plural_noun, plural_noun);
+    new_list->singular_noun = pcmk__str_copy(singular_noun);
+    new_list->plural_noun = pcmk__str_copy(plural_noun);
 
     g_queue_push_tail(priv->parent_q, new_list);
 }

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -221,7 +221,7 @@ text_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plur
 
     va_end(ap);
 
-    new_list = calloc(1, sizeof(text_list_data_t));
+    new_list = pcmk__assert_alloc(1, sizeof(text_list_data_t));
     new_list->len = 0;
     pcmk__str_update(&new_list->singular_noun, singular_noun);
     pcmk__str_update(&new_list->plural_noun, plural_noun);
@@ -502,7 +502,7 @@ pcmk__text_prompt(const char *prompt, bool echo, char **dest)
 #if HAVE_SSCANF_M
         rc = scanf("%ms", dest);
 #else
-        *dest = calloc(1, 1024);
+        *dest = pcmk__assert_alloc(1, 1024);
         rc = scanf("%1023s", *dest);
 #endif
         fprintf(stderr, "\n");

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -1041,16 +1041,16 @@ search_v2_xpath(const xmlNode *top, const char *key, int target_position)
      */
 
     remainder = calloc(key_len, sizeof(char));
-    CRM_ASSERT(remainder != NULL);
+    pcmk__mem_assert(remainder);
 
     section = calloc(key_len, sizeof(char));
-    CRM_ASSERT(section != NULL);
+    pcmk__mem_assert(section);
 
     id = calloc(key_len, sizeof(char));
-    CRM_ASSERT(id != NULL);
+    pcmk__mem_assert(id);
 
     tag = calloc(key_len, sizeof(char));
-    CRM_ASSERT(tag != NULL);
+    pcmk__mem_assert(tag);
 
     do {
         // Look for /NEXT_COMPONENT/REMAINING_COMPONENTS
@@ -1182,7 +1182,7 @@ apply_v2_patchset(xmlNode *xml, const xmlNode *patchset)
             // Delay the adding of a PCMK_VALUE_CREATE object
             xml_change_obj_t *change_obj = calloc(1, sizeof(xml_change_obj_t));
 
-            CRM_ASSERT(change_obj != NULL);
+            pcmk__mem_assert(change_obj);
 
             change_obj->change = change;
             change_obj->match = match;

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -1040,17 +1040,10 @@ search_v2_xpath(const xmlNode *top, const char *key, int target_position)
      * than key_len - 1 characters plus a null terminator.
      */
 
-    remainder = calloc(key_len, sizeof(char));
-    pcmk__mem_assert(remainder);
-
-    section = calloc(key_len, sizeof(char));
-    pcmk__mem_assert(section);
-
-    id = calloc(key_len, sizeof(char));
-    pcmk__mem_assert(id);
-
-    tag = calloc(key_len, sizeof(char));
-    pcmk__mem_assert(tag);
+    remainder = pcmk__assert_alloc(key_len, sizeof(char));
+    section = pcmk__assert_alloc(key_len, sizeof(char));
+    id = pcmk__assert_alloc(key_len, sizeof(char));
+    tag = pcmk__assert_alloc(key_len, sizeof(char));
 
     do {
         // Look for /NEXT_COMPONENT/REMAINING_COMPONENTS
@@ -1180,9 +1173,8 @@ apply_v2_patchset(xmlNode *xml, const xmlNode *patchset)
         } else if (pcmk__str_any_of(op,
                                     PCMK_VALUE_CREATE, PCMK_VALUE_MOVE, NULL)) {
             // Delay the adding of a PCMK_VALUE_CREATE object
-            xml_change_obj_t *change_obj = calloc(1, sizeof(xml_change_obj_t));
-
-            pcmk__mem_assert(change_obj);
+            xml_change_obj_t *change_obj =
+                pcmk__assert_alloc(1, sizeof(xml_change_obj_t));
 
             change_obj->change = change;
             change_obj->match = match;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -506,7 +506,7 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
               g_string_free(xml_text, TRUE); return EINVAL);
 
     header = calloc(1, sizeof(struct remote_header_v0));
-    CRM_ASSERT(header != NULL);
+    pcmk__mem_assert(header);
 
     iov[0].iov_base = header;
     iov[0].iov_len = sizeof(struct remote_header_v0);

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -505,8 +505,7 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
     CRM_CHECK(xml_text->len > 0,
               g_string_free(xml_text, TRUE); return EINVAL);
 
-    header = calloc(1, sizeof(struct remote_header_v0));
-    pcmk__mem_assert(header);
+    header = pcmk__assert_alloc(1, sizeof(struct remote_header_v0));
 
     iov[0].iov_base = header;
     iov[0].iov_len = sizeof(struct remote_header_v0);
@@ -556,7 +555,8 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
     if (header->payload_compressed) {
         int rc = 0;
         unsigned int size_u = 1 + header->payload_uncompressed;
-        char *uncompressed = calloc(1, header->payload_offset + size_u);
+        char *uncompressed =
+            pcmk__assert_alloc(1, header->payload_offset + size_u);
 
         crm_trace("Decompressing message data %d bytes into %d bytes",
                  header->payload_compressed, size_u);
@@ -980,7 +980,7 @@ connect_socket_retry(int sock, const struct sockaddr *addr, socklen_t addrlen,
         return rc;
     }
 
-    cb_data = calloc(1, sizeof(struct tcp_async_cb_data));
+    cb_data = pcmk__assert_alloc(1, sizeof(struct tcp_async_cb_data));
     cb_data->userdata = userdata;
     cb_data->callback = callback;
     cb_data->sock = sock;

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1091,9 +1091,9 @@ pcmk__copy_result(const pcmk__action_result_t *src, pcmk__action_result_t *dst)
     CRM_CHECK((src != NULL) && (dst != NULL), return);
     dst->exit_status = src->exit_status;
     dst->execution_status = src->execution_status;
-    pcmk__str_update(&dst->exit_reason, src->exit_reason);
-    pcmk__str_update(&dst->action_stdout, src->action_stdout);
-    pcmk__str_update(&dst->action_stderr, src->action_stderr);
+    dst->exit_reason = pcmk__str_copy(src->exit_reason);
+    dst->action_stdout = pcmk__str_copy(src->action_stdout);
+    dst->action_stderr = pcmk__str_copy(src->action_stderr);
 }
 
 // Deprecated functions kept only for backward API compatibility

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -700,7 +700,7 @@ pcmk__replace_submatches(const char *string, const char *match,
 
     // Allocate enough space for expanded string
     result = calloc(nbytes, sizeof(char));
-    CRM_ASSERT(result != NULL);
+    pcmk__mem_assert(result);
 
     // Expand submatches
     (void) process_submatches(string, match, submatches, nmatches, result,

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -10,7 +10,6 @@
 #include <crm_internal.h>
 
 #include <stdio.h>                          // NULL, size_t
-#include <stdlib.h>                         // calloc()
 #include <stdbool.h>                        // bool
 #include <ctype.h>                          // isdigit()
 #include <regex.h>                          // regmatch_t
@@ -699,8 +698,7 @@ pcmk__replace_submatches(const char *string, const char *match,
     }
 
     // Allocate enough space for expanded string
-    result = calloc(nbytes, sizeof(char));
-    pcmk__mem_assert(result);
+    result = pcmk__assert_alloc(nbytes, sizeof(char));
 
     // Expand submatches
     (void) process_submatches(string, match, submatches, nmatches, result,

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -241,7 +241,7 @@ add_schema(enum pcmk__schema_validator validator, const pcmk__schema_version_t *
     int last = g_list_length(known_schemas);
 
     schema = calloc(1, sizeof(pcmk__schema_t));
-    CRM_ASSERT(schema != NULL);
+    pcmk__mem_assert(schema);
 
     schema->validator = validator;
     schema->version.v[0] = version->v[0];
@@ -251,18 +251,15 @@ add_schema(enum pcmk__schema_validator validator, const pcmk__schema_version_t *
     if (version->v[0] || version->v[1]) {
         schema->name = schema_strdup_printf("pacemaker-", *version, "");
     } else {
-        schema->name = strdup(name);
-        CRM_ASSERT(schema->name != NULL);
+        pcmk__str_update(&(schema->name), name);
     }
 
     if (transform) {
-        schema->transform = strdup(transform);
-        CRM_ASSERT(schema->transform != NULL);
+        pcmk__str_update(&(schema->transform), transform);
     }
 
     if (transform_enter) {
-        schema->transform_enter = strdup(transform_enter);
-        CRM_ASSERT(schema->transform_enter != NULL);
+        pcmk__str_update(&(schema->transform_enter), transform_enter);
     }
 
     known_schemas = g_list_append(known_schemas, schema);
@@ -1404,8 +1401,7 @@ append_href(xmlNode *xml, void *user_data)
         return;
     }
 
-    s = strdup(href);
-    CRM_ASSERT(s != NULL);
+    pcmk__str_update(&s, href);
     *list = g_list_prepend(*list, s);
 }
 
@@ -1460,8 +1456,7 @@ add_schema_file_to_xml(xmlNode *parent, const char *file, GList **already_includ
     if (!pcmk__ends_with(file, ".rng") && !pcmk__ends_with(file, ".xsl")) {
         path = crm_strdup_printf("%s.rng", file);
     } else {
-        path = strdup(file);
-        CRM_ASSERT(path != NULL);
+        pcmk__str_update(&path, file);
     }
 
     rc = read_file_contents(path, &contents);

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -240,8 +240,7 @@ add_schema(enum pcmk__schema_validator validator, const pcmk__schema_version_t *
     pcmk__schema_t *schema = NULL;
     int last = g_list_length(known_schemas);
 
-    schema = calloc(1, sizeof(pcmk__schema_t));
-    pcmk__mem_assert(schema);
+    schema = pcmk__assert_alloc(1, sizeof(pcmk__schema_t));
 
     schema->validator = validator;
     schema->version.v[0] = version->v[0];
@@ -528,7 +527,7 @@ validate_with_relaxng(xmlDocPtr doc, xmlRelaxNGValidityErrorFunc error_handler, 
 
     } else {
         crm_debug("Creating RNG parser context");
-        ctx = calloc(1, sizeof(relaxng_ctx_cache_t));
+        ctx = pcmk__assert_alloc(1, sizeof(relaxng_ctx_cache_t));
 
         ctx->parser = xmlRelaxNGNewParserCtxt(relaxng_file);
         CRM_CHECK(ctx->parser != NULL, goto cleanup);

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -250,15 +250,15 @@ add_schema(enum pcmk__schema_validator validator, const pcmk__schema_version_t *
     if (version->v[0] || version->v[1]) {
         schema->name = schema_strdup_printf("pacemaker-", *version, "");
     } else {
-        pcmk__str_update(&(schema->name), name);
+        schema->name = pcmk__str_copy(name);
     }
 
     if (transform) {
-        pcmk__str_update(&(schema->transform), transform);
+        schema->transform = pcmk__str_copy(transform);
     }
 
     if (transform_enter) {
-        pcmk__str_update(&(schema->transform_enter), transform_enter);
+        schema->transform_enter = pcmk__str_copy(transform_enter);
     }
 
     known_schemas = g_list_append(known_schemas, schema);
@@ -1393,15 +1393,12 @@ static void
 append_href(xmlNode *xml, void *user_data)
 {
     GList **list = user_data;
-    const char *href = crm_element_value(xml, "href");
-    char *s = NULL;
+    char *href = crm_element_value_copy(xml, "href");
 
     if (href == NULL) {
         return;
     }
-
-    pcmk__str_update(&s, href);
-    *list = g_list_prepend(*list, s);
+    *list = g_list_prepend(*list, href);
 }
 
 static void
@@ -1455,7 +1452,7 @@ add_schema_file_to_xml(xmlNode *parent, const char *file, GList **already_includ
     if (!pcmk__ends_with(file, ".rng") && !pcmk__ends_with(file, ".xsl")) {
         path = crm_strdup_printf("%s.rng", file);
     } else {
-        pcmk__str_update(&path, file);
+        path = pcmk__str_copy(file);
     }
 
     rc = read_file_contents(path, &contents);

--- a/lib/common/scores.c
+++ b/lib/common/scores.c
@@ -147,10 +147,7 @@ pcmk__add_scores(int score1, int score2)
 char *
 score2char(int score)
 {
-    char *result = NULL;
-
-    pcmk__str_update(&result, pcmk_readable_score(score));
-    return result;
+    return pcmk__str_copy(pcmk_readable_score(score));
 }
 
 char *

--- a/lib/common/scores.c
+++ b/lib/common/scores.c
@@ -147,9 +147,9 @@ pcmk__add_scores(int score1, int score2)
 char *
 score2char(int score)
 {
-    char *result = strdup(pcmk_readable_score(score));
+    char *result = NULL;
 
-    CRM_ASSERT(result != NULL);
+    pcmk__str_update(&result, pcmk_readable_score(score));
     return result;
 }
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1299,7 +1299,7 @@ pcmk__str_update(char **str, const char *value)
             *str = NULL;
         } else {
             *str = strdup(value);
-            CRM_ASSERT(*str != NULL);
+            pcmk__mem_assert(*str);
         }
     }
 }

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -700,16 +700,9 @@ pcmk__strkey_table(GDestroyNotify key_destroy_func,
 void
 pcmk__insert_dup(GHashTable *table, const char *name, const char *value)
 {
-    char *name_copy = NULL;
-    char *value_copy = NULL;
-
     CRM_ASSERT((table != NULL) && (name != NULL));
 
-    pcmk__str_update(&name_copy, name);
-    if (value != NULL) {
-        pcmk__str_update(&value_copy, value);
-    }
-    g_hash_table_insert(table, name_copy, value_copy);
+    g_hash_table_insert(table, pcmk__str_copy(name), pcmk__str_copy(value));
 }
 
 /* used with hash tables where case does not matter */
@@ -1294,12 +1287,7 @@ pcmk__str_update(char **str, const char *value)
 {
     if ((str != NULL) && !pcmk__str_eq(*str, value, pcmk__str_none)) {
         free(*str);
-        if (value == NULL) {
-            *str = NULL;
-        } else {
-            *str = strdup(value);
-            pcmk__mem_assert(*str);
-        }
+        *str = pcmk__str_copy(value);
     }
 }
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -860,8 +860,7 @@ pcmk__compress(const char *data, unsigned int length, unsigned int max,
     clock_gettime(CLOCK_MONOTONIC, &before_t);
 #endif
 
-    compressed = calloc((size_t) max, sizeof(char));
-    CRM_ASSERT(compressed);
+    compressed = pcmk__assert_alloc((size_t) max, sizeof(char));
 
     *result_len = max;
     rc = BZ2_bzBuffToBuffCompress(compressed, result_len, uncompressed, length,

--- a/lib/common/tests/acl/xml_acl_denied_test.c
+++ b/lib/common/tests/acl/xml_acl_denied_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the Pacemaker project contributors
+ * Copyright 2020-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -38,7 +38,7 @@ is_xml_acl_denied_with_node(void **state)
     xmlNode *test_xml = create_xml_node(NULL, "test_xml");
 
     // allocate memory for _private, which is NULL by default
-    test_xml->doc->_private = calloc(1, sizeof(xml_doc_private_t));
+    test_xml->doc->_private = pcmk__assert_alloc(1, sizeof(xml_doc_private_t));
 
     assert_false(xml_acl_denied(test_xml));
 

--- a/lib/common/tests/acl/xml_acl_enabled_test.c
+++ b/lib/common/tests/acl/xml_acl_enabled_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the Pacemaker project contributors
+ * Copyright 2020-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -38,7 +38,7 @@ is_xml_acl_enabled_with_node(void **state)
     xmlNode *test_xml = create_xml_node(NULL, "test_xml");
 
     // allocate memory for _private, which is NULL by default
-    test_xml->doc->_private = calloc(1, sizeof(xml_doc_private_t));
+    test_xml->doc->_private = pcmk__assert_alloc(1, sizeof(xml_doc_private_t));
 
     assert_false(xml_acl_enabled(test_xml));
 

--- a/lib/common/tests/procfs/pcmk__procfs_pid2path_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_pid2path_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -21,7 +21,7 @@ static void
 no_exe_file(void **state)
 {
     size_t len = PATH_MAX;
-    char *path = calloc(len, sizeof(char));
+    char *path = pcmk__assert_alloc(len, sizeof(char));
 
     // Set readlink() errno and link contents
     pcmk__mock_readlink = true;
@@ -43,7 +43,7 @@ static void
 contents_too_long(void **state)
 {
     size_t len = 10;
-    char *path = calloc(len, sizeof(char));
+    char *path = pcmk__assert_alloc(len, sizeof(char));
 
     // Set readlink() errno and link contents
     pcmk__mock_readlink = true;
@@ -66,7 +66,7 @@ static void
 contents_ok(void **state)
 {
     size_t len = PATH_MAX;
-    char *path = calloc(len, sizeof(char));
+    char *path = pcmk__assert_alloc(len, sizeof(char));
 
     // Set readlink() errno and link contents
     pcmk__mock_readlink = true;

--- a/lib/common/tests/strings/pcmk__compress_test.c
+++ b/lib/common/tests/strings/pcmk__compress_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -20,7 +20,7 @@ const char *SIMPLE_COMPRESSED = "BZh41AY&SYO\x1ai";
 static void
 simple_compress(void **state)
 {
-    char *result = calloc(1024, sizeof(char));
+    char *result = pcmk__assert_alloc(1024, sizeof(char));
     unsigned int len;
 
     assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, 0, &result, &len), pcmk_rc_ok);
@@ -30,7 +30,7 @@ simple_compress(void **state)
 static void
 max_too_small(void **state)
 {
-    char *result = calloc(1024, sizeof(char));
+    char *result = pcmk__assert_alloc(1024, sizeof(char));
     unsigned int len;
 
     assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, 10, &result, &len), EFBIG);
@@ -38,7 +38,7 @@ max_too_small(void **state)
 
 static void
 calloc_fails(void **state) {
-    char *result = calloc(1024, sizeof(char));
+    char *result = pcmk__assert_alloc(1024, sizeof(char));
     unsigned int len;
 
     pcmk__assert_asserts(

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -433,7 +433,7 @@ crm_generate_uuid(void)
     unsigned char uuid[16];
     char *buffer = malloc(37);  /* Including NUL byte */
 
-    CRM_ASSERT(buffer != NULL);
+    pcmk__mem_assert(buffer);
     uuid_generate(uuid);
     uuid_unparse(uuid, buffer);
     return buffer;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -738,7 +738,7 @@ free_xml_with_position(xmlNode * child, int position)
                     deleted_obj =
                         pcmk__assert_alloc(1, sizeof(pcmk__deleted_xml_t));
 
-                    pcmk__str_update(&(deleted_obj->path), xpath->str);
+                    deleted_obj->path = pcmk__str_copy(xpath->str);
                     g_string_free(xpath, TRUE);
 
                     deleted_obj->position = -1;
@@ -1124,7 +1124,7 @@ pcmk__xml_escape(const char *text, bool escape_quote)
         return NULL;
     }
     length = strlen(text);
-    pcmk__str_update(&copy, text);
+    copy = pcmk__str_copy(text);
 
     for (size_t index = 0; index < length; index++) {
         // Don't escape any non-ASCII characters
@@ -2206,7 +2206,7 @@ crm_xml_escape(const char *text)
     }
 
     length = strlen(text);
-    pcmk__str_update(&copy, text);
+    copy = pcmk__str_copy(text);
     for (size_t index = 0; index <= length; index++) {
         if(copy[index] & 0x80 && copy[index+1] & 0x80){
             index++;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -205,9 +205,9 @@ new_private_data(xmlNode *node)
 {
     switch (node->type) {
         case XML_DOCUMENT_NODE: {
-            xml_doc_private_t *docpriv = NULL;
-            docpriv = calloc(1, sizeof(xml_doc_private_t));
-            pcmk__mem_assert(docpriv);
+            xml_doc_private_t *docpriv =
+                pcmk__assert_alloc(1, sizeof(xml_doc_private_t));
+
             docpriv->check = XML_DOC_PRIVATE_MAGIC;
             /* Flags will be reset if necessary when tracking is enabled */
             pcmk__set_xml_flags(docpriv, pcmk__xf_dirty|pcmk__xf_created);
@@ -217,9 +217,9 @@ new_private_data(xmlNode *node)
         case XML_ELEMENT_NODE:
         case XML_ATTRIBUTE_NODE:
         case XML_COMMENT_NODE: {
-            xml_node_private_t *nodepriv = NULL;
-            nodepriv = calloc(1, sizeof(xml_node_private_t));
-            pcmk__mem_assert(nodepriv);
+            xml_node_private_t *nodepriv =
+                pcmk__assert_alloc(1, sizeof(xml_node_private_t));
+
             nodepriv->check = XML_NODE_PRIVATE_MAGIC;
             /* Flags will be reset if necessary when tracking is enabled */
             pcmk__set_xml_flags(nodepriv, pcmk__xf_dirty|pcmk__xf_created);
@@ -735,8 +735,8 @@ free_xml_with_position(xmlNode * child, int position)
                     crm_trace("Deleting %s %p from %p",
                               (const char *) xpath->str, child, doc);
 
-                    deleted_obj = calloc(1, sizeof(pcmk__deleted_xml_t));
-                    pcmk__mem_assert(deleted_obj);
+                    deleted_obj =
+                        pcmk__assert_alloc(1, sizeof(pcmk__deleted_xml_t));
 
                     pcmk__str_update(&(deleted_obj->path), xpath->str);
                     g_string_free(xpath, TRUE);

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -207,7 +207,7 @@ new_private_data(xmlNode *node)
         case XML_DOCUMENT_NODE: {
             xml_doc_private_t *docpriv = NULL;
             docpriv = calloc(1, sizeof(xml_doc_private_t));
-            CRM_ASSERT(docpriv != NULL);
+            pcmk__mem_assert(docpriv);
             docpriv->check = XML_DOC_PRIVATE_MAGIC;
             /* Flags will be reset if necessary when tracking is enabled */
             pcmk__set_xml_flags(docpriv, pcmk__xf_dirty|pcmk__xf_created);
@@ -219,7 +219,7 @@ new_private_data(xmlNode *node)
         case XML_COMMENT_NODE: {
             xml_node_private_t *nodepriv = NULL;
             nodepriv = calloc(1, sizeof(xml_node_private_t));
-            CRM_ASSERT(nodepriv != NULL);
+            pcmk__mem_assert(nodepriv);
             nodepriv->check = XML_NODE_PRIVATE_MAGIC;
             /* Flags will be reset if necessary when tracking is enabled */
             pcmk__set_xml_flags(nodepriv, pcmk__xf_dirty|pcmk__xf_created);
@@ -736,9 +736,9 @@ free_xml_with_position(xmlNode * child, int position)
                               (const char *) xpath->str, child, doc);
 
                     deleted_obj = calloc(1, sizeof(pcmk__deleted_xml_t));
-                    deleted_obj->path = strdup((const char *) xpath->str);
+                    pcmk__mem_assert(deleted_obj);
 
-                    CRM_ASSERT(deleted_obj->path != NULL);
+                    pcmk__str_update(&(deleted_obj->path), xpath->str);
                     g_string_free(xpath, TRUE);
 
                     deleted_obj->position = -1;
@@ -796,16 +796,16 @@ pcmk__xml_copy(xmlNode *parent, xmlNode *src)
         CRM_ASSERT(src->type == XML_ELEMENT_NODE);
 
         doc = xmlNewDoc(PCMK__XML_VERSION);
-        CRM_ASSERT(doc != NULL);
+        pcmk__mem_assert(doc);
 
         copy = xmlDocCopyNode(src, doc, 1);
-        CRM_ASSERT(copy != NULL);
+        pcmk__mem_assert(copy);
 
         xmlDocSetRootElement(doc, copy);
 
     } else {
         copy = xmlDocCopyNode(src, parent->doc, 1);
-        CRM_ASSERT(copy != NULL);
+        pcmk__mem_assert(copy);
 
         xmlAddChild(parent, copy);
     }
@@ -1834,7 +1834,7 @@ replace_xml_child(xmlNode * parent, xmlNode * child, xmlNode * update, gboolean 
             xmlNode *old = child;
             xmlNode *new = xmlCopyNode(update, 1);
 
-            CRM_ASSERT(new != NULL);
+            pcmk__mem_assert(new);
 
             // May be unnecessary but avoids slight changes to some test outputs
             reset_xml_node_flags(new);
@@ -2206,8 +2206,7 @@ crm_xml_escape(const char *text)
     }
 
     length = strlen(text);
-    copy = strdup(text);
-    CRM_ASSERT(copy != NULL);
+    pcmk__str_update(&copy, text);
     for (size_t index = 0; index <= length; index++) {
         if(copy[index] & 0x80 && copy[index+1] & 0x80){
             index++;
@@ -2259,9 +2258,13 @@ xmlNode *
 copy_xml(xmlNode *src)
 {
     xmlDoc *doc = xmlNewDoc(PCMK__XML_VERSION);
-    xmlNode *copy = xmlDocCopyNode(src, doc, 1);
+    xmlNode *copy = NULL;
 
-    CRM_ASSERT(copy != NULL);
+    pcmk__mem_assert(doc);
+
+    copy = xmlDocCopyNode(src, doc, 1);
+    pcmk__mem_assert(copy);
+
     xmlDocSetRootElement(doc, copy);
     return copy;
 }

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -780,7 +780,7 @@ dump_xml_formatted(const xmlNode *xml)
 
     pcmk__xml_string(xml, pcmk__xml_fmt_pretty, buffer, 0);
 
-    pcmk__str_update(&str, buffer->str);
+    str = pcmk__str_copy(buffer->str);
     g_string_free(buffer, TRUE);
     return str;
 }
@@ -793,7 +793,7 @@ dump_xml_formatted_with_text(const xmlNode *xml)
 
     pcmk__xml_string(xml, pcmk__xml_fmt_pretty|pcmk__xml_fmt_text, buffer, 0);
 
-    pcmk__str_update(&str, buffer->str);
+    str = pcmk__str_copy(buffer->str);
     g_string_free(buffer, TRUE);
     return str;
 }
@@ -806,7 +806,7 @@ dump_xml_unformatted(const xmlNode *xml)
 
     pcmk__xml_string(xml, 0, buffer, 0);
 
-    pcmk__str_update(&str, buffer->str);
+    str = pcmk__str_copy(buffer->str);
     g_string_free(buffer, TRUE);
     return str;
 }

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -715,7 +715,7 @@ pcmk__xml2fd(int fd, xmlNode *cur)
     bool success;
 
     xmlOutputBuffer *fd_out = xmlOutputBufferCreateFd(fd, NULL);
-    CRM_ASSERT(fd_out != NULL);
+    pcmk__mem_assert(fd_out);
     xmlNodeDumpOutput(fd_out, cur->doc, cur, 0, pcmk__xml_fmt_pretty, NULL);
 
     success = xmlOutputBufferWrite(fd_out, sizeof("\n") - 1, "\n") != -1;

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -387,9 +387,7 @@ xml_get_path(const xmlNode *xml)
     if (g_path == NULL) {
         return NULL;
     }
-
-    pcmk__str_update(&path, g_path->str);
-
+    path = pcmk__str_copy(g_path->str);
     g_string_free(g_path, TRUE);
     return path;
 }

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -147,7 +147,7 @@ xpath_search(const xmlNode *xml_top, const char *path)
     CRM_CHECK(strlen(path) > 0, return NULL);
 
     xpathCtx = xmlXPathNewContext(xml_top->doc);
-    CRM_ASSERT(xpathCtx != NULL);
+    pcmk__mem_assert(xpathCtx);
 
     xpathObj = xmlXPathEvalExpression(xpathExpr, xpathCtx);
     xmlXPathFreeContext(xpathCtx);
@@ -388,8 +388,7 @@ xml_get_path(const xmlNode *xml)
         return NULL;
     }
 
-    path = strdup((const char *) g_path->str);
-    CRM_ASSERT(path != NULL);
+    pcmk__str_update(&path, g_path->str);
 
     g_string_free(g_path, TRUE);
     return path;

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -267,7 +267,7 @@ stonith__action_create(const char *agent, const char *action_name,
 {
     stonith_action_t *action = calloc(1, sizeof(stonith_action_t));
 
-    CRM_ASSERT(action != NULL);
+    pcmk__mem_assert(action);
 
     action->args = make_args(agent, action_name, target, target_nodeid,
                              device_args, port_map, host_arg);

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -265,9 +265,7 @@ stonith__action_create(const char *agent, const char *action_name,
                        int timeout_sec, GHashTable *device_args,
                        GHashTable *port_map, const char *host_arg)
 {
-    stonith_action_t *action = calloc(1, sizeof(stonith_action_t));
-
-    pcmk__mem_assert(action);
+    stonith_action_t *action = pcmk__assert_alloc(1, sizeof(stonith_action_t));
 
     action->args = make_args(agent, action_name, target, target_nodeid,
                              device_args, port_map, host_arg);

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1416,10 +1416,10 @@ xml_to_event(xmlNode *msg)
     stonith_event_t *event = calloc(1, sizeof(stonith_event_t));
     struct event_private *event_private = NULL;
 
-    CRM_ASSERT(event != NULL);
+    pcmk__mem_assert(event);
 
     event->opaque = calloc(1, sizeof(struct event_private));
-    CRM_ASSERT(event->opaque != NULL);
+    pcmk__mem_assert(event->opaque);
     event_private = (struct event_private *) event->opaque;
 
     crm_log_xml_trace(msg, "stonith_notify");
@@ -2163,7 +2163,7 @@ parse_list_line(const char *line, int len, GList **output)
             }
 
             entry = calloc(i - entry_start + 1, sizeof(char));
-            CRM_ASSERT(entry != NULL);
+            pcmk__mem_assert(entry);
 
             /* Read entry, stopping at first separator
              *

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1931,8 +1931,8 @@ stonith_key_value_add(stonith_key_value_t * head, const char *key, const char *v
     stonith_key_value_t *p, *end;
 
     p = pcmk__assert_alloc(1, sizeof(stonith_key_value_t));
-    pcmk__str_update(&p->key, key);
-    pcmk__str_update(&p->value, value);
+    p->key = pcmk__str_copy(key);
+    p->value = pcmk__str_copy(value);
 
     end = head;
     while (end && end->next) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -733,7 +733,7 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
             long long completed;
             long long completed_nsec = 0L;
 
-            kvp = calloc(1, sizeof(stonith_history_t));
+            kvp = pcmk__assert_alloc(1, sizeof(stonith_history_t));
             kvp->target = crm_element_value_copy(op, PCMK__XA_ST_TARGET);
             kvp->action = crm_element_value_copy(op, PCMK__XA_ST_DEVICE_ACTION);
             kvp->origin = crm_element_value_copy(op, PCMK__XA_ST_ORIGIN);
@@ -1009,7 +1009,7 @@ set_callback_timeout(stonith_callback_client_t * callback, stonith_t * stonith, 
     }
 
     if (!async_timer) {
-        async_timer = calloc(1, sizeof(struct timer_rec_s));
+        async_timer = pcmk__assert_alloc(1, sizeof(struct timer_rec_s));
         callback->timer = async_timer;
     }
 
@@ -1229,7 +1229,7 @@ stonith_api_add_notification(stonith_t * stonith, const char *event,
     private = stonith->st_private;
     crm_trace("Adding callback for %s events (%d)", event, g_list_length(private->notify_list));
 
-    new_client = calloc(1, sizeof(stonith_notify_client_t));
+    new_client = pcmk__assert_alloc(1, sizeof(stonith_notify_client_t));
     new_client->event = event;
     new_client->notify = callback;
 
@@ -1278,7 +1278,7 @@ stonith_api_del_notification(stonith_t * stonith, const char *event)
 
     crm_debug("Removing callback for %s events", event);
 
-    new_client = calloc(1, sizeof(stonith_notify_client_t));
+    new_client = pcmk__assert_alloc(1, sizeof(stonith_notify_client_t));
     new_client->event = event;
     new_client->notify = NULL;
 
@@ -1336,7 +1336,7 @@ stonith_api_add_callback(stonith_t * stonith, int call_id, int timeout, int opti
         return FALSE;
     }
 
-    blob = calloc(1, sizeof(stonith_callback_client_t));
+    blob = pcmk__assert_alloc(1, sizeof(stonith_callback_client_t));
     blob->id = callback_name;
     blob->only_success = (options & st_opt_report_only_success) ? TRUE : FALSE;
     blob->user_data = user_data;
@@ -1413,13 +1413,10 @@ get_event_data_xml(xmlNode *msg, const char *ntype)
 static stonith_event_t *
 xml_to_event(xmlNode *msg)
 {
-    stonith_event_t *event = calloc(1, sizeof(stonith_event_t));
+    stonith_event_t *event = pcmk__assert_alloc(1, sizeof(stonith_event_t));
     struct event_private *event_private = NULL;
 
-    pcmk__mem_assert(event);
-
-    event->opaque = calloc(1, sizeof(struct event_private));
-    pcmk__mem_assert(event->opaque);
+    event->opaque = pcmk__assert_alloc(1, sizeof(struct event_private));
     event_private = (struct event_private *) event->opaque;
 
     crm_log_xml_trace(msg, "stonith_notify");
@@ -1933,7 +1930,7 @@ stonith_key_value_add(stonith_key_value_t * head, const char *key, const char *v
 {
     stonith_key_value_t *p, *end;
 
-    p = calloc(1, sizeof(stonith_key_value_t));
+    p = pcmk__assert_alloc(1, sizeof(stonith_key_value_t));
     pcmk__str_update(&p->key, key);
     pcmk__str_update(&p->value, value);
 
@@ -2162,8 +2159,7 @@ parse_list_line(const char *line, int len, GList **output)
                 continue;
             }
 
-            entry = calloc(i - entry_start + 1, sizeof(char));
-            pcmk__mem_assert(entry);
+            entry = pcmk__assert_alloc(i - entry_start + 1, sizeof(char));
 
             /* Read entry, stopping at first separator
              *

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -211,22 +211,23 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
         stonith_obj = (*st_new_fn) (agent);
         if (stonith_obj) {
             (*st_log_fn) (stonith_obj, (PILLogFun) & stonith_plugin);
-            pcmk__str_update(&meta_longdesc,
-                             (*st_info_fn) (stonith_obj, ST_DEVICEDESCR));
+
+            meta_longdesc = pcmk__str_copy((*st_info_fn)(stonith_obj,
+                                                         ST_DEVICEDESCR));
             if (meta_longdesc == NULL) {
                 crm_warn("no long description in %s's metadata.", agent);
                 meta_longdesc = strdup(no_parameter_info);
             }
 
-            pcmk__str_update(&meta_shortdesc,
-                             (*st_info_fn) (stonith_obj, ST_DEVICEID));
+            meta_shortdesc = pcmk__str_copy((*st_info_fn)(stonith_obj,
+                                                          ST_DEVICEID));
             if (meta_shortdesc == NULL) {
                 crm_warn("no short description in %s's metadata.", agent);
                 meta_shortdesc = strdup(no_parameter_info);
             }
 
-            pcmk__str_update(&meta_param,
-                             (*st_info_fn) (stonith_obj, ST_CONF_XML));
+            meta_param = pcmk__str_copy((*st_info_fn)(stonith_obj,
+                                                      ST_CONF_XML));
             if (meta_param == NULL) {
                 crm_warn("no list of parameters in %s's metadata.", agent);
                 meta_param = strdup(no_parameter_info);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -196,8 +196,9 @@ lrmd_new_event(const char *rsc_id, const char *task, guint interval_ms)
 {
     lrmd_event_data_t *event = pcmk__assert_alloc(1, sizeof(lrmd_event_data_t));
 
-    pcmk__str_update((char **) &event->rsc_id, rsc_id);
-    pcmk__str_update((char **) &event->op_type, task);
+    // lrmd_event_data_t has (const char *) members that lrmd_free_event() frees
+    event->rsc_id = pcmk__str_copy(rsc_id);
+    event->op_type = pcmk__str_copy(task);
     event->interval_ms = interval_ms;
     return event;
 }
@@ -210,9 +211,15 @@ lrmd_copy_event(lrmd_event_data_t * event)
     copy = pcmk__assert_alloc(1, sizeof(lrmd_event_data_t));
 
     copy->type = event->type;
-    pcmk__str_update((char **) &copy->rsc_id, event->rsc_id);
-    pcmk__str_update((char **) &copy->op_type, event->op_type);
-    pcmk__str_update((char **) &copy->user_data, event->user_data);
+
+    // lrmd_event_data_t has (const char *) members that lrmd_free_event() frees
+    copy->rsc_id = pcmk__str_copy(event->rsc_id);
+    copy->op_type = pcmk__str_copy(event->op_type);
+    copy->user_data = pcmk__str_copy(event->user_data);
+    copy->output = pcmk__str_copy(event->output);
+    copy->remote_nodename = pcmk__str_copy(event->remote_nodename);
+    copy->exit_reason = pcmk__str_copy(event->exit_reason);
+
     copy->call_id = event->call_id;
     copy->timeout = event->timeout;
     copy->interval_ms = event->interval_ms;
@@ -220,15 +227,12 @@ lrmd_copy_event(lrmd_event_data_t * event)
     copy->rsc_deleted = event->rsc_deleted;
     copy->rc = event->rc;
     copy->op_status = event->op_status;
-    pcmk__str_update((char **) &copy->output, event->output);
     copy->t_run = event->t_run;
     copy->t_rcchange = event->t_rcchange;
     copy->exec_time = event->exec_time;
     copy->queue_time = event->queue_time;
     copy->connection_rc = event->connection_rc;
     copy->params = pcmk__str_table_dup(event->params);
-    pcmk__str_update((char **) &copy->remote_nodename, event->remote_nodename);
-    pcmk__str_update((char **) &copy->exit_reason, event->exit_reason);
 
     return copy;
 }
@@ -1774,10 +1778,10 @@ lrmd_new_rsc_info(const char *rsc_id, const char *standard,
 {
     lrmd_rsc_info_t *rsc_info = pcmk__assert_alloc(1, sizeof(lrmd_rsc_info_t));
 
-    pcmk__str_update(&rsc_info->id, rsc_id);
-    pcmk__str_update(&rsc_info->standard, standard);
-    pcmk__str_update(&rsc_info->provider, provider);
-    pcmk__str_update(&rsc_info->type, type);
+    rsc_info->id = pcmk__str_copy(rsc_id);
+    rsc_info->standard = pcmk__str_copy(standard);
+    rsc_info->provider = pcmk__str_copy(provider);
+    rsc_info->type = pcmk__str_copy(type);
     return rsc_info;
 }
 
@@ -2529,6 +2533,8 @@ lrmd__set_result(lrmd_event_data_t *event, enum ocf_exitcode rc, int op_status,
 
     event->rc = rc;
     event->op_status = op_status;
+
+    // lrmd_event_data_t has (const char *) members that lrmd_free_event() frees
     pcmk__str_update((char **) &event->exit_reason, exit_reason);
 }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -196,7 +196,7 @@ lrmd_new_event(const char *rsc_id, const char *task, guint interval_ms)
 {
     lrmd_event_data_t *event = calloc(1, sizeof(lrmd_event_data_t));
 
-    CRM_ASSERT(event != NULL);
+    pcmk__mem_assert(event);
     pcmk__str_update((char **) &event->rsc_id, rsc_id);
     pcmk__str_update((char **) &event->op_type, task);
     event->interval_ms = interval_ms;
@@ -1106,7 +1106,7 @@ copy_gnutls_datum(gnutls_datum_t *dest, gnutls_datum_t *source)
     CRM_ASSERT((dest != NULL) && (source != NULL) && (source->data != NULL));
 
     dest->data = gnutls_malloc(source->size);
-    CRM_ASSERT(dest->data);
+    pcmk__mem_assert(dest->data);
 
     memcpy(dest->data, source->data, source->size);
     dest->size = source->size;

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -110,7 +110,7 @@ lrmd_list_add(lrmd_list_t * head, const char *value)
 {
     lrmd_list_t *p, *end;
 
-    p = calloc(1, sizeof(lrmd_list_t));
+    p = pcmk__assert_alloc(1, sizeof(lrmd_list_t));
     p->val = strdup(value);
 
     end = head;
@@ -147,7 +147,7 @@ lrmd_key_value_add(lrmd_key_value_t * head, const char *key, const char *value)
 {
     lrmd_key_value_t *p, *end;
 
-    p = calloc(1, sizeof(lrmd_key_value_t));
+    p = pcmk__assert_alloc(1, sizeof(lrmd_key_value_t));
     p->key = strdup(key);
     p->value = strdup(value);
 
@@ -194,9 +194,8 @@ lrmd_key_value_freeall(lrmd_key_value_t * head)
 lrmd_event_data_t *
 lrmd_new_event(const char *rsc_id, const char *task, guint interval_ms)
 {
-    lrmd_event_data_t *event = calloc(1, sizeof(lrmd_event_data_t));
+    lrmd_event_data_t *event = pcmk__assert_alloc(1, sizeof(lrmd_event_data_t));
 
-    pcmk__mem_assert(event);
     pcmk__str_update((char **) &event->rsc_id, rsc_id);
     pcmk__str_update((char **) &event->op_type, task);
     event->interval_ms = interval_ms;
@@ -208,7 +207,7 @@ lrmd_copy_event(lrmd_event_data_t * event)
 {
     lrmd_event_data_t *copy = NULL;
 
-    copy = calloc(1, sizeof(lrmd_event_data_t));
+    copy = pcmk__assert_alloc(1, sizeof(lrmd_event_data_t));
 
     copy->type = event->type;
     pcmk__str_update((char **) &copy->rsc_id, event->rsc_id);
@@ -1773,9 +1772,8 @@ lrmd_rsc_info_t *
 lrmd_new_rsc_info(const char *rsc_id, const char *standard,
                   const char *provider, const char *type)
 {
-    lrmd_rsc_info_t *rsc_info = calloc(1, sizeof(lrmd_rsc_info_t));
+    lrmd_rsc_info_t *rsc_info = pcmk__assert_alloc(1, sizeof(lrmd_rsc_info_t));
 
-    CRM_ASSERT(rsc_info);
     pcmk__str_update(&rsc_info->id, rsc_id);
     pcmk__str_update(&rsc_info->standard, standard);
     pcmk__str_update(&rsc_info->provider, provider);

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -175,7 +175,7 @@ remote_proxy_new(lrmd_t *lrmd, struct ipc_client_callbacks *proxy_callbacks,
         return NULL;
     }
 
-    proxy = calloc(1, sizeof(remote_proxy_t));
+    proxy = pcmk__assert_alloc(1, sizeof(remote_proxy_t));
 
     proxy->node_name = strdup(node_name);
     proxy->session_id = strdup(session_id);

--- a/lib/pacemaker/pcmk_acl.c
+++ b/lib/pacemaker/pcmk_acl.c
@@ -329,7 +329,7 @@ pcmk__acl_evaled_render(xmlDoc *annotated_doc, enum pcmk__acl_render_how how,
     parser_ctxt = xmlNewParserCtxt();
 
     CRM_ASSERT(sfile != NULL);
-    CRM_ASSERT(parser_ctxt != NULL);
+    pcmk__mem_assert(parser_ctxt);
 
     xslt_doc = xmlCtxtReadFile(parser_ctxt, sfile, NULL, XML_PARSE_NONET);
 
@@ -343,7 +343,7 @@ pcmk__acl_evaled_render(xmlDoc *annotated_doc, enum pcmk__acl_render_how how,
     xmlFreeParserCtxt(parser_ctxt);
 
     xslt_ctxt = xsltNewTransformContext(xslt, annotated_doc);
-    CRM_ASSERT(xslt_ctxt != NULL);
+    pcmk__mem_assert(xslt_ctxt);
 
     switch (how) {
         case pcmk__acl_render_namespace:

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -727,10 +727,10 @@ pcmk__unpack_graph(const xmlNode *xml_graph, const char *reference)
         buf = crm_element_value(xml_graph, PCMK_OPT_MIGRATION_LIMIT);
         pcmk__scan_min_int(buf, &(new_graph->migration_limit), -1);
 
-        pcmk__str_update(&(new_graph->failed_stop_offset),
-                         crm_element_value(xml_graph, "failed-stop-offset"));
-        pcmk__str_update(&(new_graph->failed_start_offset),
-                         crm_element_value(xml_graph, "failed-start-offset"));
+        new_graph->failed_stop_offset =
+            crm_element_value_copy(xml_graph, "failed-stop-offset");
+        new_graph->failed_start_offset =
+            crm_element_value_copy(xml_graph, "failed-start-offset");
 
         if (crm_element_value_epoch(xml_graph, "recheck-by",
                                     &(new_graph->recheck_by)) != pcmk_ok) {

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -582,8 +582,8 @@ inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
 
     out->message(out, "inject-spec", spec);
 
-    key = calloc(1, strlen(spec) + 1);
-    node = calloc(1, strlen(spec) + 1);
+    key = pcmk__assert_alloc(1, strlen(spec) + 1);
+    node = pcmk__assert_alloc(1, strlen(spec) + 1);
     rc = sscanf(spec, "%[^@]@%[^=]=%d", key, node, &outcome);
     if (rc != 3) {
         out->err(out, "Invalid operation spec: %s.  Only found %d fields",

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -155,8 +155,7 @@ action_uuid_for_ordering(const char *first_uuid,
 
 done:
     if (uuid == NULL) {
-        uuid = strdup(first_uuid);
-        CRM_ASSERT(uuid != NULL);
+        pcmk__str_update(&uuid, first_uuid);
     }
     free(first_task_str);
     free(rid);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -154,12 +154,9 @@ action_uuid_for_ordering(const char *first_uuid,
     }
 
 done:
-    if (uuid == NULL) {
-        pcmk__str_update(&uuid, first_uuid);
-    }
     free(first_task_str);
     free(rid);
-    return uuid;
+    return (uuid != NULL)? uuid : pcmk__str_copy(first_uuid);
 }
 
 /*!

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -368,7 +368,7 @@ pcmk__new_colocation(const char *id, const char *node_attr, int score,
     }
 
     new_con = calloc(1, sizeof(pcmk__colocation_t));
-    CRM_ASSERT(new_con != NULL);
+    pcmk__mem_assert(new_con);
 
     if (pcmk__str_eq(dependent_role, PCMK__ROLE_STARTED,
                      pcmk__str_null_matches|pcmk__str_casei)) {

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -367,8 +367,7 @@ pcmk__new_colocation(const char *id, const char *node_attr, int score,
         return;
     }
 
-    new_con = calloc(1, sizeof(pcmk__colocation_t));
-    pcmk__mem_assert(new_con);
+    new_con = pcmk__assert_alloc(1, sizeof(pcmk__colocation_t));
 
     if (pcmk__str_eq(dependent_role, PCMK__ROLE_STARTED,
                      pcmk__str_null_matches|pcmk__str_casei)) {

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -354,7 +354,7 @@ unpack_simple_location(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
 
     value = crm_element_value(xml_obj, PCMK_XA_RSC_PATTERN);
     if (value) {
-        regex_t *r_patt = calloc(1, sizeof(regex_t));
+        regex_t *r_patt = pcmk__assert_alloc(1, sizeof(regex_t));
         bool invert = false;
 
         if (value[0] == '!') {
@@ -383,7 +383,7 @@ unpack_simple_location(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
             } else {
                 nregs = 1;
             }
-            pmatch = calloc(nregs, sizeof(regmatch_t));
+            pmatch = pcmk__assert_alloc(nregs, sizeof(regmatch_t));
 
             status = regexec(r_patt, r->id, nregs, pmatch, 0);
 

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -243,8 +243,7 @@ task_from_action_or_key(const pcmk_action_t *action, const char *key)
     char *res = NULL;
 
     if (action != NULL) {
-        res = strdup(action->task);
-        CRM_ASSERT(res != NULL);
+        pcmk__str_update(&res, action->task);
     } else if (key != NULL) {
         parse_op_key(key, NULL, &res, NULL);
     }

--- a/lib/pacemaker/pcmk_sched_migration.c
+++ b/lib/pacemaker/pcmk_sched_migration.c
@@ -243,7 +243,7 @@ task_from_action_or_key(const pcmk_action_t *action, const char *key)
     char *res = NULL;
 
     if (action != NULL) {
-        pcmk__str_update(&res, action->task);
+        res = pcmk__str_copy(action->task);
     } else if (key != NULL) {
         parse_op_key(key, NULL, &res, NULL);
     }

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -547,8 +547,7 @@ pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_action_task,
         then_rsc = then_action->rsc;
     }
 
-    order = calloc(1, sizeof(pcmk__action_relation_t));
-    pcmk__mem_assert(order);
+    order = pcmk__assert_alloc(1, sizeof(pcmk__action_relation_t));
 
     order->id = sched->order_id++;
     order->flags = flags;

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -548,7 +548,7 @@ pcmk__new_ordering(pcmk_resource_t *first_rsc, char *first_action_task,
     }
 
     order = calloc(1, sizeof(pcmk__action_relation_t));
-    CRM_ASSERT(order != NULL);
+    pcmk__mem_assert(order);
 
     order->id = sched->order_id++;
     order->flags = flags;

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -656,8 +656,8 @@ pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *task,
     cancel_op = custom_action(rsc, key, PCMK_ACTION_CANCEL, node, FALSE,
                               rsc->cluster);
 
-    pcmk__str_update(&cancel_op->task, PCMK_ACTION_CANCEL);
-    pcmk__str_update(&cancel_op->cancel_task, task);
+    cancel_op->task = pcmk__str_copy(PCMK_ACTION_CANCEL);
+    cancel_op->cancel_task = pcmk__str_copy(task);
 
     interval_ms_s = crm_strdup_printf("%u", interval_ms);
     pcmk__insert_meta(cancel_op, PCMK_XA_OPERATION, task);

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -101,7 +101,7 @@ pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith, cib_t *cib,
     }
 
     scheduler = pe_new_working_set();
-    CRM_ASSERT(scheduler != NULL);
+    pcmk__mem_assert(scheduler);
     pcmk__set_scheduler_flags(scheduler, pcmk_sched_no_compat);
 
     scheduler->input = cib_copy;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -864,9 +864,9 @@ static void
 mount_add(pe__bundle_variant_data_t *bundle_data, const char *source,
           const char *target, const char *options, uint32_t flags)
 {
-    pe__bundle_mount_t *mount = calloc(1, sizeof(pe__bundle_mount_t));
+    pe__bundle_mount_t *mount = pcmk__assert_alloc(1,
+                                                   sizeof(pe__bundle_mount_t));
 
-    pcmk__mem_assert(mount);
     pcmk__str_update(&mount->source, source);
     pcmk__str_update(&mount->target, target);
     pcmk__str_update(&mount->options, options);
@@ -995,7 +995,7 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
     CRM_ASSERT(rsc != NULL);
     pcmk__rsc_trace(rsc, "Processing resource %s...", rsc->id);
 
-    bundle_data = calloc(1, sizeof(pe__bundle_variant_data_t));
+    bundle_data = pcmk__assert_alloc(1, sizeof(pe__bundle_variant_data_t));
     rsc->variant_opaque = bundle_data;
     bundle_data->prefix = strdup(rsc->id);
 
@@ -1075,7 +1075,9 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
         for (xml_child = first_named_child(xml_obj, PCMK_XE_PORT_MAPPING);
              xml_child != NULL; xml_child = crm_next_same_xml(xml_child)) {
 
-            pe__bundle_port_t *port = calloc(1, sizeof(pe__bundle_port_t));
+            pe__bundle_port_t *port =
+                pcmk__assert_alloc(1, sizeof(pe__bundle_port_t));
+
             port->source = crm_element_value_copy(xml_child, PCMK_XA_PORT);
 
             if(port->source == NULL) {
@@ -1216,7 +1218,7 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
                       pe__bundle_mount_subdir);
         }
 
-        port = calloc(1, sizeof(pe__bundle_port_t));
+        port = pcmk__assert_alloc(1, sizeof(pe__bundle_port_t));
         if(bundle_data->control_port) {
             port->source = strdup(bundle_data->control_port);
         } else {
@@ -1240,7 +1242,7 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
             pcmk__bundle_replica_t *replica = NULL;
 
-            replica = calloc(1, sizeof(pcmk__bundle_replica_t));
+            replica = pcmk__assert_alloc(1, sizeof(pcmk__bundle_replica_t));
             replica->child = childIter->data;
             replica->child->exclusive_discover = TRUE;
             replica->offset = lpc++;
@@ -1274,7 +1276,7 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
         for (int lpc = 0; lpc < bundle_data->nreplicas; lpc++) {
             pcmk__bundle_replica_t *replica = NULL;
 
-            replica = calloc(1, sizeof(pcmk__bundle_replica_t));
+            replica = pcmk__assert_alloc(1, sizeof(pcmk__bundle_replica_t));
             replica->offset = lpc;
             allocate_ip(bundle_data, replica, buffer);
             bundle_data->replicas = g_list_append(bundle_data->replicas,

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -866,9 +866,9 @@ mount_add(pe__bundle_variant_data_t *bundle_data, const char *source,
 {
     pe__bundle_mount_t *mount = calloc(1, sizeof(pe__bundle_mount_t));
 
-    CRM_ASSERT(mount != NULL);
-    mount->source = strdup(source);
-    mount->target = strdup(target);
+    pcmk__mem_assert(mount);
+    pcmk__str_update(&mount->source, source);
+    pcmk__str_update(&mount->target, target);
     pcmk__str_update(&mount->options, options);
     mount->flags = flags;
     bundle_data->mounts = g_list_append(bundle_data->mounts, mount);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -867,9 +867,9 @@ mount_add(pe__bundle_variant_data_t *bundle_data, const char *source,
     pe__bundle_mount_t *mount = pcmk__assert_alloc(1,
                                                    sizeof(pe__bundle_mount_t));
 
-    pcmk__str_update(&mount->source, source);
-    pcmk__str_update(&mount->target, target);
-    pcmk__str_update(&mount->options, options);
+    mount->source = pcmk__str_copy(source);
+    mount->target = pcmk__str_copy(target);
+    mount->options = pcmk__str_copy(options);
     mount->flags = flags;
     bundle_data->mounts = g_list_append(bundle_data->mounts, mount);
 }

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -334,7 +334,7 @@ clone_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
     pcmk__rsc_trace(rsc, "Processing resource %s...", rsc->id);
 
-    clone_data = calloc(1, sizeof(clone_variant_data_t));
+    clone_data = pcmk__assert_alloc(1, sizeof(clone_variant_data_t));
     rsc->variant_opaque = clone_data;
 
     if (pcmk_is_set(rsc->flags, pcmk_rsc_promotable)) {
@@ -350,9 +350,6 @@ clone_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
             unpack_meta_int(rsc, PCMK_META_PROMOTED_NODE_MAX,
                             PCMK__META_PROMOTED_NODE_MAX_LEGACY, 1);
     }
-
-    // Implied by calloc()
-    /* clone_data->xml_obj_child = NULL; */
 
     // Use 1 as default but 0 for minimum and invalid
     clone_data->clone_node_max = unpack_meta_int(rsc, PCMK_META_CLONE_NODE_MAX,

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -186,7 +186,7 @@ group_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
     pcmk__rsc_trace(rsc, "Processing resource %s...", rsc->id);
 
-    group_data = calloc(1, sizeof(group_variant_data_t));
+    group_data = pcmk__assert_alloc(1, sizeof(group_variant_data_t));
     group_data->last_child = NULL;
     rsc->variant_opaque = group_data;
 

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1222,7 +1222,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
         if (rsc_table) {
             rsc_counter = g_hash_table_lookup(rsc_table, buffer);
             if (rsc_counter == NULL) {
-                rsc_counter = calloc(1, sizeof(int));
+                rsc_counter = pcmk__assert_alloc(1, sizeof(int));
                 *rsc_counter = 0;
                 g_hash_table_insert(rsc_table, strdup(buffer), rsc_counter);
             }
@@ -1249,7 +1249,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
 
                 active_counter = g_hash_table_lookup(node_table, buffer);
                 if (active_counter == NULL) {
-                    active_counter = calloc(1, sizeof(int));
+                    active_counter = pcmk__assert_alloc(1, sizeof(int));
                     *active_counter = 0;
                     g_hash_table_insert(node_table, strdup(buffer), active_counter);
                 }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -329,7 +329,6 @@ char *
 native_parameter(pcmk_resource_t *rsc, pcmk_node_t *node, gboolean create,
                  const char *name, pcmk_scheduler_t *scheduler)
 {
-    char *value_copy = NULL;
     const char *value = NULL;
     GHashTable *params = NULL;
 
@@ -343,8 +342,7 @@ native_parameter(pcmk_resource_t *rsc, pcmk_node_t *node, gboolean create,
         /* try meta attributes instead */
         value = g_hash_table_lookup(rsc->meta, name);
     }
-    pcmk__str_update(&value_copy, value);
-    return value_copy;
+    return pcmk__str_copy(value);
 }
 
 gboolean

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -171,7 +171,7 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
     pcmk_action_t *action = pcmk__assert_alloc(1, sizeof(pcmk_action_t));
 
     action->rsc = rsc;
-    pcmk__str_update(&(action->task), task);
+    action->task = pcmk__str_copy(task);
     action->uuid = key;
 
     if (node) {
@@ -699,7 +699,6 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
                          const xmlNode *action_config)
 {
     GHashTable *meta = NULL;
-    char *name = NULL;
     const char *timeout_spec = NULL;
     const char *str = NULL;
 
@@ -770,9 +769,8 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
 
     // Normalize interval to milliseconds
     if (interval_ms > 0) {
-        name = strdup(PCMK_META_INTERVAL);
-        CRM_ASSERT(name != NULL);
-        g_hash_table_insert(meta, name, crm_strdup_printf("%u", interval_ms));
+        g_hash_table_insert(meta, pcmk__str_copy(PCMK_META_INTERVAL),
+                            crm_strdup_printf("%u", interval_ms));
     } else {
         g_hash_table_remove(meta, PCMK_META_INTERVAL);
     }
@@ -806,10 +804,9 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
     }
 
     // Normalize timeout to positive milliseconds
-    name = strdup(PCMK_META_TIMEOUT);
-    CRM_ASSERT(name != NULL);
     timeout_spec = g_hash_table_lookup(meta, PCMK_META_TIMEOUT);
-    g_hash_table_insert(meta, name, pcmk__itoa(unpack_timeout(timeout_spec)));
+    g_hash_table_insert(meta, pcmk__str_copy(PCMK_META_TIMEOUT),
+                        pcmk__itoa(unpack_timeout(timeout_spec)));
 
     // Ensure on-fail has a valid value
     validate_on_fail(rsc, action_name, action_config, meta);
@@ -824,9 +821,7 @@ pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
         str = g_hash_table_lookup(meta, PCMK_META_INTERVAL_ORIGIN);
         if (unpack_interval_origin(str, action_config, interval_ms,
                                    rsc->cluster->now, &start_delay)) {
-            name = strdup(PCMK_META_START_DELAY);
-            CRM_ASSERT(name != NULL);
-            g_hash_table_insert(meta, name,
+            g_hash_table_insert(meta, pcmk__str_copy(PCMK_META_START_DELAY),
                                 crm_strdup_printf("%lld", start_delay));
         }
     }
@@ -1869,11 +1864,8 @@ pe__new_rsc_pseudo_action(pcmk_resource_t *rsc, const char *task, bool optional,
 void
 pe__add_action_expected_result(pcmk_action_t *action, int expected_result)
 {
-    char *name = NULL;
-
     CRM_ASSERT((action != NULL) && (action->meta != NULL));
 
-    pcmk__str_update(&name, PCMK__META_OP_TARGET_RC);
-
-    g_hash_table_insert(action->meta, name, pcmk__itoa(expected_result));
+    g_hash_table_insert(action->meta, pcmk__str_copy(PCMK__META_OP_TARGET_RC),
+                        pcmk__itoa(expected_result));
 }

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -168,9 +168,7 @@ static pcmk_action_t *
 new_action(char *key, const char *task, pcmk_resource_t *rsc,
            const pcmk_node_t *node, bool optional, pcmk_scheduler_t *scheduler)
 {
-    pcmk_action_t *action = calloc(1, sizeof(pcmk_action_t));
-
-    pcmk__mem_assert(action);
+    pcmk_action_t *action = pcmk__assert_alloc(1, sizeof(pcmk_action_t));
 
     action->rsc = rsc;
     pcmk__str_update(&(action->task), task);

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -97,7 +97,7 @@ dup_notify_entry(const notify_entry_t *entry)
 {
     notify_entry_t *dup = calloc(1, sizeof(notify_entry_t));
 
-    CRM_ASSERT(dup != NULL);
+    pcmk__mem_assert(dup);
     dup->rsc = entry->rsc;
     dup->node = entry->node;
     return dup;
@@ -440,7 +440,7 @@ pe__action_notif_pseudo_ops(pcmk_resource_t *rsc, const char *task,
     }
 
     n_data = calloc(1, sizeof(notify_data_t));
-    CRM_ASSERT(n_data != NULL);
+    pcmk__mem_assert(n_data);
 
     n_data->action = task;
 
@@ -522,7 +522,7 @@ new_notify_entry(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
     notify_entry_t *entry = calloc(1, sizeof(notify_entry_t));
 
-    CRM_ASSERT(entry != NULL);
+    pcmk__mem_assert(entry);
     entry->rsc = rsc;
     entry->node = node;
     return entry;

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -95,9 +95,8 @@ compare_notify_entries(gconstpointer a, gconstpointer b)
 static notify_entry_t *
 dup_notify_entry(const notify_entry_t *entry)
 {
-    notify_entry_t *dup = calloc(1, sizeof(notify_entry_t));
+    notify_entry_t *dup = pcmk__assert_alloc(1, sizeof(notify_entry_t));
 
-    pcmk__mem_assert(dup);
     dup->rsc = entry->rsc;
     dup->node = entry->node;
     return dup;
@@ -439,8 +438,7 @@ pe__action_notif_pseudo_ops(pcmk_resource_t *rsc, const char *task,
         return NULL;
     }
 
-    n_data = calloc(1, sizeof(notify_data_t));
-    pcmk__mem_assert(n_data);
+    n_data = pcmk__assert_alloc(1, sizeof(notify_data_t));
 
     n_data->action = task;
 
@@ -520,9 +518,8 @@ pe__action_notif_pseudo_ops(pcmk_resource_t *rsc, const char *task,
 static notify_entry_t *
 new_notify_entry(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 {
-    notify_entry_t *entry = calloc(1, sizeof(notify_entry_t));
+    notify_entry_t *entry = pcmk__assert_alloc(1, sizeof(notify_entry_t));
 
-    pcmk__mem_assert(entry);
     entry->rsc = rsc;
     entry->node = node;
     return entry;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -590,7 +590,7 @@ pe__node_display_name(pcmk_node_t *node, bool print_detail)
 
     /* Allocate and populate display name */
     node_name = malloc(name_len);
-    CRM_ASSERT(node_name != NULL);
+    pcmk__mem_assert(node_name);
     strcpy(node_name, node->details->uname);
     if (node_host) {
         strcat(node_name, "@");
@@ -1373,8 +1373,9 @@ failed_action_friendly(pcmk__output_t *out, const xmlNode *xml_op,
 
     if (pcmk__str_empty(op_key)
         || !parse_op_key(op_key, &rsc_id, &task, &interval_ms)) {
-        rsc_id = strdup("unknown resource");
-        task = strdup("unknown action");
+
+        pcmk__str_update(&rsc_id, "unknown resource");
+        pcmk__str_update(&task, "unknown action");
         interval_ms = 0;
     }
     CRM_ASSERT((rsc_id != NULL) && (task != NULL));

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -589,8 +589,7 @@ pe__node_display_name(pcmk_node_t *node, bool print_detail)
     }
 
     /* Allocate and populate display name */
-    node_name = malloc(name_len);
-    pcmk__mem_assert(node_name);
+    node_name = pcmk__assert_alloc(name_len, sizeof(char));
     strcpy(node_name, node->details->uname);
     if (node_host) {
         strcat(node_name, "@");

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -195,7 +195,7 @@ pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
     CRM_CHECK(scheduler && rsc_op && rsc && node, return);
 
     check_op = calloc(1, sizeof(struct check_op));
-    CRM_ASSERT(check_op != NULL);
+    pcmk__mem_assert(check_op);
 
     crm_trace("Deferring checks of %s until after allocation",
               pcmk__xe_id(rsc_op));

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -194,8 +194,7 @@ pe__add_param_check(const xmlNode *rsc_op, pcmk_resource_t *rsc,
 
     CRM_CHECK(scheduler && rsc_op && rsc && node, return);
 
-    check_op = calloc(1, sizeof(struct check_op));
-    pcmk__mem_assert(check_op);
+    check_op = pcmk__assert_alloc(1, sizeof(struct check_op));
 
     crm_trace("Deferring checks of %s until after allocation",
               pcmk__xe_id(rsc_op));

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -255,7 +255,7 @@ make_pairs(xmlNode *top, const xmlNode *xml_obj, const char *set_name,
                 continue; // Not possible with schema validation enabled
             }
 
-            pair = calloc(1, sizeof(sorted_set_t));
+            pair = pcmk__assert_alloc(1, sizeof(sorted_set_t));
             pair->name = pcmk__xe_id(expanded_attr_set);
             pair->special_name = always_first;
             pair->attr_set = expanded_attr_set;

--- a/lib/pengine/tests/status/pe_find_node_any_test.c
+++ b/lib/pengine/tests/status/pe_find_node_any_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -24,13 +24,13 @@ static void
 non_null_list(void **state) {
     GList *nodes = NULL;
 
-    pcmk_node_t *a = calloc(1, sizeof(pcmk_node_t));
-    pcmk_node_t *b = calloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *a = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *b = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
 
-    a->details = calloc(1, sizeof(struct pe_node_shared_s));
+    a->details = pcmk__assert_alloc(1, sizeof(struct pe_node_shared_s));
     a->details->uname = "cluster1";
     a->details->id = "id1";
-    b->details = calloc(1, sizeof(struct pe_node_shared_s));
+    b->details = pcmk__assert_alloc(1, sizeof(struct pe_node_shared_s));
     b->details->uname = "cluster2";
     b->details->id = "id2";
 

--- a/lib/pengine/tests/status/pe_find_node_id_test.c
+++ b/lib/pengine/tests/status/pe_find_node_id_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,12 +22,12 @@ static void
 non_null_list(void **state) {
     GList *nodes = NULL;
 
-    pcmk_node_t *a = calloc(1, sizeof(pcmk_node_t));
-    pcmk_node_t *b = calloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *a = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *b = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
 
-    a->details = calloc(1, sizeof(struct pe_node_shared_s));
+    a->details = pcmk__assert_alloc(1, sizeof(struct pe_node_shared_s));
     a->details->id = "id1";
-    b->details = calloc(1, sizeof(struct pe_node_shared_s));
+    b->details = pcmk__assert_alloc(1, sizeof(struct pe_node_shared_s));
     b->details->id = "id2";
 
     nodes = g_list_append(nodes, a);

--- a/lib/pengine/tests/status/pe_find_node_test.c
+++ b/lib/pengine/tests/status/pe_find_node_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,12 +22,12 @@ static void
 non_null_list(void **state) {
     GList *nodes = NULL;
 
-    pcmk_node_t *a = calloc(1, sizeof(pcmk_node_t));
-    pcmk_node_t *b = calloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *a = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    pcmk_node_t *b = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
 
-    a->details = calloc(1, sizeof(struct pe_node_shared_s));
+    a->details = pcmk__assert_alloc(1, sizeof(struct pe_node_shared_s));
     a->details->uname = "cluster1";
-    b->details = calloc(1, sizeof(struct pe_node_shared_s));
+    b->details = pcmk__assert_alloc(1, sizeof(struct pe_node_shared_s));
     b->details->uname = "cluster2";
 
     nodes = g_list_append(nodes, a);

--- a/lib/pengine/tests/status/set_working_set_defaults_test.c
+++ b/lib/pengine/tests/status/set_working_set_defaults_test.c
@@ -20,7 +20,8 @@
 static void
 check_defaults(void **state) {
     uint32_t flags;
-    pcmk_scheduler_t *scheduler = calloc(1, sizeof(pcmk_scheduler_t));
+    pcmk_scheduler_t *scheduler = pcmk__assert_alloc(1,
+                                                     sizeof(pcmk_scheduler_t));
 
     set_working_set_defaults(scheduler);
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1943,8 +1943,7 @@ clone_zero(const char *last_rsc_id)
     char *zero = NULL;
 
     CRM_ASSERT(end);
-    zero = calloc(base_name_len + 3, sizeof(char));
-    CRM_ASSERT(zero);
+    zero = pcmk__assert_alloc(base_name_len + 3, sizeof(char));
     memcpy(zero, last_rsc_id, base_name_len);
     zero[base_name_len] = ':';
     zero[base_name_len + 1] = '0';

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3516,13 +3516,13 @@ last_change_str(const xmlNode *xml_op)
 
         // Skip day of week to make message shorter
         if ((p != NULL) && (*(++p) != '\0')) {
-            pcmk__str_update(&result, p);
+            result = pcmk__str_copy(p);
         }
         free(when_s);
     }
 
     if (result == NULL) {
-        pcmk__str_update(&result, "unknown time");
+        result = pcmk__str_copy("unknown_time");
     }
 
     return result;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -3517,15 +3517,13 @@ last_change_str(const xmlNode *xml_op)
 
         // Skip day of week to make message shorter
         if ((p != NULL) && (*(++p) != '\0')) {
-            result = strdup(p);
-            CRM_ASSERT(result != NULL);
+            pcmk__str_update(&result, p);
         }
         free(when_s);
     }
 
     if (result == NULL) {
-        result = strdup("unknown time");
-        CRM_ASSERT(result != NULL);
+        pcmk__str_update(&result, "unknown time");
     }
 
     return result;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -92,8 +92,7 @@ pe__copy_node(const pcmk_node_t *this_node)
 
     CRM_ASSERT(this_node != NULL);
 
-    new_node = calloc(1, sizeof(pcmk_node_t));
-    pcmk__mem_assert(new_node);
+    new_node = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
 
     new_node->rsc_discover_mode = this_node->rsc_discover_mode;
     new_node->weight = this_node->weight;
@@ -478,14 +477,14 @@ order_actions(pcmk_action_t *lh_action, pcmk_action_t *rh_action,
         }
     }
 
-    wrapper = calloc(1, sizeof(pcmk__related_action_t));
+    wrapper = pcmk__assert_alloc(1, sizeof(pcmk__related_action_t));
     wrapper->action = rh_action;
     wrapper->type = flags;
     list = lh_action->actions_after;
     list = g_list_prepend(list, wrapper);
     lh_action->actions_after = list;
 
-    wrapper = calloc(1, sizeof(pcmk__related_action_t));
+    wrapper = pcmk__assert_alloc(1, sizeof(pcmk__related_action_t));
     wrapper->action = lh_action;
     wrapper->type = flags;
     list = rh_action->actions_before;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -93,7 +93,7 @@ pe__copy_node(const pcmk_node_t *this_node)
     CRM_ASSERT(this_node != NULL);
 
     new_node = calloc(1, sizeof(pcmk_node_t));
-    CRM_ASSERT(new_node != NULL);
+    pcmk__mem_assert(new_node);
 
     new_node->rsc_discover_mode = this_node->rsc_discover_mode;
     new_node->weight = this_node->weight;

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -415,9 +415,8 @@ services_alert_create(const char *id, const char *exec, int timeout,
 {
     svc_action_t *action = services_action_create_generic(exec, NULL);
 
-    pcmk__str_update(&(action->id), id);
-    pcmk__str_update(&(action->standard), PCMK_RESOURCE_CLASS_ALERT);
-
+    action->id = pcmk__str_copy(id);
+    action->standard = pcmk__str_copy(PCMK_RESOURCE_CLASS_ALERT);
     action->timeout = timeout;
     action->params = params;
     action->sequence = sequence;

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -357,7 +357,7 @@ services_action_create_generic(const char *exec, const char *args[])
 {
     svc_action_t *op = new_action();
 
-    CRM_ASSERT(op != NULL);
+    pcmk__mem_assert(op);
 
     op->opaque->exec = strdup(exec);
     op->opaque->args[0] = strdup(exec);
@@ -415,9 +415,8 @@ services_alert_create(const char *id, const char *exec, int timeout,
 {
     svc_action_t *action = services_action_create_generic(exec, NULL);
 
-    action->id = strdup(id);
-    action->standard = strdup(PCMK_RESOURCE_CLASS_ALERT);
-    CRM_ASSERT((action->id != NULL) && (action->standard != NULL));
+    pcmk__str_update(&(action->id), id);
+    pcmk__str_update(&(action->standard), PCMK_RESOURCE_CLASS_ALERT);
 
     action->timeout = timeout;
     action->params = params;

--- a/lib/services/services_nagios.c
+++ b/lib/services/services_nagios.c
@@ -203,7 +203,7 @@ services__get_nagios_metadata(const char *type, char **output)
 
     } else {
         crm_trace("Reading %d bytes from file", length);
-        *output = calloc(1, (length + 1));
+        *output = pcmk__assert_alloc(1, (length + 1));
         read_len = fread(*output, 1, length, file_strm);
         if (read_len != length) {
             crm_err("Calculated and read bytes differ: %d vs. %d",

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -205,7 +205,7 @@ curses_begin_list(pcmk__output_t *out, const char *singular_noun, const char *pl
         va_end(ap);
     }
 
-    new_list = calloc(1, sizeof(curses_list_data_t));
+    new_list = pcmk__assert_alloc(1, sizeof(curses_list_data_t));
     new_list->len = 0;
     pcmk__str_update(&new_list->singular_noun, singular_noun);
     pcmk__str_update(&new_list->plural_noun, plural_noun);
@@ -314,7 +314,7 @@ curses_prompt(const char *prompt, bool do_echo, char **dest)
             free(*dest);
         }
 
-        *dest = calloc(1, 1024);
+        *dest = pcmk__assert_alloc(1, 1024);
         /* On older systems, scanw is defined as taking a char * for its first argument,
          * while newer systems rightly want a const char *.  Accomodate both here due
          * to building with -Werror.

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -207,8 +207,8 @@ curses_begin_list(pcmk__output_t *out, const char *singular_noun, const char *pl
 
     new_list = pcmk__assert_alloc(1, sizeof(curses_list_data_t));
     new_list->len = 0;
-    pcmk__str_update(&new_list->singular_noun, singular_noun);
-    pcmk__str_update(&new_list->plural_noun, plural_noun);
+    new_list->singular_noun = pcmk__str_copy(singular_noun);
+    new_list->plural_noun = pcmk__str_copy(plural_noun);
 
     g_queue_push_tail(priv->parent_q, new_list);
 }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1519,8 +1519,8 @@ main(int argc, char **argv)
     if ((options.remainder != NULL) && (options.override_params != NULL)) {
         // Commands that use positional arguments will create override_params
         for (gchar **s = options.remainder; *s; s++) {
-            char *name = calloc(1, strlen(*s));
-            char *value = calloc(1, strlen(*s));
+            char *name = pcmk__assert_alloc(1, strlen(*s));
+            char *value = pcmk__assert_alloc(1, strlen(*s));
             int rc = sscanf(*s, "%[^=]=%s", name, value);
 
             if (rc == 2) {
@@ -1552,7 +1552,7 @@ main(int argc, char **argv)
         /* Add 1 for the strv[0] string below, and add another 1 for the NULL
          * at the end of the array so g_strjoinv knows when to stop.
          */
-        strv = calloc(len+2, sizeof(char *));
+        strv = pcmk__assert_alloc(len+2, sizeof(char *));
         strv[0] = strdup("non-option ARGV-elements:\n");
 
         for (gchar **s = options.remainder; *s; s++) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -27,7 +27,7 @@ build_node_info_list(const pcmk_resource_t *rsc)
              iter2 != NULL; iter2 = iter2->next) {
 
             const pcmk_node_t *node = (const pcmk_node_t *) iter2->data;
-            node_info_t *ni = calloc(1, sizeof(node_info_t));
+            node_info_t *ni = pcmk__assert_alloc(1, sizeof(node_info_t));
 
             ni->node_name = node->details->uname;
             ni->promoted = pcmk_is_set(rsc->flags, pcmk_rsc_promotable) &&
@@ -62,7 +62,8 @@ cli_resource_search(pcmk_resource_t *rsc, const char *requested_name,
     } else if (rsc->running_on != NULL) {
         for (GList *iter = rsc->running_on; iter != NULL; iter = iter->next) {
             pcmk_node_t *node = (pcmk_node_t *) iter->data;
-            node_info_t *ni = calloc(1, sizeof(node_info_t));
+            node_info_t *ni = pcmk__assert_alloc(1, sizeof(node_info_t));
+
             ni->node_name = node->details->uname;
             ni->promoted = (rsc->fns->state(rsc, TRUE) == pcmk_role_promoted);
 


### PR DESCRIPTION
This is tedious. I want to run cts-lab but it throws an exception for no output lines when we query for the syslog service. If I try to hack that out (it looks like nothing uses the "syslogd" environment variable), then it doesn't actually running any tests; it just hangs after starting the cluster. We can discuss further in Slack.

There are some lines that are changed around a couple of times (e.g., `strdup()` -> `pcmk__str_update()` -> `pcmk__str_copy()`). Sorry. I didn't know what all I'd be adding when I started, and I definitely don't want to go undo things now just to make the commits slightly smaller.