### PR TITLE
Fix: libcrmcommon: Avoid use-after-free in mark_xml_changes()

### DIFF
--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1459,6 +1459,8 @@ mark_child_moved(xmlNode *old_child, xmlNode *new_parent, xmlNode *new_child,
 static void
 mark_xml_changes(xmlNode *old_xml, xmlNode *new_xml, bool check_top)
 {
+    xmlNode *old_child = NULL;
+    xmlNode *new_child = NULL;
     xml_node_private_t *nodepriv = NULL;
 
     CRM_CHECK(new_xml != NULL, return);
@@ -1480,13 +1482,13 @@ mark_xml_changes(xmlNode *old_xml, xmlNode *new_xml, bool check_top)
     xml_diff_attrs(old_xml, new_xml);
 
     // Check for differences in the original children
-    for (xmlNode *old_child = pcmk__xml_first_child(old_xml); old_child != NULL;
+    for (old_child = pcmk__xml_first_child(old_xml); old_child != NULL;
          old_child = pcmk__xml_next(old_child)) {
 
-        xmlNode *new_child = pcmk__xml_match(new_xml, old_child, true);
+        new_child = pcmk__xml_match(new_xml, old_child, true);
 
-        if(new_child) {
-            mark_xml_changes(old_child, new_child, TRUE);
+        if (new_child != NULL) {
+            mark_xml_changes(old_child, new_child, true);
 
         } else {
             mark_child_deleted(old_child, new_xml);
@@ -1494,16 +1496,19 @@ mark_xml_changes(xmlNode *old_xml, xmlNode *new_xml, bool check_top)
     }
 
     // Check for moved or created children
-    for (xmlNode *new_child = pcmk__xml_first_child(new_xml); new_child != NULL;
-         new_child = pcmk__xml_next(new_child)) {
+    new_child = pcmk__xml_first_child(new_xml);
+    while (new_child != NULL) {
+        xmlNode *next = pcmk__xml_next(new_child);
 
-        xmlNode *old_child = pcmk__xml_match(old_xml, new_child, true);
+        old_child = pcmk__xml_match(old_xml, new_child, true);
 
-        if(old_child == NULL) {
+        if (old_child == NULL) {
             // This is a newly created child
             nodepriv = new_child->_private;
             pcmk__set_xml_flags(nodepriv, pcmk__xf_skip);
-            mark_xml_changes(old_child, new_child, TRUE);
+
+            // May free new_child
+            mark_xml_changes(old_child, new_child, true);
 
         } else {
             /* Check for movement, we already checked for differences */
@@ -1514,6 +1519,8 @@ mark_xml_changes(xmlNode *old_xml, xmlNode *new_xml, bool check_top)
                 mark_child_moved(old_child, new_xml, new_child, p_old, p_new);
             }
         }
+
+        new_child = next;
     }
 }
 


### PR DESCRIPTION
`mark_xml_changes()` with `check_top=true` may free `new_child` via `pcmk__apply_creation_acl()`. Calling `pcmk__xml_next(new_child)` after that is a use-after-free error. This caused a seg fault on FreeBSD.

There are other opportunities to refactor `mark_xml_created()` and change-tracking in general, and I bet we can avoid `check_top` and make things easier to reason about. This should fix the immediate issue.