### PR TITLE
Combine attribute formatted output messages

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -1365,8 +1365,8 @@ Revised Cluster Status:
 =#=#=#= End test: Create second node attribute - OK (0) =#=#=#=
 * Passed: crm_attribute  - Create second node attribute
 =#=#=#= Begin test: Query node attributes by pattern =#=#=#=
-scope=nodes  name=ram value=1024M
-scope=nodes  name=rattr value=XYZ
+scope=nodes name=ram value=1024M
+scope=nodes name=rattr value=XYZ
 =#=#=#= End test: Query node attributes by pattern - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query node attributes by pattern
 =#=#=#= Begin test: Update node attributes by pattern =#=#=#=
@@ -1548,8 +1548,8 @@ Current cluster status:
 =#=#=#= End test: Set a second transient node attribute - OK (0) =#=#=#=
 * Passed: crm_attribute  - Set a second transient node attribute
 =#=#=#= Begin test: Query transient node attributes by pattern =#=#=#=
-scope=status  name=fail-count-foo value=3
-scope=status  name=fail-count-bar value=5
+scope=status name=fail-count-foo value=3
+scope=status name=fail-count-bar value=5
 =#=#=#= End test: Query transient node attributes by pattern - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query transient node attributes by pattern
 =#=#=#= Begin test: Update transient node attributes by pattern =#=#=#=
@@ -1661,7 +1661,7 @@ crm_attribute: Error: must specify attribute name or pattern to delete
 =#=#=#= End test: Set a utilization node attribute - OK (0) =#=#=#=
 * Passed: crm_attribute  - Set a utilization node attribute
 =#=#=#= Begin test: Query utilization node attribute =#=#=#=
-scope=nodes  name=cpu value=1
+scope=nodes name=cpu value=1
 =#=#=#= End test: Query utilization node attribute - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query utilization node attribute
 =#=#=#= Begin test: Digest calculation =#=#=#=
@@ -1736,7 +1736,7 @@ Call failed: Update was older than existing configuration
 =#=#=#= End test: Replace operation should fail - Update was older than existing configuration (103) =#=#=#=
 * Passed: cibadmin       - Replace operation should fail
 =#=#=#= Begin test: Default standby value =#=#=#=
-scope=status  name=standby value=off
+scope=status name=standby value=off
 =#=#=#= Current cib after: Default standby value =#=#=#=
 <cib epoch="14" num_updates="0" admin_epoch="0">
   <configuration>
@@ -1808,7 +1808,7 @@ scope=status  name=standby value=off
 =#=#=#= End test: Set standby status - OK (0) =#=#=#=
 * Passed: crm_standby    - Set standby status
 =#=#=#= Begin test: Query standby value =#=#=#=
-scope=nodes  name=standby value=true
+scope=nodes name=standby value=true
 =#=#=#= Current cib after: Query standby value =#=#=#=
 <cib epoch="15" num_updates="0" admin_epoch="0">
   <configuration>
@@ -8237,7 +8237,7 @@ crm_attribute: Error performing operation: No such device or address
 =#=#=#= End test: Update a nonexistent promotable score attribute (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Update a nonexistent promotable score attribute (XML)
 =#=#=#= Begin test: Query after updating a nonexistent promotable score attribute =#=#=#=
-scope=status  name=master-promotable-rsc value=1
+scope=status name=master-promotable-rsc value=1
 =#=#=#= End test: Query after updating a nonexistent promotable score attribute - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a nonexistent promotable score attribute
 =#=#=#= Begin test: Query after updating a nonexistent promotable score attribute (XML) =#=#=#=
@@ -8257,7 +8257,7 @@ scope=status  name=master-promotable-rsc value=1
 =#=#=#= End test: Update an existing promotable score attribute (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Update an existing promotable score attribute (XML)
 =#=#=#= Begin test: Query after updating an existing promotable score attribute =#=#=#=
-scope=status  name=master-promotable-rsc value=5
+scope=status name=master-promotable-rsc value=5
 =#=#=#= End test: Query after updating an existing promotable score attribute - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating an existing promotable score attribute
 =#=#=#= Begin test: Query after updating an existing promotable score attribute (XML) =#=#=#=
@@ -8301,7 +8301,7 @@ crm_attribute: Error performing operation: No such device or address
 =#=#=#= End test: Update a promotable score attribute to -INFINITY (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Update a promotable score attribute to -INFINITY (XML)
 =#=#=#= Begin test: Query after updating a promotable score attribute to -INFINITY =#=#=#=
