### PR TITLE
libcrmcluster deprecations: crm_peer_init() and crm_peer_destroy()

### DIFF
--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -120,7 +120,7 @@ attrd_cpg_dispatch(cpg_handle_t handle,
         crm_err("Bad message of class %d received from %s[%u]: '%.120s'", kind, from, nodeid, data);
     } else {
         attrd_peer_message(pcmk__get_node(nodeid, from, NULL,
-                                          pcmk__node_search_cluster),
+                                          pcmk__node_search_cluster_member),
                            xml);
     }
 
@@ -214,7 +214,7 @@ static void
 record_peer_nodeid(attribute_value_t *v, const char *host)
 {
     crm_node_t *known_peer = pcmk__get_node(v->nodeid, host, NULL,
-                                            pcmk__node_search_cluster);
+                                            pcmk__node_search_cluster_member);
 
     crm_trace("Learned %s has node id %s", known_peer->uname, known_peer->uuid);
     if (attrd_election_won()) {
@@ -442,7 +442,7 @@ attrd_peer_clear_failure(pcmk__request_t *request)
     regex_t regex;
 
     crm_node_t *peer = pcmk__get_node(0, request->peer, NULL,
-                                      pcmk__node_search_cluster);
+                                      pcmk__node_search_cluster_member);
 
     pcmk_parse_interval_spec(interval_spec, &interval_ms);
 

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -156,7 +156,7 @@ attrd_client_peer_remove(pcmk__request_t *request)
             char *host_alloc = NULL;
 
             node = pcmk__search_node_caches(nodeid, NULL,
-                                            pcmk__node_search_cluster);
+                                            pcmk__node_search_cluster_member);
             if (node && node->uname) {
                 // Use cached name if available
                 host = node->uname;

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -182,7 +182,7 @@ handle_sync_response_request(pcmk__request_t *request)
     } else {
         if (request->peer != NULL) {
             crm_node_t *peer = pcmk__get_node(0, request->peer, NULL,
-                                              pcmk__node_search_cluster);
+                                              pcmk__node_search_cluster_member);
             bool peer_won = attrd_check_for_new_writer(peer, request->xml);
 
             if (!pcmk__str_eq(peer->uname, attrd_cluster->uname, pcmk__str_casei)) {
@@ -201,7 +201,7 @@ handle_update_request(pcmk__request_t *request)
     if (request->peer != NULL) {
         const char *host = crm_element_value(request->xml, PCMK__XA_ATTR_HOST);
         crm_node_t *peer = pcmk__get_node(0, request->peer, NULL,
-                                          pcmk__node_search_cluster);
+                                          pcmk__node_search_cluster_member);
 
         attrd_peer_update(peer, request->xml, host, false);
         pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -959,7 +959,7 @@ forward_request(xmlNode *request)
     crm_xml_add(request, PCMK__XA_CIB_DELEGATED_FROM, OUR_NODENAME);
 
     if (host != NULL) {
-        peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster);
+        peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster_member);
     }
     send_cluster_message(peer, crm_msg_cib, request, FALSE);
 
@@ -1020,11 +1020,13 @@ send_peer_reply(xmlNode * msg, xmlNode * result_diff, const char *originator, gb
 
     } else if (originator != NULL) {
         /* send reply via HA to originating node */
+        const crm_node_t *node =
+            pcmk__get_node(0, originator, NULL,
+                           pcmk__node_search_cluster_member);
+
         crm_trace("Sending request result to %s only", originator);
         crm_xml_add(msg, PCMK__XA_CIB_ISREPLYTO, originator);
-        return send_cluster_message(pcmk__get_node(0, originator, NULL,
-                                                   pcmk__node_search_cluster),
-                                    crm_msg_cib, msg, FALSE);
+        return send_cluster_message(node, crm_msg_cib, msg, FALSE);
     }
 
     return FALSE;

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -128,7 +128,7 @@ send_sync_request(const char *host)
                 stand_alone? "localhost" : crm_cluster->uname);
 
     if (host != NULL) {
-        peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster);
+        peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster_member);
     }
     send_cluster_message(peer, crm_msg_cib, sync_me, FALSE);
     free_xml(sync_me);
@@ -255,7 +255,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
             crm_node_t *origin = NULL;
 
             origin = pcmk__search_node_caches(0, host,
-                                              pcmk__node_search_cluster);
+                                              pcmk__node_search_cluster_member);
 
             crm_info("Rejecting upgrade request from %s: %s "
                      CRM_XS " rc=%d peer=%s", host, pcmk_strerror(rc), rc,
@@ -455,7 +455,7 @@ sync_our_cib(xmlNode * request, gboolean all)
     pcmk__xml_copy(wrapper, the_cib);
 
     if (!all) {
-        peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster);
+        peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster_member);
     }
     if (!send_cluster_message(peer, crm_msg_cib, replace_request, FALSE)) {
         result = -ENOTCONN;

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -271,7 +271,7 @@ main(int argc, char **argv)
         goto done;
     }
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     // Read initial CIB, connect to cluster, and start IPC servers
     cib_init();

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -291,7 +291,7 @@ done:
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
 
