### PR TITLE
Refactor: include: Run test-headers.sh on internal header files.

### DIFF
--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -7,11 +7,12 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef CIB_INTERNAL__H
-#  define CIB_INTERNAL__H
+#ifndef PCMK__CRM_CIB_INTERNAL__H
+#  define PCMK__CRM_CIB_INTERNAL__H
 #  include <crm/cib.h>
 #  include <crm/common/ipc_internal.h>
 #  include <crm/common/output_internal.h>
+#  include <crm/common/strings_internal.h>
 
 // Request types for CIB manager IPC/CPG
 #define PCMK__CIB_REQUEST_SECONDARY     "cib_slave"

--- a/include/crm/cluster/election_internal.h
+++ b/include/crm/cluster/election_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2022 the Pacemaker project contributors
+ * Copyright 2009-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -7,8 +7,13 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef CRM_COMMON_ELECTION__H
-#  define CRM_COMMON_ELECTION__H
+#ifndef PCMK__CRM_CLUSTER_ELECTION_INTERNAL__H
+#  define PCMK__CRM_CLUSTER_ELECTION_INTERNAL__H
+
+#include <stdbool.h>
+
+#include <glib.h>           // guint, GSourceFunc
+#include <libxml/tree.h>    // xmlNode
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/acl_internal.h
+++ b/include/crm/common/acl_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef CRM_COMMON_ACL_INTERNAL__H
-#define CRM_COMMON_ACL_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_ACL_INTERNAL__H
+#define PCMK__CRM_COMMON_ACL_INTERNAL__H
 
 #include <string.h>         // strcmp()
 #include <libxml/tree.h>    // xmlNode
@@ -32,4 +32,4 @@ void pcmk__enable_acl(xmlNode *acl_source, xmlNode *target, const char *user);
 bool pcmk__check_acl(xmlNode *xml, const char *name,
                      enum xml_private_flags mode);
 
-#endif /* CRM_COMMON_INTERNAL__H */
+#endif /* PCMK__CRM_COMMON_INTERNAL__H */

--- a/include/crm/common/alerts_internal.h
+++ b/include/crm/common/alerts_internal.h
@@ -7,11 +7,12 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__ALERT_INTERNAL__H
-#define PCMK__ALERT_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_ALERTS_INTERNAL__H
+#define PCMK__CRM_COMMON_ALERTS_INTERNAL__H
 
 #include <glib.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 /* Default-Timeout to use before killing a alerts script (in milliseconds) */
 #define PCMK__ALERT_DEFAULT_TIMEOUT_MS (30000)

--- a/include/crm/common/clone_internal.h
+++ b/include/crm/common/clone_internal.h
@@ -13,8 +13,9 @@
 #include <stdio.h>                          // NULL
 #include <stdbool.h>                        // bool
 #include <crm/common/scheduler_types.h>     // pcmk_resource_t
-#include <crm/common/resources.h>           // pcmk_rsc_unique
+#include <crm/common/resources.h>           // pcmk_rsc_unique,
 #include <crm/common/resources_internal.h>  // pcmk__rsc_variant_clone etc.
+#include <crm/common/util.h>                // pcmk_is_set
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the Pacemaker project contributors
+ * Copyright 2019-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__CMDLINE_INTERNAL__H
-#define PCMK__CMDLINE_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_CMDLINE_INTERNAL__H
+#define PCMK__CRM_COMMON_CMDLINE_INTERNAL__H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/digests_internal.h
+++ b/include/crm/common/digests_internal.h
@@ -10,6 +10,7 @@
 #ifndef PCMK__CRM_COMMON_DIGESTS_INTERNAL__H
 #define PCMK__CRM_COMMON_DIGESTS_INTERNAL__H
 
+#include <stdbool.h>
 #include <libxml/tree.h>            // xmlNode
 
 #ifdef __cplusplus

--- a/include/crm/common/health_internal.h
+++ b/include/crm/common/health_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,6 +9,8 @@
 
 #ifndef PCMK__CRM_COMMON_HEALTH_INTERNAL__H
 #define PCMK__CRM_COMMON_HEALTH_INTERNAL__H
+
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef CRM_COMMON_INTERNAL__H
-#define CRM_COMMON_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_INTERNAL__H
+#define PCMK__CRM_COMMON_INTERNAL__H
 
 #include <unistd.h>             // pid_t, getpid()
 #include <stdbool.h>            // bool
