### PR TITLE
Fix: libcrmcommon: Revert daemon metadata output to pre-3e84f934

### DIFF
--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -10,7 +10,7 @@
     Cluster Information Base manager options
   </shortdesc>
   <parameters>
-    <parameter name="enable-acl" advanced="0" generated="0">
+    <parameter name="enable-acl">
       <longdesc lang="en">
         Enable Access Control Lists (ACLs) for the CIB
       </longdesc>
@@ -19,7 +19,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="cluster-ipc-limit" advanced="0" generated="0">
+    <parameter name="cluster-ipc-limit">
       <longdesc lang="en">
         Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
       </longdesc>
@@ -44,7 +44,7 @@
     Pacemaker controller options
   </shortdesc>
   <parameters>
-    <parameter name="dc-version" advanced="0" generated="1">
+    <parameter name="dc-version">
       <longdesc lang="en">
         Includes a hash which identifies the exact revision the code was built from. Used for diagnostic purposes.
       </longdesc>
@@ -53,7 +53,7 @@
       </shortdesc>
       <content type="string"/>
     </parameter>
-    <parameter name="cluster-infrastructure" advanced="0" generated="1">
+    <parameter name="cluster-infrastructure">
       <longdesc lang="en">
         Used for informational and diagnostic purposes.
       </longdesc>
@@ -62,7 +62,7 @@
       </shortdesc>
       <content type="string"/>
     </parameter>
-    <parameter name="cluster-name" advanced="0" generated="0">
+    <parameter name="cluster-name">
       <longdesc lang="en">
         This optional value is mostly for users' convenience as desired in administration, but may also be used in Pacemaker configuration rules via the #cluster-name node attribute, and by higher-level tools and resource agents.
       </longdesc>
@@ -71,7 +71,7 @@
       </shortdesc>
       <content type="string"/>
     </parameter>
-    <parameter name="dc-deadtime" advanced="0" generated="0">
+    <parameter name="dc-deadtime">
       <longdesc lang="en">
         The optimal value will depend on the speed and load of your network and the type of switches used.
       </longdesc>
@@ -80,7 +80,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="cluster-recheck-interval" advanced="0" generated="0">
+    <parameter name="cluster-recheck-interval">
       <longdesc lang="en">
         Pacemaker is primarily event-driven, and looks ahead to know when to recheck cluster state for failure-timeout settings and most time-based rules. However, it will also recheck the cluster after this amount of inactivity, to evaluate rules with date specifications and serve as a fail-safe for certain types of scheduler bugs. A value of 0 disables polling. A positive value sets an interval in seconds, unless other units are specified (for example, "5min").
       </longdesc>
@@ -89,9 +89,9 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="fence-reaction" advanced="0" generated="0">
+    <parameter name="fence-reaction">
       <longdesc lang="en">
-        A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure.
+        A cluster node may receive notification of a "succeeded" fencing that targeted it if fencing is misconfigured, or if fabric fencing is in use that doesn't cut cluster communication. Use "stop" to attempt to immediately stop Pacemaker and stay stopped, or "panic" to attempt to immediately reboot the local node, falling back to stop on failure.  Allowed values: stop, panic
       </longdesc>
       <shortdesc lang="en">
         How a cluster node should react if notified of its own fencing
@@ -101,52 +101,52 @@
         <option value="panic"/>
       </content>
     </parameter>
-    <parameter name="election-timeout" advanced="1" generated="0">
+    <parameter name="election-timeout">
       <longdesc lang="en">
         Declare an election failed if it is not decided within this much time. If you need to adjust this value, it probably indicates the presence of a bug.
       </longdesc>
       <shortdesc lang="en">
-        Declare an election failed if it is not decided within this much time. If you need to adjust this value, it probably indicates the presence of a bug.
+        *** Advanced Use Only ***
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="shutdown-escalation" advanced="1" generated="0">
+    <parameter name="shutdown-escalation">
       <longdesc lang="en">
         Exit immediately if shutdown does not complete within this much time. If you need to adjust this value, it probably indicates the presence of a bug.
       </longdesc>
       <shortdesc lang="en">