-    crm_peer_destroy();
+    pcmk__cluster_destroy_node_caches();
 
     if (local_notify_queue != NULL) {
         g_hash_table_destroy(local_notify_queue);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -241,7 +241,7 @@ crmd_exit(crm_exit_t exit_code)
     controld_destroy_transition_trigger();
 
     pcmk__client_cleanup();
-    crm_peer_destroy();
+    pcmk__cluster_destroy_node_caches();
 
     controld_free_fsa_timers();
     te_cleanup_stonith_history_sync(NULL, TRUE);

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -48,7 +48,7 @@ crmd_cs_dispatch(cpg_handle_t handle, const struct cpg_name *groupName,
 
         crm_xml_add(xml, PCMK__XA_SRC, from);
 
-        peer = pcmk__get_node(0, from, NULL, pcmk__node_search_cluster);
+        peer = pcmk__get_node(0, from, NULL, pcmk__node_search_cluster_member);
         if (!pcmk_is_set(peer->processes, crm_proc_cpg)) {
             /* If we can still talk to our peer process on that node,
              * then it must be part of the corosync membership
@@ -119,7 +119,7 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
         crm_node_t *peer = NULL;
 
         peer = pcmk__search_node_caches(0, controld_globals.dc_name,
-                                        pcmk__node_search_cluster);
+                                        pcmk__node_search_cluster_member);
         if (peer != NULL) {
             for (int i = 0; i < left_list_entries; ++i) {
                 if (left_list[i].nodeid == peer->id) {

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -269,8 +269,9 @@ do_dc_release(long long action,
         crm_info("DC role released");
         if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
             xmlNode *update = NULL;
-            crm_node_t *node = pcmk__get_node(0, controld_globals.our_nodename,
-                                              NULL, pcmk__node_search_cluster);
+            crm_node_t *node =
+                pcmk__get_node(0, controld_globals.our_nodename,
+                               NULL, pcmk__node_search_cluster_member);
 
             pcmk__update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
             update = create_node_state_update(node, node_update_expected, NULL,

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1764,7 +1764,7 @@ controld_ack_event_directly(const char *to_host, const char *to_sys,
     }
 
     peer = pcmk__get_node(0, controld_globals.our_nodename, NULL,
-                          pcmk__node_search_cluster);
+                          pcmk__node_search_cluster_member);
     update = create_node_state_update(peer, node_update_none, NULL,
                                       __func__);
 

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -375,8 +375,8 @@ execute_stonith_cleanup(void)
 
     for (iter = stonith_cleanup_list; iter != NULL; iter = iter->next) {
         char *target = iter->data;
-        crm_node_t *target_node = pcmk__get_node(0, target, NULL,
-                                                 pcmk__node_search_cluster);
+        crm_node_t *target_node =
+            pcmk__get_node(0, target, NULL, pcmk__node_search_cluster_member);
         const char *uuid = crm_peer_uuid(target_node);
 
         crm_notice("Marking %s, target of a previous stonith action, as clean", target);
@@ -582,9 +582,10 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
                event->id);
 
     if (succeeded) {
-        crm_node_t *peer = pcmk__search_node_caches(0, event->target,
-                                                    pcmk__node_search_any
-                                                    |pcmk__node_search_cluster_cib);
+        const uint32_t flags = pcmk__node_search_any
+                               |pcmk__node_search_cluster_cib;
+
+        crm_node_t *peer = pcmk__search_node_caches(0, event->target, flags);
         const char *uuid = NULL;
 
         if (peer == NULL) {

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -584,7 +584,7 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
     if (succeeded) {
         crm_node_t *peer = pcmk__search_node_caches(0, event->target,
                                                     pcmk__node_search_any
-                                                    |pcmk__node_search_known);
+                                                    |pcmk__node_search_cluster_cib);
         const char *uuid = NULL;
 
         if (peer == NULL) {

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -35,7 +35,7 @@ update_dc_expected(const xmlNode *msg)
     if ((controld_globals.dc_name != NULL)
         && pcmk__xe_attr_is_true(msg, PCMK__XA_DC_LEAVING)) {
         crm_node_t *dc_node = pcmk__get_node(0, controld_globals.dc_name, NULL,
-                                             pcmk__node_search_cluster);
+                                             pcmk__node_search_cluster_member);
 
         pcmk__update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_DOWN);
     }
@@ -178,7 +178,7 @@ join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
         crm_xml_add(reply, PCMK__XA_JOIN_ID, join_id);
         crm_xml_add(reply, PCMK_XA_CRM_FEATURE_SET, CRM_FEATURE_SET);
         send_cluster_message(pcmk__get_node(0, controld_globals.dc_name, NULL,
-                                            pcmk__node_search_cluster),
+                                            pcmk__node_search_cluster_member),
                              crm_msg_crmd, reply, TRUE);
         free_xml(reply);
     }
@@ -338,7 +338,7 @@ do_cl_join_finalize_respond(long long action,
         }
 
         send_cluster_message(pcmk__get_node(0, controld_globals.dc_name, NULL,
-                                            pcmk__node_search_cluster),
+                                            pcmk__node_search_cluster_member),
                              crm_msg_crmd, reply, TRUE);
         free_xml(reply);
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -317,7 +317,7 @@ do_dc_join_offer_one(long long action,
         crm_err("Can't make join-%d offer to unknown node", current_join_id);
         return;
     }
-    member = pcmk__get_node(0, join_to, NULL, pcmk__node_search_cluster);
+    member = pcmk__get_node(0, join_to, NULL, pcmk__node_search_cluster_member);
 
     /* It is possible that a node will have been sick or starting up when the
      * original offer was made. However, it will either re-announce itself in
@@ -332,7 +332,7 @@ do_dc_join_offer_one(long long action,
      */
     if (strcasecmp(join_to, controld_globals.our_nodename) != 0) {
         member = pcmk__get_node(0, controld_globals.our_nodename, NULL,
-                                pcmk__node_search_cluster);
+                                pcmk__node_search_cluster_member);
         join_make_offer(NULL, member, NULL);
     }
 
@@ -397,7 +397,8 @@ do_dc_join_filter_offer(long long action,
         crm_err("Ignoring invalid join request without node name");
         return;
     }
-    join_node = pcmk__get_node(0, join_from, NULL, pcmk__node_search_cluster);
+    join_node = pcmk__get_node(0, join_from, NULL,
+                               pcmk__node_search_cluster_member);
 
     crm_element_value_int(join_ack->msg, PCMK__XA_JOIN_ID, &join_id);
     if (join_id != current_join_id) {
@@ -743,7 +744,7 @@ do_dc_join_ack(long long action,
         goto done;
     }
 
-    peer = pcmk__get_node(0, join_from, NULL, pcmk__node_search_cluster);
+    peer = pcmk__get_node(0, join_from, NULL, pcmk__node_search_cluster_member);
     if (peer->join != crm_join_finalized) {
         crm_info("Ignoring out-of-sequence join-%d confirmation from %s "
                  "(currently %s not %s)",
@@ -877,7 +878,8 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
         return;
     }
 
-    join_node = pcmk__get_node(0, join_to, NULL, pcmk__node_search_cluster);
+    join_node = pcmk__get_node(0, join_to, NULL,
+                               pcmk__node_search_cluster_member);
     if (!pcmk__cluster_is_node_active(join_node)) {
         /*
          * NACK'ing nodes that the membership layer doesn't know about yet

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -463,7 +463,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
             crm_log_xml_trace(msg, "relayed");
             if (!broadcast) {
                 node_to = pcmk__get_node(0, host_to, NULL,
-                                         pcmk__node_search_cluster);
+                                         pcmk__node_search_cluster_member);
             }
             send_cluster_message(node_to, dest, msg, TRUE);
             return TRUE;
@@ -490,7 +490,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
 
     if (!broadcast) {
         node_to = pcmk__search_node_caches(0, host_to,
-                                           pcmk__node_search_cluster);
+                                           pcmk__node_search_cluster_member);
         if (node_to == NULL) {
             crm_warn("Ignoring message %s because node %s is unknown",
                      ref, host_to);
@@ -1045,8 +1045,8 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
 
     if (strcmp(op, CRM_OP_SHUTDOWN_REQ) == 0) {
         const char *from = crm_element_value(stored_msg, PCMK__XA_SRC);
-        crm_node_t *node = pcmk__search_node_caches(0, from,
-                                                    pcmk__node_search_cluster);
+        crm_node_t *node =
+            pcmk__search_node_caches(0, from, pcmk__node_search_cluster_member);
 
         pcmk__update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);
         if(AM_I_DC == FALSE) {

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -207,7 +207,7 @@ should_purge_attributes(crm_node_t *node)
      * peer cache.  That's the one we really care about here.
      */
     conn_node = pcmk__get_node(0, node->conn_host, NULL,
-                               pcmk__node_search_cluster);
+                               pcmk__node_search_cluster_member);
     if (conn_node == NULL) {
         return purge;
     }

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -158,7 +158,7 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_DO_SHUTDOWN, pcmk__str_none)) {
         crm_node_t *peer = pcmk__get_node(0, router_node, NULL,
-                                          pcmk__node_search_cluster);
+                                          pcmk__node_search_cluster_member);
 
         pcmk__update_peer_expected(__func__, peer, CRMD_JOINSTATE_DOWN);
     }
@@ -171,7 +171,7 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     crm_xml_add(cmd, PCMK__XA_TRANSITION_KEY, counter);
 
     rc = send_cluster_message(pcmk__get_node(0, router_node, NULL,
-                                             pcmk__node_search_cluster),
+                                             pcmk__node_search_cluster_member),
                               crm_msg_crmd, cmd, TRUE);
     free(counter);
     free_xml(cmd);