@@ -392,4 +392,4 @@ pcmk__lastfailure_name(const char *rsc_id, const char *op, guint interval_ms)
 // internal resource agent functions (from agents.c)
 int pcmk__effective_rc(int rc);
 
-#endif /* CRM_COMMON_INTERNAL__H */
+#endif /* PCMK__CRM_COMMON_INTERNAL__H */

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__IPC_INTERNAL_H
-#define PCMK__IPC_INTERNAL_H
+#ifndef PCMK__CRM_COMMON_IPC_INTERNAL__H
+#define PCMK__CRM_COMMON_IPC_INTERNAL__H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -7,9 +7,10 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__ISO8601_INTERNAL__H
-#define PCMK__ISO8601_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_ISO8601_INTERNAL__H
+#define PCMK__CRM_COMMON_ISO8601_INTERNAL__H
 
+#include <glib.h>
 #include <time.h>
 #include <sys/time.h>
 #include <ctype.h>

--- a/include/crm/common/lists_internal.h
+++ b/include/crm/common/lists_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the Pacemaker project contributors
+ * Copyright 2020-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__LISTS_INTERNAL__H
-#define PCMK__LISTS_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_LISTS_INTERNAL__H
+#define PCMK__CRM_COMMON_LISTS_INTERNAL__H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -11,8 +11,8 @@
 extern "C" {
 #endif
 
-#ifndef PCMK__LOGGING_INTERNAL_H
-#define PCMK__LOGGING_INTERNAL_H
+#ifndef PCMK__CRM_COMMON_LOGGING_INTERNAL__H
+#define PCMK__CRM_COMMON_LOGGING_INTERNAL__H
 
 #include <glib.h>
 

--- a/include/crm/common/nodes_internal.h
+++ b/include/crm/common/nodes_internal.h
@@ -7,8 +7,14 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__NODES_INTERNAL__H
-#define PCMK__NODES_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_NODES_INTERNAL__H
+#define PCMK__CRM_COMMON_NODES_INTERNAL__H
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <glib.h>
+#include <crm/common/nodes.h>
 
 /*
  * Special node attributes
@@ -67,4 +73,4 @@ pcmk__same_node(const pcmk_node_t *node1, const pcmk_node_t *node2)
            && (node1->details == node2->details);
 }
 
-#endif  // PCMK__NODES_INTERNAL__H
+#endif  // PCMK__CRM_COMMON_NODES_INTERNAL__H

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__OPTIONS_INTERNAL__H
-#define PCMK__OPTIONS_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_OPTIONS_INTERNAL__H
+#define PCMK__CRM_COMMON_OPTIONS_INTERNAL__H
 
 #ifndef PCMK__CONFIG_H
 #define PCMK__CONFIG_H
@@ -18,7 +18,8 @@
 #include <glib.h>     // GHashTable
 #include <stdbool.h>  // bool
 
-#include <crm/common/util.h>    // pcmk_parse_interval_spec()
+#include <crm/common/util.h>                // pcmk_parse_interval_spec()
+#include <crm/common/output_internal.h>     // pcmk__output_t
 
 _Noreturn void pcmk__cli_help(char cmd);
 

--- a/include/crm/common/output_internal.h
+++ b/include/crm/common/output_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__OUTPUT_INTERNAL__H
-#define PCMK__OUTPUT_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_OUTPUT_INTERNAL__H
+#define PCMK__CRM_COMMON_OUTPUT_INTERNAL__H
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -12,6 +12,7 @@
 
 #include <stdbool.h>                    // bool
 
+#include <crm/common/ipc_internal.h>    // pcmk__client_t
 #include <crm/common/nodes.h>           // pcmk_node_variant_remote
 #include <crm/common/scheduler_types.h> // pcmk_node_t
 

--- a/include/crm/common/resources_internal.h
+++ b/include/crm/common/resources_internal.h
@@ -11,8 +11,10 @@
 #define PCMK__CRM_COMMON_RESOURCES_INTERNAL__H
 
 #include <glib.h>                       // gboolean, GList
+#include <libxml/tree.h>                // xmlNode
+#include <crm/common/resources.h>       // pcmk_resource_t
 #include <crm/common/roles.h>           // enum rsc_role_e
-#include <crm/common/scheduler_types.h> // pcmk_node_t, pcmk_resource_t, etc.
+#include <crm/common/scheduler_types.h> // pcmk_node_t, etc.
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/common/results_internal.h
+++ b/include/crm/common/results_internal.h
@@ -7,10 +7,14 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__COMMON_RESULTS_INTERNAL__H
-#define PCMK__COMMON_RESULTS_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_RESULTS_INTERNAL__H
+#define PCMK__CRM_COMMON_RESULTS_INTERNAL__H
+
+#include <stdbool.h>
 
 #include <glib.h>               // GQuark
+
+#include <crm/common/results.h>
 
 extern const size_t pcmk__n_rc;
 

--- a/include/crm/common/schemas_internal.h
+++ b/include/crm/common/schemas_internal.h
@@ -7,11 +7,13 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__SCHEMAS_INTERNAL__H
-#define PCMK__SCHEMAS_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_SCHEMAS_INTERNAL__H
+#define PCMK__CRM_COMMON_SCHEMAS_INTERNAL__H
 
+#include <stdbool.h>
 #include <glib.h>           // GList, gboolean
-#include <libxml/tree.h>    // xmlNode, xmlRelaxNGValidityErrorFunc
+#include <libxml/relaxng.h> // xmlRelaxNGValidityErrorFunc
+#include <libxml/tree.h>    // xmlNode
 
 void pcmk__schema_init(void);
 void pcmk__schema_cleanup(void);

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -7,12 +7,16 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__STRINGS_INTERNAL__H
-#define PCMK__STRINGS_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_STRINGS_INTERNAL__H
+#define PCMK__CRM_COMMON_STRINGS_INTERNAL__H
 
 #include <stdbool.h>            // bool
+#include <stdint.h>             // uint32_t, etc.
 
 #include <glib.h>               // guint, GList, GHashTable
+
+#include <crm/common/options.h> // PCMK_VALUE_TRUE, PCMK_VALUE_FALSE
+#include <crm/common/util.h>    // crm_strdup_printf
 
 /* internal constants for generic string functions (from strings.c) */
 
@@ -229,4 +233,4 @@ pcmk__btoa(bool condition)
     return condition? PCMK_VALUE_TRUE : PCMK_VALUE_FALSE;
 }
 
