### PR TITLE
Warn on deprecated CIB syntax

### DIFF
--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -47,6 +47,12 @@ enum pcmk__warnings {
     pcmk__wo_op_attr_expr   = (1 << 19),
     pcmk__wo_instance_defaults  = (1 << 20),
     pcmk__wo_multiple_rules     = (1 << 21),
+    pcmk__wo_master_element = (1 << 22),
+    pcmk__wo_clone_master_max       = (1 << 23),
+    pcmk__wo_clone_master_node_max  = (1 << 24),
+    pcmk__wo_bundle_master  = (1 << 25),
+    pcmk__wo_master_role    = (1 << 26),
+    pcmk__wo_slave_role     = (1 << 27),
 };
 
 /*!

--- a/lib/common/roles.c
+++ b/lib/common/roles.c
@@ -65,11 +65,23 @@ pcmk_parse_role(const char *role)
         return pcmk_role_stopped;
     } else if (pcmk__str_eq(role, PCMK_ROLE_STARTED, pcmk__str_casei)) {
         return pcmk_role_started;
-    } else if (pcmk__strcase_any_of(role, PCMK_ROLE_UNPROMOTED,
-                                    PCMK__ROLE_UNPROMOTED_LEGACY, NULL)) {
+    } else if (pcmk__str_eq(role, PCMK__ROLE_UNPROMOTED_LEGACY, pcmk__str_casei)) {
+        pcmk__warn_once(pcmk__wo_slave_role,
+                        "Support for the " PCMK__ROLE_UNPROMOTED_LEGACY
+                        " role is deprecated and will be removed in a "
+                        "future release. Use " PCMK_ROLE_UNPROMOTED
+                        " instead.");
         return pcmk_role_unpromoted;
-    } else if (pcmk__strcase_any_of(role, PCMK_ROLE_PROMOTED,
-                                    PCMK__ROLE_PROMOTED_LEGACY, NULL)) {
+    } else if (pcmk__str_eq(role, PCMK_ROLE_UNPROMOTED, pcmk__str_casei)) {
+        return pcmk_role_unpromoted;
+    } else if (pcmk__str_eq(role, PCMK__ROLE_PROMOTED_LEGACY, pcmk__str_casei)) {
+        pcmk__warn_once(pcmk__wo_master_role,
+                        "Support for the " PCMK__ROLE_PROMOTED_LEGACY
+                        " role is deprecated and will be removed in a "
+                        "future release. Use " PCMK_ROLE_PROMOTED
+                        " instead.");
+        return pcmk_role_promoted;
+    } else if (pcmk__str_eq(role, PCMK_ROLE_PROMOTED, pcmk__str_casei)) {
         return pcmk_role_promoted;
     }
     return pcmk_role_unknown; // Invalid role given

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1026,6 +1026,15 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
     if (value == NULL) {
         // @COMPAT deprecated since 2.0.0
         value = crm_element_value(xml_obj, PCMK__XA_PROMOTED_MAX_LEGACY);
+
+        if (value != NULL) {
+            pcmk__warn_once(pcmk__wo_bundle_master,
+                            "Support for the " PCMK__XA_PROMOTED_MAX_LEGACY
+                            " attribute (such as in %s) is deprecated and "
+                            "will be removed in a future release. Use "
+                            PCMK_XA_PROMOTED_MAX " instead.",
+                            rsc->id);
+        }
     }
     pcmk__scan_min_int(value, &bundle_data->promoted_max, 0);
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -317,6 +317,26 @@ unpack_meta_int(const pcmk_resource_t *rsc, const char *meta_name,
 
     if ((value == NULL) && (deprecated_name != NULL)) {
         value = g_hash_table_lookup(rsc->meta, deprecated_name);
+
+        if (value != NULL) {
+            if (pcmk__str_eq(deprecated_name, PCMK__META_PROMOTED_MAX_LEGACY,
+                             pcmk__str_none)) {
+                pcmk__warn_once(pcmk__wo_clone_master_max,
+                                "Support for the " PCMK__META_PROMOTED_MAX_LEGACY
+                                " meta-attribute (such as in %s) is deprecated "
+                                "and will be removed in a future release. Use the "
+                                PCMK_META_PROMOTED_MAX " meta-attribute instead.",
+                                rsc->id);
+            } else if (pcmk__str_eq(deprecated_name, PCMK__META_PROMOTED_NODE_MAX_LEGACY,
+                                    pcmk__str_none)) {
+                pcmk__warn_once(pcmk__wo_clone_master_node_max,
+                                "Support for the " PCMK__META_PROMOTED_NODE_MAX_LEGACY
+                                " meta-attribute (such as in %s) is deprecated "
+                                "and will be removed in a future release. Use the "
+                                PCMK_META_PROMOTED_NODE_MAX " meta-attribute instead.",
+                                rsc->id);
+            }
+        }
     }
     if (value != NULL) {
         pcmk__scan_min_int(value, &integer, 0);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -447,9 +447,12 @@ detect_promotable(pcmk_resource_t *rsc)
 
     // @COMPAT deprecated since 2.0.0
     if (pcmk__xe_is(rsc->xml, PCMK__XE_PROMOTABLE_LEGACY)) {
-        /* @TODO in some future version, pcmk__warn_once() here,
-         *       then drop support in even later version
-         */
+        pcmk__warn_once(pcmk__wo_master_element,
+                        "Support for <" PCMK__XE_PROMOTABLE_LEGACY "> (such "
+                        "as in %s) is deprecated and will be removed in a "
+                        "future release. Use <" PCMK_XE_CLONE "> with a "
+                        PCMK_META_PROMOTABLE " meta-attribute instead.",
+                        rsc->id);
         pcmk__insert_dup(rsc->meta, PCMK_META_PROMOTABLE, PCMK_VALUE_TRUE);
         return TRUE;
     }


### PR DESCRIPTION
I think there's another PR out there at the moment that also touches the `pcmk__wo_` constants, so whichever goes second will have to make some changes there.  Also note that this does not address deprecating `crm_map_element_name`, which is also going to be in a separate PR.