@@ -427,9 +427,11 @@ execute_rsc_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                       I_NULL, &msg);
 
     } else {
-        rc = send_cluster_message(pcmk__get_node(0, router_node, NULL,
-                                                 pcmk__node_search_cluster),
-                                  crm_msg_lrmd, cmd, TRUE);
+        const crm_node_t *node =
+            pcmk__get_node(0, router_node, NULL,
+                           pcmk__node_search_cluster_member);
+
+        rc = send_cluster_message(node, crm_msg_lrmd, cmd, TRUE);
     }
 
     free(counter);

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -120,8 +120,9 @@ fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node)
                                             PCMK__META_ON_NODE_UUID);
             router = crm_element_value(action->xml, PCMK__XA_ROUTER_NODE);
             if (router) {
-                crm_node_t *node = pcmk__get_node(0, router, NULL,
-                                                  pcmk__node_search_cluster);
+                const crm_node_t *node =
+                    pcmk__get_node(0, router, NULL,
+                                   pcmk__node_search_cluster_member);
 
                 if (node) {
                     router_uuid = node->uuid;

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -734,7 +734,7 @@ update_dc(xmlNode * msg)
 
     } else if (controld_globals.dc_name != NULL) {
         crm_node_t *dc_node = pcmk__get_node(0, controld_globals.dc_name, NULL,
-                                             pcmk__node_search_cluster);
+                                             pcmk__node_search_cluster_member);
 
         crm_info("Set DC to %s (%s)",
                  controld_globals.dc_name,

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -196,7 +196,7 @@ crmd_init(void)
     init_dotfile();
     register_fsa_input(C_STARTUP, I_STARTUP, NULL);
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
     state = s_crmd_fsa(C_STARTUP);
 
     if (state == S_PENDING || state == S_STARTING) {

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2940,7 +2940,7 @@ fence_locally(xmlNode *msg, pcmk__action_result_t *result)
             pcmk__scan_min_int(host, &nodeid, 0);
             node = pcmk__search_node_caches(nodeid, NULL,
                                             pcmk__node_search_any
-                                            |pcmk__node_search_known);
+                                            |pcmk__node_search_cluster_cib);
             if (node != NULL) {
                 host = node->uname;
             }

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -645,7 +645,7 @@ schedule_stonith_command(async_command_t * cmd, stonith_device_t * device)
 
     if (device->include_nodeid && (cmd->target != NULL)) {
         crm_node_t *node = pcmk__get_node(0, cmd->target, NULL,
-                                          pcmk__node_search_cluster);
+                                          pcmk__node_search_cluster_member);
 
         cmd->target_nodeid = node->id;
     }
@@ -2415,7 +2415,7 @@ stonith_send_reply(const xmlNode *reply, int call_options,
         do_local_reply(reply, client, call_options);
     } else {
         send_cluster_message(pcmk__get_node(0, remote_peer, NULL,
-                                            pcmk__node_search_cluster),
+                                            pcmk__node_search_cluster_member),
                              crm_msg_stonith_ng, reply, FALSE);
     }
 }
