### PR TITLE
Enable access-render test in cts-cli

### DIFF
--- a/cts/cli/regression.access_render.exp
+++ b/cts/cli/regression.access_render.exp
@@ -1,7 +1,6 @@
 Created new pacemaker configuration
-Setting up shadow instance
-A new shadow instance was created.  To begin using it paste the following into your shell:
-  CIB_shadow=cts-cli ; export CIB_shadow
+A new shadow instance was created. To begin using it, enter the following into your shell:
+	export CIB_shadow=cts-cli
 =#=#=#= Begin test: Configure some ACLs =#=#=#=
 =#=#=#= Current cib after: Configure some ACLs =#=#=#=
 <cib epoch="1" num_updates="0" admin_epoch="0">

--- a/cts/cli/regression.access_render.exp
+++ b/cts/cli/regression.access_render.exp
@@ -10,12 +10,13 @@ A new shadow instance was created. To begin using it, enter the following into y
     <resources/>
     <constraints/>
     <acls>
-      <acl_role id="role-deny-acls">
+      <acl_role id="role-deny-acls-write-resources">
         <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="write-resources" kind="write" xpath="/cib/configuration/resources"/>
         <acl_permission id="read-rest" kind="read" xpath="/cib"/>
       </acl_role>
       <acl_target id="tony">
-        <role id="role-deny-acls"/>
+        <role id="role-deny-acls-write-resources"/>
       </acl_target>
     </acls>
   </configuration>
@@ -36,12 +37,13 @@ A new shadow instance was created. To begin using it, enter the following into y
     <resources/>
     <constraints/>
     <acls>
-      <acl_role id="role-deny-acls">
+      <acl_role id="role-deny-acls-write-resources">
         <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="write-resources" kind="write" xpath="/cib/configuration/resources"/>
         <acl_permission id="read-rest" kind="read" xpath="/cib"/>
       </acl_role>
       <acl_target id="tony">
-        <role id="role-deny-acls"/>
+        <role id="role-deny-acls-write-resources"/>
       </acl_target>
     </acls>
   </configuration>
