### PR TITLE
Doc: tools: cibadmin incorrect example for score update

### DIFF
--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -391,23 +391,23 @@ static GOptionEntry addl_entries[] = {
 
     { "score", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &options.score_update,
       "Treat new attribute values as atomic score updates where possible "
-      "(with --modify/-M)\n\n"
+      "(with --modify/-M).\n"
 
       INDENT "This currently happens by default and cannot be disabled, but\n"
       INDENT "this default behavior is deprecated and will be removed in a\n"
-      INDENT "future release. Set this flag if this behavior is desired.\n\n"
+      INDENT "future release. Set this flag if this behavior is desired.\n"
 
       INDENT "This option takes effect when updating XML attributes. For an\n"
       INDENT "attribute named \"name\", if the new value is \"name++\" or\n"
       INDENT "\"name+=X\" for some score X, the new value is set as follows:\n"
-      INDENT " * If attribute \"name\" is not already set to some value in\n"
-      INDENT "   the element being updated, the new value is set as a literal\n"
-      INDENT "   string.\n"
-      INDENT " * If the new value is \"name++\", then the attribute is set to\n"
-      INDENT "   its existing value (parsed as a score) plus 1.\n"
-      INDENT " * If the new value is \"name+=X\" for some score X, then the\n"
-      INDENT "   attribute is set to its existing value plus X, where the\n"
-      INDENT "   existing value and X are parsed and added as scores.\n\n"
+      INDENT "If attribute \"name\" is not already set to some value in\n"
+      INDENT "the element being updated, the new value is set as a literal\n"
+      INDENT "string.\n"
+      INDENT "If the new value is \"name++\", then the attribute is set to \n"
+      INDENT "its existing value (parsed as a score) plus 1.\n"
+      INDENT "If the new value is \"name+=X\" for some score X, then the\n"
+      INDENT "attribute is set to its existing value plus X, where the\n"
+      INDENT "existing value and X are parsed and added as scores.\n"
 
       INDENT "Scores are integer values capped at INFINITY and -INFINITY.\n"
       INDENT "Refer to Pacemaker Explained and to the char2score() function\n"
@@ -483,7 +483,7 @@ build_arg_context(pcmk__common_args_t *args)
                " --xml-file $HOME/constraints.xml\n\n"
            "Increase configuration version to prevent old configurations from "
                "being loaded accidentally:\n\n"
-           "\t# cibadmin --modify --xml-text "
+           "\t# cibadmin --modify --score --xml-text "
                "'<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH
                    "=\"" PCMK_XA_ADMIN_EPOCH "++\"/>'\n\n"
            "Edit the configuration with your favorite $EDITOR:\n\n"


### PR DESCRIPTION
Should use --score.

Also change formatting of --score option documentation. It appeared correctly in help output, but the man page generation yielded ugly indentation.

The new formatting looks worse (but passable) for --help output and looks better (previously unpassable) for man page.