### PR TITLE
Avoid schema unit test vs production discrepancy

### DIFF
--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -412,7 +412,7 @@ typedef struct {
 } pcmk__schema_t;
 
 G_GNUC_INTERNAL
-int pcmk__find_x_0_schema_index(GList *schemas);
+int pcmk__find_x_0_schema_index(void);
 
 
 #endif  // CRMCOMMON_PRIVATE__H

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -57,20 +57,19 @@ xml_log(int priority, const char *fmt, ...)
 static int
 xml_latest_schema_index(GList *schemas)
 {
-    // @COMPAT: pacemaker-next is deprecated since 2.1.5
-    // FIXME: This function assumes at least three schemas have been added
-    // before it has been called for the first time, which is only the case
-    // if we are not unit testing.
-#if defined(PCMK__UNIT_TESTING)
-    return g_list_length(schemas) - 1; // index from 0
-#else
+    /* This function assumes that crm_schema_init() has been called beforehand,
+     * so we have at least three schemas (one real schema, the "pacemaker-next"
+     * schema, and the "none" schema).
+     *
+     * @COMPAT: pacemaker-next is deprecated since 2.1.5.
+     * Update this when we drop that schema.
+     */
     return g_list_length(schemas) - 3; // index from 0, ignore "pacemaker-next"/"none"
-#endif
 }
 
 /* Return the index of the most recent X.0 schema. */
 int