@@ -59,15 +61,16 @@ A new shadow instance was created. To begin using it, enter the following into y
       \x1b[34m</cluster_property_set>[0m
     \x1b[34m</crm_config>[0m
     \x1b[34m<nodes/>[0m
-    \x1b[34m<resources/>[0m
+    \x1b[32m<resources/>[0m
     \x1b[34m<constraints/>[0m
     \x1b[31m<acls>
-      \x1b[31m<acl_role id="role-deny-acls">
+      \x1b[31m<acl_role id="role-deny-acls-write-resources">
         \x1b[31m<acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>[0m
+        \x1b[31m<acl_permission id="write-resources" kind="write" xpath="/cib/configuration/resources"/>[0m
         \x1b[31m<acl_permission id="read-rest" kind="read" xpath="/cib"/>[0m
       \x1b[31m</acl_role>[0m
       \x1b[31m<acl_target id="tony">
-        \x1b[31m<role id="role-deny-acls"/>[0m
+        \x1b[31m<role id="role-deny-acls-write-resources"/>[0m
       \x1b[31m</acl_target>[0m
     \x1b[31m</acls>[0m
   \x1b[34m</configuration>[0m
@@ -77,7 +80,7 @@ A new shadow instance was created. To begin using it, enter the following into y
 * Passed: cibadmin       - An instance of ACLs render (into color)
 =#=#=#= Begin test: An instance of ACLs render (into namespacing) =#=#=#=
 <!-- ACLs as evaluated for user tony -->
-<pcmk-access-readable:cib epoch="3" num_updates="0" admin_epoch="0" xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable" xmlns:pcmk-access-denied="http://clusterlabs.org/ns/pacemaker/access/denied">
+<pcmk-access-readable:cib epoch="3" num_updates="0" admin_epoch="0" xmlns:pcmk-access-writable="http://clusterlabs.org/ns/pacemaker/access/writable" xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable" xmlns:pcmk-access-denied="http://clusterlabs.org/ns/pacemaker/access/denied">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -85,15 +88,16 @@ A new shadow instance was created. To begin using it, enter the following into y
       </cluster_property_set>
     </crm_config>
     <nodes/>
-    <resources/>
+    <pcmk-access-writable:resources/>
     <constraints/>
     <pcmk-access-denied:acls>
-      <acl_role id="role-deny-acls">
+      <acl_role id="role-deny-acls-write-resources">
         <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="write-resources" kind="write" xpath="/cib/configuration/resources"/>
         <acl_permission id="read-rest" kind="read" xpath="/cib"/>
       </acl_role>
       <acl_target id="tony">
-        <role id="role-deny-acls"/>
+        <role id="role-deny-acls-write-resources"/>
       </acl_target>
     </pcmk-access-denied:acls>
   </configuration>
@@ -112,17 +116,20 @@ vvv---[ READABLE ]---vvv
       </cluster_property_set>
     </crm_config>
     <nodes/>
+    
+    vvv---[ WRITABLE ]---vvv
     <resources/>
     <constraints/>
     
     vvv---[ ~DENIED~ ]---vvv
     <acls>
-      <acl_role id="role-deny-acls">
+      <acl_role id="role-deny-acls-write-resources">
         <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+        <acl_permission id="write-resources" kind="write" xpath="/cib/configuration/resources"/>
         <acl_permission id="read-rest" kind="read" xpath="/cib"/>
       </acl_role>
       <acl_target id="tony">
-        <role id="role-deny-acls"/>
+        <role id="role-deny-acls-write-resources"/>
       </acl_target>
     </acls>
   </configuration>

--- a/cts/cli/regression.access_render.exp
+++ b/cts/cli/regression.access_render.exp
@@ -3,7 +3,7 @@ A new shadow instance was created. To begin using it, enter the following into y
 	export CIB_shadow=cts-cli
 =#=#=#= Begin test: Configure some ACLs =#=#=#=
 =#=#=#= Current cib after: Configure some ACLs =#=#=#=
-<cib epoch="1" num_updates="0" admin_epoch="0">
+<cib epoch="2" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config/>
     <nodes/>
@@ -25,7 +25,7 @@ A new shadow instance was created. To begin using it, enter the following into y
 * Passed: cibadmin       - Configure some ACLs
 =#=#=#= Begin test: Enable ACLs =#=#=#=
 =#=#=#= Current cib after: Enable ACLs =#=#=#=
-<cib epoch="2" num_updates="0" admin_epoch="0">
+<cib epoch="3" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -51,7 +51,7 @@ A new shadow instance was created. To begin using it, enter the following into y
 * Passed: crm_attribute  - Enable ACLs
 =#=#=#= Begin test: An instance of ACLs render (into color) =#=#=#=
 <!-- ACLs as evaluated for user tony -->
-\x1b[34m<cib epoch="2" num_updates="0" admin_epoch="0">
+\x1b[34m<cib epoch="3" num_updates="0" admin_epoch="0">
   \x1b[34m<configuration>
     \x1b[34m<crm_config>
       \x1b[34m<cluster_property_set id="cib-bootstrap-options">
@@ -77,7 +77,7 @@ A new shadow instance was created. To begin using it, enter the following into y
 * Passed: cibadmin       - An instance of ACLs render (into color)
 =#=#=#= Begin test: An instance of ACLs render (into namespacing) =#=#=#=
 <!-- ACLs as evaluated for user tony -->
-<pcmk-access-readable:cib epoch="2" num_updates="0" admin_epoch="0" xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable" xmlns:pcmk-access-denied="http://clusterlabs.org/ns/pacemaker/access/denied">
+<pcmk-access-readable:cib epoch="3" num_updates="0" admin_epoch="0" xmlns:pcmk-access-readable="http://clusterlabs.org/ns/pacemaker/access/readable" xmlns:pcmk-access-denied="http://clusterlabs.org/ns/pacemaker/access/denied">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">
@@ -104,7 +104,7 @@ A new shadow instance was created. To begin using it, enter the following into y
 =#=#=#= Begin test: An instance of ACLs render (into text) =#=#=#=
 <!-- ACLs as evaluated for user tony -->
 vvv---[ READABLE ]---vvv
-<cib epoch="2" num_updates="0" admin_epoch="0">
+<cib epoch="3" num_updates="0" admin_epoch="0">
   <configuration>
     <crm_config>
       <cluster_property_set id="cib-bootstrap-options">

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -23,8 +23,8 @@ Options:
  --help          Display this text, then exit
  -V, --verbose   Display any differences from expected output
  -t 'TEST [...]' Run only specified tests
-                 (default: 'daemons dates error_codes tools crm_mon acls
-                            validity upgrade rules feature_set').
+                 (default: 'access_render daemons dates error_codes tools
+                            crm_mon acls validity upgrade rules feature_set').
                  Other tests: agents (must be run in an installed environment).
  -p DIR          Look for executables in DIR (may be specified multiple times)
  -v, --valgrind  Run all commands under valgrind
@@ -43,8 +43,8 @@ shadow_dir=$(mktemp -d ${TMPDIR:-/tmp}/cts-cli.shadow.XXXXXXXXXX)
 num_errors=0
 num_passed=0
 verbose=0
-tests="daemons dates error_codes tools crm_mon acls validity upgrade rules "
-tests="$tests feature_set"
+tests="access_render daemons dates error_codes tools crm_mon acls validity"
+tests="$tests upgrade rules feature_set"
 do_save=0
 XMLLINT_CMD=
 VALGRIND_CMD=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1,6 +1,6 @@
 #!@BASH_PATH@
 #
-# Copyright 2008-2023 the Pacemaker project contributors
+# Copyright 2008-2024 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -3375,6 +3375,7 @@ done
 
 for t in $tests; do
     case "$t" in
+        access_render) ;;
         agents) ;;
         daemons) ;;
         dates) ;;

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -3426,6 +3426,12 @@ for t in $tests; do
     eval TMPFILE_$t="$TMPFILE"
     test_$t > "$TMPFILE"
 
+    # @TODO Add a way to suppress this message within cibadmin, and then drop
+    # the handling here.
+    suppress="The supplied command can provide skewed result since it is run"
+    suppress="$suppress under user that also gets guarded per ACLs on their"
+    suppress="$suppress own right. Continuing since --force flag was provided."
+
     # last-rc-change= is always numeric in the CIB. However, for the crm_mon
     # test we also need to compare against the XML output of the crm_mon
     # program. There, these are shown as human readable strings (like the
@@ -3478,6 +3484,7 @@ for t in $tests; do
         -e 's/Master/Promoted/' \
         -e 's/Slave/Unpromoted/' \
         -e 's/\x1b/\\x1b/' \
+        -e "/$suppress/d" \
         "$TMPFILE" > "${TMPFILE}.$$"
     mv -- "${TMPFILE}.$$" "$TMPFILE"
 

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -3262,12 +3262,14 @@ test_access_render() {
     # Create a test CIB that has ACL roles
     cat <<EOF > "$TMPXML"
 <acls>
-  <acl_role id="role-deny-acls">
+  <acl_role id="role-deny-acls-write-resources">
     <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+    <acl_permission id="write-resources" kind="write"
+                    xpath="/cib/configuration/resources"/>
     <acl_permission id="read-rest" kind="read" xpath="/cib"/>
   </acl_role>
   <acl_target id="tony">
-    <role id="role-deny-acls"/>
+    <role id="role-deny-acls-write-resources"/>
   </acl_target>
 </acls>
 EOF

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -3255,25 +3255,21 @@ EOF
 # Ensure all command output is in portable locale for comparison
 export LC_ALL="C"
 test_access_render() {
-    local TMPXML
+    local TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.access_render.xml.XXXXXXXXXX)
 
-    TMPXML=$(mktemp ${TMPDIR:-/tmp}/cts-cli.access_render.xml.XXXXXXXXXX)
-    export CIB_shadow_dir="${shadow_dir}"
-
-    $VALGRIND_CMD crm_shadow --batch --force --create-empty $shadow 2>&1
-    export CIB_shadow=$shadow
+    create_shadow_cib --create-empty
 
     # Create a test CIB that has ACL roles
     cat <<EOF > "$TMPXML"
-    <acls>
-      <acl_role id="role-deny-acls">
-        <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
-        <acl_permission id="read-rest" kind="read" xpath="/cib"/>
-      </acl_role>
-      <acl_target id="tony">
-        <role id="role-deny-acls"/>
-      </acl_target>
-    </acls>
+<acls>
+  <acl_role id="role-deny-acls">
+    <acl_permission id="deny-acls" kind="deny" xpath="/cib/configuration/acls"/>
+    <acl_permission id="read-rest" kind="read" xpath="/cib"/>
+  </acl_role>
+  <acl_target id="tony">
+    <role id="role-deny-acls"/>
+  </acl_target>
+</acls>
 EOF
 
     desc="Configure some ACLs"
@@ -3286,7 +3282,7 @@ EOF
 
     unset CIB_user
 
-    # Run cibadmin --show-access on the test CIB with different users (tony here)
+    # Run cibadmin --show-access on the test CIB as an ACL-restricted user
 
     desc="An instance of ACLs render (into color)"
     cmd="cibadmin --force --show-access=color -Q --user tony"


### PR DESCRIPTION
I find it strange that tony is able to see the ACLs in the output, since he's denied any permissions on `<acls>`. I changed "tony" to "reid" (my username), and the output is identical except for the name change... so it's not about which user is running the test.

I see that the test was disabled in the first place via 326eb9f6 due to unspecified output mismatches that appear only in CI... so we'll see if they happen again, and document them if so.