### PR TITLE
Fix: cts-lab: Parse log watch timestamps on exerciser side

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,22 +57,23 @@ Also:
 | RPM packages via "make rpm"                     | 4.11 or later  | rpm                     | rpm                     | (n/a)                   |
 | unit tests                                      | 1.1.0 or later | libcmocka-devel         | libcmocka-devel         | libcmocka-dev           |
 
-## Optional testing dependencies
-* procps and psmisc (if running cts-exec, cts-fencing, or CTS)
-* valgrind (if running CTS valgrind tests)
-* python3-systemd (if using CTS on cluster nodes running systemd)
+## Optional Testing Dependencies
+* procps and psmisc (if running cts-exec, cts-fencing, or CTS lab)
+* valgrind (if running valgrind tests in cts-cli, cts-scheduler, or CTS lab)
+* python3-dateutil and python3-systemd (if running CTS lab on cluster nodes
+  running systemd)
 * nmap (if not specifying an IP address base)
-* oprofile (if running CTS profiling tests)
-* dlm (to log DLM debugging info after CTS tests)
+* oprofile (if running CTS lab profiling tests)
+* dlm (to log DLM debugging info after CTS lab tests)
 * xmllint (to validate tool output in cts-cli)
 
-## Simple install
+## Simple Install
 
     $ make && sudo make install
 
 If GNU make is not your default make, use "gmake" instead.
 
-## Detailed install
+## Detailed Install
 
 First, browse the build options that are available:
 

--- a/python/pacemaker/_cts/watcher.py
+++ b/python/pacemaker/_cts/watcher.py
@@ -65,6 +65,9 @@ class SearchObj:
         else:
             self.host = "localhost"
 
+        async_task = self.harvest_async()
+        async_task.join()
+
     def __str__(self):
         if self.host:
             return "%s:%s" % (self.host, self.filename)
@@ -80,11 +83,6 @@ class SearchObj:
         """Log a debug message."""
         message = "lw: %s: %s" % (self, args)
         self.logger.debug(message)
-
-    def harvest(self, delegate=None):
-        """Collect lines from a log, optionally calling delegate when complete."""
-        async_task = self.harvest_async(delegate)
-        async_task.join()
 
     def harvest_async(self, delegate=None):
         """
@@ -121,8 +119,6 @@ class FileObj(SearchObj):
         """
         SearchObj.__init__(self, filename, host, name)
         self._delegate = None
-
-        self.harvest()
 
     def async_complete(self, pid, returncode, out, err):
         """
@@ -210,8 +206,6 @@ class JournalObj(SearchObj):
         """
         SearchObj.__init__(self, name, host, name)
         self._delegate = None
-
-        self.harvest()
 
     def async_complete(self, pid, returncode, out, err):
         """

--- a/python/pacemaker/_cts/watcher.py
+++ b/python/pacemaker/_cts/watcher.py
@@ -65,6 +65,8 @@ class SearchObj:
         else:
             self.host = "localhost"
 
+        self._delegate = None
+
         async_task = self.harvest_async()
         async_task.join()
 
@@ -118,7 +120,6 @@ class FileObj(SearchObj):
         name     -- A unique name to use when logging about this watch
         """
         SearchObj.__init__(self, filename, host, name)
-        self._delegate = None
 
     def async_complete(self, pid, returncode, out, err):
         """
@@ -205,7 +206,6 @@ class JournalObj(SearchObj):
         name     -- A unique name to use when logging about this watch
         """
         SearchObj.__init__(self, name, host, name)
-        self._delegate = None
 
     def async_complete(self, pid, returncode, out, err):
         """


### PR DESCRIPTION
At least as of systemd v254, journalctl has the following bug: if `--after-cursor`, `--until`, and `--lines` options are all three used, the `--until` option is ignored.

This results in an infinite loop in `LogWatcher.look()`. When we reach the timeout, we call `set_end()` on the `JournalObj` to set a limit timestamp, so that we can get all remaining logs that were created until the timeout expired. Then we run the following repeatedly until we reach the limit (as determined by the output containing only a cursor):
```
journalctl --after-cursor=X --until=self.limit --lines=200
```

Due to the bug, the command above will continue to yield log messages indefinitely. As long as we keep finding log messages and adding them to our line cache, we'll keep looping.

Here we work around the issue by moving the limit timestamp handling from `journalctl`'s `--until` option into the
`JournalObj.async_complete()` method. It's not as clean as letting `journalctl` handle it, but that's not an option anymore.

Systemd bug report:
* https://github.com/systemd/systemd/issues/31776