-pcmk__find_x_0_schema_index(GList *schemas)
+pcmk__find_x_0_schema_index(void)
 {
     /* We can't just use best to determine whether we've found the index
      * or not.  What if we have a very long list of schemas all in the
@@ -96,32 +95,20 @@ pcmk__find_x_0_schema_index(GList *schemas)
         return best;
     }
 
-    CRM_ASSERT(schemas != NULL);
-
     /* Get the most recent schema so we can look at its version number. */
-    best = xml_latest_schema_index(schemas);
-    best_node = g_list_nth(schemas, best);
+    best = xml_latest_schema_index(known_schemas);
+    best_node = g_list_nth(known_schemas, best);
     best_schema = best_node->data;
 
-    /* If we are unit testing, we don't add the pacemaker-next/none schemas
-     * to the list because we're not using the standard schema adding
-     * functions.  Thus, a singleton list means we're done.
+    /* The "pacemaker-next" and "none" schemas are added to the real schemas,
+     * so a list of length three actually only has one useful schema.
      *
-     * On the other hand, if we are running as usually, we have those two
-     * schemas added to the list.  A list of length three actually only has
-     * one useful schema.  So we're still done.
-     *
-     * @COMPAT Change this when we stop adding those schemas.
+     * @COMPAT pacemaker-next is deprecated since 2.1.5.
+     * Update this when we drop that schema.
      */
-#if defined(PCMK__UNIT_TESTING)
-    if (pcmk__list_of_1(schemas)) {
+    if (g_list_length(known_schemas) == 3) {
         goto done;
     }
-#else
-    if (g_list_length(schemas) == 3) {
-        goto done;
-    }
-#endif
 
     /* Start comparing the list from the node before the best schema (there's
      * no point in comparing something to itself).  Then, 'i' is an index
@@ -1233,7 +1220,7 @@ cli_config_update(xmlNode **xml, int *best_version, gboolean to_logs)
 
     int version = get_schema_version(value);
     int orig_version = version;
-    int min_version = pcmk__find_x_0_schema_index(known_schemas);
+    int min_version = pcmk__find_x_0_schema_index();
 
     if (version < min_version) {
         // Current configuration schema is not acceptable, try to update

--- a/lib/common/tests/schemas/crm_schema_init_test.c
+++ b/lib/common/tests/schemas/crm_schema_init_test.c
@@ -16,16 +16,11 @@
 #include <crm/common/unittest_internal.h>
 #include <crm/common/xml_internal.h>
 
-/* crm_schema_init is best tested by writing tests for all the other public
- * functions it calls.  However, it's useful to have a test to make sure
- * incorporating a second directory of schema files (like may be seen on
- * Pacemaker Remote nodes) works.
- */
-
 static char *remote_schema_dir = NULL;
 
 static int
-symlink_schema(const char *tmpdir, const char *target_file, const char *link_file) {
+symlink_schema(const char *tmpdir, const char *target_file, const char *link_file)
+{
     int rc = 0;
     char *oldpath = NULL;
     char *newpath = NULL;
@@ -47,12 +42,14 @@ rm_files(const char *pathname, const struct stat *sbuf, int type, struct FTW *ft
 }
 
 static int
-rmtree(const char *dir) {
+rmtree(const char *dir)
+{
     return nftw(dir, rm_files, 10, FTW_DEPTH|FTW_MOUNT|FTW_PHYS);
 }
 
 static int
-setup(void **state) {
+setup(void **state)
+{
     char *dir = NULL;
 
     /* Create a directory to hold additional schema files.  These don't need
@@ -96,7 +93,8 @@ setup(void **state) {
 }
 
 static int
-teardown(void **state) {
+teardown(void **state)
+{
     int rc = 0;
     char *f = NULL;
 
@@ -112,7 +110,8 @@ teardown(void **state) {
 }
 
 static void
-extra_schema_files(void **state) {
+extra_schema_files(void **state)
+{
     crm_schema_init();
 
     pcmk__log_known_schemas();
@@ -128,7 +127,7 @@ extra_schema_files(void **state) {
     assert_string_equal("pacemaker-3.1", get_schema_name(15));
     assert_string_equal("pacemaker-3.2", get_schema_name(16));
 
-    /* This will one day be removed */
+    // @COMPAT pacemaker-next is deprecated since 2.1.5
     assert_string_equal("pacemaker-next", get_schema_name(17));
 
     assert_string_equal(PCMK_VALUE_NONE, get_schema_name(18));

--- a/lib/common/tests/schemas/get_schema_name_test.c
+++ b/lib/common/tests/schemas/get_schema_name_test.c
@@ -14,32 +14,41 @@
 #include <crm/common/xml_internal.h>
 
 static int
-setup(void **state) {
+setup(void **state)
+{
     setenv("PCMK_schema_directory", PCMK__TEST_SCHEMA_DIR, 1);
     crm_schema_init();
     return 0;
 }
 
 static int
-teardown(void **state) {
+teardown(void **state)
+{
     crm_schema_cleanup();
     unsetenv("PCMK_schema_directory");
     return 0;
 }
 
 static void
-bad_input(void **state) {
+bad_input(void **state)
+{
     assert_string_equal("unknown", get_schema_name(-1));
     assert_string_equal("unknown", get_schema_name(47000));
 }
 
 static void
-typical_usage(void **state) {
+typical_usage(void **state)
+{
     assert_string_equal("pacemaker-1.0", get_schema_name(0));
     assert_string_equal("pacemaker-1.2", get_schema_name(1));
     assert_string_equal("pacemaker-2.0", get_schema_name(3));
     assert_string_equal("pacemaker-2.5", get_schema_name(8));
     assert_string_equal("pacemaker-3.0", get_schema_name(14));
+
+    // @COMPAT pacemaker-next is deprecated since 2.1.5
+    assert_string_equal("pacemaker-next", get_schema_name(15));
+
+    assert_string_equal(PCMK_VALUE_NONE, get_schema_name(16));
 }
 
 PCMK__UNIT_TEST(setup, teardown,

--- a/lib/common/tests/schemas/get_schema_version_test.c
+++ b/lib/common/tests/schemas/get_schema_version_test.c
@@ -14,22 +14,24 @@
 #include <crm/common/xml_internal.h>
 
 static int
-setup(void **state) {
+setup(void **state)
+{
     setenv("PCMK_schema_directory", PCMK__TEST_SCHEMA_DIR, 1);
     crm_schema_init();
     return 0;
 }
 
 static int
-teardown(void **state) {
+teardown(void **state)
+{
     crm_schema_cleanup();
     unsetenv("PCMK_schema_directory");
     return 0;
 }
 
 static void
-bad_input(void **state) {
-    assert_int_equal(16, get_schema_version(NULL));
+bad_input(void **state)
+{
     assert_int_equal(-1, get_schema_version(""));
     assert_int_equal(-1, get_schema_version("blahblah"));
     assert_int_equal(-1, get_schema_version("pacemaker-2.47"));
@@ -37,7 +39,8 @@ bad_input(void **state) {
 }
 
 static void
-typical_usage(void **state) {
+typical_usage(void **state)
+{
     assert_int_equal(0, get_schema_version("pacemaker-1.0"));
     assert_int_equal(0, get_schema_version("PACEMAKER-1.0"));
     assert_int_equal(1, get_schema_version("pacemaker-1.2"));
@@ -46,6 +49,13 @@ typical_usage(void **state) {
     assert_int_equal(8, get_schema_version("pacemaker-2.5"));
     assert_int_equal(14, get_schema_version("pacemaker-3.0"));
     assert_int_equal(14, get_schema_version("paceMAKER-3.0"));
+
+    // @COMPAT pacemaker-next is deprecated since 2.1.5
+    assert_int_equal(15, get_schema_version("pacemaker-next"));
+
+    assert_int_equal(16, get_schema_version("none"));
+    assert_int_equal(16, get_schema_version("NONE"));
+    assert_int_equal(16, get_schema_version(NULL)); // defaults to "none"
 }
 
 PCMK__UNIT_TEST(setup, teardown,

--- a/lib/common/tests/schemas/pcmk__build_schema_xml_node_test.c
+++ b/lib/common/tests/schemas/pcmk__build_schema_xml_node_test.c
@@ -30,14 +30,16 @@ const char *rngs2[] = { "pacemaker-2.0.rng", "status-1.0.rng", "tags-1.3.rng",
 const char *rngs3[] = { "pacemaker-2.1.rng", "constraints-2.1.rng", NULL };
 
 static int
-setup(void **state) {
+setup(void **state)
+{
     setenv("PCMK_schema_directory", PCMK__TEST_SCHEMA_DIR, 1);
     crm_schema_init();
     return 0;
 }
 
 static int
-teardown(void **state) {
+teardown(void **state)
+{
     crm_schema_cleanup();
     unsetenv("PCMK_schema_directory");
     return 0;

--- a/lib/common/tests/schemas/pcmk__find_x_0_schema_index_test.c
+++ b/lib/common/tests/schemas/pcmk__find_x_0_schema_index_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the Pacemaker project contributors
+ * Copyright 2023-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -8,105 +8,85 @@
  */
 
 #include <crm_internal.h>
-#include <crm/common/unittest_internal.h>
 
+#include <stdio.h>  // NULL, rename()
+#include <stdlib.h> // setenv(), unsetenv()
 #include <glib.h>
 
+#include <crm/common/unittest_internal.h>
 #include "crmcommon_private.h"
 
-static pcmk__schema_t *
-mk_schema(const char *name, unsigned char x, unsigned char y)
-{
-    pcmk__schema_t *schema = malloc(sizeof(pcmk__schema_t));
+#define SCHEMA_PREFIX PCMK__TEST_SCHEMA_DIR "/pacemaker-"
 
-    schema->name = strdup(name);
-    schema->version.v[0] = x;
-    schema->version.v[1] = y;
-    return schema;
+static int
+setup(void **state)
+{
+    setenv("PCMK_schema_directory", PCMK__TEST_SCHEMA_DIR, 1);
+    return 0;
+}
+
+static int
+teardown(void **state)
+{
+    unsetenv("PCMK_schema_directory");
+    return 0;
 }
 
 static void
-free_schema(void *data)
+last_is_0(void **state)
 {
-    pcmk__schema_t *schema = data;
-    free(schema->name);
-    free(schema);
+    /* This uses all the schemas normally linked for unit testing, so we have a
+     * many 1.x and 2.x schemas and a single pacemaker-3.0 schema at index 14.
+     */
+    crm_schema_init();
+
+    assert_int_equal(14, pcmk__find_x_0_schema_index());
+    assert_string_equal(get_schema_name(14), "pacemaker-3.0");
+
+    crm_schema_cleanup();
 }
 
 static void
-empty_schema_list(void **state)
+last_is_not_0(void **state)
 {
-    pcmk__assert_asserts(pcmk__find_x_0_schema_index(NULL));
+    /* Disable the pacemaker-3.0 schema, so we now should get pacemaker-2.0 at
+     * index 3.
+     */
+    assert_int_equal(0, rename(SCHEMA_PREFIX "3.0.rng",
+                               SCHEMA_PREFIX "3.0.bak"));
+    crm_schema_init();
+
+    assert_int_equal(3, pcmk__find_x_0_schema_index());
+    assert_string_equal(get_schema_name(3), "pacemaker-2.0");
+
+    assert_int_equal(0, rename(SCHEMA_PREFIX "3.0.bak",
+                               SCHEMA_PREFIX "3.0.rng"));
+    crm_schema_cleanup();
 }
 
 static void
-singleton_schema_list(void **state)
+schema_0_missing(void **state)
 {
-    GList *schemas = NULL;
+    /* Disable the pacemaker-3.0 and pacemaker-2.0 schemas, so we now should get
+     * pacemaker-2.1 at index 3.
+     */
+    assert_int_equal(0, rename(SCHEMA_PREFIX "3.0.rng",
+                               SCHEMA_PREFIX "3.0.bak"));
+    assert_int_equal(0, rename(SCHEMA_PREFIX "2.0.rng",
+                               SCHEMA_PREFIX "2.0.bak"));
+    crm_schema_init();
 
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
-    assert_int_equal(0, pcmk__find_x_0_schema_index(schemas));
-    g_list_free_full(schemas, free_schema);
+    assert_int_equal(3, pcmk__find_x_0_schema_index());
+    assert_string_equal(get_schema_name(3), "pacemaker-2.1");
+
+    assert_int_equal(0, rename(SCHEMA_PREFIX "2.0.bak",
+                               SCHEMA_PREFIX "2.0.rng"));
+    assert_int_equal(0, rename(SCHEMA_PREFIX "3.0.bak",
+                               SCHEMA_PREFIX "3.0.rng"));
+    crm_schema_cleanup();
 }
 
-static void
-one_major_version(void **state)
-{
-    GList *schemas = NULL;
-
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.2", 1, 2));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.3", 1, 3));
-    assert_int_equal(0, pcmk__find_x_0_schema_index(schemas));
-    g_list_free_full(schemas, free_schema);
-}
-
-static void
-first_version_is_not_0(void **state)
-{
-    GList *schemas = NULL;
-
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.1", 1, 1));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.2", 1, 2));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.3", 1, 3));
-    assert_int_equal(0, pcmk__find_x_0_schema_index(schemas));
-    g_list_free_full(schemas, free_schema);
-}
-
-static void
-multiple_major_versions(void **state)
-{
-    GList *schemas = NULL;
-
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.1", 1, 1));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-2.0", 2, 0));
-    assert_int_equal(2, pcmk__find_x_0_schema_index(schemas));
-    g_list_free_full(schemas, free_schema);
-}
-
-static void
-many_versions(void **state)
-{
-    GList *schemas = NULL;
-
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.0", 1, 0));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.1", 1, 1));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-1.2", 1, 2));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-2.0", 2, 0));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-2.1", 2, 1));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-2.2", 2, 2));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-3.0", 3, 0));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-3.1", 3, 1));
-    schemas = g_list_append(schemas, mk_schema("pacemaker-3.2", 3, 2));
-    assert_int_equal(6, pcmk__find_x_0_schema_index(schemas));
-    g_list_free_full(schemas, free_schema);
-}
-
-PCMK__UNIT_TEST(NULL, NULL,
-                cmocka_unit_test(empty_schema_list),
-                cmocka_unit_test(singleton_schema_list),
-                cmocka_unit_test(one_major_version),
-                cmocka_unit_test(first_version_is_not_0),
-                cmocka_unit_test(multiple_major_versions),
-                cmocka_unit_test(many_versions))
+PCMK__UNIT_TEST(setup, teardown,
+                cmocka_unit_test(last_is_0),
+                cmocka_unit_test(last_is_not_0),
+                cmocka_unit_test(schema_0_missing))

--- a/lib/common/tests/schemas/pcmk__schema_files_later_than_test.c
+++ b/lib/common/tests/schemas/pcmk__schema_files_later_than_test.c
@@ -15,14 +15,16 @@
 #include <glib.h>
 
 static int
-setup(void **state) {
+setup(void **state)
+{
     setenv("PCMK_schema_directory", PCMK__TEST_SCHEMA_DIR, 1);
     crm_schema_init();
     return 0;
 }
 
 static int
-teardown(void **state) {
+teardown(void **state)
+{
     crm_schema_cleanup();
     unsetenv("PCMK_schema_directory");
     return 0;


### PR DESCRIPTION
…it testing

Previously, we had special logic in schemas.c for unit tests to get around the fact that the test for pcmk__find_x_0_schema_index() didn't call crm_schema_init() and thus didn't have the "pacemaker-next" and "none" schemas.

However it's a bad idea to have differences between unit tests and production, and an even worse idea to change functional behavior for a single test that would fail if called by the unit test for any other function.

Restructure the pcmk__find_x_0_schema_index() test so it calls crm_schema_init(), and drop the unit-testing functional differences. While we're at it, make sure we're testing the "pacemaker-next" and "none" schemas while they're still supported.