### PR TITLE
Refactor: python: Fix a couple minor pyflake issues

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -26,6 +26,9 @@ pylint:
 	pylint $(SUBDIRS)
 
 # Disabled warnings:
+# W503 - Line break occurred before a binary operator
+#        (newer versions of pyflake and PEP8 want line breaks after binary
+#        operators, but older versions still suggest before)
 # E501 - Line too long
 #
 # Disable unused imports on __init__.py files (we likely just have them
@@ -33,4 +36,4 @@ pylint:
 # Disable docstrings warnings on unit tests.
 .PHONY: pyflake
 pyflake:
-	flake8 --ignore=E501 --per-file-ignores="__init__.py:F401 tests/*:D100,D101,D102,D104" $(SUBDIRS)
+	flake8 --ignore=W503,E501 --per-file-ignores="__init__.py:F401 tests/*:D100,D101,D102,D104" $(SUBDIRS)

--- a/python/pacemaker/_cts/watcher.py
+++ b/python/pacemaker/_cts/watcher.py
@@ -92,9 +92,7 @@ class SearchObj:
         raise NotImplementedError
 
     def harvest_cached(self):
-        """
-        Return cached logs from before the limit timestamp.
-        """
+        """Return cached logs from before the limit timestamp."""
         raise NotImplementedError
 
     def end(self):
@@ -177,9 +175,7 @@ class FileObj(SearchObj):
         return self.rsh.call_async(self.host, cmd, delegate=self)
 
     def harvest_cached(self):
-        """
-        Return cached logs from before the limit timestamp.
-        """
+        """Return cached logs from before the limit timestamp."""
         # cts-log-watcher script renders caching unnecessary for FileObj.
         # @TODO Caching might be slightly more efficient, if not too complex.
         return []
@@ -320,9 +316,7 @@ class JournalObj(SearchObj):
         return self.rsh.call_async(self.host, command, delegate=self)
 
     def harvest_cached(self):
-        """
-        Return cached logs from before the limit timestamp.
-        """
+        """Return cached logs from before the limit timestamp."""
         before, self._cache = self._split_msgs_by_limit(self._cache)
         return before
 


### PR DESCRIPTION
* Disable older warnings that way occur depending on which version of pyflake you have installed.

* Single-line docstrings should be on a single line.