-        Exit immediately if shutdown does not complete within this much time. If you need to adjust this value, it probably indicates the presence of a bug.
+        *** Advanced Use Only ***
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="join-integration-timeout" advanced="1" generated="0">
+    <parameter name="join-integration-timeout">
       <longdesc lang="en">
         If you need to adjust this value, it probably indicates the presence of a bug.
       </longdesc>
       <shortdesc lang="en">
-        If you need to adjust this value, it probably indicates the presence of a bug.
+        *** Advanced Use Only ***
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="join-finalization-timeout" advanced="1" generated="0">
+    <parameter name="join-finalization-timeout">
       <longdesc lang="en">
         If you need to adjust this value, it probably indicates the presence of a bug.
       </longdesc>
       <shortdesc lang="en">
-        If you need to adjust this value, it probably indicates the presence of a bug.
+        *** Advanced Use Only ***
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="transition-delay" advanced="1" generated="0">
+    <parameter name="transition-delay">
       <longdesc lang="en">
         Delay cluster recovery for this much time to allow for additional events to occur. Useful if your configuration is sensitive to the order in which ping updates arrive.
       </longdesc>
       <shortdesc lang="en">
-        Enabling this option will slow down cluster recovery under all conditions
+        *** Advanced Use Only *** Enabling this option will slow down cluster recovery under all conditions
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="stonith-watchdog-timeout" advanced="0" generated="0">
+    <parameter name="stonith-watchdog-timeout">
       <longdesc lang="en">
         If this is set to a positive value, lost nodes are assumed to achieve self-fencing using watchdog-based SBD within this much time. This does not require a fencing resource to be explicitly configured, though a fence_watchdog resource can be configured, to limit use to specific nodes. If this is set to 0 (the default), the cluster will never assume watchdog-based self-fencing. If this is set to a negative value, the cluster will use twice the local value of the `SBD_WATCHDOG_TIMEOUT` environment variable if that is positive, or otherwise treat this as 0. WARNING: When used, this timeout must be larger than `SBD_WATCHDOG_TIMEOUT` on all nodes that use watchdog-based SBD, and Pacemaker will refuse to start on any of those nodes where this is not true for the local value or SBD is not active. When this is set to a negative value, `SBD_WATCHDOG_TIMEOUT` must be set to the same value on all nodes that use SBD, otherwise data corruption or loss could occur.
       </longdesc>
@@ -155,7 +155,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="stonith-max-attempts" advanced="0" generated="0">
+    <parameter name="stonith-max-attempts">
       <longdesc lang="en">
         How many times fencing can fail before it will no longer be immediately re-attempted on a target
       </longdesc>
@@ -164,7 +164,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="load-threshold" advanced="0" generated="0">
+    <parameter name="load-threshold">
       <longdesc lang="en">
         The cluster will slow down its recovery process when the amount of system resources used (currently CPU) approaches this limit
       </longdesc>
@@ -173,7 +173,7 @@
       </shortdesc>
       <content type="percentage" default=""/>
     </parameter>
-    <parameter name="node-action-limit" advanced="0" generated="0">
+    <parameter name="node-action-limit">
       <longdesc lang="en">
         Maximum number of jobs that can be scheduled per node (defaults to 2x cores)
       </longdesc>
@@ -198,16 +198,16 @@
     Instance attributes available for all "stonith"-class resources
   </shortdesc>
   <parameters>
-    <parameter name="pcmk_host_argument" advanced="1" generated="0">
+    <parameter name="pcmk_host_argument">
       <longdesc lang="en">
         Some devices do not support the standard 'port' parameter or may provide additional ones. Use this to specify an alternate, device-specific, parameter that should indicate the machine to be fenced. A value of "none" can be used to tell the cluster not to supply any additional parameters.
       </longdesc>
       <shortdesc lang="en">