-#endif /* PCMK__STRINGS_INTERNAL__H */
+#endif /* PCMK__CRM_COMMON_STRINGS_INTERNAL__H */

--- a/include/crm/common/unittest_internal.h
+++ b/include/crm/common/unittest_internal.h
@@ -21,8 +21,8 @@
 
 #include <crm/common/xml.h>
 
-#ifndef CRM_COMMON_UNITTEST_INTERNAL__H
-#define CRM_COMMON_UNITTEST_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_UNITTEST_INTERNAL__H
+#define PCMK__CRM_COMMON_UNITTEST_INTERNAL__H
 
 /* internal unit testing related utilities */
 
@@ -206,4 +206,4 @@ main(int argc, char **argv) \
     return cmocka_run_group_tests(t, group_setup, group_teardown); \
 }
 
-#endif /* CRM_COMMON_UNITTEST_INTERNAL__H */
+#endif /* PCMK__CRM_COMMON_UNITTEST_INTERNAL__H */

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__XML_INTERNAL__H
-#define PCMK__XML_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_XML_INTERNAL__H
+#define PCMK__CRM_COMMON_XML_INTERNAL__H
 
 /*
  * Internal-only wrappers for and extensions to libxml2 (libxslt)
@@ -23,6 +23,7 @@
 #include <crm/common/output_internal.h>
 #include <crm/common/xml_io_internal.h>
 #include <crm/common/xml_names_internal.h>    // PCMK__XE_PROMOTABLE_LEGACY
+#include <crm/common/xml_names.h>             // PCMK_XA_ID, PCMK_XE_CLONE
 
 #include <libxml/relaxng.h>
 
@@ -601,4 +602,4 @@ pcmk__map_element_name(const xmlNode *xml)
     }
 }
 
-#endif // PCMK__XML_INTERNAL__H
+#endif // PCMK__CRM_COMMON_XML_INTERNAL__H

--- a/include/crm/common/xml_io_internal.h
+++ b/include/crm/common/xml_io_internal.h
@@ -7,14 +7,15 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__XML_IO_INTERNAL__H
-#define PCMK__XML_IO_INTERNAL__H
+#ifndef PCMK__CRM_COMMON_XML_IO_INTERNAL__H
+#define PCMK__CRM_COMMON_XML_IO_INTERNAL__H
 
 /*
  * Internal-only wrappers for and extensions to libxml2 I/O
  */
 
 #include <stdbool.h>        // bool