-scope=status  name=master-promotable-rsc value=-INFINITY
+scope=status name=master-promotable-rsc value=-INFINITY
 =#=#=#= End test: Query after updating a promotable score attribute to -INFINITY - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY
 =#=#=#= Begin test: Query after updating a promotable score attribute to -INFINITY (XML) =#=#=#=
@@ -8312,7 +8312,7 @@ scope=status  name=master-promotable-rsc value=-INFINITY
 =#=#=#= End test: Query after updating a promotable score attribute to -INFINITY (XML) - OK (0) =#=#=#=
 * Passed: crm_attribute  - Query after updating a promotable score attribute to -INFINITY (XML)
 =#=#=#= Begin test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string =#=#=#=
-scope=status  name=master-promotable-rsc value=-INFINITY
+scope=status name=master-promotable-rsc value=-INFINITY
 =#=#=#= End test: Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string - OK (0) =#=#=#=
 * Passed: crm_attribute  - Try OCF_RESOURCE_INSTANCE if -p is specified with an empty string
 =#=#=#= Begin test: Return usage error if both -p and OCF_RESOURCE_INSTANCE are empty strings =#=#=#=

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -2129,7 +2129,7 @@ cluster_status_html(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("attribute", "const char *", "const char *", "const char *",
-                  "const char *", "const char *")
+                  "const char *", "const char *", "bool")
 static int
 attribute_default(pcmk__output_t *out, va_list args)
 {
@@ -2138,10 +2138,20 @@ attribute_default(pcmk__output_t *out, va_list args)
     const char *name = va_arg(args, const char *);
     const char *value = va_arg(args, const char *);
     const char *host = va_arg(args, const char *);
+    bool quiet = va_arg(args, int);
 
     gchar *value_esc = NULL;
+    GString *s = NULL;
 
-    GString *s = g_string_sized_new(50);
+    if (quiet) {
+        if (value != NULL) {
+            out->info(out, "%s", value);
+        }
+
+        return pcmk_rc_ok;
+    }
+
+    s = g_string_sized_new(50);
 
     if (pcmk__xml_needs_escape(value, pcmk__xml_escape_attr_pretty)) {
         value_esc = pcmk__xml_escape(value, pcmk__xml_escape_attr_pretty);
@@ -2172,7 +2182,7 @@ attribute_default(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("attribute", "const char *", "const char *", "const char *",
-                  "const char *", "const char *")
+                  "const char *", "const char *", "bool")
 static int
 attribute_xml(pcmk__output_t *out, va_list args)
 {
@@ -2181,6 +2191,7 @@ attribute_xml(pcmk__output_t *out, va_list args)
     const char *name = va_arg(args, const char *);
     const char *value = va_arg(args, const char *);
     const char *host = va_arg(args, const char *);
+    bool quiet G_GNUC_UNUSED = va_arg(args, int);
 
     xmlNodePtr node = NULL;
 

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -2128,6 +2128,14 @@ cluster_status_html(pcmk__output_t *out, va_list args)
     return pcmk_rc_ok;
 }
 
+#define KV_PAIR(k, v) do { \
+    if (legacy) { \
+        pcmk__g_strcat(s, k "=", pcmk__s(v, ""), " ", NULL); \
+    } else { \
+        pcmk__g_strcat(s, k "=\"", pcmk__s(v, ""), "\"", NULL); \
+    } \
+} while (0)
+
 PCMK__OUTPUT_ARGS("attribute", "const char *", "const char *", "const char *",
                   "const char *", "const char *", "bool", "bool")
 static int
@@ -2169,33 +2177,17 @@ attribute_default(pcmk__output_t *out, va_list args)
     }
 
     if (!pcmk__str_empty(scope)) {
-        if (legacy) {
-            pcmk__g_strcat(s, PCMK_XA_SCOPE "=", scope, " ", NULL);
-        } else {
-            pcmk__g_strcat(s, PCMK_XA_SCOPE "=\"", scope, "\" ", NULL);
-        }
+        KV_PAIR(PCMK_XA_SCOPE, scope);
     }
 
     if (!pcmk__str_empty(instance)) {
-        if (legacy) {
-            pcmk__g_strcat(s, PCMK_XA_ID "=", instance, " ", NULL);
-        } else {
-            pcmk__g_strcat(s, PCMK_XA_ID "=\"", instance, "\" ", NULL);
-        }
+        KV_PAIR(PCMK_XA_ID, instance);
     }
 
