### PR TITLE
Log: fencer: always format time_t values as long long

### DIFF
--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1048,8 +1048,8 @@ merge_duplicates(remote_fencing_op_t *op)
         }
         if ((other->total_timeout > 0)
             && (now > (other->total_timeout + other->created))) {
-            crm_trace("%.8s not duplicate of %.8s: old (%ld vs. %ld + %ds)",
-                      op->id, other->id, now, other->created,
+            crm_trace("%.8s not duplicate of %.8s: old (%lld vs. %lld + %ds)",
+                      op->id, other->id, (long long)now, (long long)other->created,
                       other->total_timeout);
             continue;
         }


### PR DESCRIPTION
Conventionally it's signed long under the GNU C library, which is 32 bits on 32-bit architectures, but Glibc provides the __TIME_BITS==64 option, which makes it signed long long instead (64 bits) and makes no difference on 64-bit architectures [1].  This enables using the %lld conversion specifier uniformly across all supported architectures. This got exposed by Debian recently transitioning to 64-bit time_t [2].

[1] https://sourceware.org/glibc/wiki/Y2038ProofnessDesign
[2] https://wiki.debian.org/ReleaseGoals/64bit-time