-        An alternate parameter to supply instead of 'port'
+        *** Advanced Use Only *** An alternate parameter to supply instead of 'port'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_host_map" advanced="0" generated="0">
+    <parameter name="pcmk_host_map">
       <longdesc lang="en">
         For example, "node1:1;node2:2,3" would tell the cluster to use port 1 for node1 and ports 2 and 3 for node2.
       </longdesc>
@@ -216,7 +216,7 @@
       </shortdesc>
       <content type="string"/>
     </parameter>
-    <parameter name="pcmk_host_list" advanced="0" generated="0">
+    <parameter name="pcmk_host_list">
       <longdesc lang="en">
         Comma-separated list of nodes that can be targeted by this device (for example, "node1,node2,node3"). If pcmk_host_check is "static-list", either this or pcmk_host_map must be set.
       </longdesc>
@@ -225,9 +225,9 @@
       </shortdesc>
       <content type="string"/>
     </parameter>
-    <parameter name="pcmk_host_check" advanced="0" generated="0">
+    <parameter name="pcmk_host_check">
       <longdesc lang="en">
-        Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node. The default value is "static-list" if pcmk_host_map or pcmk_host_list is set; otherwise "dynamic-list" if the device supports the list operation; otherwise "status" if the device supports the status operation; otherwise "none"
+        Use "dynamic-list" to query the device via the 'list' command; "static-list" to check the pcmk_host_list attribute; "status" to query the device via the 'status' command; or "none" to assume every device can fence every node. The default value is "static-list" if pcmk_host_map or pcmk_host_list is set; otherwise "dynamic-list" if the device supports the list operation; otherwise "status" if the device supports the status operation; otherwise "none"  Allowed values: dynamic-list, static-list, status, none
       </longdesc>
       <shortdesc lang="en">
         How to determine which nodes can be targeted by the device
@@ -239,7 +239,7 @@
         <option value="none"/>
       </content>
     </parameter>
-    <parameter name="pcmk_delay_max" advanced="0" generated="0">
+    <parameter name="pcmk_delay_max">
       <longdesc lang="en">
         Enable a delay of no more than the time specified before executing fencing actions. Pacemaker derives the overall delay by taking the value of pcmk_delay_base and adding a random delay value such that the sum is kept below this maximum.
       </longdesc>
@@ -248,7 +248,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_delay_base" advanced="0" generated="0">
+    <parameter name="pcmk_delay_base">
       <longdesc lang="en">
         This enables a static delay for fencing actions, which can help avoid "death matches" where two nodes try to fence each other at the same time. If pcmk_delay_max is also used, a random delay will be added such that the total delay is kept below that value. This can be set to a single time value to apply to any node targeted by this device (useful if a separate device is configured for each target), or to a node map (for example, "node1:1s;node2:5") to set a different value for each target.
       </longdesc>
@@ -257,7 +257,7 @@
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_action_limit" advanced="0" generated="0">
+    <parameter name="pcmk_action_limit">
       <longdesc lang="en">
         Cluster property concurrent-fencing="true" needs to be configured first. Then use this to specify the maximum number of actions can be performed in parallel on this device. A value of -1 means an unlimited number of actions can be performed in parallel.
       </longdesc>
@@ -266,165 +266,165 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pcmk_reboot_action" advanced="1" generated="0">
+    <parameter name="pcmk_reboot_action">
       <longdesc lang="en">
         Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'reboot' action.
       </longdesc>
       <shortdesc lang="en">
-        An alternate command to run instead of 'reboot'
+        *** Advanced Use Only *** An alternate command to run instead of 'reboot'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_reboot_timeout" advanced="1" generated="0">
+    <parameter name="pcmk_reboot_timeout">
       <longdesc lang="en">
         Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'reboot' actions.
       </longdesc>
       <shortdesc lang="en">
-        Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'reboot' actions instead of stonith-timeout
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_reboot_retries" advanced="1" generated="0">
+    <parameter name="pcmk_reboot_retries">
       <longdesc lang="en">
         Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'reboot' action before giving up.
       </longdesc>
       <shortdesc lang="en">