@@ -3382,6 +3382,8 @@ handle_fence_request(pcmk__request_t *request)
         if (alternate_host != NULL) {
             const char *client_id = NULL;
             remote_fencing_op_t *op = NULL;
+            crm_node_t *node = pcmk__get_node(0, alternate_host, NULL,
+                                              pcmk__node_search_cluster_member);
 
             if (request->ipc_client->id == 0) {
                 client_id = crm_element_value(request->xml,
@@ -3400,9 +3402,7 @@ handle_fence_request(pcmk__request_t *request)
             crm_xml_add(request->xml, PCMK__XA_ST_CLIENTID,
                         request->ipc_client->id);
             crm_xml_add(request->xml, PCMK__XA_ST_REMOTE_OP, op->id);
-            send_cluster_message(pcmk__get_node(0, alternate_host, NULL,
-                                                pcmk__node_search_cluster),
-                                 crm_msg_stonith_ng, request->xml, FALSE);
+            send_cluster_message(node, crm_msg_stonith_ng, request->xml, FALSE);
             pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_PENDING,
                              NULL);
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -488,7 +488,7 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
             pcmk__scan_min_int(target, &nodeid, 0);
             node = pcmk__search_node_caches(nodeid, NULL,
                                             pcmk__node_search_any
-                                            |pcmk__node_search_known);
+                                            |pcmk__node_search_cluster_cib);
             if (node) {
                 target = node->uname;
             }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1238,7 +1238,7 @@ create_remote_stonith_op(const char *client, xmlNode *request, gboolean peer)
         pcmk__scan_min_int(op->target, &nodeid, 0);
         node = pcmk__search_node_caches(nodeid, NULL,
                                         pcmk__node_search_any
-                                        |pcmk__node_search_known);
+                                        |pcmk__node_search_cluster_cib);
 
         /* Ensure the conversion only happens once */
         stonith__clear_call_options(op->call_options, op->id, st_opt_cs_nodeid);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1008,6 +1008,7 @@ merge_duplicates(remote_fencing_op_t *op)
     g_hash_table_iter_init(&iter, stonith_remote_op_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&other)) {
         const char *other_action = op_requested_action(other);
+        crm_node_t *node = NULL;
 
         if (!strcmp(op->id, other->id)) {
             continue; // Don't compare against self
@@ -1037,8 +1038,11 @@ merge_duplicates(remote_fencing_op_t *op)
                       op->id, other->id, other->target);
             continue;
         }
-        if (!fencing_peer_active(pcmk__get_node(0, other->originator, NULL,
-                                                pcmk__node_search_cluster))) {
+
+        node = pcmk__get_node(0, other->originator, NULL,
+                              pcmk__node_search_cluster_member);
+
+        if (!fencing_peer_active(node)) {
             crm_notice("Failing action '%s' targeting %s originating from "
                        "client %s@%s: Originator is dead " CRM_XS " id=%.8s",
                        other->action, other->target, other->client_name,
@@ -1734,7 +1738,7 @@ report_timeout_period(remote_fencing_op_t * op, int op_timeout)
     crm_xml_add_int(update, PCMK__XA_ST_TIMEOUT, op_timeout);
 
     send_cluster_message(pcmk__get_node(0, client_node, NULL,
-                                        pcmk__node_search_cluster),
+                                        pcmk__node_search_cluster_member),
                          crm_msg_stonith_ng, update, FALSE);
 
     free_xml(update);
@@ -1988,7 +1992,7 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
         }
 
         send_cluster_message(pcmk__get_node(0, peer->host, NULL,
-                                            pcmk__node_search_cluster),
+                                            pcmk__node_search_cluster_member),
                              crm_msg_stonith_ng, remote_op, FALSE);
         peer->tried = TRUE;
         free_xml(remote_op);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -430,7 +430,7 @@ stonith_cleanup(void)
         qb_ipcs_destroy(ipcs);
     }
 
