### PR TITLE
Low: libpacemaker: Add spaces back to attrd_updater query output.

### DIFF
--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -2132,7 +2132,7 @@ cluster_status_html(pcmk__output_t *out, va_list args)
     if (legacy) { \
         pcmk__g_strcat(s, k "=", pcmk__s(v, ""), " ", NULL); \
     } else { \
-        pcmk__g_strcat(s, k "=\"", pcmk__s(v, ""), "\"", NULL); \
+        pcmk__g_strcat(s, k "=\"", pcmk__s(v, ""), "\" ", NULL); \
     } \
 } while (0)
 


### PR DESCRIPTION
Introduced by 8d12f32efa06878778c86045fb01ee2d0bbe05ab, but never in a final release.