-        The maximum number of times to try the 'reboot' command within the timeout period
+        *** Advanced Use Only *** The maximum number of times to try the 'reboot' command within the timeout period
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pcmk_off_action" advanced="1" generated="0">
+    <parameter name="pcmk_off_action">
       <longdesc lang="en">
         Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'off' action.
       </longdesc>
       <shortdesc lang="en">
-        An alternate command to run instead of 'off'
+        *** Advanced Use Only *** An alternate command to run instead of 'off'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_off_timeout" advanced="1" generated="0">
+    <parameter name="pcmk_off_timeout">
       <longdesc lang="en">
         Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'off' actions.
       </longdesc>
       <shortdesc lang="en">
-        Specify an alternate timeout to use for 'off' actions instead of stonith-timeout
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'off' actions instead of stonith-timeout
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_off_retries" advanced="1" generated="0">
+    <parameter name="pcmk_off_retries">
       <longdesc lang="en">
         Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'off' action before giving up.
       </longdesc>
       <shortdesc lang="en">
-        The maximum number of times to try the 'off' command within the timeout period
+        *** Advanced Use Only *** The maximum number of times to try the 'off' command within the timeout period
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pcmk_on_action" advanced="1" generated="0">
+    <parameter name="pcmk_on_action">
       <longdesc lang="en">
         Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'on' action.
       </longdesc>
       <shortdesc lang="en">
-        An alternate command to run instead of 'on'
+        *** Advanced Use Only *** An alternate command to run instead of 'on'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_on_timeout" advanced="1" generated="0">
+    <parameter name="pcmk_on_timeout">
       <longdesc lang="en">
         Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'on' actions.
       </longdesc>
       <shortdesc lang="en">
-        Specify an alternate timeout to use for 'on' actions instead of stonith-timeout
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'on' actions instead of stonith-timeout
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_on_retries" advanced="1" generated="0">
+    <parameter name="pcmk_on_retries">
       <longdesc lang="en">
         Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'on' action before giving up.
       </longdesc>
       <shortdesc lang="en">
-        The maximum number of times to try the 'on' command within the timeout period
+        *** Advanced Use Only *** The maximum number of times to try the 'on' command within the timeout period
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pcmk_list_action" advanced="1" generated="0">
+    <parameter name="pcmk_list_action">
       <longdesc lang="en">
         Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'list' action.
       </longdesc>
       <shortdesc lang="en">
-        An alternate command to run instead of 'list'
+        *** Advanced Use Only *** An alternate command to run instead of 'list'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_list_timeout" advanced="1" generated="0">
+    <parameter name="pcmk_list_timeout">
       <longdesc lang="en">
         Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'list' actions.
       </longdesc>
       <shortdesc lang="en">
-        Specify an alternate timeout to use for 'list' actions instead of stonith-timeout
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'list' actions instead of stonith-timeout
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_list_retries" advanced="1" generated="0">
+    <parameter name="pcmk_list_retries">
       <longdesc lang="en">
         Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'list' action before giving up.
       </longdesc>
       <shortdesc lang="en">
-        The maximum number of times to try the 'list' command within the timeout period
+        *** Advanced Use Only *** The maximum number of times to try the 'list' command within the timeout period
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pcmk_monitor_action" advanced="1" generated="0">
+    <parameter name="pcmk_monitor_action">
       <longdesc lang="en">
         Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'monitor' action.
       </longdesc>
       <shortdesc lang="en">
-        An alternate command to run instead of 'monitor'
+        *** Advanced Use Only *** An alternate command to run instead of 'monitor'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_monitor_timeout" advanced="1" generated="0">
+    <parameter name="pcmk_monitor_timeout">
       <longdesc lang="en">
         Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'monitor' actions.
       </longdesc>
       <shortdesc lang="en">
-        Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'monitor' actions instead of stonith-timeout
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_monitor_retries" advanced="1" generated="0">
+    <parameter name="pcmk_monitor_retries">
       <longdesc lang="en">
         Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'monitor' action before giving up.
       </longdesc>
       <shortdesc lang="en">
