### PR TITLE
Drop almost all of msg_xml_compat.h

### DIFF
--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -62,9 +62,6 @@ extern "C" {
 //! \deprecated Do not use
 #define PCMK_XA_PROMOTED_NODE_MAX_LEGACY "master-node-max"
 
-//! \deprecated Do not use
-#define PCMK_XE_PROMOTED_NODE_MAX_LEGACY PCMK_XA_PROMOTED_NODE_MAX_LEGACY
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -173,9 +173,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_NUM_UPDATES instead
 #define XML_ATTR_NUMUPDATES PCMK_XA_NUM_UPDATES
 
-//! \deprecated Use \c PCMK_XA_CRM_DEBUG_ORIGIN instead
-#define XML_ATTR_ORIGIN PCMK_XA_CRM_DEBUG_ORIGIN
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -92,9 +92,6 @@ extern "C" {
 //! \deprecated Use \p PCMK_XA_ID instead
 #define XML_ATTR_UUID "id"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_ATTR_VERBOSE "verbose"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -167,9 +167,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_EPOCH instead
 #define XML_ATTR_GENERATION PCMK_XA_EPOCH
 
-//! \deprecated Use \c PCMK_XA_ADMIN_EPOCH instead
-#define XML_ATTR_GENERATION_ADMIN PCMK_XA_ADMIN_EPOCH
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -8,10 +8,9 @@
  */
 
 #ifndef PCMK__CRM_MSG_XML_COMPAT__H
-#  define PCMK__CRM_MSG_XML_COMPAT__H
+#define PCMK__CRM_MSG_XML_COMPAT__H
 
-#include <crm/common/agents.h>      // PCMK_STONITH_PROVIDES
-#include <crm/common/xml.h>
+#include <crm/common/xml.h> // PCMK_XE_CIB
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -113,9 +113,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_NODE_JOIN_STATE "join"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_RSC_OP_LAST_RUN "last-run"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -44,9 +44,6 @@ extern "C" {
 //! \deprecated Use PCMK_STONITH_PROVIDES instead
 #define XML_RSC_ATTR_PROVIDES PCMK_STONITH_PROVIDES
 
-//! \deprecated Do not use
-#define PCMK_XE_PROMOTABLE_LEGACY "master"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -71,9 +71,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_MIGRATION_THRESHOLD instead
 #define XML_RSC_ATTR_FAIL_STICKINESS PCMK_META_MIGRATION_THRESHOLD
 
-//! \deprecated Use PCMK_META_FAILURE_TIMEOUT instead
-#define XML_RSC_ATTR_FAIL_TIMEOUT PCMK_META_FAILURE_TIMEOUT
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -35,9 +35,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_CLONE_NODE_MAX instead
 #define XML_RSC_ATTR_INCARNATION_NODEMAX PCMK_META_CLONE_NODE_MAX
 
-//! \deprecated Use PCMK_META_PROMOTED_MAX instead
-#define XML_RSC_ATTR_PROMOTED_MAX PCMK_META_PROMOTED_MAX
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -89,9 +89,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_TAG_OP_VER_META "op_versioned_meta"
 
-//! \deprecated Use \p PCMK_XA_ID instead
-#define XML_ATTR_UUID "id"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -125,9 +125,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_DC_DEADTIME instead
 #define XML_CONFIG_ATTR_DC_DEADTIME PCMK_OPT_DC_DEADTIME
 
-//! \deprecated Use \c PCMK_OPT_ELECTION_TIMEOUT instead
-#define XML_CONFIG_ATTR_ELECTION_FAIL PCMK_OPT_ELECTION_TIMEOUT
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -170,9 +170,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_ADMIN_EPOCH instead
 #define XML_ATTR_GENERATION_ADMIN PCMK_XA_ADMIN_EPOCH
 
-//! \deprecated Use \c PCMK_XA_NUM_UPDATES instead
-#define XML_ATTR_NUMUPDATES PCMK_XA_NUM_UPDATES
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -149,9 +149,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_SHUTDOWN_LOCK_LIMIT instead
 #define XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT PCMK_OPT_SHUTDOWN_LOCK_LIMIT
 
-//! \deprecated Use \c PCMK_XA_CRM_FEATURE_SET instead
-#define XML_ATTR_CRM_VERSION PCMK_XA_CRM_FEATURE_SET
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -50,9 +50,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_CIB_TAG_MASTER PCMK_XE_PROMOTABLE_LEGACY
 
-//! \deprecated Do not use
-#define PCMK_XA_PROMOTED_MAX_LEGACY "master-max"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -194,9 +194,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_ID instead
 #define XML_FAILCIB_ATTR_ID PCMK_XA_ID
 
-//! \deprecated Use \c PCMK_META_CONTAINER_ATTRIBUTE_TARGET instead
-#define XML_RSC_ATTR_TARGET PCMK_META_CONTAINER_ATTRIBUTE_TARGET
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -203,9 +203,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_META_ORDERED instead
 #define XML_RSC_ATTR_ORDERED PCMK_META_ORDERED
 
-//! \deprecated Use \c PCMK_META_INTERLEAVE instead
-#define XML_RSC_ATTR_INTERLEAVE PCMK_META_INTERLEAVE
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -38,9 +38,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_PROMOTED_MAX instead
 #define XML_RSC_ATTR_PROMOTED_MAX PCMK_META_PROMOTED_MAX
 
-//! \deprecated Use PCMK_META_PROMOTED_NODE_MAX instead
-#define XML_RSC_ATTR_PROMOTED_NODEMAX PCMK_META_PROMOTED_NODE_MAX
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -86,9 +86,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_TAG_OP_VER_ATTRS "op_versioned_attrs"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_TAG_OP_VER_META "op_versioned_meta"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -107,9 +107,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_NODE_IN_CLUSTER "in_ccm"
 
-//! \deprecated Do not use
-#define XML_NODE_IS_PEER "crmd"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -152,9 +152,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_CRM_FEATURE_SET instead
 #define XML_ATTR_CRM_VERSION PCMK_XA_CRM_FEATURE_SET
 
-//! \deprecated Do not use
-#define XML_ATTR_DIGEST "digest"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -134,9 +134,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_HAVE_WATCHDOG instead
 #define XML_ATTR_HAVE_WATCHDOG PCMK_OPT_HAVE_WATCHDOG
 
-//! \deprecated Use \c PCMK_OPT_NODE_PENDING_TIMEOUT instead
-#define XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT PCMK_OPT_NODE_PENDING_TIMEOUT
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -188,9 +188,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_DESCRIPTION instead
 #define XML_ATTR_DESC PCMK_XA_DESCRIPTION
 
-//! \deprecated Use \c PCMK_XA_ID instead
-#define XML_ATTR_ID PCMK_XA_ID
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -116,9 +116,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_RSC_OP_LAST_RUN "last-run"
 
-//! \deprecated Use name member directly
-#define TYPE(x) (((x) == NULL)? NULL : (const char *) ((x)->name))
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -53,9 +53,6 @@ extern "C" {
 //! \deprecated Do not use
 #define PCMK_XA_PROMOTED_MAX_LEGACY "master-max"
 
-//! \deprecated Do not use
-#define PCMK_XE_PROMOTED_MAX_LEGACY PCMK_XA_PROMOTED_MAX_LEGACY
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -200,9 +200,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_RSC_ATTR_RESTART "restart-type"
 
-//! \deprecated Use \c PCMK_META_ORDERED instead
-#define XML_RSC_ATTR_ORDERED PCMK_META_ORDERED
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -83,9 +83,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_TAG_RSC_VER_ATTRS "rsc_versioned_attrs"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_TAG_OP_VER_ATTRS "op_versioned_attrs"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -215,9 +215,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_META_IS_MANAGED instead
 #define XML_RSC_ATTR_MANAGED PCMK_META_IS_MANAGED
 
-//! \deprecated Use \c PCMK_META_TARGET_ROLE instead
-#define XML_RSC_ATTR_TARGET_ROLE PCMK_META_TARGET_ROLE
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -131,9 +131,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_FENCE_REACTION instead
 #define XML_CONFIG_ATTR_FENCE_REACTION PCMK_OPT_FENCE_REACTION
 
-//! \deprecated Use \c PCMK_OPT_HAVE_WATCHDOG instead
-#define XML_ATTR_HAVE_WATCHDOG PCMK_OPT_HAVE_WATCHDOG
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -122,9 +122,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_CLUSTER_RECHECK_INTERVAL instead
 #define XML_CONFIG_ATTR_RECHECK PCMK_OPT_CLUSTER_RECHECK_INTERVAL
 
-//! \deprecated Use \c PCMK_OPT_DC_DEADTIME instead
-#define XML_CONFIG_ATTR_DC_DEADTIME PCMK_OPT_DC_DEADTIME
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -137,9 +137,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_NODE_PENDING_TIMEOUT instead
 #define XML_CONFIG_ATTR_NODE_PENDING_TIMEOUT PCMK_OPT_NODE_PENDING_TIMEOUT
 
-//! \deprecated Use \c PCMK_OPT_PRIORITY_FENCING_DELAY instead
-#define XML_CONFIG_ATTR_PRIORITY_FENCING_DELAY PCMK_OPT_PRIORITY_FENCING_DELAY
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -101,9 +101,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_CIB_ATTR_SOURCE "source"
 
-//! \deprecated Do not use
-#define XML_NODE_EXPECTED "expected"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -143,9 +143,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_SHUTDOWN_ESCALATION instead
 #define XML_CONFIG_ATTR_FORCE_QUIT PCMK_OPT_SHUTDOWN_ESCALATION
 
-//! \deprecated Use \c PCMK_OPT_SHUTDOWN_LOCK instead
-#define XML_CONFIG_ATTR_SHUTDOWN_LOCK PCMK_OPT_SHUTDOWN_LOCK
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -119,9 +119,6 @@ extern "C" {
 //! \deprecated Use name member directly
 #define TYPE(x) (((x) == NULL)? NULL : (const char *) ((x)->name))
 
-//! \deprecated Use \c PCMK_OPT_CLUSTER_RECHECK_INTERVAL instead
-#define XML_CONFIG_ATTR_RECHECK PCMK_OPT_CLUSTER_RECHECK_INTERVAL
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -182,9 +182,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_CIB_LAST_WRITTEN instead
 #define XML_CIB_ATTR_WRITTEN PCMK_XA_CIB_LAST_WRITTEN
 
-//! \deprecated Use \c PCMK_XA_VERSION instead
-#define XML_ATTR_VERSION PCMK_XA_VERSION
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -29,9 +29,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_CLONE_MAX instead
 #define XML_RSC_ATTR_INCARNATION_MAX PCMK_META_CLONE_MAX
 
-//! \deprecated Use PCMK_META_CLONE_MIN instead
-#define XML_RSC_ATTR_INCARNATION_MIN PCMK_META_CLONE_MIN
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -209,9 +209,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_RSC_ATTR_INCARNATION "clone"
 
-//! \deprecated Use \c PCMK_META_PROMOTABLE instead
-#define XML_RSC_ATTR_PROMOTABLE PCMK_META_PROMOTABLE
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -158,9 +158,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_VALIDATE_WITH instead
 #define XML_ATTR_VALIDATION PCMK_XA_VALIDATE_WITH
 
-//! \deprecated Use \c PCMK_XA_NO_QUORUM_PANIC instead
-#define XML_ATTR_QUORUM_PANIC PCMK_XA_NO_QUORUM_PANIC
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -74,9 +74,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_FAILURE_TIMEOUT instead
 #define XML_RSC_ATTR_FAIL_TIMEOUT PCMK_META_FAILURE_TIMEOUT
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_ATTR_RA_VERSION "ra-version"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -95,9 +95,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_ATTR_VERBOSE "verbose"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_CIB_TAG_DOMAINS "domains"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -164,9 +164,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_HAVE_QUORUM instead
 #define XML_ATTR_HAVE_QUORUM PCMK_XA_HAVE_QUORUM
 
-//! \deprecated Use \c PCMK_XA_EPOCH instead
-#define XML_ATTR_GENERATION PCMK_XA_EPOCH
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -155,9 +155,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_ATTR_DIGEST "digest"
 
-//! \deprecated Use \c PCMK_XA_VALIDATE_WITH instead
-#define XML_ATTR_VALIDATION PCMK_XA_VALIDATE_WITH
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -32,9 +32,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_CLONE_MIN instead
 #define XML_RSC_ATTR_INCARNATION_MIN PCMK_META_CLONE_MIN
 
-//! \deprecated Use PCMK_META_CLONE_NODE_MAX instead
-#define XML_RSC_ATTR_INCARNATION_NODEMAX PCMK_META_CLONE_NODE_MAX
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -146,9 +146,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_SHUTDOWN_LOCK instead
 #define XML_CONFIG_ATTR_SHUTDOWN_LOCK PCMK_OPT_SHUTDOWN_LOCK
 
-//! \deprecated Use \c PCMK_OPT_SHUTDOWN_LOCK_LIMIT instead
-#define XML_CONFIG_ATTR_SHUTDOWN_LOCK_LIMIT PCMK_OPT_SHUTDOWN_LOCK_LIMIT
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -68,9 +68,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_RSC_ATTR_MASTER_NODEMAX PCMK_XA_PROMOTED_NODE_MAX_LEGACY
 
-//! \deprecated Use PCMK_META_MIGRATION_THRESHOLD instead
-#define XML_RSC_ATTR_FAIL_STICKINESS PCMK_META_MIGRATION_THRESHOLD
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -47,9 +47,6 @@ extern "C" {
 //! \deprecated Do not use
 #define PCMK_XE_PROMOTABLE_LEGACY "master"
 
-//! \deprecated Do not use
-#define XML_CIB_TAG_MASTER PCMK_XE_PROMOTABLE_LEGACY
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -185,9 +185,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_VERSION instead
 #define XML_ATTR_VERSION PCMK_XA_VERSION
 
-//! \deprecated Use \c PCMK_XA_DESCRIPTION instead
-#define XML_ATTR_DESC PCMK_XA_DESCRIPTION
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -128,9 +128,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_ELECTION_TIMEOUT instead
 #define XML_CONFIG_ATTR_ELECTION_FAIL PCMK_OPT_ELECTION_TIMEOUT
 
-//! \deprecated Use \c PCMK_OPT_FENCE_REACTION instead
-#define XML_CONFIG_ATTR_FENCE_REACTION PCMK_OPT_FENCE_REACTION
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -26,9 +26,6 @@ extern "C" {
  *             release.
  */
 
-//! \deprecated Use PCMK_META_CLONE_MAX instead
-#define XML_RSC_ATTR_INCARNATION_MAX PCMK_META_CLONE_MAX
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -176,9 +176,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_CRM_DEBUG_ORIGIN instead
 #define XML_ATTR_ORIGIN PCMK_XA_CRM_DEBUG_ORIGIN
 
-//! \deprecated Use \c PCMK_XA_CRM_TIMESTAMP instead
-#define XML_ATTR_TSTAMP PCMK_XA_CRM_TIMESTAMP
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -80,9 +80,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_TAG_FRAGMENT "cib_fragment"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_TAG_RSC_VER_ATTRS "rsc_versioned_attrs"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -110,9 +110,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_NODE_IS_PEER "crmd"
 
-//! \deprecated Do not use
-#define XML_NODE_JOIN_STATE "join"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -41,9 +41,6 @@ extern "C" {
 //! \deprecated Use PCMK_META_PROMOTED_NODE_MAX instead
 #define XML_RSC_ATTR_PROMOTED_NODEMAX PCMK_META_PROMOTED_NODE_MAX
 
-//! \deprecated Use PCMK_STONITH_PROVIDES instead
-#define XML_RSC_ATTR_PROVIDES PCMK_STONITH_PROVIDES
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -59,9 +59,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_RSC_ATTR_MASTER_MAX PCMK_XA_PROMOTED_MAX_LEGACY
 
-//! \deprecated Do not use
-#define PCMK_XA_PROMOTED_NODE_MAX_LEGACY "master-node-max"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -140,9 +140,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_OPT_PRIORITY_FENCING_DELAY instead
 #define XML_CONFIG_ATTR_PRIORITY_FENCING_DELAY PCMK_OPT_PRIORITY_FENCING_DELAY
 
-//! \deprecated Use \c PCMK_OPT_SHUTDOWN_ESCALATION instead
-#define XML_CONFIG_ATTR_FORCE_QUIT PCMK_OPT_SHUTDOWN_ESCALATION
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -161,9 +161,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_NO_QUORUM_PANIC instead
 #define XML_ATTR_QUORUM_PANIC PCMK_XA_NO_QUORUM_PANIC
 
-//! \deprecated Use \c PCMK_XA_HAVE_QUORUM instead
-#define XML_ATTR_HAVE_QUORUM PCMK_XA_HAVE_QUORUM
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -104,9 +104,6 @@ extern "C" {
 //! \deprecated Do not use
 #define XML_NODE_EXPECTED "expected"
 
-//! \deprecated Do not use
-#define XML_NODE_IN_CLUSTER "in_ccm"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -56,9 +56,6 @@ extern "C" {
 //! \deprecated Do not use
 #define PCMK_XE_PROMOTED_MAX_LEGACY PCMK_XA_PROMOTED_MAX_LEGACY
 
-//! \deprecated Do not use
-#define XML_RSC_ATTR_MASTER_MAX PCMK_XA_PROMOTED_MAX_LEGACY
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -179,9 +179,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_CRM_TIMESTAMP instead
 #define XML_ATTR_TSTAMP PCMK_XA_CRM_TIMESTAMP
 
-//! \deprecated Use \c PCMK_XA_CIB_LAST_WRITTEN instead
-#define XML_CIB_ATTR_WRITTEN PCMK_XA_CIB_LAST_WRITTEN
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -65,9 +65,6 @@ extern "C" {
 //! \deprecated Do not use
 #define PCMK_XE_PROMOTED_NODE_MAX_LEGACY PCMK_XA_PROMOTED_NODE_MAX_LEGACY
 
-//! \deprecated Do not use
-#define XML_RSC_ATTR_MASTER_NODEMAX PCMK_XA_PROMOTED_NODE_MAX_LEGACY
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -206,9 +206,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_META_INTERLEAVE instead
 #define XML_RSC_ATTR_INTERLEAVE PCMK_META_INTERLEAVE
 
-//! \deprecated Do not use
-#define XML_RSC_ATTR_INCARNATION "clone"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -191,9 +191,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_XA_ID instead
 #define XML_ATTR_ID PCMK_XA_ID
 
-//! \deprecated Use \c PCMK_XA_ID instead
-#define XML_FAILCIB_ATTR_ID PCMK_XA_ID
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -212,9 +212,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_META_PROMOTABLE instead
 #define XML_RSC_ATTR_PROMOTABLE PCMK_META_PROMOTABLE
 
-//! \deprecated Use \c PCMK_META_IS_MANAGED instead
-#define XML_RSC_ATTR_MANAGED PCMK_META_IS_MANAGED
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -98,9 +98,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_CIB_TAG_DOMAINS "domains"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_CIB_ATTR_SOURCE "source"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -77,9 +77,6 @@ extern "C" {
 //! \deprecated Do not use (will be removed in a future release)
 #define XML_ATTR_RA_VERSION "ra-version"
 
-//! \deprecated Do not use (will be removed in a future release)
-#define XML_TAG_FRAGMENT "cib_fragment"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB

--- a/include/crm/msg_xml_compat.h
+++ b/include/crm/msg_xml_compat.h
@@ -197,9 +197,6 @@ extern "C" {
 //! \deprecated Use \c PCMK_META_CONTAINER_ATTRIBUTE_TARGET instead
 #define XML_RSC_ATTR_TARGET PCMK_META_CONTAINER_ATTRIBUTE_TARGET
 
-//! \deprecated Do not use
-#define XML_RSC_ATTR_RESTART "restart-type"
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use \c PCMK_XE_CIB instead
 #define XML_TAG_CIB PCMK_XE_CIB


### PR DESCRIPTION
We have to keep one single constant (`XML_TAG_CIB`) because it's used by sbd. Since we're at a compatibility break anyway, perhaps we could move it to `xml_compat.h` and get rid of `msg_xml_compat.h`.

There are a LOT of commits, but they're all as simple as can be. I'm putting them all in one PR in case you want to power through and avoid an extra build clogging up CI. However, we can break it up if you'd like.