-    crm_peer_destroy();
+    pcmk__cluster_destroy_node_caches();
     pcmk__client_cleanup();
     free_stonith_remote_op_list();
     free_topology_list();

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -608,7 +608,7 @@ main(int argc, char **argv)
 
     mainloop_add_signal(SIGTERM, stonith_shutdown);
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     rc = fenced_scheduler_init();
     if (rc != pcmk_rc_ok) {

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -128,8 +128,6 @@ typedef struct crm_peer_node_s {
     time_t when_online;         // Since when peer has been online in CPG
 } crm_node_t;
 
-void crm_peer_destroy(void);
-
 // Implementation of pcmk_cluster_t
 // @COMPAT Make this internal when we can break API backward compatibility
 //!@{

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -128,7 +128,6 @@ typedef struct crm_peer_node_s {
     time_t when_online;         // Since when peer has been online in CPG
 } crm_node_t;
 
-void crm_peer_init(void);
 void crm_peer_destroy(void);
 
 // Implementation of pcmk_cluster_t

--- a/include/crm/cluster/compat.h
+++ b/include/crm/cluster/compat.h
@@ -111,6 +111,9 @@ enum cluster_type_e get_cluster_type(void);
 // \deprecated Use \c pcmk_get_cluster_layer() instead
 gboolean is_corosync_cluster(void);
 
+// \deprecated Do not use
+void crm_peer_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/cluster/compat.h
+++ b/include/crm/cluster/compat.h
@@ -114,6 +114,9 @@ gboolean is_corosync_cluster(void);
 // \deprecated Do not use
 void crm_peer_init(void);
 
+// \deprecated Do not use
+void crm_peer_destroy(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -45,7 +45,8 @@ enum pcmk__node_search_flags {
      * support for enum crm_get_peer_flags
      */
 
-    pcmk__node_search_known     = (1 << 2), // Search previously known nodes
+    //! Search for cluster nodes from CIB (as of last cache refresh)
+    pcmk__node_search_cluster_cib   = (1 << 2),
 };
 
 /*!

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -149,6 +149,10 @@ void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
                                                         gboolean),
                                    void (*destroy) (gpointer));
 
+// Membership
+
+void pcmk__cluster_init_node_caches(void);
+
 bool pcmk__cluster_is_node_active(const crm_node_t *node);
 unsigned int pcmk__cluster_num_active_nodes(void);
 unsigned int pcmk__cluster_num_remote_nodes(void);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -152,6 +152,7 @@ void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
 // Membership
 
 void pcmk__cluster_init_node_caches(void);
+void pcmk__cluster_destroy_node_caches(void);
 
 bool pcmk__cluster_is_node_active(const crm_node_t *node);
 unsigned int pcmk__cluster_num_active_nodes(void);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -35,18 +35,25 @@ enum crm_proc_flag {
 
 // Used with node cache search functions
 enum pcmk__node_search_flags {
-    pcmk__node_search_none      = 0,
-    pcmk__node_search_cluster   = (1 << 0), // Search for cluster nodes
-    pcmk__node_search_remote    = (1 << 1), // Search for remote nodes
-    pcmk__node_search_any       = pcmk__node_search_cluster
-                                  |pcmk__node_search_remote,
+    //! Does not affect search
+    pcmk__node_search_none              = 0,
+
+    //! Search for cluster nodes from membership cache
+    pcmk__node_search_cluster_member    = (1 << 0),
+
+    //! Search for remote nodes
+    pcmk__node_search_remote            = (1 << 1),
+
+    //! Search for cluster member nodes and remote nodes
+    pcmk__node_search_any               = pcmk__node_search_cluster_member
+                                          |pcmk__node_search_remote,
 
     /* @COMPAT The values before this must stay the same until we can drop
      * support for enum crm_get_peer_flags
      */
 
     //! Search for cluster nodes from CIB (as of last cache refresh)
-    pcmk__node_search_cluster_cib   = (1 << 2),
+    pcmk__node_search_cluster_cib       = (1 << 2),
 };
 
 /*!

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -174,23 +174,25 @@ int pcmk__xml_show_changes(pcmk__output_t *out, const xmlNode *xml);
 /* search string to find CIB resources entries for cluster nodes */
 #define PCMK__XP_MEMBER_NODE_CONFIG                                 \
     "//" PCMK_XE_CIB "/" PCMK_XE_CONFIGURATION "/" PCMK_XE_NODES    \
-    "/" PCMK_XE_NODE "[not(@type) or @type='member']"
+    "/" PCMK_XE_NODE                                                \
+    "[not(@" PCMK_XA_TYPE ") or @" PCMK_XA_TYPE "='" PCMK_VALUE_MEMBER "']"
 
 /* search string to find CIB resources entries for guest nodes */
 #define PCMK__XP_GUEST_NODE_CONFIG \
     "//" PCMK_XE_CIB "//" PCMK_XE_CONFIGURATION "//" PCMK_XE_PRIMITIVE  \
     "//" PCMK_XE_META_ATTRIBUTES "//" PCMK_XE_NVPAIR                    \
-    "[@name='" PCMK_META_REMOTE_NODE "']"
+    "[@" PCMK_XA_NAME "='" PCMK_META_REMOTE_NODE "']"
 
 /* search string to find CIB resources entries for remote nodes */
 #define PCMK__XP_REMOTE_NODE_CONFIG                                     \
     "//" PCMK_XE_CIB "//" PCMK_XE_CONFIGURATION "//" PCMK_XE_PRIMITIVE  \
-    "[@type='remote'][@provider='pacemaker']"
+    "[@" PCMK_XA_TYPE "='" PCMK_VALUE_REMOTE "']"                       \
+    "[@" PCMK_XA_PROVIDER "='pacemaker']"
 
 /* search string to find CIB node status entries for pacemaker_remote nodes */
 #define PCMK__XP_REMOTE_NODE_STATUS                                 \
     "//" PCMK_XE_CIB "//" PCMK_XE_STATUS "//" PCMK__XE_NODE_STATE   \
-    "[@" PCMK_XA_REMOTE_NODE "='true']"
+    "[@" PCMK_XA_REMOTE_NODE "='" PCMK_VALUE_TRUE "']"
 /*!
  * \internal
  * \brief Serialize XML (using libxml) into provided descriptor

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -35,6 +35,7 @@
 #define PCMK_ALLOW_DEPRECATED 0
 
 #  include <crm/lrmd.h>
+#  include <crm/cluster/internal.h>
 #  include <crm/common/logging.h>
 #  include <crm/common/logging_internal.h>
 #  include <crm/common/ipc_internal.h>

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -115,7 +115,7 @@ pcmk_cluster_disconnect(pcmk_cluster_t *cluster)
     switch (cluster_layer) {
         case pcmk_cluster_layer_corosync:
 #if SUPPORT_COROSYNC
-            crm_peer_destroy();
+            pcmk__cluster_destroy_node_caches();
             pcmk__corosync_disconnect(cluster);
             return pcmk_rc_ok;
 #else

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -312,7 +312,7 @@ crm_peer_uname(const char *uuid)
         }
 
         node = pcmk__search_node_caches((uint32_t) id, NULL,
-                                        pcmk__node_search_cluster);
+                                        pcmk__node_search_cluster_member);
         if (node != NULL) {
             crm_info("Setting uuid for node %s[%u] to %s",
                      node->uname, node->id, uuid);

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -83,7 +83,7 @@ pcmk_cluster_connect(pcmk_cluster_t *cluster)
     switch (cluster_layer) {
         case pcmk_cluster_layer_corosync:
 #if SUPPORT_COROSYNC
-            crm_peer_init();
+            pcmk__cluster_init_node_caches();
             return pcmk__corosync_connect(cluster);
 #else
             break;

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -313,12 +313,13 @@ quorum_notification_cb(quorum_handle_t handle, uint32_t quorate,
         crm_debug("Member[%d] %u ", i, id);
 
         /* Get this node's peer cache entry (adding one if not already there) */
-        node = pcmk__get_node(id, NULL, NULL, pcmk__node_search_cluster);
+        node = pcmk__get_node(id, NULL, NULL, pcmk__node_search_cluster_member);
         if (node->uname == NULL) {
             char *name = pcmk__corosync_name(0, id);
 
             crm_info("Obtaining name for new node %u", id);
-            node = pcmk__get_node(id, name, NULL, pcmk__node_search_cluster);
+            node = pcmk__get_node(id, name, NULL,
+                                  pcmk__node_search_cluster_member);
             free(name);
         }
 
@@ -490,7 +491,7 @@ pcmk__corosync_connect(pcmk_cluster_t *cluster)
 
     // Ensure local node always exists in peer cache
     peer = pcmk__get_node(cluster->nodeid, cluster->uname, NULL,
-                          pcmk__node_search_cluster);
+                          pcmk__node_search_cluster_member);
     cluster->uuid = pcmk__corosync_uuid(peer);
 
     return pcmk_rc_ok;
