### PR TITLE
Fix: sysconfig: Fix VALGRIND_OPTS default value

### DIFF
--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -394,7 +394,8 @@
 # commands, which would otherwise leave a bunch of unremovable files in /tmp.
 #
 # Default: VALGRIND_OPTS=""
-VALGRIND_OPTS="--leak-check=full --trace-children=no --vgdb=no --num-callers=25"
-VALGRIND_OPTS="$VALGRIND_OPTS --log-file=@CRM_PACEMAKER_DIR@/valgrind-%p"
-VALGRIND_OPTS="$VALGRIND_OPTS --suppressions=@datadir@/pacemaker/tests/valgrind-pcmk.suppressions"
-VALGRIND_OPTS="$VALGRIND_OPTS --gen-suppressions=all"
+VALGRIND_OPTS="""
+--leak-check=full --trace-children=no --vgdb=no --num-callers=25 \
+--log-file=@CRM_PACEMAKER_DIR@/valgrind-%p \
+--suppressions=@datadir@/pacemaker/tests/valgrind-pcmk.suppressions \
+--gen-suppressions=all"""


### PR DESCRIPTION
This fixes a regression introduced by 0c3631e9 that causes all daemons (except pacemakerd) to fail immediately when run under valgrind.

The sysconfig file is used as a systemd environment file. When systemd reads an environment file, it parses it line-by-line in a particular way as described in the systemd.exec man page (see EnvironmentFile).

It does not interpret the file as a shell script, and variable names are not expanded. So the following four lines:
```
VALGRIND_OPTS="--leak-check=full --trace-children=no --vgdb=no --num-callers=25"
VALGRIND_OPTS="$VALGRIND_OPTS --log-file=/var/lib/pacemaker/valgrind-%p"
VALGRIND_OPTS="$VALGRIND_OPTS --suppressions=/usr/share/pacemaker/tests/valgrind-pcmk.suppressions"
VALGRIND_OPTS="$VALGRIND_OPTS --gen-suppressions=all"
```

result in VALGRIND_OPTS being set to the literal value "$VALGRIND_OPTS --gen-suppressions=all". Apparently valgrind barfs upon finding that in the environment.

Unexpected behavior like this is another good reason for us to replace the current sysconfig with a true configuration file.

Ref T574