-        The maximum number of times to try the 'monitor' command within the timeout period
+        *** Advanced Use Only *** The maximum number of times to try the 'monitor' command within the timeout period
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pcmk_status_action" advanced="1" generated="0">
+    <parameter name="pcmk_status_action">
       <longdesc lang="en">
         Some devices do not support the standard commands or may provide additional ones. Use this to specify an alternate, device-specific, command that implements the 'status' action.
       </longdesc>
       <shortdesc lang="en">
-        An alternate command to run instead of 'status'
+        *** Advanced Use Only *** An alternate command to run instead of 'status'
       </shortdesc>
       <content type="string" default=""/>
     </parameter>
-    <parameter name="pcmk_status_timeout" advanced="1" generated="0">
+    <parameter name="pcmk_status_timeout">
       <longdesc lang="en">
         Some devices need much more/less time to complete than normal. Use this to specify an alternate, device-specific, timeout for 'status' actions.
       </longdesc>
       <shortdesc lang="en">
-        Specify an alternate timeout to use for 'status' actions instead of stonith-timeout
+        *** Advanced Use Only *** Specify an alternate timeout to use for 'status' actions instead of stonith-timeout
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="pcmk_status_retries" advanced="1" generated="0">
+    <parameter name="pcmk_status_retries">
       <longdesc lang="en">
         Some devices do not support multiple connections. Operations may "fail" if the device is busy with another task. In that case, Pacemaker will automatically retry the operation if there is time remaining. Use this option to alter the number of times Pacemaker tries a 'status' action before giving up.
       </longdesc>
       <shortdesc lang="en">
-        The maximum number of times to try the 'status' command within the timeout period
+        *** Advanced Use Only *** The maximum number of times to try the 'status' command within the timeout period
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
@@ -444,9 +444,9 @@
     Pacemaker scheduler options
   </shortdesc>
   <parameters>
-    <parameter name="no-quorum-policy" advanced="0" generated="0">
+    <parameter name="no-quorum-policy">
       <longdesc lang="en">
-        What to do when the cluster does not have quorum
+        What to do when the cluster does not have quorum  Allowed values: stop, freeze, ignore, demote, suicide
       </longdesc>
       <shortdesc lang="en">
         What to do when the cluster does not have quorum
@@ -459,7 +459,7 @@
         <option value="suicide"/>
       </content>
     </parameter>
-    <parameter name="shutdown-lock" advanced="0" generated="0">
+    <parameter name="shutdown-lock">
       <longdesc lang="en">
         When true, resources active on a node when it is cleanly shut down are kept "locked" to that node (not allowed to run elsewhere) until they start again on that node after it rejoins (or for at most shutdown-lock-limit, if set). Stonith resources and Pacemaker Remote connections are never locked. Clone and bundle instances and the promoted role of promotable clones are currently never locked, though support could be added in a future release.
       </longdesc>
@@ -468,7 +468,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="shutdown-lock-limit" advanced="0" generated="0">
+    <parameter name="shutdown-lock-limit">
       <longdesc lang="en">
         If shutdown-lock is true and this is set to a nonzero time duration, shutdown locks will expire after this much time has passed since the shutdown was initiated, even if the node has not rejoined.
       </longdesc>
@@ -477,7 +477,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="symmetric-cluster" advanced="0" generated="0">
+    <parameter name="symmetric-cluster">
       <longdesc lang="en">
         Whether resources can run on any node by default
       </longdesc>
@@ -486,7 +486,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="maintenance-mode" advanced="0" generated="0">
+    <parameter name="maintenance-mode">
       <longdesc lang="en">
         Whether the cluster should refrain from monitoring, starting, and stopping resources
       </longdesc>
@@ -495,7 +495,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="start-failure-is-fatal" advanced="0" generated="0">
+    <parameter name="start-failure-is-fatal">
       <longdesc lang="en">
         When true, the cluster will immediately ban a resource from a node if it fails to start there. When false, the cluster will instead check the resource's fail count against its migration-threshold.
       </longdesc>