@@ -638,7 +639,7 @@ pcmk__corosync_add_nodes(xmlNode *xml_parent)
 
         if (nodeid > 0 || name != NULL) {
             crm_trace("Initializing node[%d] %u = %s", lpc, nodeid, name);
-            pcmk__get_node(nodeid, name, NULL, pcmk__node_search_cluster);
+            pcmk__get_node(nodeid, name, NULL, pcmk__node_search_cluster_member);
         }
 
         if (nodeid > 0 && name != NULL) {

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -462,7 +462,7 @@ pcmk__corosync_connect(pcmk_cluster_t *cluster)
     const char *cluster_layer_s = pcmk_cluster_layer_text(cluster_layer);
     int rc = pcmk_rc_ok;
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     if (cluster_layer != pcmk_cluster_layer_corosync) {
         crm_err("Invalid cluster layer: %s " CRM_XS " cluster_layer=%d",
@@ -605,7 +605,7 @@ pcmk__corosync_add_nodes(xmlNode *xml_parent)
         goto bail;
     }
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
     crm_trace("Initializing Corosync node list");
     for (lpc = 0; TRUE; lpc++) {
         uint32_t nodeid = 0;

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -446,7 +446,7 @@ pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void 
         msg->sender.id = nodeid;
         if (msg->sender.size == 0) {
             crm_node_t *peer = pcmk__get_node(nodeid, NULL, NULL,
-                                              pcmk__node_search_cluster);
+                                              pcmk__node_search_cluster_member);
 
             if (peer == NULL) {
                 crm_err("Peer with nodeid=%u is unknown", nodeid);
@@ -508,7 +508,7 @@ pcmk_message_common_cs(cpg_handle_t handle, uint32_t nodeid, uint32_t pid, void 
 
     // Is this necessary?
     pcmk__get_node(msg->sender.id, msg->sender.uname, NULL,
-                   pcmk__node_search_cluster);
+                   pcmk__node_search_cluster_member);
 
     crm_trace("Payload: %.200s", data);
     return data;
@@ -609,8 +609,9 @@ node_left(const char *cpg_group_name, int event_counter,
           const struct cpg_address **sorted_member_list,
           size_t member_list_entries)
 {
-    crm_node_t *peer = pcmk__search_node_caches(cpg_peer->nodeid, NULL,
-                                                pcmk__node_search_cluster);
+    crm_node_t *peer =
+        pcmk__search_node_caches(cpg_peer->nodeid, NULL,
+                                 pcmk__node_search_cluster_member);
     const struct cpg_address **rival = NULL;
 
     /* Most CPG-related Pacemaker code assumes that only one process on a node
@@ -703,7 +704,7 @@ pcmk_cpg_membership(cpg_handle_t handle,
 
     for (i = 0; i < member_list_entries; i++) {
         crm_node_t *peer = pcmk__get_node(member_list[i].nodeid, NULL, NULL,
-                                          pcmk__node_search_cluster);
+                                          pcmk__node_search_cluster_member);
 
         if (member_list[i].nodeid == local_nodeid
                 && member_list[i].pid != getpid()) {
@@ -893,7 +894,7 @@ pcmk__cpg_connect(pcmk_cluster_t *cluster)
         return ENOTCONN;
     }
 
-    peer = pcmk__get_node(id, NULL, NULL, pcmk__node_search_cluster);
+    peer = pcmk__get_node(id, NULL, NULL, pcmk__node_search_cluster_member);
     crm_update_peer_proc(__func__, peer, crm_proc_cpg, PCMK_VALUE_ONLINE);
     return pcmk_rc_ok;
 }

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -297,7 +297,8 @@ election_vote(election_t *e)
         return;
     }
 
-    our_node = pcmk__get_node(0, e->uname, NULL, pcmk__node_search_cluster);
+    our_node = pcmk__get_node(0, e->uname, NULL,
+                              pcmk__node_search_cluster_member);
     if (!pcmk__cluster_is_node_active(our_node)) {
         crm_trace("Cannot vote in %s yet: local node not connected to cluster",
                   e->name);
@@ -543,8 +544,10 @@ election_count_vote(election_t *e, const xmlNode *message, bool can_win)
         return election_error;
     }
 
-    your_node = pcmk__get_node(0, vote.from, NULL, pcmk__node_search_cluster);
-    our_node = pcmk__get_node(0, e->uname, NULL, pcmk__node_search_cluster);
+    your_node = pcmk__get_node(0, vote.from, NULL,
+                               pcmk__node_search_cluster_member);
+    our_node = pcmk__get_node(0, e->uname, NULL,
+                              pcmk__node_search_cluster_member);
     we_are_owner = (our_node != NULL)
                    && pcmk__str_eq(our_node->uuid, vote.election_owner,
                                    pcmk__str_none);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -550,12 +550,6 @@ pcmk__cluster_init_node_caches(void)
 }
 
 void
-crm_peer_init(void)
-{
-    pcmk__cluster_init_node_caches();
-}
-
-void
 crm_peer_destroy(void)
 {
     if (crm_peer_cache != NULL) {
@@ -1551,6 +1545,12 @@ reap_crm_member(uint32_t id, const char *name)
 
     free(search.uname);
     return matches;
+}
+
+void
+crm_peer_init(void)
+{
+    pcmk__cluster_init_node_caches();
 }
 
 // LCOV_EXCL_STOP

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -549,11 +549,16 @@ pcmk__cluster_init_node_caches(void)
     }
 }
 
+/*!
+ * \internal
+ * \brief Initialize node caches
+ */
 void
-crm_peer_destroy(void)
+pcmk__cluster_destroy_node_caches(void)
 {
     if (crm_peer_cache != NULL) {
-        crm_trace("Destroying peer cache with %d members", g_hash_table_size(crm_peer_cache));
+        crm_trace("Destroying peer cache with %d members",
+                  g_hash_table_size(crm_peer_cache));
         g_hash_table_destroy(crm_peer_cache);
         crm_peer_cache = NULL;
     }
@@ -571,7 +576,12 @@ crm_peer_destroy(void)
         g_hash_table_destroy(cluster_node_cib_cache);
         cluster_node_cib_cache = NULL;
     }
+}
 
+void
+crm_peer_destroy(void)
+{
+    pcmk__cluster_destroy_node_caches();
 }
 
 static void (*peer_status_callback)(enum crm_status_type, crm_node_t *,

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -134,7 +134,8 @@ pcmk__cluster_lookup_remote_node(const char *node_name)
      * entry unless it has a node ID, which means the name actually is
      * associated with a cluster node. (@TODO return an error in that case?)
      */
-    node = pcmk__search_node_caches(0, node_name, pcmk__node_search_cluster);
+    node = pcmk__search_node_caches(0, node_name,
+                                    pcmk__node_search_cluster_member);
     if ((node != NULL) && (node->uuid == NULL)) {
         /* node_name could be a pointer into the cache entry being removed, so
          * reassign it to a copy before the original gets freed
@@ -647,7 +648,9 @@ pcmk__search_node_caches(unsigned int id, const char *uname, uint32_t flags)
         node = g_hash_table_lookup(crm_remote_peer_cache, uname);
     }
 
-    if ((node == NULL) && pcmk_is_set(flags, pcmk__node_search_cluster)) {
+    if ((node == NULL)
+        && pcmk_is_set(flags, pcmk__node_search_cluster_member)) {
+
         node = pcmk__search_cluster_node_cache(id, uname, NULL);
     }
 
@@ -885,7 +888,7 @@ pcmk__get_node(unsigned int id, const char *uname, const char *uuid,
         }
     }
 
-    if (!pcmk_is_set(flags, pcmk__node_search_cluster)) {
+    if (!pcmk_is_set(flags, pcmk__node_search_cluster_member)) {
         return NULL;
     }
 
@@ -1460,7 +1463,7 @@ crm_terminate_member_no_mainloop(int nodeid, const char *uname, int *connection)
 crm_node_t *
 crm_get_peer(unsigned int id, const char *uname)
 {
-    return pcmk__get_node(id, uname, NULL, pcmk__node_search_cluster);
+    return pcmk__get_node(id, uname, NULL, pcmk__node_search_cluster_member);
 }
 
 crm_node_t *

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -578,12 +578,6 @@ pcmk__cluster_destroy_node_caches(void)
     }
 }
 
-void
-crm_peer_destroy(void)
-{
-    pcmk__cluster_destroy_node_caches();
-}
-
 static void (*peer_status_callback)(enum crm_status_type, crm_node_t *,
                                     const void *) = NULL;
 
@@ -1561,6 +1555,12 @@ void
 crm_peer_init(void)
 {
     pcmk__cluster_init_node_caches();
+}
+
+void
+crm_peer_destroy(void)
+{
+    pcmk__cluster_destroy_node_caches();
 }
 
 // LCOV_EXCL_STOP

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -651,7 +651,7 @@ pcmk__search_node_caches(unsigned int id, const char *uname, uint32_t flags)
         node = pcmk__search_cluster_node_cache(id, uname, NULL);
     }
 
-    if ((node == NULL) && pcmk_is_set(flags, pcmk__node_search_known)) {
+    if ((node == NULL) && pcmk_is_set(flags, pcmk__node_search_cluster_cib)) {
         char *id_str = (id == 0)? NULL : crm_strdup_printf("%u", id);
 
         node = find_cib_cluster_node(id_str, uname);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -299,7 +299,7 @@ refresh_remote_nodes(xmlNode *cib)
 {
     struct refresh_data data;
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     /* First, we mark all existing cache entries as dirty,
      * so that later we can remove any that weren't in the CIB.
@@ -529,8 +529,12 @@ destroy_crm_node(gpointer data)
     free(node);
 }
 
+/*!
+ * \internal
+ * \brief Initialize node caches
+ */
 void
-crm_peer_init(void)
+pcmk__cluster_init_node_caches(void)
 {
     if (crm_peer_cache == NULL) {
         crm_peer_cache = pcmk__strikey_table(free, destroy_crm_node);
@@ -543,6 +547,12 @@ crm_peer_init(void)
     if (cluster_node_cib_cache == NULL) {
         cluster_node_cib_cache = pcmk__strikey_table(free, destroy_crm_node);
     }
+}
+
+void
+crm_peer_init(void)
+{
+    pcmk__cluster_init_node_caches();
 }
 
 void
@@ -642,7 +652,7 @@ pcmk__search_node_caches(unsigned int id, const char *uname, uint32_t flags)
 
     CRM_ASSERT(id > 0 || uname != NULL);
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     if ((uname != NULL) && pcmk_is_set(flags, pcmk__node_search_remote)) {
         node = g_hash_table_lookup(crm_remote_peer_cache, uname);
@@ -726,7 +736,7 @@ pcmk__search_cluster_node_cache(unsigned int id, const char *uname,
 
     CRM_ASSERT(id > 0 || uname != NULL);
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     if (uname != NULL) {
         g_hash_table_iter_init(&iter, crm_peer_cache);
@@ -878,7 +888,7 @@ pcmk__get_node(unsigned int id, const char *uname, const char *uuid,
 
     CRM_ASSERT(id > 0 || uname != NULL);
 
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     // Check the Pacemaker Remote node cache first
     if (pcmk_is_set(flags, pcmk__node_search_remote)) {
@@ -1425,7 +1435,7 @@ cluster_node_cib_cache_refresh_helper(xmlNode *xml_node, void *user_data)
 static void
 refresh_cluster_node_cib_cache(xmlNode *cib)
 {
-    crm_peer_init();
+    pcmk__cluster_init_node_caches();
 
     g_hash_table_foreach(cluster_node_cib_cache, mark_dirty, NULL);
 


### PR DESCRIPTION
I also found `known_node_cache` (and its comment) misleading. The first few commits are for changing names in a way that I hope makes things clearer. Those commits are optional, not needed for deprecations.

I didn't get much done today besides finalizing #3443. This PR is the last little bit I had stored from Monday night.