### PR TITLE
Fix: libcrmcommon: Escape newlines and tabs in XML attribute values

### DIFF
--- a/doc/sphinx/Pacemaker_Explained/nodes.rst
+++ b/doc/sphinx/Pacemaker_Explained/nodes.rst
@@ -105,6 +105,44 @@ To read back the value that was just set:
 The ``--type nodes`` indicates that this is a permanent node attribute;
 ``--type status`` would indicate a transient node attribute.
 
+.. warning::
+
+   Attribute values with newline or tab characters are currently displayed with
+   newlines as ``"\n"`` and tabs as ``"\t"``, when ``crm_attribute`` or
+   ``attrd_updater`` query commands use ``--output-as=text`` or leave
+   ``--output-as`` unspecified:
+
+   .. code-block:: none
+
+      # crm_attribute -N node1 -n test_attr -v "$(echo -e "a\nb\tc")" -t status
+      # crm_attribute -N node1 -n test_attr --query -t status
+      scope=status  name=test_attr value=a\nb\tc
+
+   This format is deprecated. In a future release, the values will be displayed
+   with literal whitespace characters:
+
+   .. code-block:: none
+
+      # crm_attribute -N node1 -n test_attr --query -t status
+      scope=status  name=test_attr value=a
+      b	c
+
+   Users should either avoid attribute values with newlines and tabs, or ensure
+   that they can handle both formats.
+
+   However, it's best to use ``--output-as=xml`` when parsing attribute values
+   from output. Newlines, tabs, and special characters are replaced with XML
+   character references that a conforming XML processor can recognize and
+   convert to literals:
+
+   .. code-block:: none
+
+      # crm_attribute -N node1 -n test_attr --query -t status --output-as=xml
+      <pacemaker-result api-version="2.35" request="crm_attribute -N laptop -n test_attr --query -t status --output-as=xml">
+        <attribute name="test_attr" value="a&#10;b&#9;c" scope="status"/>
+        <status code="0" message="OK"/>
+      </pacemaker-result>
+
 
 .. _special_node_attributes:
 

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -281,6 +281,23 @@ enum pcmk__xml_escape_type {
      *   character references.
      */
     pcmk__xml_escape_attr,
+
+    /* @COMPAT Drop escaping of at least '\n' and '\t' for
+     * pcmk__xml_escape_attr_pretty when openstack-info, openstack-floating-ip,
+     * and openstack-virtual-ip resource agents no longer depend on it.
+     *
+     * At time of writing, openstack-info may set a multiline value for the
+     * openstack_ports node attribute. The other two agents query the value and
+     * require it to be on one line with no spaces.
+     */
+    /*!
+     * For attribute values displayed in text output delimited by double quotes.
+     * * Escape \c '\n' as \c "\\n"
+     * * Escape \c '\r' as \c "\\r"
+     * * Escape \c '\t' as \c "\\t"
+     * * Escape \c '"' as \c "\\""
+     */
+    pcmk__xml_escape_attr_pretty,
 };
 
 bool pcmk__xml_needs_escape(const char *text, enum pcmk__xml_escape_type type);

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -221,8 +221,70 @@ void pcmk__xe_remove_matching_attrs(xmlNode *element,
 
 GString *pcmk__element_xpath(const xmlNode *xml);
 
-bool pcmk__xml_needs_escape(const char *text, bool escape_quote);
-char *pcmk__xml_escape(const char *text, bool escape_quote);
+/*!
+ * \internal
+ * \enum pcmk__xml_escape_type
+ * \brief Indicators of which XML characters to escape
+ *
+ * XML allows the escaping of special characters by replacing them with entity
+ * references (for example, <tt>"&quot;"</tt>) or character references (for
+ * example, <tt>"&#13;"</tt>).
+ *
+ * The special characters <tt>'&'</tt> (except as the beginning of an entity
+ * reference) and <tt>'<'</tt> are not allowed in their literal forms in XML
+ * character data. Character data is non-markup text (for example, the content
+ * of a text node). <tt>'>'</tt> is allowed under most circumstances; we escape
+ * it for safety and symmetry.
+ *
+ * For more details, see the "Character Data and Markup" section of the XML
+ * spec, currently section 2.4:
+ * https://www.w3.org/TR/xml/#dt-markup
+ *
+ * Attribute values are handled specially.
+ * * If an attribute value is delimited by single quotes, then single quotes
+ *   must be escaped within the value.
+ * * Similarly, if an attribute value is delimited by double quotes, then double
+ *   quotes must be escaped within the value.
+ * * A conformant XML processor replaces a literal whitespace character (tab,
+ *   newline, carriage return, space) in an attribute value with a space
+ *   (\c '#x20') character. However, a reference to a whitespace character (for
+ *   example, \c "&#x0A;" for \c '\n') does not get replaced.
+ *   * For more details, see the "Attribute-Value Normalization" section of the
+ *     XML spec, currently section 3.3.3. Note that the default attribute type
+ *     is CDATA; we don't deal with NMTOKENS, etc.:
+ *     https://www.w3.org/TR/xml/#AVNormalize
+ *
+ * Pacemaker always delimits attribute values with double quotes, so there's no
+ * need to escape single quotes.
+ *
+ * Newlines and tabs should be escaped in attribute values when XML is
+ * serialized to text, so that future parsing preserves them rather than
+ * normalizing them to spaces.
+ *
+ * We always escape carriage returns, so that they're not converted to spaces
+ * during attribute-value normalization and because displaying them as literals
+ * is messy.
+ */
+enum pcmk__xml_escape_type {
+    /*!
+     * For text nodes.
+     * * Escape \c '<', \c '>', and \c '&' using entity references.
+     * * Do not escape \c '\n' and \c '\t'.
+     * * Escape other non-printing characters using character references.
+     */
+    pcmk__xml_escape_text,
+
+    /*!
+     * For attribute values.
+     * * Escape \c '<', \c '>', \c '&', and \c '"' using entity references.
+     * * Escape \c '\n', \c '\t', and other non-printing characters using
+     *   character references.
+     */
+    pcmk__xml_escape_attr,
+};
+
+bool pcmk__xml_needs_escape(const char *text, enum pcmk__xml_escape_type type);
+char *pcmk__xml_escape(const char *text, enum pcmk__xml_escape_type type);
 
 /*!
  * \internal

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -50,6 +50,13 @@ typedef struct xml_doc_private_s {
         GList *deleted_objs; // List of pcmk__deleted_xml_t
 } xml_doc_private_t;
 
+// XML entity references
+
+#define PCMK__XML_ENTITY_AMP    "&amp;"
+#define PCMK__XML_ENTITY_GT     "&gt;"
+#define PCMK__XML_ENTITY_LT     "&lt;"
+#define PCMK__XML_ENTITY_QUOT   "&quot;"
+
 //! libxml2 supports only XML version 1.0, at least as of libxml2-2.12.5
 #define PCMK__XML_VERSION ((pcmkXmlStr) "1.0")
 

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -12,6 +12,8 @@
 #include <crm/common/unittest_internal.h>
 #include <crm/common/xml_internal.h>
 
+#include "crmcommon_private.h"
+
 static void
 assert_escape(const char *str, const char *reference,
               enum pcmk__xml_escape_type type)
@@ -67,7 +69,8 @@ static void
 escape_left_angle(void **state)
 {
     const char *l_angle = "<abc<def<";
-    const char *l_angle_esc = "&lt;abc&lt;def&lt;";
+    const char *l_angle_esc = PCMK__XML_ENTITY_LT "abc"
+                              PCMK__XML_ENTITY_LT "def" PCMK__XML_ENTITY_LT;
 
     assert_escape(l_angle, l_angle_esc, pcmk__xml_escape_text);
     assert_escape(l_angle, l_angle_esc, pcmk__xml_escape_attr);
@@ -78,7 +81,8 @@ static void
 escape_right_angle(void **state)
 {
     const char *r_angle = ">abc>def>";
-    const char *r_angle_esc = "&gt;abc&gt;def&gt;";
+    const char *r_angle_esc = PCMK__XML_ENTITY_GT "abc"
+                              PCMK__XML_ENTITY_GT "def" PCMK__XML_ENTITY_GT;
 
     assert_escape(r_angle, r_angle_esc, pcmk__xml_escape_text);
     assert_escape(r_angle, r_angle_esc, pcmk__xml_escape_attr);
@@ -89,7 +93,8 @@ static void
 escape_ampersand(void **state)
 {
     const char *ampersand = "&abc&def&";
-    const char *ampersand_esc = "&amp;abc&amp;def&amp;";
+    const char *ampersand_esc = PCMK__XML_ENTITY_AMP "abc"
+                                PCMK__XML_ENTITY_AMP "def" PCMK__XML_ENTITY_AMP;
 
     assert_escape(ampersand, ampersand_esc, pcmk__xml_escape_text);
     assert_escape(ampersand, ampersand_esc, pcmk__xml_escape_attr);
@@ -100,7 +105,9 @@ static void
 escape_double_quote(void **state)
 {
     const char *double_quote = "\"abc\"def\"";
-    const char *double_quote_esc_ref = "&quot;abc&quot;def&quot;";
+    const char *double_quote_esc_ref = PCMK__XML_ENTITY_QUOT "abc"
+                                       PCMK__XML_ENTITY_QUOT "def"
+                                       PCMK__XML_ENTITY_QUOT;
     const char *double_quote_esc_backslash = "\\\"abc\\\"def\\\"";
 
     assert_escape(double_quote, double_quote, pcmk__xml_escape_text);
@@ -164,11 +171,15 @@ escape_utf8(void **state)
      */
     const char *chinese = "仅高级使用";
     const char *two_byte = "abc""\xCF\xA6""d<ef";
-    const char *two_byte_esc = "abc""\xCF\xA6""d&lt;ef";
+    const char *two_byte_esc = "abc""\xCF\xA6""d" PCMK__XML_ENTITY_LT "ef";
+
     const char *three_byte = "abc""\xEF\x98\x98""d<ef";
-    const char *three_byte_esc = "abc""\xEF\x98\x98""d&lt;ef";
+    const char *three_byte_esc = "abc""\xEF\x98\x98""d"
+                                 PCMK__XML_ENTITY_LT "ef";
+
     const char *four_byte = "abc""\xF0\x94\x81\x90""d<ef";
-    const char *four_byte_esc = "abc""\xF0\x94\x81\x90""d&lt;ef";
+    const char *four_byte_esc = "abc""\xF0\x94\x81\x90""d"
+                                PCMK__XML_ENTITY_LT "ef";
 
     assert_escape(chinese, chinese, pcmk__xml_escape_text);
     assert_escape(chinese, chinese, pcmk__xml_escape_attr);

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -15,7 +15,7 @@
 static void
 null_empty(void **state)
 {
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(NULL, false);
     assert_null(str);
@@ -25,11 +25,11 @@ null_empty(void **state)
 
     str = pcmk__xml_escape("", false);
     assert_string_equal(str, "");
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape("", true);
     assert_string_equal(str, "");
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -40,15 +40,15 @@ escape_unchanged(void **state)
                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                             "0123456789"
                             "`~!@#$%^*()-_=+/|\\[]{}?.,'";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(unchanged, false);
     assert_string_equal(str, unchanged);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(unchanged, true);
     assert_string_equal(str, unchanged);
-    free(str);
+    g_free(str);
 }
 
 // Ensure special characters get escaped at start, middle, and end
@@ -58,15 +58,15 @@ escape_left_angle(void **state)
 {
     const char *l_angle = "<abc<def<";
     const char *l_angle_esc = "&lt;abc&lt;def&lt;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(l_angle, false);
     assert_string_equal(str, l_angle_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(l_angle, true);
     assert_string_equal(str, l_angle_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -74,15 +74,15 @@ escape_right_angle(void **state)
 {
     const char *r_angle = ">abc>def>";
     const char *r_angle_esc = "&gt;abc&gt;def&gt;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(r_angle, false);
     assert_string_equal(str, r_angle_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(r_angle, true);
     assert_string_equal(str, r_angle_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -90,15 +90,15 @@ escape_ampersand(void **state)
 {
     const char *ampersand = "&abc&def&";
     const char *ampersand_esc = "&amp;abc&amp;def&amp;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(ampersand, false);
     assert_string_equal(str, ampersand_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(ampersand, true);
     assert_string_equal(str, ampersand_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -106,15 +106,15 @@ escape_double_quote(void **state)
 {
     const char *double_quote = "\"abc\"def\"";
     const char *double_quote_esc = "&quot;abc&quot;def&quot;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(double_quote, false);
     assert_string_equal(str, double_quote);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(double_quote, true);
     assert_string_equal(str, double_quote_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -122,15 +122,15 @@ escape_newline(void **state)
 {
     const char *newline = "\nabc\ndef\n";
     const char *newline_esc = "&#x0A;abc&#x0A;def&#x0A;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(newline, false);
     assert_string_equal(str, newline);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(newline, true);
     assert_string_equal(str, newline_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -138,15 +138,15 @@ escape_tab(void **state)
 {
     const char *tab = "\tabc\tdef\t";
     const char *tab_esc = "&#x09;abc&#x09;def&#x09;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(tab, false);
     assert_string_equal(str, tab);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(tab, true);
     assert_string_equal(str, tab_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -154,15 +154,15 @@ escape_carriage_return(void **state)
 {
     const char *cr = "\rabc\rdef\r";
     const char *cr_esc = "&#x0D;abc&#x0D;def&#x0D;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(cr, false);
     assert_string_equal(str, cr_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(cr, true);
     assert_string_equal(str, cr_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -170,15 +170,15 @@ escape_nonprinting(void **state)
 {
     const char *nonprinting = "\a\x7F\x1B";
     const char *nonprinting_esc = "&#x07;&#x7F;&#x1B;";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(nonprinting, false);
     assert_string_equal(str, nonprinting_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(nonprinting, true);
     assert_string_equal(str, nonprinting_esc);
-    free(str);
+    g_free(str);
 }
 
 static void
@@ -194,39 +194,39 @@ escape_utf8(void **state)
     const char *three_byte_esc = "abc""\xEF\x98\x98""d&lt;ef";
     const char *four_byte = "abc""\xF0\x94\x81\x90""d<ef";
     const char *four_byte_esc = "abc""\xF0\x94\x81\x90""d&lt;ef";
-    char *str = NULL;
+    gchar *str = NULL;
 
     str = pcmk__xml_escape(chinese, false);
     assert_string_equal(str, chinese);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(chinese, true);
     assert_string_equal(str, chinese);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(two_byte, false);
     assert_string_equal(str, two_byte_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(two_byte, true);
     assert_string_equal(str, two_byte_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(three_byte, false);
     assert_string_equal(str, three_byte_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(three_byte, true);
     assert_string_equal(str, three_byte_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(four_byte, false);
     assert_string_equal(str, four_byte_esc);
-    free(str);
+    g_free(str);
 
     str = pcmk__xml_escape(four_byte, true);
     assert_string_equal(str, four_byte_esc);
-    free(str);
+    g_free(str);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -120,8 +120,8 @@ escape_double_quote(void **state)
 static void
 escape_nonprinting(void **state)
 {
-    const char *nonprinting = "\a\r\x7f\x1b";
-    const char *nonprinting_esc = "&#x07;&#x0d;&#x7f;&#x1b;";
+    const char *nonprinting = "\a\r\x7F\x1B";
+    const char *nonprinting_esc = "&#x07;&#x0D;&#x7F;&#x1B;";
     char *str = NULL;
 
     str = pcmk__xml_escape(nonprinting, false);
@@ -140,12 +140,12 @@ escape_utf8(void **state)
      * and should not be escaped.
      */
     const char *chinese = "仅高级使用";
-    const char *two_byte = "abc""\xcf\xa6""d<ef";
-    const char *two_byte_esc = "abc""\xcf\xa6""d&lt;ef";
-    const char *three_byte = "abc""\xef\x98\x98""d<ef";
-    const char *three_byte_esc = "abc""\xef\x98\x98""d&lt;ef";
-    const char *four_byte = "abc""\xf0\x94\x81\x90""d<ef";
-    const char *four_byte_esc = "abc""\xf0\x94\x81\x90""d&lt;ef";
+    const char *two_byte = "abc""\xCF\xA6""d<ef";
+    const char *two_byte_esc = "abc""\xCF\xA6""d&lt;ef";
+    const char *three_byte = "abc""\xEF\x98\x98""d<ef";
+    const char *three_byte_esc = "abc""\xEF\x98\x98""d&lt;ef";
+    const char *four_byte = "abc""\xF0\x94\x81\x90""d<ef";
+    const char *four_byte_esc = "abc""\xF0\x94\x81\x90""d&lt;ef";
     char *str = NULL;
 
     str = pcmk__xml_escape(chinese, false);

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -39,7 +39,7 @@ escape_unchanged(void **state)
     const char *unchanged = "abcdefghijklmnopqrstuvwxyz"
                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                             "0123456789"
-                            "\n\t`~!@#$%^*()-_=+/|\\[]{}?.,'";
+                            "`~!@#$%^*()-_=+/|\\[]{}?.,'";
     char *str = NULL;
 
     str = pcmk__xml_escape(unchanged, false);
@@ -118,10 +118,58 @@ escape_double_quote(void **state)
 }
 
 static void
+escape_newline(void **state)
+{
+    const char *newline = "\nabc\ndef\n";
+    const char *newline_esc = "&#x0A;abc&#x0A;def&#x0A;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(newline, false);
+    assert_string_equal(str, newline);
+    free(str);
+
+    str = pcmk__xml_escape(newline, true);
+    assert_string_equal(str, newline_esc);
+    free(str);
+}
+
+static void
+escape_tab(void **state)
+{
+    const char *tab = "\tabc\tdef\t";
+    const char *tab_esc = "&#x09;abc&#x09;def&#x09;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(tab, false);
+    assert_string_equal(str, tab);
+    free(str);
+
+    str = pcmk__xml_escape(tab, true);
+    assert_string_equal(str, tab_esc);
+    free(str);
+}
+
+static void
+escape_carriage_return(void **state)
+{
+    const char *cr = "\rabc\rdef\r";
+    const char *cr_esc = "&#x0D;abc&#x0D;def&#x0D;";
+    char *str = NULL;
+
+    str = pcmk__xml_escape(cr, false);
+    assert_string_equal(str, cr_esc);
+    free(str);
+
+    str = pcmk__xml_escape(cr, true);
+    assert_string_equal(str, cr_esc);
+    free(str);
+}
+
+static void
 escape_nonprinting(void **state)
 {
-    const char *nonprinting = "\a\r\x7F\x1B";
-    const char *nonprinting_esc = "&#x07;&#x0D;&#x7F;&#x1B;";
+    const char *nonprinting = "\a\x7F\x1B";
+    const char *nonprinting_esc = "&#x07;&#x7F;&#x1B;";
     char *str = NULL;
 
     str = pcmk__xml_escape(nonprinting, false);
@@ -188,5 +236,8 @@ PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(escape_right_angle),
                 cmocka_unit_test(escape_ampersand),
                 cmocka_unit_test(escape_double_quote),
+                cmocka_unit_test(escape_newline),
+                cmocka_unit_test(escape_tab),
+                cmocka_unit_test(escape_carriage_return),
                 cmocka_unit_test(escape_nonprinting),
                 cmocka_unit_test(escape_utf8));

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -17,19 +17,36 @@ null_empty(void **state)
 {
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(NULL, false);
+    str = pcmk__xml_escape(NULL, pcmk__xml_escape_text);
     assert_null(str);
 
-    str = pcmk__xml_escape(NULL, true);
+    str = pcmk__xml_escape(NULL, pcmk__xml_escape_attr);
     assert_null(str);
 
-    str = pcmk__xml_escape("", false);
+    str = pcmk__xml_escape("", pcmk__xml_escape_text);
     assert_string_equal(str, "");
     g_free(str);
 
-    str = pcmk__xml_escape("", true);
+    str = pcmk__xml_escape("", pcmk__xml_escape_attr);
     assert_string_equal(str, "");
     g_free(str);
+}
+
+static void
+invalid_type(void **state)
+{
+    const enum pcmk__xml_escape_type type = (enum pcmk__xml_escape_type) -1;
+    gchar *str = NULL;
+
+    // Easier to ignore invalid type for NULL or empty string
+    assert_null(pcmk__xml_escape(NULL, type));
+
+    str = pcmk__xml_escape("", type);
+    assert_string_equal(str, "");
+    g_free(str);
+
+    // Otherwise, assert if we somehow passed an invalid type
+    pcmk__assert_asserts(pcmk__xml_escape("he<>llo", type));
 }
 
 static void
@@ -42,11 +59,11 @@ escape_unchanged(void **state)
                             "`~!@#$%^*()-_=+/|\\[]{}?.,'";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(unchanged, false);
+    str = pcmk__xml_escape(unchanged, pcmk__xml_escape_text);
     assert_string_equal(str, unchanged);
     g_free(str);
 
-    str = pcmk__xml_escape(unchanged, true);
+    str = pcmk__xml_escape(unchanged, pcmk__xml_escape_attr);
     assert_string_equal(str, unchanged);
     g_free(str);
 }
@@ -60,11 +77,11 @@ escape_left_angle(void **state)
     const char *l_angle_esc = "&lt;abc&lt;def&lt;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(l_angle, false);
+    str = pcmk__xml_escape(l_angle, pcmk__xml_escape_text);
     assert_string_equal(str, l_angle_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(l_angle, true);
+    str = pcmk__xml_escape(l_angle, pcmk__xml_escape_attr);
     assert_string_equal(str, l_angle_esc);
     g_free(str);
 }
@@ -76,11 +93,11 @@ escape_right_angle(void **state)
     const char *r_angle_esc = "&gt;abc&gt;def&gt;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(r_angle, false);
+    str = pcmk__xml_escape(r_angle, pcmk__xml_escape_text);
     assert_string_equal(str, r_angle_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(r_angle, true);
+    str = pcmk__xml_escape(r_angle, pcmk__xml_escape_attr);
     assert_string_equal(str, r_angle_esc);
     g_free(str);
 }
@@ -92,11 +109,11 @@ escape_ampersand(void **state)
     const char *ampersand_esc = "&amp;abc&amp;def&amp;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(ampersand, false);
+    str = pcmk__xml_escape(ampersand, pcmk__xml_escape_text);
     assert_string_equal(str, ampersand_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(ampersand, true);
+    str = pcmk__xml_escape(ampersand, pcmk__xml_escape_attr);
     assert_string_equal(str, ampersand_esc);
     g_free(str);
 }
@@ -108,11 +125,11 @@ escape_double_quote(void **state)
     const char *double_quote_esc = "&quot;abc&quot;def&quot;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(double_quote, false);
+    str = pcmk__xml_escape(double_quote, pcmk__xml_escape_text);
     assert_string_equal(str, double_quote);
     g_free(str);
 
-    str = pcmk__xml_escape(double_quote, true);
+    str = pcmk__xml_escape(double_quote, pcmk__xml_escape_attr);
     assert_string_equal(str, double_quote_esc);
     g_free(str);
 }
@@ -124,11 +141,11 @@ escape_newline(void **state)
     const char *newline_esc = "&#x0A;abc&#x0A;def&#x0A;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(newline, false);
+    str = pcmk__xml_escape(newline, pcmk__xml_escape_text);
     assert_string_equal(str, newline);
     g_free(str);
 
-    str = pcmk__xml_escape(newline, true);
+    str = pcmk__xml_escape(newline, pcmk__xml_escape_attr);
     assert_string_equal(str, newline_esc);
     g_free(str);
 }
@@ -140,11 +157,11 @@ escape_tab(void **state)
     const char *tab_esc = "&#x09;abc&#x09;def&#x09;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(tab, false);
+    str = pcmk__xml_escape(tab, pcmk__xml_escape_text);
     assert_string_equal(str, tab);
     g_free(str);
 
-    str = pcmk__xml_escape(tab, true);
+    str = pcmk__xml_escape(tab, pcmk__xml_escape_attr);
     assert_string_equal(str, tab_esc);
     g_free(str);
 }
@@ -156,11 +173,11 @@ escape_carriage_return(void **state)
     const char *cr_esc = "&#x0D;abc&#x0D;def&#x0D;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(cr, false);
+    str = pcmk__xml_escape(cr, pcmk__xml_escape_text);
     assert_string_equal(str, cr_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(cr, true);
+    str = pcmk__xml_escape(cr, pcmk__xml_escape_attr);
     assert_string_equal(str, cr_esc);
     g_free(str);
 }
@@ -172,11 +189,11 @@ escape_nonprinting(void **state)
     const char *nonprinting_esc = "&#x07;&#x7F;&#x1B;";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(nonprinting, false);
+    str = pcmk__xml_escape(nonprinting, pcmk__xml_escape_text);
     assert_string_equal(str, nonprinting_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(nonprinting, true);
+    str = pcmk__xml_escape(nonprinting, pcmk__xml_escape_attr);
     assert_string_equal(str, nonprinting_esc);
     g_free(str);
 }
@@ -196,41 +213,42 @@ escape_utf8(void **state)
     const char *four_byte_esc = "abc""\xF0\x94\x81\x90""d&lt;ef";
     gchar *str = NULL;
 
-    str = pcmk__xml_escape(chinese, false);
+    str = pcmk__xml_escape(chinese, pcmk__xml_escape_text);
     assert_string_equal(str, chinese);
     g_free(str);
 
-    str = pcmk__xml_escape(chinese, true);
+    str = pcmk__xml_escape(chinese, pcmk__xml_escape_attr);
     assert_string_equal(str, chinese);
     g_free(str);
 
-    str = pcmk__xml_escape(two_byte, false);
+    str = pcmk__xml_escape(two_byte, pcmk__xml_escape_text);
     assert_string_equal(str, two_byte_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(two_byte, true);
+    str = pcmk__xml_escape(two_byte, pcmk__xml_escape_attr);
     assert_string_equal(str, two_byte_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(three_byte, false);
+    str = pcmk__xml_escape(three_byte, pcmk__xml_escape_text);
     assert_string_equal(str, three_byte_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(three_byte, true);
+    str = pcmk__xml_escape(three_byte, pcmk__xml_escape_attr);
     assert_string_equal(str, three_byte_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(four_byte, false);
+    str = pcmk__xml_escape(four_byte, pcmk__xml_escape_text);
     assert_string_equal(str, four_byte_esc);
     g_free(str);
 
-    str = pcmk__xml_escape(four_byte, true);
+    str = pcmk__xml_escape(four_byte, pcmk__xml_escape_attr);
     assert_string_equal(str, four_byte_esc);
     g_free(str);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(null_empty),
+                cmocka_unit_test(invalid_type),
                 cmocka_unit_test(escape_unchanged),
                 cmocka_unit_test(escape_left_angle),
                 cmocka_unit_test(escape_right_angle),

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -13,37 +13,33 @@
 #include <crm/common/xml_internal.h>
 
 static void
+assert_escape(const char *str, const char *reference,
+              enum pcmk__xml_escape_type type)
+{
+    gchar *buf = pcmk__xml_escape(str, type);
+
+    assert_string_equal(buf, reference);
+    g_free(buf);
+}
+
+static void
 null_empty(void **state)
 {
-    gchar *str = NULL;
+    assert_null(pcmk__xml_escape(NULL, pcmk__xml_escape_text));
+    assert_null(pcmk__xml_escape(NULL, pcmk__xml_escape_attr));
 
-    str = pcmk__xml_escape(NULL, pcmk__xml_escape_text);
-    assert_null(str);
-
-    str = pcmk__xml_escape(NULL, pcmk__xml_escape_attr);
-    assert_null(str);
-
-    str = pcmk__xml_escape("", pcmk__xml_escape_text);
-    assert_string_equal(str, "");
-    g_free(str);
-
-    str = pcmk__xml_escape("", pcmk__xml_escape_attr);
-    assert_string_equal(str, "");
-    g_free(str);
+    assert_escape("", "", pcmk__xml_escape_text);
+    assert_escape("", "", pcmk__xml_escape_attr);
 }
 
 static void
 invalid_type(void **state)
 {
     const enum pcmk__xml_escape_type type = (enum pcmk__xml_escape_type) -1;
-    gchar *str = NULL;
 
     // Easier to ignore invalid type for NULL or empty string
     assert_null(pcmk__xml_escape(NULL, type));
-
-    str = pcmk__xml_escape("", type);
-    assert_string_equal(str, "");
-    g_free(str);
+    assert_escape("", "", type);
 
     // Otherwise, assert if we somehow passed an invalid type
     pcmk__assert_asserts(pcmk__xml_escape("he<>llo", type));
@@ -57,15 +53,9 @@ escape_unchanged(void **state)
                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                             "0123456789"
                             "`~!@#$%^*()-_=+/|\\[]{}?.,'";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(unchanged, pcmk__xml_escape_text);
-    assert_string_equal(str, unchanged);
-    g_free(str);
-
-    str = pcmk__xml_escape(unchanged, pcmk__xml_escape_attr);
-    assert_string_equal(str, unchanged);
-    g_free(str);
+    assert_escape(unchanged, unchanged, pcmk__xml_escape_text);
+    assert_escape(unchanged, unchanged, pcmk__xml_escape_attr);
 }
 
 // Ensure special characters get escaped at start, middle, and end
@@ -75,15 +65,9 @@ escape_left_angle(void **state)
 {
     const char *l_angle = "<abc<def<";
     const char *l_angle_esc = "&lt;abc&lt;def&lt;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(l_angle, pcmk__xml_escape_text);
-    assert_string_equal(str, l_angle_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(l_angle, pcmk__xml_escape_attr);
-    assert_string_equal(str, l_angle_esc);
-    g_free(str);
+    assert_escape(l_angle, l_angle_esc, pcmk__xml_escape_text);
+    assert_escape(l_angle, l_angle_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -91,15 +75,9 @@ escape_right_angle(void **state)
 {
     const char *r_angle = ">abc>def>";
     const char *r_angle_esc = "&gt;abc&gt;def&gt;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(r_angle, pcmk__xml_escape_text);
-    assert_string_equal(str, r_angle_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(r_angle, pcmk__xml_escape_attr);
-    assert_string_equal(str, r_angle_esc);
-    g_free(str);
+    assert_escape(r_angle, r_angle_esc, pcmk__xml_escape_text);
+    assert_escape(r_angle, r_angle_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -107,15 +85,9 @@ escape_ampersand(void **state)
 {
     const char *ampersand = "&abc&def&";
     const char *ampersand_esc = "&amp;abc&amp;def&amp;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(ampersand, pcmk__xml_escape_text);
-    assert_string_equal(str, ampersand_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(ampersand, pcmk__xml_escape_attr);
-    assert_string_equal(str, ampersand_esc);
-    g_free(str);
+    assert_escape(ampersand, ampersand_esc, pcmk__xml_escape_text);
+    assert_escape(ampersand, ampersand_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -123,15 +95,9 @@ escape_double_quote(void **state)
 {
     const char *double_quote = "\"abc\"def\"";
     const char *double_quote_esc = "&quot;abc&quot;def&quot;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(double_quote, pcmk__xml_escape_text);
-    assert_string_equal(str, double_quote);
-    g_free(str);
-
-    str = pcmk__xml_escape(double_quote, pcmk__xml_escape_attr);
-    assert_string_equal(str, double_quote_esc);
-    g_free(str);
+    assert_escape(double_quote, double_quote, pcmk__xml_escape_text);
+    assert_escape(double_quote, double_quote_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -139,15 +105,9 @@ escape_newline(void **state)
 {
     const char *newline = "\nabc\ndef\n";
     const char *newline_esc = "&#x0A;abc&#x0A;def&#x0A;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(newline, pcmk__xml_escape_text);
-    assert_string_equal(str, newline);
-    g_free(str);
-
-    str = pcmk__xml_escape(newline, pcmk__xml_escape_attr);
-    assert_string_equal(str, newline_esc);
-    g_free(str);
+    assert_escape(newline, newline, pcmk__xml_escape_text);
+    assert_escape(newline, newline_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -155,15 +115,9 @@ escape_tab(void **state)
 {
     const char *tab = "\tabc\tdef\t";
     const char *tab_esc = "&#x09;abc&#x09;def&#x09;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(tab, pcmk__xml_escape_text);
-    assert_string_equal(str, tab);
-    g_free(str);
-
-    str = pcmk__xml_escape(tab, pcmk__xml_escape_attr);
-    assert_string_equal(str, tab_esc);
-    g_free(str);
+    assert_escape(tab, tab, pcmk__xml_escape_text);
+    assert_escape(tab, tab_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -171,15 +125,9 @@ escape_carriage_return(void **state)
 {
     const char *cr = "\rabc\rdef\r";
     const char *cr_esc = "&#x0D;abc&#x0D;def&#x0D;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(cr, pcmk__xml_escape_text);
-    assert_string_equal(str, cr_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(cr, pcmk__xml_escape_attr);
-    assert_string_equal(str, cr_esc);
-    g_free(str);
+    assert_escape(cr, cr_esc, pcmk__xml_escape_text);
+    assert_escape(cr, cr_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -187,15 +135,9 @@ escape_nonprinting(void **state)
 {
     const char *nonprinting = "\a\x7F\x1B";
     const char *nonprinting_esc = "&#x07;&#x7F;&#x1B;";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(nonprinting, pcmk__xml_escape_text);
-    assert_string_equal(str, nonprinting_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(nonprinting, pcmk__xml_escape_attr);
-    assert_string_equal(str, nonprinting_esc);
-    g_free(str);
+    assert_escape(nonprinting, nonprinting_esc, pcmk__xml_escape_text);
+    assert_escape(nonprinting, nonprinting_esc, pcmk__xml_escape_attr);
 }
 
 static void
@@ -211,39 +153,18 @@ escape_utf8(void **state)
     const char *three_byte_esc = "abc""\xEF\x98\x98""d&lt;ef";
     const char *four_byte = "abc""\xF0\x94\x81\x90""d<ef";
     const char *four_byte_esc = "abc""\xF0\x94\x81\x90""d&lt;ef";
-    gchar *str = NULL;
 
-    str = pcmk__xml_escape(chinese, pcmk__xml_escape_text);
-    assert_string_equal(str, chinese);
-    g_free(str);
+    assert_escape(chinese, chinese, pcmk__xml_escape_text);
+    assert_escape(chinese, chinese, pcmk__xml_escape_attr);
 
-    str = pcmk__xml_escape(chinese, pcmk__xml_escape_attr);
-    assert_string_equal(str, chinese);
-    g_free(str);
+    assert_escape(two_byte, two_byte_esc, pcmk__xml_escape_text);
+    assert_escape(two_byte, two_byte_esc, pcmk__xml_escape_attr);
 
-    str = pcmk__xml_escape(two_byte, pcmk__xml_escape_text);
-    assert_string_equal(str, two_byte_esc);
-    g_free(str);
+    assert_escape(three_byte, three_byte_esc, pcmk__xml_escape_text);
+    assert_escape(three_byte, three_byte_esc, pcmk__xml_escape_attr);
 
-    str = pcmk__xml_escape(two_byte, pcmk__xml_escape_attr);
-    assert_string_equal(str, two_byte_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(three_byte, pcmk__xml_escape_text);
-    assert_string_equal(str, three_byte_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(three_byte, pcmk__xml_escape_attr);
-    assert_string_equal(str, three_byte_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(four_byte, pcmk__xml_escape_text);
-    assert_string_equal(str, four_byte_esc);
-    g_free(str);
-
-    str = pcmk__xml_escape(four_byte, pcmk__xml_escape_attr);
-    assert_string_equal(str, four_byte_esc);
-    g_free(str);
+    assert_escape(four_byte, four_byte_esc, pcmk__xml_escape_text);
+    assert_escape(four_byte, four_byte_esc, pcmk__xml_escape_attr);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/lib/common/tests/xml/pcmk__xml_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_escape_test.c
@@ -27,9 +27,11 @@ null_empty(void **state)
 {
     assert_null(pcmk__xml_escape(NULL, pcmk__xml_escape_text));
     assert_null(pcmk__xml_escape(NULL, pcmk__xml_escape_attr));
+    assert_null(pcmk__xml_escape(NULL, pcmk__xml_escape_attr_pretty));
 
     assert_escape("", "", pcmk__xml_escape_text);
     assert_escape("", "", pcmk__xml_escape_attr);
+    assert_escape("", "", pcmk__xml_escape_attr_pretty);
 }
 
 static void
@@ -56,6 +58,7 @@ escape_unchanged(void **state)
 
     assert_escape(unchanged, unchanged, pcmk__xml_escape_text);
     assert_escape(unchanged, unchanged, pcmk__xml_escape_attr);
+    assert_escape(unchanged, unchanged, pcmk__xml_escape_attr_pretty);
 }
 
 // Ensure special characters get escaped at start, middle, and end
@@ -68,6 +71,7 @@ escape_left_angle(void **state)
 
     assert_escape(l_angle, l_angle_esc, pcmk__xml_escape_text);
     assert_escape(l_angle, l_angle_esc, pcmk__xml_escape_attr);
+    assert_escape(l_angle, l_angle, pcmk__xml_escape_attr_pretty);
 }
 
 static void
@@ -78,6 +82,7 @@ escape_right_angle(void **state)
 
     assert_escape(r_angle, r_angle_esc, pcmk__xml_escape_text);
     assert_escape(r_angle, r_angle_esc, pcmk__xml_escape_attr);
+    assert_escape(r_angle, r_angle, pcmk__xml_escape_attr_pretty);
 }
 
 static void
@@ -88,46 +93,56 @@ escape_ampersand(void **state)
 
     assert_escape(ampersand, ampersand_esc, pcmk__xml_escape_text);
     assert_escape(ampersand, ampersand_esc, pcmk__xml_escape_attr);
+    assert_escape(ampersand, ampersand, pcmk__xml_escape_attr_pretty);
 }
 
 static void
 escape_double_quote(void **state)
 {
     const char *double_quote = "\"abc\"def\"";
-    const char *double_quote_esc = "&quot;abc&quot;def&quot;";
+    const char *double_quote_esc_ref = "&quot;abc&quot;def&quot;";
+    const char *double_quote_esc_backslash = "\\\"abc\\\"def\\\"";
 
     assert_escape(double_quote, double_quote, pcmk__xml_escape_text);
-    assert_escape(double_quote, double_quote_esc, pcmk__xml_escape_attr);
+    assert_escape(double_quote, double_quote_esc_ref, pcmk__xml_escape_attr);
+    assert_escape(double_quote, double_quote_esc_backslash,
+                  pcmk__xml_escape_attr_pretty);
 }
 
 static void
 escape_newline(void **state)
 {
     const char *newline = "\nabc\ndef\n";
-    const char *newline_esc = "&#x0A;abc&#x0A;def&#x0A;";
+    const char *newline_esc_ref = "&#x0A;abc&#x0A;def&#x0A;";
+    const char *newline_esc_backslash = "\\nabc\\ndef\\n";
 
     assert_escape(newline, newline, pcmk__xml_escape_text);
-    assert_escape(newline, newline_esc, pcmk__xml_escape_attr);
+    assert_escape(newline, newline_esc_ref, pcmk__xml_escape_attr);
+    assert_escape(newline, newline_esc_backslash, pcmk__xml_escape_attr_pretty);
 }
 
 static void
 escape_tab(void **state)
 {
     const char *tab = "\tabc\tdef\t";
-    const char *tab_esc = "&#x09;abc&#x09;def&#x09;";
+    const char *tab_esc_ref = "&#x09;abc&#x09;def&#x09;";
+    const char *tab_esc_backslash = "\\tabc\\tdef\\t";
 
     assert_escape(tab, tab, pcmk__xml_escape_text);
-    assert_escape(tab, tab_esc, pcmk__xml_escape_attr);
+    assert_escape(tab, tab_esc_ref, pcmk__xml_escape_attr);
+    assert_escape(tab, tab_esc_backslash, pcmk__xml_escape_attr_pretty);
 }
 
 static void
 escape_carriage_return(void **state)
 {
     const char *cr = "\rabc\rdef\r";
-    const char *cr_esc = "&#x0D;abc&#x0D;def&#x0D;";
+    const char *cr_esc_ref = "&#x0D;abc&#x0D;def&#x0D;";
+    const char *cr_esc_backslash = "\\rabc\\rdef\\r";
 
-    assert_escape(cr, cr_esc, pcmk__xml_escape_text);
-    assert_escape(cr, cr_esc, pcmk__xml_escape_attr);
+    assert_escape(cr, cr_esc_ref, pcmk__xml_escape_text);
+    assert_escape(cr, cr_esc_ref, pcmk__xml_escape_attr);
+    assert_escape(cr, cr_esc_backslash, pcmk__xml_escape_attr_pretty);
 }
 
 static void
@@ -138,6 +153,7 @@ escape_nonprinting(void **state)
 
     assert_escape(nonprinting, nonprinting_esc, pcmk__xml_escape_text);
     assert_escape(nonprinting, nonprinting_esc, pcmk__xml_escape_attr);
+    assert_escape(nonprinting, nonprinting, pcmk__xml_escape_attr_pretty);
 }
 
 static void
@@ -156,15 +172,19 @@ escape_utf8(void **state)
 
     assert_escape(chinese, chinese, pcmk__xml_escape_text);
     assert_escape(chinese, chinese, pcmk__xml_escape_attr);
+    assert_escape(chinese, chinese, pcmk__xml_escape_attr_pretty);
 
     assert_escape(two_byte, two_byte_esc, pcmk__xml_escape_text);
     assert_escape(two_byte, two_byte_esc, pcmk__xml_escape_attr);
+    assert_escape(two_byte, two_byte, pcmk__xml_escape_attr_pretty);
 
     assert_escape(three_byte, three_byte_esc, pcmk__xml_escape_text);
     assert_escape(three_byte, three_byte_esc, pcmk__xml_escape_attr);
+    assert_escape(three_byte, three_byte, pcmk__xml_escape_attr_pretty);
 
     assert_escape(four_byte, four_byte_esc, pcmk__xml_escape_text);
     assert_escape(four_byte, four_byte_esc, pcmk__xml_escape_attr);
+    assert_escape(four_byte, four_byte, pcmk__xml_escape_attr_pretty);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -108,11 +108,11 @@ escape_nonprinting(void **state)
     const char *alert_mid = "abc\adef";
     const char *alert_right = "abcdef\a";
 
-    const char *delete_left = "\x7f""abcdef";
-    const char *delete_mid = "abc\x7f""def";
-    const char *delete_right = "abcdef\x7f";
+    const char *delete_left = "\x7F""abcdef";
+    const char *delete_mid = "abc\x7F""def";
+    const char *delete_right = "abcdef\x7F";
 
-    const char *nonprinting_all = "\a\r\x7f\x1b";
+    const char *nonprinting_all = "\a\r\x7F\x1B";
 
     assert_true(pcmk__xml_needs_escape(alert_left, false));
     assert_true(pcmk__xml_needs_escape(alert_mid, false));
@@ -141,12 +141,12 @@ escape_utf8(void **state)
      * and should not be escaped.
      */
     const char *chinese = "仅高级使用";
-    const char *two_byte = "abc""\xcf\xa6""def";
-    const char *two_byte_special = "abc""\xcf\xa6""d<ef";
-    const char *three_byte = "abc""\xef\x98\x98""def";
-    const char *three_byte_special = "abc""\xef\x98\x98""d<ef";
-    const char *four_byte = "abc""\xf0\x94\x81\x90""def";
-    const char *four_byte_special = "abc""\xf0\x94\x81\x90""d<ef";
+    const char *two_byte = "abc""\xCF\xA6""def";
+    const char *two_byte_special = "abc""\xCF\xA6""d<ef";
+    const char *three_byte = "abc""\xEF\x98\x98""def";
+    const char *three_byte_special = "abc""\xEF\x98\x98""d<ef";
+    const char *four_byte = "abc""\xF0\x94\x81\x90""def";
+    const char *four_byte_special = "abc""\xF0\x94\x81\x90""d<ef";
 
     assert_false(pcmk__xml_needs_escape(chinese, false));
     assert_false(pcmk__xml_needs_escape(chinese, true));

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -12,6 +12,8 @@
 #include <crm/common/unittest_internal.h>
 #include <crm/common/xml_internal.h>
 
+#include "crmcommon_private.h"
+
 static void
 null_empty(void **state)
 {

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -15,11 +15,24 @@
 static void
 null_empty(void **state)
 {
-    assert_false(pcmk__xml_needs_escape(NULL, false));
-    assert_false(pcmk__xml_needs_escape(NULL, true));
+    assert_false(pcmk__xml_needs_escape(NULL, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(NULL, pcmk__xml_escape_attr));
 
-    assert_false(pcmk__xml_needs_escape("", false));
-    assert_false(pcmk__xml_needs_escape("", true));
+    assert_false(pcmk__xml_needs_escape("", pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape("", pcmk__xml_escape_attr));
+}
+
+static void
+invalid_type(void **state)
+{
+    const enum pcmk__xml_escape_type type = (enum pcmk__xml_escape_type) -1;
+
+    // Easier to ignore invalid type for NULL or empty string
+    assert_false(pcmk__xml_needs_escape(NULL, type));
+    assert_false(pcmk__xml_needs_escape("", type));
+
+    // Otherwise, assert if we somehow passed an invalid type
+    pcmk__assert_asserts(pcmk__xml_needs_escape("he<>llo", type));
 }
 
 static void
@@ -31,8 +44,8 @@ escape_unchanged(void **state)
                             "0123456789"
                             "`~!@#$%^*()-_=+/|\\[]{}?.,'";
 
-    assert_false(pcmk__xml_needs_escape(unchanged, false));
-    assert_false(pcmk__xml_needs_escape(unchanged, true));
+    assert_false(pcmk__xml_needs_escape(unchanged, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(unchanged, pcmk__xml_escape_attr));
 }
 
 // Ensure special characters get escaped at start, middle, and end
@@ -44,13 +57,13 @@ escape_left_angle(void **state)
     const char *l_angle_mid = "abc<def";
     const char *l_angle_right = "abcdef<";
 
-    assert_true(pcmk__xml_needs_escape(l_angle_left, false));
-    assert_true(pcmk__xml_needs_escape(l_angle_mid, false));
-    assert_true(pcmk__xml_needs_escape(l_angle_right, false));
+    assert_true(pcmk__xml_needs_escape(l_angle_left, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(l_angle_mid, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(l_angle_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(l_angle_left, true));
-    assert_true(pcmk__xml_needs_escape(l_angle_mid, true));
-    assert_true(pcmk__xml_needs_escape(l_angle_right, true));
+    assert_true(pcmk__xml_needs_escape(l_angle_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(l_angle_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(l_angle_right, pcmk__xml_escape_attr));
 }
 
 static void
@@ -60,13 +73,13 @@ escape_right_angle(void **state)
     const char *r_angle_mid = "abc>def";
     const char *r_angle_right = "abcdef>";
 
-    assert_true(pcmk__xml_needs_escape(r_angle_left, false));
-    assert_true(pcmk__xml_needs_escape(r_angle_mid, false));
-    assert_true(pcmk__xml_needs_escape(r_angle_right, false));
+    assert_true(pcmk__xml_needs_escape(r_angle_left, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(r_angle_mid, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(r_angle_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(r_angle_left, true));
-    assert_true(pcmk__xml_needs_escape(r_angle_mid, true));
-    assert_true(pcmk__xml_needs_escape(r_angle_right, true));
+    assert_true(pcmk__xml_needs_escape(r_angle_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(r_angle_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(r_angle_right, pcmk__xml_escape_attr));
 }
 
 static void
@@ -76,13 +89,13 @@ escape_ampersand(void **state)
     const char *ampersand_mid = "abc&def";
     const char *ampersand_right = "abcdef&";
 
-    assert_true(pcmk__xml_needs_escape(ampersand_left, false));
-    assert_true(pcmk__xml_needs_escape(ampersand_mid, false));
-    assert_true(pcmk__xml_needs_escape(ampersand_right, false));
+    assert_true(pcmk__xml_needs_escape(ampersand_left, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(ampersand_mid, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(ampersand_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(ampersand_left, true));
-    assert_true(pcmk__xml_needs_escape(ampersand_mid, true));
-    assert_true(pcmk__xml_needs_escape(ampersand_right, true));
+    assert_true(pcmk__xml_needs_escape(ampersand_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(ampersand_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(ampersand_right, pcmk__xml_escape_attr));
 }
 
 static void
@@ -92,13 +105,19 @@ escape_double_quote(void **state)
     const char *double_quote_mid = "abc\"def";
     const char *double_quote_right = "abcdef\"";
 
-    assert_false(pcmk__xml_needs_escape(double_quote_left, false));
-    assert_false(pcmk__xml_needs_escape(double_quote_mid, false));
-    assert_false(pcmk__xml_needs_escape(double_quote_right, false));
+    assert_false(pcmk__xml_needs_escape(double_quote_left,
+                                        pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(double_quote_mid,
+                                        pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(double_quote_right,
+                                        pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(double_quote_left, true));
-    assert_true(pcmk__xml_needs_escape(double_quote_mid, true));
-    assert_true(pcmk__xml_needs_escape(double_quote_right, true));
+    assert_true(pcmk__xml_needs_escape(double_quote_left,
+                                       pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(double_quote_mid,
+                                       pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(double_quote_right,
+                                       pcmk__xml_escape_attr));
 }
 
 static void
@@ -108,13 +127,13 @@ escape_newline(void **state)
     const char *newline_mid = "abc\ndef";
     const char *newline_right = "abcdef\n";
 
-    assert_false(pcmk__xml_needs_escape(newline_left, false));
-    assert_false(pcmk__xml_needs_escape(newline_mid, false));
-    assert_false(pcmk__xml_needs_escape(newline_right, false));
+    assert_false(pcmk__xml_needs_escape(newline_left, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(newline_mid, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(newline_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(newline_left, true));
-    assert_true(pcmk__xml_needs_escape(newline_mid, true));
-    assert_true(pcmk__xml_needs_escape(newline_right, true));
+    assert_true(pcmk__xml_needs_escape(newline_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(newline_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(newline_right, pcmk__xml_escape_attr));
 }
 
 static void
@@ -124,13 +143,13 @@ escape_tab(void **state)
     const char *tab_mid = "abc\tdef";
     const char *tab_right = "abcdef\t";
 
-    assert_false(pcmk__xml_needs_escape(tab_left, false));
-    assert_false(pcmk__xml_needs_escape(tab_mid, false));
-    assert_false(pcmk__xml_needs_escape(tab_right, false));
+    assert_false(pcmk__xml_needs_escape(tab_left, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(tab_mid, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(tab_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(tab_left, true));
-    assert_true(pcmk__xml_needs_escape(tab_mid, true));
-    assert_true(pcmk__xml_needs_escape(tab_right, true));
+    assert_true(pcmk__xml_needs_escape(tab_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(tab_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(tab_right, pcmk__xml_escape_attr));
 }
 
 static void
@@ -140,13 +159,13 @@ escape_carriage_return(void **state)
     const char *cr_mid = "abc\rdef";
     const char *cr_right = "abcdef\r";
 
-    assert_true(pcmk__xml_needs_escape(cr_left, false));
-    assert_true(pcmk__xml_needs_escape(cr_mid, false));
-    assert_true(pcmk__xml_needs_escape(cr_right, false));
+    assert_true(pcmk__xml_needs_escape(cr_left, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(cr_mid, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(cr_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(cr_left, true));
-    assert_true(pcmk__xml_needs_escape(cr_mid, true));
-    assert_true(pcmk__xml_needs_escape(cr_right, true));
+    assert_true(pcmk__xml_needs_escape(cr_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(cr_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(cr_right, pcmk__xml_escape_attr));
 }
 
 static void
@@ -162,24 +181,24 @@ escape_nonprinting(void **state)
 
     const char *nonprinting_all = "\a\x7F\x1B";
 
-    assert_true(pcmk__xml_needs_escape(alert_left, false));
-    assert_true(pcmk__xml_needs_escape(alert_mid, false));
-    assert_true(pcmk__xml_needs_escape(alert_right, false));
+    assert_true(pcmk__xml_needs_escape(alert_left, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(alert_mid, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(alert_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(alert_left, true));
-    assert_true(pcmk__xml_needs_escape(alert_mid, true));
-    assert_true(pcmk__xml_needs_escape(alert_right, true));
+    assert_true(pcmk__xml_needs_escape(alert_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(alert_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(alert_right, pcmk__xml_escape_attr));
 
-    assert_true(pcmk__xml_needs_escape(delete_left, false));
-    assert_true(pcmk__xml_needs_escape(delete_mid, false));
-    assert_true(pcmk__xml_needs_escape(delete_right, false));
+    assert_true(pcmk__xml_needs_escape(delete_left, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(delete_mid, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(delete_right, pcmk__xml_escape_text));
 
-    assert_true(pcmk__xml_needs_escape(delete_left, true));
-    assert_true(pcmk__xml_needs_escape(delete_mid, true));
-    assert_true(pcmk__xml_needs_escape(delete_right, true));
+    assert_true(pcmk__xml_needs_escape(delete_left, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(delete_mid, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(delete_right, pcmk__xml_escape_attr));
 
-    assert_true(pcmk__xml_needs_escape(nonprinting_all, false));
-    assert_true(pcmk__xml_needs_escape(nonprinting_all, true));
+    assert_true(pcmk__xml_needs_escape(nonprinting_all, pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(nonprinting_all, pcmk__xml_escape_attr));
 }
 
 static void
@@ -196,27 +215,34 @@ escape_utf8(void **state)
     const char *four_byte = "abc""\xF0\x94\x81\x90""def";
     const char *four_byte_special = "abc""\xF0\x94\x81\x90""d<ef";
 
-    assert_false(pcmk__xml_needs_escape(chinese, false));
-    assert_false(pcmk__xml_needs_escape(chinese, true));
+    assert_false(pcmk__xml_needs_escape(chinese, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(chinese, pcmk__xml_escape_attr));
 
-    assert_false(pcmk__xml_needs_escape(two_byte, false));
-    assert_false(pcmk__xml_needs_escape(two_byte, true));
-    assert_true(pcmk__xml_needs_escape(two_byte_special, false));
-    assert_true(pcmk__xml_needs_escape(two_byte_special, true));
+    assert_false(pcmk__xml_needs_escape(two_byte, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(two_byte, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(two_byte_special,
+                                       pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(two_byte_special,
+                                       pcmk__xml_escape_attr));
 
-    assert_false(pcmk__xml_needs_escape(three_byte, false));
-    assert_false(pcmk__xml_needs_escape(three_byte, true));
-    assert_true(pcmk__xml_needs_escape(three_byte_special, false));
-    assert_true(pcmk__xml_needs_escape(three_byte_special, true));
+    assert_false(pcmk__xml_needs_escape(three_byte, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(three_byte, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(three_byte_special,
+                                       pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(three_byte_special,
+                                       pcmk__xml_escape_attr));
 
-    assert_false(pcmk__xml_needs_escape(four_byte, false));
-    assert_false(pcmk__xml_needs_escape(four_byte, true));
-    assert_true(pcmk__xml_needs_escape(four_byte_special, false));
-    assert_true(pcmk__xml_needs_escape(four_byte_special, true));
+    assert_false(pcmk__xml_needs_escape(four_byte, pcmk__xml_escape_text));
+    assert_false(pcmk__xml_needs_escape(four_byte, pcmk__xml_escape_attr));
+    assert_true(pcmk__xml_needs_escape(four_byte_special,
+                                       pcmk__xml_escape_text));
+    assert_true(pcmk__xml_needs_escape(four_byte_special,
+                                       pcmk__xml_escape_attr));
 }
 
 PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(null_empty),
+                cmocka_unit_test(invalid_type),
                 cmocka_unit_test(escape_unchanged),
                 cmocka_unit_test(escape_left_angle),
                 cmocka_unit_test(escape_right_angle),

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -17,9 +17,11 @@ null_empty(void **state)
 {
     assert_false(pcmk__xml_needs_escape(NULL, pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape(NULL, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(NULL, pcmk__xml_escape_attr_pretty));
 
     assert_false(pcmk__xml_needs_escape("", pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape("", pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape("", pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -46,6 +48,8 @@ escape_unchanged(void **state)
 
     assert_false(pcmk__xml_needs_escape(unchanged, pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape(unchanged, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(unchanged,
+                                        pcmk__xml_escape_attr_pretty));
 }
 
 // Ensure special characters get escaped at start, middle, and end
@@ -64,6 +68,13 @@ escape_left_angle(void **state)
     assert_true(pcmk__xml_needs_escape(l_angle_left, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(l_angle_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(l_angle_right, pcmk__xml_escape_attr));
+
+    assert_false(pcmk__xml_needs_escape(l_angle_left,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(l_angle_mid,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(l_angle_right,
+                                        pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -80,6 +91,13 @@ escape_right_angle(void **state)
     assert_true(pcmk__xml_needs_escape(r_angle_left, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(r_angle_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(r_angle_right, pcmk__xml_escape_attr));
+
+    assert_false(pcmk__xml_needs_escape(r_angle_left,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(r_angle_mid,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(r_angle_right,
+                                        pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -96,6 +114,13 @@ escape_ampersand(void **state)
     assert_true(pcmk__xml_needs_escape(ampersand_left, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(ampersand_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(ampersand_right, pcmk__xml_escape_attr));
+
+    assert_false(pcmk__xml_needs_escape(ampersand_left,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(ampersand_mid,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(ampersand_right,
+                                        pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -118,6 +143,13 @@ escape_double_quote(void **state)
                                        pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(double_quote_right,
                                        pcmk__xml_escape_attr));
+
+    assert_true(pcmk__xml_needs_escape(double_quote_left,
+                                       pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(double_quote_mid,
+                                       pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(double_quote_right,
+                                       pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -134,6 +166,13 @@ escape_newline(void **state)
     assert_true(pcmk__xml_needs_escape(newline_left, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(newline_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(newline_right, pcmk__xml_escape_attr));
+
+    assert_true(pcmk__xml_needs_escape(newline_left,
+                                       pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(newline_mid,
+                                       pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(newline_right,
+                                       pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -150,6 +189,11 @@ escape_tab(void **state)
     assert_true(pcmk__xml_needs_escape(tab_left, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(tab_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(tab_right, pcmk__xml_escape_attr));
+
+    assert_true(pcmk__xml_needs_escape(tab_left, pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(tab_mid, pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(tab_right,
+                                       pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -166,6 +210,10 @@ escape_carriage_return(void **state)
     assert_true(pcmk__xml_needs_escape(cr_left, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(cr_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(cr_right, pcmk__xml_escape_attr));
+
+    assert_true(pcmk__xml_needs_escape(cr_left, pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(cr_mid, pcmk__xml_escape_attr_pretty));
+    assert_true(pcmk__xml_needs_escape(cr_right, pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -189,6 +237,13 @@ escape_nonprinting(void **state)
     assert_true(pcmk__xml_needs_escape(alert_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(alert_right, pcmk__xml_escape_attr));
 
+    assert_false(pcmk__xml_needs_escape(alert_left,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(alert_mid,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(alert_right,
+                                        pcmk__xml_escape_attr_pretty));
+
     assert_true(pcmk__xml_needs_escape(delete_left, pcmk__xml_escape_text));
     assert_true(pcmk__xml_needs_escape(delete_mid, pcmk__xml_escape_text));
     assert_true(pcmk__xml_needs_escape(delete_right, pcmk__xml_escape_text));
@@ -197,8 +252,17 @@ escape_nonprinting(void **state)
     assert_true(pcmk__xml_needs_escape(delete_mid, pcmk__xml_escape_attr));
     assert_true(pcmk__xml_needs_escape(delete_right, pcmk__xml_escape_attr));
 
+    assert_false(pcmk__xml_needs_escape(delete_left,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(delete_mid,
+                                        pcmk__xml_escape_attr_pretty));
+    assert_false(pcmk__xml_needs_escape(delete_right,
+                                        pcmk__xml_escape_attr_pretty));
+
     assert_true(pcmk__xml_needs_escape(nonprinting_all, pcmk__xml_escape_text));
     assert_true(pcmk__xml_needs_escape(nonprinting_all, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(nonprinting_all,
+                                        pcmk__xml_escape_attr_pretty));
 }
 
 static void
@@ -217,27 +281,43 @@ escape_utf8(void **state)
 
     assert_false(pcmk__xml_needs_escape(chinese, pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape(chinese, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(chinese, pcmk__xml_escape_attr_pretty));
 
     assert_false(pcmk__xml_needs_escape(two_byte, pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape(two_byte, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(two_byte,
+                                        pcmk__xml_escape_attr_pretty));
+
     assert_true(pcmk__xml_needs_escape(two_byte_special,
                                        pcmk__xml_escape_text));
     assert_true(pcmk__xml_needs_escape(two_byte_special,
                                        pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(two_byte_special,
+                                        pcmk__xml_escape_attr_pretty));
 
     assert_false(pcmk__xml_needs_escape(three_byte, pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape(three_byte, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(three_byte,
+                                        pcmk__xml_escape_attr_pretty));
+
     assert_true(pcmk__xml_needs_escape(three_byte_special,
                                        pcmk__xml_escape_text));
     assert_true(pcmk__xml_needs_escape(three_byte_special,
                                        pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(three_byte_special,
+                                        pcmk__xml_escape_attr_pretty));
 
     assert_false(pcmk__xml_needs_escape(four_byte, pcmk__xml_escape_text));
     assert_false(pcmk__xml_needs_escape(four_byte, pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(four_byte,
+                                        pcmk__xml_escape_attr_pretty));
+
     assert_true(pcmk__xml_needs_escape(four_byte_special,
                                        pcmk__xml_escape_text));
     assert_true(pcmk__xml_needs_escape(four_byte_special,
                                        pcmk__xml_escape_attr));
+    assert_false(pcmk__xml_needs_escape(four_byte_special,
+                                        pcmk__xml_escape_attr_pretty));
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
+++ b/lib/common/tests/xml/pcmk__xml_needs_escape_test.c
@@ -29,7 +29,7 @@ escape_unchanged(void **state)
     const char *unchanged = "abcdefghijklmnopqrstuvwxyz"
                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                             "0123456789"
-                            "\n\t`~!@#$%^*()-_=+/|\\[]{}?.,'";
+                            "`~!@#$%^*()-_=+/|\\[]{}?.,'";
 
     assert_false(pcmk__xml_needs_escape(unchanged, false));
     assert_false(pcmk__xml_needs_escape(unchanged, true));
@@ -102,6 +102,54 @@ escape_double_quote(void **state)
 }
 
 static void
+escape_newline(void **state)
+{
+    const char *newline_left = "\nabcdef";
+    const char *newline_mid = "abc\ndef";
+    const char *newline_right = "abcdef\n";
+
+    assert_false(pcmk__xml_needs_escape(newline_left, false));
+    assert_false(pcmk__xml_needs_escape(newline_mid, false));
+    assert_false(pcmk__xml_needs_escape(newline_right, false));
+
+    assert_true(pcmk__xml_needs_escape(newline_left, true));
+    assert_true(pcmk__xml_needs_escape(newline_mid, true));
+    assert_true(pcmk__xml_needs_escape(newline_right, true));
+}
+
+static void
+escape_tab(void **state)
+{
+    const char *tab_left = "\tabcdef";
+    const char *tab_mid = "abc\tdef";
+    const char *tab_right = "abcdef\t";
+
+    assert_false(pcmk__xml_needs_escape(tab_left, false));
+    assert_false(pcmk__xml_needs_escape(tab_mid, false));
+    assert_false(pcmk__xml_needs_escape(tab_right, false));
+
+    assert_true(pcmk__xml_needs_escape(tab_left, true));
+    assert_true(pcmk__xml_needs_escape(tab_mid, true));
+    assert_true(pcmk__xml_needs_escape(tab_right, true));
+}
+
+static void
+escape_carriage_return(void **state)
+{
+    const char *cr_left = "\rabcdef";
+    const char *cr_mid = "abc\rdef";
+    const char *cr_right = "abcdef\r";
+
+    assert_true(pcmk__xml_needs_escape(cr_left, false));
+    assert_true(pcmk__xml_needs_escape(cr_mid, false));
+    assert_true(pcmk__xml_needs_escape(cr_right, false));
+
+    assert_true(pcmk__xml_needs_escape(cr_left, true));
+    assert_true(pcmk__xml_needs_escape(cr_mid, true));
+    assert_true(pcmk__xml_needs_escape(cr_right, true));
+}
+
+static void
 escape_nonprinting(void **state)
 {
     const char *alert_left = "\aabcdef";
@@ -112,7 +160,7 @@ escape_nonprinting(void **state)
     const char *delete_mid = "abc\x7F""def";
     const char *delete_right = "abcdef\x7F";
 
-    const char *nonprinting_all = "\a\r\x7F\x1B";
+    const char *nonprinting_all = "\a\x7F\x1B";
 
     assert_true(pcmk__xml_needs_escape(alert_left, false));
     assert_true(pcmk__xml_needs_escape(alert_mid, false));
@@ -174,5 +222,8 @@ PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(escape_right_angle),
                 cmocka_unit_test(escape_ampersand),
                 cmocka_unit_test(escape_double_quote),
+                cmocka_unit_test(escape_newline),
+                cmocka_unit_test(escape_tab),
+                cmocka_unit_test(escape_carriage_return),
                 cmocka_unit_test(escape_nonprinting),
                 cmocka_unit_test(escape_utf8));

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1144,13 +1144,13 @@ pcmk__xml_escape(const char *text, enum pcmk__xml_escape_type type)
             case pcmk__xml_escape_text:
                 switch (*text) {
                     case '<':
-                        g_string_append(copy, "&lt;");
+                        g_string_append(copy, PCMK__XML_ENTITY_LT);
                         break;
                     case '>':
-                        g_string_append(copy, "&gt;");
+                        g_string_append(copy, PCMK__XML_ENTITY_GT);
                         break;
                     case '&':
-                        g_string_append(copy, "&amp;");
+                        g_string_append(copy, PCMK__XML_ENTITY_AMP);
                         break;
                     case '\n':
                     case '\t':
@@ -1169,16 +1169,16 @@ pcmk__xml_escape(const char *text, enum pcmk__xml_escape_type type)
             case pcmk__xml_escape_attr:
                 switch (*text) {
                     case '<':
-                        g_string_append(copy, "&lt;");
+                        g_string_append(copy, PCMK__XML_ENTITY_LT);
                         break;
                     case '>':
-                        g_string_append(copy, "&gt;");
+                        g_string_append(copy, PCMK__XML_ENTITY_GT);
                         break;
                     case '&':
-                        g_string_append(copy, "&amp;");
+                        g_string_append(copy, PCMK__XML_ENTITY_AMP);
                         break;
                     case '"':
-                        g_string_append(copy, "&quot;");
+                        g_string_append(copy, PCMK__XML_ENTITY_QUOT);
                         break;
                     default:
                         if (!isprint(*text)) {

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1102,7 +1102,7 @@ pcmk__xml_needs_escape(const char *text, bool escape_quote)
                 // Don't escape newline or tab
                 break;
             default:
-                if ((text[index] < 0x20) || (text[index] >= 0x7f)) {
+                if ((text[index] < 0x20) || (text[index] >= 0x7F)) {
                     // Escape non-printing characters
                     return true;
                 }
@@ -1191,9 +1191,9 @@ pcmk__xml_escape(const char *text, bool escape_quote)
                 // Don't escape newlines and tabs
                 break;
             default:
-                if ((copy[index] < 0x20) || (copy[index] >= 0x7f)) {
+                if ((copy[index] < 0x20) || (copy[index] >= 0x7F)) {
                     // Escape non-printing characters
-                    snprintf(buf, sizeof(buf), "&#x%.2x;", copy[index]);
+                    snprintf(buf, sizeof(buf), "&#x%.2X;", copy[index]);
                     copy = replace_text(copy, &index, &length, buf);
                 }
                 break;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1075,21 +1075,20 @@ replace_text(char *text, size_t *index, size_t *length, const char *replace)
 bool
 pcmk__xml_needs_escape(const char *text, bool for_attr)
 {
-    size_t length = 0;
-
     if (text == NULL) {
         return false;
     }
-    length = strlen(text);
 
-    for (size_t index = 0; index < length; index++) {
+    while (*text != '\0') {
         // Don't escape any non-ASCII characters
-        index += utf8_bytes(&(text[index]));
+        size_t ubytes = utf8_bytes(text);
 
-        switch (text[index]) {
-            case '\0':
-                // Reached end of string by skipping UTF-8 bytes
-                return false;
+        if (ubytes > 0) {
+            text += ubytes;
+            continue;
+        }
+
+        switch (*text) {
             case '<':
                 return true;
             case '>':
@@ -1104,12 +1103,13 @@ pcmk__xml_needs_escape(const char *text, bool for_attr)
                 }
                 break;
             default:
-                if ((text[index] < 0x20) || (text[index] >= 0x7F)) {
-                    // Escape non-printing characters
+                if (!isprint(*text)) {
                     return true;
                 }
                 break;
         }
+
+        text++;
     }
     return false;
 }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1010,6 +1010,11 @@ utf8_bytes(const char *text)
 #endif  // CHAR_BIT != 8
     }
 
+    for (int i = 0; i < c_bytes; i++) {
+        // Sanity-check that we haven't passed end of string as "non-ASCII"
+        CRM_ASSERT(text[i] != '\0');
+    }
+
     return c_bytes;
 }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -714,13 +714,6 @@ pcmk__xe_set_content(xmlNode *node, const char *format, ...)
             va_end(ap);
         }
 
-        if (pcmk__xml_needs_escape(content, false)) {
-            char *escaped = pcmk__xml_escape(content, false);
-
-            free(buf);
-            buf = escaped;
-            content = buf;
-        }
         xmlNodeSetContent(node, (pcmkXmlStr) content);
         free(buf);
     }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1079,6 +1079,18 @@ pcmk__xml_needs_escape(const char *text, enum pcmk__xml_escape_type type)
                 }
                 break;
 
+            case pcmk__xml_escape_attr_pretty:
+                switch (*text) {
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '"':
+                        return true;
+                    default:
+                        break;
+                }
+                break;
+
             default:    // Invalid enum value
                 CRM_ASSERT(false);
                 break;
@@ -1174,6 +1186,26 @@ pcmk__xml_escape(const char *text, enum pcmk__xml_escape_type type)
                         } else {
                             g_string_append_c(copy, *text);
                         }
+                        break;
+                }
+                break;
+
+            case pcmk__xml_escape_attr_pretty:
+                switch (*text) {
+                    case '"':
+                        g_string_append(copy, "\\\"");
+                        break;
+                    case '\n':
+                        g_string_append(copy, "\\n");
+                        break;
+                    case '\r':
+                        g_string_append(copy, "\\r");
+                        break;
+                    case '\t':
+                        g_string_append(copy, "\\t");
+                        break;
+                    default:
+                        g_string_append_c(copy, *text);
                         break;
                 }
                 break;

--- a/lib/common/xml_attr.c
+++ b/lib/common/xml_attr.c
@@ -63,7 +63,7 @@ pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
 {
     const char *name = NULL;
     const char *value = NULL;
-    char *value_esc = NULL;
+    gchar *value_esc = NULL;
     xml_node_private_t *nodepriv = NULL;
 
     if (attr == NULL || attr->children == NULL) {
@@ -91,5 +91,5 @@ pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
     }
 
     pcmk__g_strcat(buffer, " ", name, "=\"", value, "\"", NULL);
-    free(value_esc);
+    g_free(value_esc);
 }

--- a/lib/common/xml_attr.c
+++ b/lib/common/xml_attr.c
@@ -85,8 +85,8 @@ pcmk__dump_xml_attr(const xmlAttr *attr, GString *buffer)
         return;
     }
 
-    if (pcmk__xml_needs_escape(value, true)) {
-        value_esc = pcmk__xml_escape(value, true);
+    if (pcmk__xml_needs_escape(value, pcmk__xml_escape_attr)) {
+        value_esc = pcmk__xml_escape(value, pcmk__xml_escape_attr);
         value = value_esc;
     }
 

--- a/lib/common/xml_display.c
+++ b/lib/common/xml_display.c
@@ -109,7 +109,7 @@ show_xml_element(pcmk__output_t *out, GString *buffer, const char *prefix,
             xml_node_private_t *nodepriv = attr->_private;
             const char *p_name = (const char *) attr->name;
             const char *p_value = pcmk__xml_attr_value(attr);
-            char *p_copy = NULL;
+            gchar *p_copy = NULL;
 
             if (pcmk_is_set(nodepriv->flags, pcmk__xf_deleted)) {
                 continue;
@@ -135,7 +135,7 @@ show_xml_element(pcmk__output_t *out, GString *buffer, const char *prefix,
 
             pcmk__g_strcat(buffer, " ", p_name, "=\"",
                            pcmk__s(p_value, "<null>"), "\"", NULL);
-            free(p_copy);
+            g_free(p_copy);
         }
 
         if ((data->children != NULL)

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -357,8 +357,8 @@ dump_xml_text(const xmlNode *data, uint32_t options, GString *buffer,
     const char *content = (const char *) data->content;
     gchar *content_esc = NULL;
 
-    if (pcmk__xml_needs_escape(content, false)) {
-        content_esc = pcmk__xml_escape(content, false);
+    if (pcmk__xml_needs_escape(content, pcmk__xml_escape_text)) {
+        content_esc = pcmk__xml_escape(content, pcmk__xml_escape_text);
         content = content_esc;
     }
 

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -355,7 +355,7 @@ dump_xml_text(const xmlNode *data, uint32_t options, GString *buffer,
     bool pretty = pcmk_is_set(options, pcmk__xml_fmt_pretty);
     int spaces = pretty? (2 * depth) : 0;
     const char *content = (const char *) data->content;
-    char *content_esc = NULL;
+    gchar *content_esc = NULL;
 
     if (pcmk__xml_needs_escape(content, false)) {
         content_esc = pcmk__xml_escape(content, false);
@@ -371,7 +371,7 @@ dump_xml_text(const xmlNode *data, uint32_t options, GString *buffer,
     if (pretty) {
         g_string_append_c(buffer, '\n');
     }
-    free(content_esc);
+    g_free(content_esc);
 }
 
 /*!

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -241,12 +241,14 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
             return -EINVAL;
         }
 
-        if (pcmk__xml_needs_escape(meta_longdesc, false)) {
-            meta_longdesc_esc = pcmk__xml_escape(meta_longdesc, false);
+        if (pcmk__xml_needs_escape(meta_longdesc, pcmk__xml_escape_text)) {
+            meta_longdesc_esc = pcmk__xml_escape(meta_longdesc,
+                                                 pcmk__xml_escape_text);
             meta_longdesc = meta_longdesc_esc;
         }
-        if (pcmk__xml_needs_escape(meta_shortdesc, false)) {
-            meta_shortdesc_esc = pcmk__xml_escape(meta_shortdesc, false);
+        if (pcmk__xml_needs_escape(meta_shortdesc, pcmk__xml_escape_text)) {
+            meta_shortdesc_esc = pcmk__xml_escape(meta_shortdesc,
+                                                  pcmk__xml_escape_text);
             meta_shortdesc = meta_shortdesc_esc;
         }
 

--- a/lib/fencing/st_lha.c
+++ b/lib/fencing/st_lha.c
@@ -208,8 +208,8 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
         const char *meta_param = NULL;
         const char *timeout_str = NULL;
 
-        char *meta_longdesc_esc = NULL;
-        char *meta_shortdesc_esc = NULL;
+        gchar *meta_longdesc_esc = NULL;
+        gchar *meta_shortdesc_esc = NULL;
 
         stonith_obj = st_new_fn(agent);
         if (stonith_obj != NULL) {
@@ -259,8 +259,8 @@ stonith__lha_metadata(const char *agent, int timeout, char **output)
                                    meta_shortdesc, meta_param,
                                    timeout_str, timeout_str, timeout_str);
 
-        free(meta_longdesc_esc);
-        free(meta_shortdesc_esc);
+        g_free(meta_longdesc_esc);
+        g_free(meta_shortdesc_esc);
     }
     if (output) {
         *output = buffer;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -2139,7 +2139,14 @@ attribute_default(pcmk__output_t *out, va_list args)
     const char *value = va_arg(args, const char *);
     const char *host = va_arg(args, const char *);
 
+    gchar *value_esc = NULL;
+
     GString *s = g_string_sized_new(50);
+
+    if (pcmk__xml_needs_escape(value, pcmk__xml_escape_attr_pretty)) {
+        value_esc = pcmk__xml_escape(value, pcmk__xml_escape_attr_pretty);
+        value = value_esc;
+    }
 
     if (!pcmk__str_empty(scope)) {
         pcmk__g_strcat(s, PCMK_XA_SCOPE "=\"", scope, "\" ", NULL);
@@ -2158,8 +2165,9 @@ attribute_default(pcmk__output_t *out, va_list args)
     pcmk__g_strcat(s, PCMK_XA_VALUE "=\"", pcmk__s(value, ""), "\"", NULL);
 
     out->info(out, "%s", s->str);
-    g_string_free(s, TRUE);
 
+    g_free(value_esc);
+    g_string_free(s, TRUE);
     return pcmk_rc_ok;
 }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1599,8 +1599,8 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
     char *rc_s = NULL;
     xmlNodePtr node = NULL;
 
-    if (pcmk__xml_needs_escape(exit_reason, true)) {
-        exit_reason_esc = pcmk__xml_escape(exit_reason, true);
+    if (pcmk__xml_needs_escape(exit_reason, pcmk__xml_escape_attr)) {
+        exit_reason_esc = pcmk__xml_escape(exit_reason, pcmk__xml_escape_attr);
         exit_reason = exit_reason_esc;
     }
     pcmk__scan_min_int(crm_element_value(xml_op, PCMK__XA_RC_CODE), &rc, 0);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1595,7 +1595,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
     const char *status_s = NULL;
 
     time_t epoch = 0;
-    char *exit_reason_esc = NULL;
+    gchar *exit_reason_esc = NULL;
     char *rc_s = NULL;
     xmlNodePtr node = NULL;
 
@@ -1652,7 +1652,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
         free(rc_change);
     }
 
-    free(exit_reason_esc);
+    g_free(exit_reason_esc);
     return pcmk_rc_ok;
 }
 

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -97,7 +97,7 @@ lsb_meta_helper_get_value(const char *line, gchar **value, const char *prefix)
      * extra variables in the caller.
      */
     if ((*value == NULL) && pcmk__starts_with(line, prefix)) {
-        *value = pcmk__xml_escape(line + strlen(prefix), false);
+        *value = pcmk__xml_escape(line + strlen(prefix), pcmk__xml_escape_text);
         return TRUE;
     }
     return FALSE;
@@ -200,7 +200,7 @@ services__get_lsb_metadata(const char *type, char **output)
             }
 
             // Make long description safe to use in XML
-            long_desc = pcmk__xml_escape(desc->str, false);
+            long_desc = pcmk__xml_escape(desc->str, pcmk__xml_escape_text);
             g_string_free(desc, TRUE);
 
             if (processed_line) {

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -91,12 +91,12 @@
  * \return TRUE if value was set, FALSE otherwise
  */
 static inline gboolean
-lsb_meta_helper_get_value(const char *line, char **value, const char *prefix)
+lsb_meta_helper_get_value(const char *line, gchar **value, const char *prefix)
 {
     /* @TODO Perhaps update later to use pcmk__xml_needs_escape(). Involves many
      * extra variables in the caller.
      */
-    if (!*value && pcmk__starts_with(line, prefix)) {
+    if ((*value == NULL) && pcmk__starts_with(line, prefix)) {
         *value = pcmk__xml_escape(line + strlen(prefix), false);
         return TRUE;
     }
@@ -109,15 +109,15 @@ services__get_lsb_metadata(const char *type, char **output)
     char ra_pathname[PATH_MAX] = { 0, };
     FILE *fp = NULL;
     char buffer[1024] = { 0, };
-    char *provides = NULL;
-    char *required_start = NULL;
-    char *required_stop = NULL;
-    char *should_start = NULL;
-    char *should_stop = NULL;
-    char *default_start = NULL;
-    char *default_stop = NULL;
-    char *short_desc = NULL;
-    char *long_desc = NULL;
+    gchar *provides = NULL;
+    gchar *required_start = NULL;
+    gchar *required_stop = NULL;
+    gchar *should_start = NULL;
+    gchar *should_stop = NULL;
+    gchar *default_start = NULL;
+    gchar *default_stop = NULL;
+    gchar *short_desc = NULL;
+    gchar *long_desc = NULL;
     bool in_header = FALSE;
 
     if (type[0] == '/') {
@@ -230,15 +230,15 @@ services__get_lsb_metadata(const char *type, char **output)
                                 pcmk__s(default_start, ""),
                                 pcmk__s(default_stop, ""));
 
-    free(long_desc);
-    free(short_desc);
-    free(provides);
-    free(required_start);
-    free(required_stop);
-    free(should_start);
-    free(should_stop);
-    free(default_start);
-    free(default_stop);
+    g_free(long_desc);
+    g_free(short_desc);
+    g_free(provides);
+    g_free(required_start);
+    g_free(required_stop);
+    g_free(should_start);
+    g_free(should_stop);
+    g_free(default_start);
+    g_free(default_stop);
     return pcmk_ok;
 }
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -709,8 +709,8 @@ systemd_unit_metadata(const char *name, int timeout)
         desc = crm_strdup_printf("Systemd unit file for %s", name);
     }
 
-    if (pcmk__xml_needs_escape(desc, false)) {
-        gchar *escaped = pcmk__xml_escape(desc, false);
+    if (pcmk__xml_needs_escape(desc, pcmk__xml_escape_text)) {
+        gchar *escaped = pcmk__xml_escape(desc, pcmk__xml_escape_text);
 
         meta = crm_strdup_printf(METADATA_FORMAT, name, escaped, name);
         g_free(escaped);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -710,13 +710,15 @@ systemd_unit_metadata(const char *name, int timeout)
     }
 
     if (pcmk__xml_needs_escape(desc, false)) {
-        char *escaped = pcmk__xml_escape(desc, false);
+        gchar *escaped = pcmk__xml_escape(desc, false);
 
-        free(desc);
-        desc = escaped;
+        meta = crm_strdup_printf(METADATA_FORMAT, name, escaped, name);
+        g_free(escaped);
+
+    } else {
+        meta = crm_strdup_printf(METADATA_FORMAT, name, desc, name);
     }
 
-    meta = crm_strdup_printf(METADATA_FORMAT, name, desc, name);
     free(desc);
     free(path);
     return meta;

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -63,6 +63,13 @@ attribute_text(pcmk__output_t *out, va_list args)
     const char *value = va_arg(args, const char *);
     const char *host G_GNUC_UNUSED = va_arg(args, const char *);
 
+    gchar *value_esc = NULL;
+
+    if (pcmk__xml_needs_escape(value, pcmk__xml_escape_attr_pretty)) {
+        value_esc = pcmk__xml_escape(value, pcmk__xml_escape_attr_pretty);
+        value = value_esc;
+    }
+
     if (out->quiet) {
         if (value != NULL) {
             pcmk__formatted_printf(out, "%s\n", value);
@@ -75,6 +82,7 @@ attribute_text(pcmk__output_t *out, va_list args)
                   value ? value : "(null)");
     }
 
+    g_free(value_esc);
     return pcmk_rc_ok;
 }
 


### PR DESCRIPTION
Regression introduced by c6d9cea9, sort of.

Before that commit, newlines and tabs were escaped as `"\n"` and `"\t"`, respectively. These are not valid XML escape sequences.

We made the decision not to escape newlines and tabs when we added the `pcmk__xml_escape()` function, with the caveat that the "right" answer was unclear:

> If not, the XML will be more visually understandable, but conformant XML parsers will treat the newline as a space (for example, if something extracts the text and displays it to the user). If we do, the parser case may be closer to our original intent, but the XML is harder to read, and it may not be appropriate (for example, the parsing tool might prefer to do line wrapping of a textual paragraph on its own)."
https://github.com/ClusterLabs/pacemaker/pull/3323#discussion_r1474790296

However, now if an attribute value contains a newline or tab, it gets replaced by a space character.

In some cases, an attribute value may contain newlines or tabs that need to be preserved. So here, we replace them with their respective character references.

---

When displaying XML attributes in text output format, escape special characters in the attribute value. (An attribute name isn't allowed to have special characters.) This ensures the entire attribute value stays on one line, that a newline doesn't get converted to a space, and that it doesn't have (for example) a double quote inside the attribute value.
    
`attrd_updater` and `crm_attribute` use this output method. It turns out that the `openstack-info` resource agent sets a multiline attribute (which I consider a bug, but it's longstanding behavior). The `openstack-virtual-ip` resource agent then depends on being able to parse it from the `attrd_updater` text output as **one line with no spaces**.
    
If there's a literal newline character in the displayed value, then there's whitespace in the output, breaking the agent's parsing.
    
(The `openstack-info` agent should set the attribute to a saner value, and the `openstack-virtual-ip` agent should parse the XML output instead of the text output, but here we are.)