@@ -504,7 +504,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="enable-startup-probes" advanced="0" generated="0">
+    <parameter name="enable-startup-probes">
       <longdesc lang="en">
         Whether the cluster should check for active resources during start-up
       </longdesc>
@@ -513,18 +513,18 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="stonith-enabled" advanced="1" generated="0">
+    <parameter name="stonith-enabled">
       <longdesc lang="en">
         If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.
       </longdesc>
       <shortdesc lang="en">
-        Whether nodes may be fenced as part of recovery
+        *** Advanced Use Only *** Whether nodes may be fenced as part of recovery
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="stonith-action" advanced="0" generated="0">
+    <parameter name="stonith-action">
       <longdesc lang="en">
-        Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")
+        Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")  Allowed values: reboot, off, poweroff
       </longdesc>
       <shortdesc lang="en">
         Action to send to fence device when a node needs to be fenced ("poweroff" is a deprecated alias for "off")
@@ -535,7 +535,7 @@
         <option value="poweroff"/>
       </content>
     </parameter>
-    <parameter name="stonith-timeout" advanced="0" generated="0">
+    <parameter name="stonith-timeout">
       <longdesc lang="en">
         How long to wait for on, off, and reboot fence actions to complete by default
       </longdesc>
@@ -544,7 +544,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="have-watchdog" advanced="0" generated="1">
+    <parameter name="have-watchdog">
       <longdesc lang="en">
         This is set automatically by the cluster according to whether SBD is detected to be in use. User-configured values are ignored. The value `true` is meaningful if diskless SBD is used and `stonith-watchdog-timeout` is nonzero. In that case, if fencing is required, watchdog-based self-fencing will be performed via SBD without requiring a fencing resource explicitly configured.
       </longdesc>
@@ -553,7 +553,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="concurrent-fencing" advanced="0" generated="0">
+    <parameter name="concurrent-fencing">
       <longdesc lang="en">
         Allow performing fencing operations in parallel
       </longdesc>
@@ -562,16 +562,16 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="startup-fencing" advanced="1" generated="0">
+    <parameter name="startup-fencing">
       <longdesc lang="en">
         Setting this to false may lead to a "split-brain" situation, potentially leading to data loss and/or service unavailability.
       </longdesc>
       <shortdesc lang="en">
-        Whether to fence unseen nodes at start-up
+        *** Advanced Use Only *** Whether to fence unseen nodes at start-up
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="priority-fencing-delay" advanced="0" generated="0">
+    <parameter name="priority-fencing-delay">
       <longdesc lang="en">
         Apply specified delay for the fencings that are targeting the lost nodes with the highest total resource priority in case we don't have the majority of the nodes in our cluster partition, so that the more significant nodes potentially win any fencing match, which is especially meaningful under split-brain of 2-node cluster. A promoted resource instance takes the base priority + 1 on calculation if the base priority is not 0. Any static/random delays that are introduced by `pcmk_delay_base/max` configured for the corresponding fencing resources will be added to this delay. This delay should be significantly greater than, safely twice, the maximum `pcmk_delay_base/max`. By default, priority fencing delay is disabled.
       </longdesc>
@@ -580,7 +580,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="node-pending-timeout" advanced="0" generated="0">
+    <parameter name="node-pending-timeout">
       <longdesc lang="en">
         Fence nodes that do not join the controller process group within this much time after joining the cluster, to allow the cluster to continue managing resources. A value of 0 means never fence pending nodes. Setting the value to 2h means fence nodes after 2 hours.
       </longdesc>
