### PR TITLE
[2.1] Fix: libpacemaker: correctly retrieve any existing fail-count for increment

### DIFF
--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -116,7 +116,7 @@ pcmk__inject_failcount(pcmk__output_t *out, cib_t *cib_conn, xmlNode *cib_node,
                             pcmk__xe_id(cib_node), NULL, NULL, NULL, name,
                             NULL, &output) == pcmk_rc_ok) {
 
-        if (crm_element_value_int(output, name, &failcount) != 0) {
+        if (crm_element_value_int(output, PCMK_XA_VALUE, &failcount) != 0) {
             failcount = 0;
         }
     }


### PR DESCRIPTION
Backport https://github.com/ClusterLabs/pacemaker/pull/3510 to 2.1

The attribute name of an nvpair for this should be "value".

Regression introduced by ce3a9863df (not yet released).