+#include <stdint.h>         // uint32_t, etc.
 
 #include <glib.h>           // GString
 #include <libxml/tree.h>    // xmlNode

--- a/include/crm/fencing/internal.h
+++ b/include/crm/fencing/internal.h
@@ -7,13 +7,14 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef STONITH_NG_INTERNAL__H
-#  define STONITH_NG_INTERNAL__H
+#ifndef PCMK__CRM_FENCING_INTERNAL__H
+#  define PCMK__CRM_FENCING_INTERNAL__H
 
 #  include <glib.h>
 #  include <crm/common/ipc.h>
 #  include <crm/common/xml.h>
 #  include <crm/common/output_internal.h>
+#  include <crm/common/results_internal.h>
 #  include <crm/stonith-ng.h>
 
 enum st_device_flags {

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef LRMD_INTERNAL__H
-#define LRMD_INTERNAL__H
+#ifndef PCMK__CRM_LRMD_INTERNAL__H
+#define PCMK__CRM_LRMD_INTERNAL__H
 
 #include <stdint.h>                     // uint32_t
 #include <glib.h>                       // GList, GHashTable, gpointer
@@ -17,6 +17,7 @@
 #include <crm/common/mainloop.h>        // mainloop_io_t, ipc_client_callbacks
 #include <crm/common/output_internal.h> // pcmk__output_t
 #include <crm/common/remote_internal.h> // pcmk__remote_t
+#include <crm/common/results_internal.h> // pcmk__action_result_t
 #include <crm/lrmd.h>           // lrmd_t, lrmd_event_data_t, lrmd_rsc_info_t
 
 int lrmd__new(lrmd_t **api, const char *nodename, const char *server, int port);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PE_INTERNAL__H
-#  define PE_INTERNAL__H
+#ifndef PCMK__CRM_PENGINE_INTERNAL__H
+#  define PCMK__CRM_PENGINE_INTERNAL__H
 
 #  include <stdbool.h>
 #  include <stdint.h>

--- a/include/crm/pengine/remote_internal.h
+++ b/include/crm/pengine/remote_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PE_REMOTE__H
-#  define PE_REMOTE__H
+#ifndef PCMK__CRM_PENGINE_REMOTE_INTERNAL__H
+#  define PCMK__CRM_PENGINE_REMOTE_INTERNAL__H
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/pengine/rules_internal.h
+++ b/include/crm/pengine/rules_internal.h
@@ -6,8 +6,8 @@
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
-#ifndef RULES_INTERNAL_H
-#define RULES_INTERNAL_H
+#ifndef PCMK__CRM_PENGINE_RULES_INTERNAL__H
+#define PCMK__CRM_PENGINE_RULES_INTERNAL__H
 
 #include <glib.h>
 #include <libxml/tree.h>

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the Pacemaker project contributors
+ * Copyright 2010-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -7,8 +7,10 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PCMK__SERVICES_INTERNAL__H
-#  define PCMK__SERVICES_INTERNAL__H
+#ifndef PCMK__CRM_SERVICES_INTERNAL__H
+#  define PCMK__CRM_SERVICES_INTERNAL__H
+
+#include <crm/services.h>       // svc_action_t
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef CRM_INTERNAL__H
-#  define CRM_INTERNAL__H
+#ifndef PCMK__CRM_INTERNAL__H
+#  define PCMK__CRM_INTERNAL__H
 
 #  ifndef PCMK__CONFIG_H
 #    define PCMK__CONFIG_H

--- a/include/pacemaker-internal.h
+++ b/include/pacemaker-internal.h
@@ -7,8 +7,8 @@
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
-#ifndef PACEMAKER_INTERNAL__H
-#  define PACEMAKER_INTERNAL__H
+#ifndef PCMK__PACEMAKER_INTERNAL__H
+#  define PCMK__PACEMAKER_INTERNAL__H
 
 #  include <pcmki/pcmki_acl.h>
 #  include <pcmki/pcmki_agents.h>

--- a/tests/test-headers.sh
+++ b/tests/test-headers.sh
@@ -7,7 +7,6 @@
 : ${SRCDIR:-..}
 
 INCLUDE_FILES="$(find "${SRCDIR}/include/" -name \*.h \
-                      -a \! -name \*internal.h        \
                       -a \! -name config.h            \
                       -a \! -name gettext.h)"
 


### PR DESCRIPTION
Update all guards to use the standard naming convention, and add missing includes where necessary to make sure the test passes.

Fixes T325