@@ -589,7 +589,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="cluster-delay" advanced="0" generated="0">
+    <parameter name="cluster-delay">
       <longdesc lang="en">
         The node elected Designated Controller (DC) will consider an action failed if it does not get a response from the node executing the action within this time (after considering the action's own timeout). The "correct" value will depend on the speed and load of your network and cluster nodes.
       </longdesc>
@@ -598,7 +598,7 @@
       </shortdesc>
       <content type="time" default=""/>
     </parameter>
-    <parameter name="batch-limit" advanced="0" generated="0">
+    <parameter name="batch-limit">
       <longdesc lang="en">
         The "correct" value will depend on the speed and load of your network and cluster nodes. If set to 0, the cluster will impose a dynamically calculated limit when any node has a high load.
       </longdesc>
@@ -607,7 +607,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="migration-limit" advanced="0" generated="0">
+    <parameter name="migration-limit">
       <longdesc lang="en">
         The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)
       </longdesc>
@@ -616,7 +616,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="stop-all-resources" advanced="0" generated="0">
+    <parameter name="stop-all-resources">
       <longdesc lang="en">
         Whether the cluster should stop all active resources
       </longdesc>
@@ -625,7 +625,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="stop-orphan-resources" advanced="0" generated="0">
+    <parameter name="stop-orphan-resources">
       <longdesc lang="en">
         Whether to stop resources that were removed from the configuration
       </longdesc>
@@ -634,7 +634,7 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="stop-orphan-actions" advanced="0" generated="0">
+    <parameter name="stop-orphan-actions">
       <longdesc lang="en">
         Whether to cancel recurring actions removed from the configuration
       </longdesc>
@@ -643,17 +643,16 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="remove-after-stop" advanced="0" generated="0">
-      <deprecated/>
+    <parameter name="remove-after-stop">
       <longdesc lang="en">
         Values other than default are poorly tested and potentially dangerous.
       </longdesc>
       <shortdesc lang="en">
-        Whether to remove stopped resources from the executor
+        *** Deprecated *** Whether to remove stopped resources from the executor
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
-    <parameter name="pe-error-series-max" advanced="0" generated="0">
+    <parameter name="pe-error-series-max">
       <longdesc lang="en">
         Zero to disable, -1 to store unlimited.
       </longdesc>
@@ -662,7 +661,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pe-warn-series-max" advanced="0" generated="0">
+    <parameter name="pe-warn-series-max">
       <longdesc lang="en">
         Zero to disable, -1 to store unlimited.
       </longdesc>
@@ -671,7 +670,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="pe-input-series-max" advanced="0" generated="0">
+    <parameter name="pe-input-series-max">
       <longdesc lang="en">
         Zero to disable, -1 to store unlimited.
       </longdesc>
@@ -680,9 +679,9 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="node-health-strategy" advanced="0" generated="0">
+    <parameter name="node-health-strategy">
       <longdesc lang="en">
-        Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green".
+        Requires external entities to create node attributes (named with the prefix "#health") with values "red", "yellow", or "green".  Allowed values: none, migrate-on-red, only-green, progressive, custom
       </longdesc>
       <shortdesc lang="en">
         How cluster should react to node health attributes
@@ -695,7 +694,7 @@
         <option value="custom"/>
       </content>
     </parameter>
-    <parameter name="node-health-base" advanced="0" generated="0">
+    <parameter name="node-health-base">
       <longdesc lang="en">
         Only used when "node-health-strategy" is set to "progressive".
       </longdesc>
@@ -704,7 +703,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="node-health-green" advanced="0" generated="0">
+    <parameter name="node-health-green">
       <longdesc lang="en">
         Only used when "node-health-strategy" is set to "custom" or "progressive".
       </longdesc>
@@ -713,7 +712,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="node-health-yellow" advanced="0" generated="0">
+    <parameter name="node-health-yellow">
       <longdesc lang="en">
         Only used when "node-health-strategy" is set to "custom" or "progressive".
       </longdesc>
@@ -722,7 +721,7 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="node-health-red" advanced="0" generated="0">
+    <parameter name="node-health-red">
       <longdesc lang="en">
         Only used when "node-health-strategy" is set to "custom" or "progressive".
       </longdesc>