-    if (legacy) {
-        pcmk__g_strcat(s, PCMK_XA_NAME "=", pcmk__s(name, ""), " ", NULL);
-    } else {
-        pcmk__g_strcat(s, PCMK_XA_NAME "=\"", pcmk__s(name, ""), "\" ", NULL);
-    }
+    KV_PAIR(PCMK_XA_NAME, name);
 
     if (!pcmk__str_empty(host)) {
-        if (legacy) {
-            pcmk__g_strcat(s, PCMK_XA_HOST "=", host, " ", NULL);
-        } else {
-            pcmk__g_strcat(s, PCMK_XA_HOST "=\"", host, "\" ", NULL);
-        }
+        KV_PAIR(PCMK_XA_HOST, host);
     }
 
     if (legacy) {

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -398,7 +398,7 @@ print_attrd_values(pcmk__output_t *out, const GList *reply)
         const pcmk__attrd_query_pair_t *pair = iter->data;
 
         out->message(out, "attribute", NULL, NULL, pair->name, pair->value,
-                     pair->node, false);
+                     pair->node, false, false);
         printed_values = true;
     }
 }

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -398,7 +398,7 @@ print_attrd_values(pcmk__output_t *out, const GList *reply)
         const pcmk__attrd_query_pair_t *pair = iter->data;
 
         out->message(out, "attribute", NULL, NULL, pair->name, pair->value,
-                     pair->node);
+                     pair->node, false);
         printed_values = true;
     }
 }

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -52,52 +52,10 @@ GError *error = NULL;
 crm_exit_t exit_code = CRM_EX_OK;
 uint64_t cib_opts = cib_sync_call;
 
-PCMK__OUTPUT_ARGS("attribute", "const char *", "const char *", "const char *",
-                  "const char *", "const char *", "bool", "bool")
-static int
-attribute_text(pcmk__output_t *out, va_list args)
-{
-    const char *scope = va_arg(args, const char *);
-    const char *instance = va_arg(args, const char *);
-    const char *name = va_arg(args, const char *);
-    const char *value = va_arg(args, const char *);
-    const char *host G_GNUC_UNUSED = va_arg(args, const char *);
-    bool quiet = va_arg(args, int);
-    bool legacy G_GNUC_UNUSED = va_arg(args, int);
-
-    gchar *value_esc = NULL;
-
-    if (pcmk__xml_needs_escape(value, pcmk__xml_escape_attr_pretty)) {
-        value_esc = pcmk__xml_escape(value, pcmk__xml_escape_attr_pretty);
-        value = value_esc;
-    }
-
-    if (quiet) {
-        if (value != NULL) {
-            pcmk__formatted_printf(out, "%s\n", value);
-        }
-    } else {
-        out->info(out, "%s%s %s%s %s%s value=%s",
-                  scope ? "scope=" : "", scope ? scope : "",
-                  instance ? "id=" : "", instance ? instance : "",
-                  name ? "name=" : "", name ? name : "",
-                  pcmk__s(value, "(null)"));
-    }
-
-    g_free(value_esc);
-    return pcmk_rc_ok;
-}
-
 static pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
     PCMK__SUPPORTED_FORMAT_TEXT,
     PCMK__SUPPORTED_FORMAT_XML,
-    { NULL, NULL, NULL }
-};
-
-static pcmk__message_entry_t fmt_functions[] = {
-    { "attribute", "text", attribute_text },
-
     { NULL, NULL, NULL }
 };
 
@@ -795,7 +753,6 @@ main(int argc, char **argv)
     }
 
     pcmk__register_lib_messages(out);
-    pcmk__register_messages(out, fmt_functions);
 
     if (args->version) {
         out->version(out, false);

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -53,7 +53,7 @@ crm_exit_t exit_code = CRM_EX_OK;
 uint64_t cib_opts = cib_sync_call;
 
 PCMK__OUTPUT_ARGS("attribute", "const char *", "const char *", "const char *",
-                  "const char *", "const char *", "bool")
+                  "const char *", "const char *", "bool", "bool")
 static int
 attribute_text(pcmk__output_t *out, va_list args)
 {
@@ -63,6 +63,7 @@ attribute_text(pcmk__output_t *out, va_list args)
     const char *value = va_arg(args, const char *);
     const char *host G_GNUC_UNUSED = va_arg(args, const char *);
     bool quiet = va_arg(args, int);
+    bool legacy G_GNUC_UNUSED = va_arg(args, int);
 
     gchar *value_esc = NULL;
 
@@ -80,7 +81,7 @@ attribute_text(pcmk__output_t *out, va_list args)
                   scope ? "scope=" : "", scope ? scope : "",
                   instance ? "id=" : "", instance ? instance : "",
                   name ? "name=" : "", name ? name : "",
-                  value ? value : "(null)");
+                  pcmk__s(value, "(null)"));
     }
 
     g_free(value_esc);
