### PR TITLE
Refactor: scheduler: Simplify pe__name_and_nvpairs_xml.

### DIFF
--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -94,8 +94,8 @@ gchar *pcmk__native_output_string(const pcmk_resource_t *rsc, const char *name,
                                   const pcmk_node_t *node, uint32_t show_opts,
                                   const char *target_role, bool show_nodes);
 
-int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name
-                         , size_t pairs_count, ...);
+int pe__name_and_nvpairs_xml(pcmk__output_t *out, bool is_list, const char *tag_name,
+                             ...) G_GNUC_NULL_TERMINATED;
 char *pe__node_display_name(pcmk_node_t *node, bool print_detail);
 
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1549,7 +1549,7 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
 
             desc = pe__resource_description(rsc, show_opts);
 
-            rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_BUNDLE, 8,
+            rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_BUNDLE,
                                           PCMK_XA_ID, rsc->id,
                                           PCMK_XA_TYPE, type,
                                           PCMK_XA_IMAGE, bundle_data->image,
@@ -1557,13 +1557,15 @@ pe__bundle_xml(pcmk__output_t *out, va_list args)
                                           PCMK_XA_MAINTENANCE, maintenance,
                                           PCMK_XA_MANAGED, managed,
                                           PCMK_XA_FAILED, failed,
-                                          PCMK_XA_DESCRIPTION, desc);
+                                          PCMK_XA_DESCRIPTION, desc,
+                                          NULL);
             CRM_ASSERT(rc == pcmk_rc_ok);
         }
 
         id = pcmk__itoa(replica->offset);
-        rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_REPLICA, 1,
-                                      PCMK_XA_ID, id);
+        rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_REPLICA,
+                                      PCMK_XA_ID, id,
+                                      NULL);
         free(id);
         CRM_ASSERT(rc == pcmk_rc_ok);
 

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -898,7 +898,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
 
             printed_header = TRUE;
 
-            rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_CLONE, 10,
+            rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_CLONE,
                                           PCMK_XA_ID, rsc->id,
                                           PCMK_XA_MULTI_STATE, multi_state,
                                           PCMK_XA_UNIQUE, unique,
@@ -908,7 +908,8 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
                                           PCMK_XA_FAILED, failed,
                                           PCMK_XA_FAILURE_IGNORED, ignored,
                                           PCMK_XA_TARGET_ROLE, target_role,
-                                          PCMK_XA_DESCRIPTION, desc);
+                                          PCMK_XA_DESCRIPTION, desc,
+                                          NULL);
             CRM_ASSERT(rc == pcmk_rc_ok);
         }
 

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -374,13 +374,14 @@ pe__group_xml(pcmk__output_t *out, va_list args)
             const char *managed = pcmk__flag_text(rsc->flags, pcmk_rsc_managed);
             const char *disabled = pcmk__btoa(pe__resource_is_disabled(rsc));
 
-            rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_GROUP, 5,
+            rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_GROUP,
                                           PCMK_XA_ID, rsc->id,
                                           PCMK_XA_NUMBER_RESOURCES, count,
                                           PCMK_XA_MAINTENANCE, maintenance,
                                           PCMK_XA_MANAGED, managed,
                                           PCMK_XA_DISABLED, disabled,
-                                          PCMK_XA_DESCRIPTION, desc);
+                                          PCMK_XA_DESCRIPTION, desc,
+                                          NULL);
             free(count);
             CRM_ASSERT(rc == pcmk_rc_ok);
         }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1014,7 +1014,7 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
         locked_to = rsc->lock_node->details->uname;
     }
 
-    rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_RESOURCE, 15,
+    rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_RESOURCE,
                                   PCMK_XA_ID, rsc_printable_id(rsc),
                                   PCMK_XA_RESOURCE_AGENT, ra_name,
                                   PCMK_XA_ROLE, rsc_state,
@@ -1029,7 +1029,8 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
                                   PCMK_XA_NODES_RUNNING_ON, nodes_running_on,
                                   PCMK_XA_PENDING, pending,
                                   PCMK_XA_LOCKED_TO, locked_to,