@@ -731,9 +730,9 @@
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>
-    <parameter name="placement-strategy" advanced="0" generated="0">
+    <parameter name="placement-strategy">
       <longdesc lang="en">
-        How the cluster should allocate resources to nodes
+        How the cluster should allocate resources to nodes  Allowed values: default, utilization, minimal, balanced
       </longdesc>
       <shortdesc lang="en">
         How the cluster should allocate resources to nodes

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -789,6 +789,7 @@ fencer_metadata(void)
         return rc;
     }
 
+    pcmk__output_set_legacy_xml(tmp_out);
     out->message(tmp_out, "option-list", name, desc_short, desc_long,
                  pcmk__opt_none, fencer_options, true);
 

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -926,12 +926,29 @@ int pcmk__text_output_new(pcmk__output_t **out, const char *filename);
 
 /*!
  * \internal
- * \brief Enable the older style XML output used by `crm_mon -X`
+ * \brief Check whether older style XML output is enabled
  *
- * \note This function should not be used anywhere except in crm_mon.
+ * The legacy flag should be used sparingly. Its meaning depends on the context
+ * in which it's used.
  *
- * @COMPAT This can be removed when `crm_mon -X` is removed
+ * \param[in] out  Output object
+ *
+ * \return \c true if the \c legacy_xml flag is enabled for \p out, or \c false
+ *         otherwise
  */
+// @COMPAT This can be removed when `crm_mon -X` and daemon metadata are removed
+bool pcmk__output_get_legacy_xml(pcmk__output_t *out);
+
+/*!
+ * \internal
+ * \brief Enable older style XML output
+ *
+ * The legacy flag should be used sparingly. Its meaning depends on the context
+ * in which it's used.
+ *
+ * \param[in,out] out  Output object
+ */
+// @COMPAT This can be removed when `crm_mon -X` and daemon metadata are removed
 void pcmk__output_set_legacy_xml(pcmk__output_t *out);
 
 /*!

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -985,6 +985,7 @@ pcmk__daemon_metadata(pcmk__output_t *out, const char *name,
         return rc;
     }
 
+    pcmk__output_set_legacy_xml(tmp_out);
     pcmk__output_cluster_options(tmp_out, name, desc_short, desc_long,
                                  (uint32_t) filter, true);
 

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -589,6 +589,23 @@ pcmk__output_xml_peek_parent(pcmk__output_t *out) {
     return g_queue_peek_tail(priv->parent_q);
 }
 
+bool
+pcmk__output_get_legacy_xml(pcmk__output_t *out)
+{
+    private_data_t *priv = NULL;
+
+    CRM_ASSERT(out != NULL);
+
+    if (!pcmk__str_eq(out->fmt_name, "xml", pcmk__str_none)) {
+        return false;
+    }
+
+    CRM_ASSERT(out->priv != NULL);
+
+    priv = out->priv;
+    return priv->legacy_xml;
+}
+
 void
 pcmk__output_set_legacy_xml(pcmk__output_t *out)
 {


### PR DESCRIPTION
We've recently deprecated daemon metadata commands in favor of `crm_attribute --list-options=cluster`, using the `"option-list"` message formatter function. Along the way, we've made a number of changes to clean up and standardize the output.

Unfortunately, some external tools (for example, `pcs` and `crmsh`) depend on very specific strings in the old output format. For example, `pcs` ignores the `<content>` element containing the list of possible values; instead it relies on the `"  Allowed values:"` string in the `<longdesc>`. It also validates the output against its own custom version of the OCF resource agent schema (many agents don't conform to the official one), which does not allow the `"advanced"` and `"generated"` attributes.

`crmsh` has some similar dependencies, though I'm not aware of the details.

These tools should eventually be updated to use `crm_attribute` and the new output format. However, in the meantime, the daemon metadata output should go back to the old format, so that the tools don't break upon a Pacemaker upgrade.

---

@tomjelinek @gao-yan Can you take a look at this? It's a follow-up to this discussion:
https://github.com/ClusterLabs/pacemaker/pull/3338#discussion_r1498402478