@@ -573,7 +574,7 @@ output_one_attribute(xmlNode *node, void *userdata)
     }
 
     od->out->message(od->out, "attribute", type, attr_id, name, value, NULL,
-                     od->out->quiet);
+                     od->out->quiet, true);
     od->did_output = true;
     crm_info("Read %s='%s' %s%s",
              pcmk__s(name, "<null>"), pcmk__s(value, ""),
@@ -613,7 +614,7 @@ command_query(pcmk__output_t *out, cib_t *cib)
         const char *attr_default = options.attr_default;
 
         out->message(out, "attribute", type, attr_id, attr_name, attr_default,
-                     NULL, out->quiet);
+                     NULL, out->quiet, true);
         rc = pcmk_rc_ok;
 
     } else if (rc != pcmk_rc_ok) {

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -564,7 +564,6 @@ output_one_attribute(xmlNode *node, void *userdata)
 
     const char *name = crm_element_value(node, PCMK_XA_NAME);
     const char *value = crm_element_value(node, PCMK_XA_VALUE);
-    const char *host = crm_element_value(node, PCMK__XA_ATTR_HOST);
 
     const char *type = options.type;
     const char *attr_id = options.attr_id;
@@ -573,7 +572,7 @@ output_one_attribute(xmlNode *node, void *userdata)
         return pcmk_rc_ok;
     }
 
-    od->out->message(od->out, "attribute", type, attr_id, name, value, host,
+    od->out->message(od->out, "attribute", type, attr_id, name, value, NULL,
                      od->out->quiet);
     od->did_output = true;
     crm_info("Read %s='%s' %s%s",
@@ -612,10 +611,9 @@ command_query(pcmk__output_t *out, cib_t *cib)
         const char *attr_id = options.attr_id;
         const char *attr_name = options.attr_name;
         const char *attr_default = options.attr_default;
-        const char *dest_uname = options.dest_uname;
 
         out->message(out, "attribute", type, attr_id, attr_name, attr_default,
-                     dest_uname, out->quiet);
+                     NULL, out->quiet);
         rc = pcmk_rc_ok;
 
     } else if (rc != pcmk_rc_ok) {

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -53,7 +53,7 @@ crm_exit_t exit_code = CRM_EX_OK;
 uint64_t cib_opts = cib_sync_call;
 
 PCMK__OUTPUT_ARGS("attribute", "const char *", "const char *", "const char *",
-                  "const char *", "const char *")
+                  "const char *", "const char *", "bool")
 static int
 attribute_text(pcmk__output_t *out, va_list args)
 {
@@ -62,6 +62,7 @@ attribute_text(pcmk__output_t *out, va_list args)
     const char *name = va_arg(args, const char *);
     const char *value = va_arg(args, const char *);
     const char *host G_GNUC_UNUSED = va_arg(args, const char *);
+    bool quiet = va_arg(args, int);
 
     gchar *value_esc = NULL;
 
@@ -70,7 +71,7 @@ attribute_text(pcmk__output_t *out, va_list args)
         value = value_esc;
     }
 
-    if (out->quiet) {
+    if (quiet) {
         if (value != NULL) {
             pcmk__formatted_printf(out, "%s\n", value);
         }
@@ -572,7 +573,8 @@ output_one_attribute(xmlNode *node, void *userdata)
         return pcmk_rc_ok;
     }
 
-    od->out->message(od->out, "attribute", type, attr_id, name, value, host);
+    od->out->message(od->out, "attribute", type, attr_id, name, value, host,
+                     od->out->quiet);
     od->did_output = true;
     crm_info("Read %s='%s' %s%s",
              pcmk__s(name, "<null>"), pcmk__s(value, ""),
@@ -613,7 +615,7 @@ command_query(pcmk__output_t *out, cib_t *cib)
         const char *dest_uname = options.dest_uname;
 
         out->message(out, "attribute", type, attr_id, attr_name, attr_default,
-                     dest_uname);
+                     dest_uname, out->quiet);
         rc = pcmk_rc_ok;
 
     } else if (rc != pcmk_rc_ok) {


### PR DESCRIPTION
This gets rid of the special output message in crm_attribute by making the one in the library support the same output format.  There's still the node-attribute message elsewhere, but I'm not sure it makes sense to combine these.  They take vastly different arguments, and the node-attribute message has a bunch of stuff about connectivity status.

I wonder if we might want to split the connectivity stuff out into its own message, and then rename both attribute and node-attribute to something that sounds less confusing.