-                                  PCMK_XA_DESCRIPTION, desc);
+                                  PCMK_XA_DESCRIPTION, desc,
+                                  NULL);
     free(nodes_running_on);
 
     CRM_ASSERT(rc == pcmk_rc_ok);
@@ -1041,10 +1042,11 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
             pcmk_node_t *node = (pcmk_node_t *) gIter->data;
             const char *cached = pcmk__btoa(node->details->online);
 
-            rc = pe__name_and_nvpairs_xml(out, false, PCMK_XE_NODE, 3,
+            rc = pe__name_and_nvpairs_xml(out, false, PCMK_XE_NODE,
                                           PCMK_XA_NAME, node->details->uname,
                                           PCMK_XA_ID, node->details->id,
-                                          PCMK_XA_CACHED, cached);
+                                          PCMK_XA_CACHED, cached,
+                                          NULL);
             CRM_ASSERT(rc == pcmk_rc_ok);
         }
     }

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2061,23 +2061,28 @@ node_xml(pcmk__output_t *out, va_list args) {
         char *resources_running = pcmk__itoa(length);
         const char *node_type = node_type_str(node->details->type);
 
-        pe__name_and_nvpairs_xml(out, true, PCMK_XE_NODE,
-                                 PCMK_XA_NAME, node->details->uname,
-                                 PCMK_XA_ID, node->details->id,
-                                 PCMK_XA_ONLINE, online,
-                                 PCMK_XA_STANDBY, standby,
-                                 PCMK_XA_STANDBY_ONFAIL, standby_onfail,
-                                 PCMK_XA_MAINTENANCE, maintenance,
-                                 PCMK_XA_PENDING, pending,
-                                 PCMK_XA_UNCLEAN, unclean,
-                                 PCMK_XA_HEALTH, health,
-                                 PCMK_XA_FEATURE_SET, feature_set,
-                                 PCMK_XA_SHUTDOWN, shutdown,
-                                 PCMK_XA_EXPECTED_UP, expected_up,
-                                 PCMK_XA_IS_DC, is_dc,
-                                 PCMK_XA_RESOURCES_RUNNING, resources_running,
-                                 PCMK_XA_TYPE, node_type,
-                                 NULL);
+        int rc = pcmk_rc_ok;
+
+        rc = pe__name_and_nvpairs_xml(out, true, PCMK_XE_NODE,
+                                      PCMK_XA_NAME, node->details->uname,
+                                      PCMK_XA_ID, node->details->id,
+                                      PCMK_XA_ONLINE, online,
+                                      PCMK_XA_STANDBY, standby,
+                                      PCMK_XA_STANDBY_ONFAIL, standby_onfail,
+                                      PCMK_XA_MAINTENANCE, maintenance,
+                                      PCMK_XA_PENDING, pending,
+                                      PCMK_XA_UNCLEAN, unclean,
+                                      PCMK_XA_HEALTH, health,
+                                      PCMK_XA_FEATURE_SET, feature_set,
+                                      PCMK_XA_SHUTDOWN, shutdown,
+                                      PCMK_XA_EXPECTED_UP, expected_up,
+                                      PCMK_XA_IS_DC, is_dc,
+                                      PCMK_XA_RESOURCES_RUNNING, resources_running,
+                                      PCMK_XA_TYPE, node_type,
+                                      NULL);
+
+        free(resources_running);
+        CRM_ASSERT(rc == pcmk_rc_ok);
 
         if (pcmk__is_guest_or_bundle_node(node)) {
             xmlNodePtr xml_node = pcmk__output_xml_peek_parent(out);
@@ -2096,8 +2101,6 @@ node_xml(pcmk__output_t *out, va_list args) {
                              rsc, only_node, only_rsc);
             }
         }
-
-        free(resources_running);
 
         out->end_list(out);
     } else {


### PR DESCRIPTION
This function doesn't need to take a count of pairs.  In fact, once it takes a NULL terminator, it's just a wrapper around pcmk__xe_set_propv.