### PR TITLE
Start dropping libcrmcluster public API

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -547,8 +547,9 @@ write_attribute(attribute_t *a, bool ignore_delay)
 
         } else {
             // This will create a cluster node cache entry if none exists
-            crm_node_t *peer = pcmk__get_node(v->nodeid, v->nodename, NULL,
-                                              pcmk__node_search_any);
+            pcmk__node_status_t *peer = pcmk__get_node(v->nodeid, v->nodename,
+                                                       NULL,
+                                                       pcmk__node_search_any);
 
             uuid = peer->uuid;
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -37,7 +37,7 @@ attrd_confirmation(int callid)
 }
 
 static void
-attrd_peer_message(crm_node_t *peer, xmlNode *xml)
+attrd_peer_message(pcmk__node_status_t *peer, xmlNode *xml)
 {
     const char *election_op = crm_element_value(xml, PCMK__XA_CRM_TASK);
 
@@ -162,7 +162,8 @@ attrd_broadcast_value(const attribute_t *a, const attribute_value_t *v)
 #define state_text(state) pcmk__s((state), "in unknown state")
 
 static void
-attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *data)
+attrd_peer_change_cb(enum crm_status_type kind, pcmk__node_status_t *peer,
+                     const void *data)
 {
     bool gone = false;
     bool is_remote = pcmk_is_set(peer->flags, crm_remote_node);
@@ -213,8 +214,8 @@ attrd_peer_change_cb(enum crm_status_type kind, crm_node_t *peer, const void *da
 static void
 record_peer_nodeid(attribute_value_t *v, const char *host)
 {
-    crm_node_t *known_peer = pcmk__get_node(v->nodeid, host, NULL,
-                                            pcmk__node_search_cluster_member);
+    pcmk__node_status_t *known_peer =
+        pcmk__get_node(v->nodeid, host, NULL, pcmk__node_search_cluster_member);
 
     crm_trace("Learned %s has node id %s", known_peer->uname, known_peer->uuid);
     if (attrd_election_won()) {
@@ -228,9 +229,9 @@ record_peer_nodeid(attribute_value_t *v, const char *host)
     (((p) == NULL)? "all peers" : pcmk__s((p)->uname, "unknown peer"))
 
 static void
-update_attr_on_host(attribute_t *a, const crm_node_t *peer, const xmlNode *xml,
-                    const char *attr, const char *value, const char *host,
-                    bool filter)
+update_attr_on_host(attribute_t *a, const pcmk__node_status_t *peer,
+                    const xmlNode *xml, const char *attr, const char *value,
+                    const char *host, bool filter)
 {
     int is_remote = 0;
     bool changed = false;
@@ -327,7 +328,8 @@ update_attr_on_host(attribute_t *a, const crm_node_t *peer, const xmlNode *xml,
 }
 
 static void
-attrd_peer_update_one(const crm_node_t *peer, xmlNode *xml, bool filter)
+attrd_peer_update_one(const pcmk__node_status_t *peer, xmlNode *xml,
+                      bool filter)
 {
     attribute_t *a = NULL;
     const char *attr = crm_element_value(xml, PCMK__XA_ATTR_NAME);
@@ -441,8 +443,9 @@ attrd_peer_clear_failure(pcmk__request_t *request)
     GHashTableIter iter;
     regex_t regex;
 
-    crm_node_t *peer = pcmk__get_node(0, request->peer, NULL,
-                                      pcmk__node_search_cluster_member);
+    pcmk__node_status_t *peer =
+        pcmk__get_node(0, request->peer, NULL,
+                       pcmk__node_search_cluster_member);
 
     pcmk_parse_interval_spec(interval_spec, &interval_ms);
 
@@ -478,7 +481,8 @@ attrd_peer_clear_failure(pcmk__request_t *request)
  * \param[in,out] xml       Request XML
  */
 void
-attrd_peer_sync_response(const crm_node_t *peer, bool peer_won, xmlNode *xml)
+attrd_peer_sync_response(const pcmk__node_status_t *peer, bool peer_won,
+                         xmlNode *xml)
 {
     crm_info("Processing " PCMK__ATTRD_CMD_SYNC_RESPONSE " from %s",
              peer->uname);
@@ -544,7 +548,7 @@ attrd_peer_remove(const char *host, bool uncache, const char *source)
  * \param[in] peer  Peer to send sync to (if NULL, broadcast to all peers)
  */
 void
-attrd_peer_sync(crm_node_t *peer)
+attrd_peer_sync(pcmk__node_status_t *peer)
 {
     GHashTableIter aIter;
     GHashTableIter vIter;
@@ -572,8 +576,8 @@ attrd_peer_sync(crm_node_t *peer)
 }
 
 void
-attrd_peer_update(const crm_node_t *peer, xmlNode *xml, const char *host,
-                  bool filter)
+attrd_peer_update(const pcmk__node_status_t *peer, xmlNode *xml,
+                  const char *host, bool filter)
 {
     bool handle_sync_point = false;
 

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -64,7 +64,7 @@ attrd_election_won(void)
 }
 
 void
-attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml)
+attrd_handle_election_op(const pcmk__node_status_t *peer, xmlNode *xml)
 {
     enum election_result rc = 0;
     enum election_result previous = election_state(writer);
@@ -113,7 +113,7 @@ attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml)
 }
 
 bool
-attrd_check_for_new_writer(const crm_node_t *peer, const xmlNode *xml)
+attrd_check_for_new_writer(const pcmk__node_status_t *peer, const xmlNode *xml)
 {
     int peer_state = 0;
 
@@ -143,7 +143,7 @@ attrd_declare_winner(void)
 }
 
 void
-attrd_remove_voter(const crm_node_t *peer)
+attrd_remove_voter(const pcmk__node_status_t *peer)
 {
     election_remove(writer, peer->uname);
     if (peer_writer && pcmk__str_eq(peer->uname, peer_writer, pcmk__str_casei)) {

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -152,7 +152,7 @@ attrd_client_peer_remove(pcmk__request_t *request)
 
         crm_element_value_int(xml, PCMK__XA_ATTR_HOST_ID, &nodeid);
         if (nodeid > 0) {
-            crm_node_t *node = NULL;
+            pcmk__node_status_t *node = NULL;
             char *host_alloc = NULL;
 
             node = pcmk__search_node_caches(nodeid, NULL,

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -167,8 +167,9 @@ handle_sync_response_request(pcmk__request_t *request)
         return handle_unknown_request(request);
     } else {
         if (request->peer != NULL) {
-            crm_node_t *peer = pcmk__get_node(0, request->peer, NULL,
-                                              pcmk__node_search_cluster_member);
+            pcmk__node_status_t *peer =
+                pcmk__get_node(0, request->peer, NULL,
+                               pcmk__node_search_cluster_member);
             bool peer_won = attrd_check_for_new_writer(peer, request->xml);
 
             if (!pcmk__str_eq(peer->uname, attrd_cluster->uname, pcmk__str_casei)) {
@@ -186,8 +187,9 @@ handle_update_request(pcmk__request_t *request)
 {
     if (request->peer != NULL) {
         const char *host = crm_element_value(request->xml, PCMK__XA_ATTR_HOST);
-        crm_node_t *peer = pcmk__get_node(0, request->peer, NULL,
-                                          pcmk__node_search_cluster_member);
+        pcmk__node_status_t *peer =
+            pcmk__get_node(0, request->peer, NULL,
+                           pcmk__node_search_cluster_member);
 
         attrd_peer_update(peer, request->xml, host, false);
         pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
@@ -322,7 +324,7 @@ attrd_broadcast_protocol(void)
 }
 
 gboolean
-attrd_send_message(crm_node_t *node, xmlNode *data, bool confirm)
+attrd_send_message(pcmk__node_status_t *node, xmlNode *data, bool confirm)
 {
     const char *op = crm_element_value(data, PCMK_XA_TASK);
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -107,10 +107,11 @@ void attrd_election_init(void);
 void attrd_election_fini(void);
 void attrd_start_election_if_needed(void);
 bool attrd_election_won(void);
-void attrd_handle_election_op(const crm_node_t *peer, xmlNode *xml);
-bool attrd_check_for_new_writer(const crm_node_t *peer, const xmlNode *xml);
+void attrd_handle_election_op(const pcmk__node_status_t *peer, xmlNode *xml);
+bool attrd_check_for_new_writer(const pcmk__node_status_t *peer,
+                                const xmlNode *xml);
 void attrd_declare_winner(void);
-void attrd_remove_voter(const crm_node_t *peer);
+void attrd_remove_voter(const pcmk__node_status_t *peer);
 void attrd_xml_add_writer(xmlNode *xml);
 
 enum attrd_attr_flags {
@@ -179,12 +180,12 @@ extern GHashTable *peer_protocol_vers;
 
 int attrd_cluster_connect(void);
 void attrd_broadcast_value(const attribute_t *a, const attribute_value_t *v);
-void attrd_peer_update(const crm_node_t *peer, xmlNode *xml, const char *host,
-                       bool filter);
-void attrd_peer_sync(crm_node_t *peer);
+void attrd_peer_update(const pcmk__node_status_t *peer, xmlNode *xml,
+                       const char *host, bool filter);
+void attrd_peer_sync(pcmk__node_status_t *peer);
 void attrd_peer_remove(const char *host, bool uncache, const char *source);
 void attrd_peer_clear_failure(pcmk__request_t *request);
-void attrd_peer_sync_response(const crm_node_t *peer, bool peer_won,
+void attrd_peer_sync_response(const pcmk__node_status_t *peer, bool peer_won,
                               xmlNode *xml);
 
 void attrd_broadcast_protocol(void);
@@ -193,7 +194,8 @@ xmlNode *attrd_client_clear_failure(pcmk__request_t *request);
 xmlNode *attrd_client_update(pcmk__request_t *request);
 xmlNode *attrd_client_refresh(pcmk__request_t *request);
 xmlNode *attrd_client_query(pcmk__request_t *request);
-gboolean attrd_send_message(crm_node_t *node, xmlNode *data, bool confirm);
+gboolean attrd_send_message(pcmk__node_status_t *node, xmlNode *data,
+                            bool confirm);
 
 xmlNode *attrd_add_value_xml(xmlNode *parent, const attribute_t *a,
                              const attribute_value_t *v, bool force_write);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -686,7 +686,7 @@ forward_request(xmlNode *request)
     const char *client_name = crm_element_value(request,
                                                 PCMK__XA_CIB_CLIENTNAME);
     const char *call_id = crm_element_value(request, PCMK__XA_CIB_CALLID);
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
 
     int log_level = LOG_INFO;
 
@@ -717,7 +717,7 @@ forward_request(xmlNode *request)
 static void
 send_peer_reply(xmlNode *msg, const char *originator)
 {
-    const crm_node_t *node = NULL;
+    const pcmk__node_status_t *node = NULL;
 
     if ((msg == NULL) || (originator == NULL)) {
         return;

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -117,7 +117,7 @@ void
 send_sync_request(const char *host)
 {
     xmlNode *sync_me = pcmk__xe_create(NULL, "sync-me");
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
 
     crm_info("Requesting re-sync from %s", (host? host : "all peers"));
     sync_in_progress = 1;
@@ -246,7 +246,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
 
         if (rc != pcmk_ok) {
             // Notify originating peer so it can notify its local clients
-            crm_node_t *origin = NULL;
+            pcmk__node_status_t *origin = NULL;
 
             origin = pcmk__search_node_caches(0, host,
                                               pcmk__node_search_cluster_member);
@@ -404,7 +404,7 @@ sync_our_cib(xmlNode * request, gboolean all)
     char *digest = NULL;
     const char *host = crm_element_value(request, PCMK__XA_SRC);
     const char *op = crm_element_value(request, PCMK__XA_CIB_OP);
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
     xmlNode *replace_request = NULL;
     xmlNode *wrapper = NULL;
 

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -351,7 +351,8 @@ cib_cs_destroy(gpointer user_data)
 #endif
 
 static void
-cib_peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
+cib_peer_update_callback(enum crm_status_type type,
+                         pcmk__node_status_t *node, const void *data)
 {
     switch (type) {
         case crm_status_uname:

--- a/daemons/controld/controld_alerts.c
+++ b/daemons/controld/controld_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -31,7 +31,7 @@ crmd_unpack_alerts(xmlNode *alerts)
 }
 
 void
-crmd_alert_node_event(crm_node_t *node)
+crmd_alert_node_event(pcmk__node_status_t *node)
 {
     lrm_state_t *lrm_state;
 

--- a/daemons/controld/controld_alerts.h
+++ b/daemons/controld/controld_alerts.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the Pacemaker project contributors
+ * Copyright 2015-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -8,14 +8,16 @@
  */
 
 #ifndef CONTROLD_ALERTS__H
-#  define CONTROLD_ALERTS__H
+#define CONTROLD_ALERTS__H
 
-#  include <crm/crm.h>
-#  include <crm/cluster.h>
-#  include <crm/stonith-ng.h>
+#include <libxml/tree.h>            // xmlNode
+
+#include <crm/cluster/internal.h>   // pcmk__node_status_t
+#include <crm/lrmd_events.h>        // lrmd_event_data_t
+#include <crm/stonith-ng.h>         // stonith_event_t
 
 void crmd_unpack_alerts(xmlNode *alerts);
-void crmd_alert_node_event(crm_node_t *node);
+void crmd_alert_node_event(pcmk__node_status_t *node);
 void crmd_alert_fencing_op(stonith_event_t *e);
 void crmd_alert_resource_op(const char *node, lrmd_event_data_t *op);
 

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -77,7 +77,7 @@ crmd_ha_msg_filter(xmlNode * msg)
  * \retval  1 if completely alive
  */
 static int
-node_alive(const crm_node_t *node)
+node_alive(const pcmk__node_status_t *node)
 {
     if (pcmk_is_set(node->flags, crm_remote_node)) {
         // Pacemaker Remote nodes can't be partially alive
@@ -100,7 +100,8 @@ node_alive(const crm_node_t *node)
 #define state_text(state) ((state)? (const char *)(state) : "in unknown state")
 
 void
-peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
+peer_update_callback(enum crm_status_type type, pcmk__node_status_t *node,
+                     const void *data)
 {
     uint32_t old = 0;
     bool appeared = FALSE;

--- a/daemons/controld/controld_callbacks.h
+++ b/daemons/controld/controld_callbacks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -10,12 +10,13 @@
 #ifndef CONTROLD_CALLBACKS__H
 #  define CONTROLD_CALLBACKS__H
 
-#include <crm/cluster.h>
+#include <crm/cluster/internal.h>
 
 extern void crmd_ha_msg_filter(xmlNode * msg);
 
 extern gboolean crm_fsa_trigger(gpointer user_data);
 
-extern void peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data);
+extern void peer_update_callback(enum crm_status_type type,
+                                 pcmk__node_status_t *node, const void *data);
 
 #endif

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -37,7 +37,7 @@ crmd_cs_dispatch(cpg_handle_t handle, const struct cpg_name *groupName,
         return;
     }
     if (kind == crm_class_cluster) {
-        crm_node_t *peer = NULL;
+        pcmk__node_status_t *peer = NULL;
         xmlNode *xml = pcmk__xml_parse(data);
 
         if (xml == NULL) {
@@ -116,7 +116,7 @@ cpg_membership_callback(cpg_handle_t handle, const struct cpg_name *cpg_name,
      * use by the peer callback.
      */
     if (controld_globals.dc_name != NULL) {
-        crm_node_t *peer = NULL;
+        pcmk__node_status_t *peer = NULL;
 
         peer = pcmk__search_node_caches(0, controld_globals.dc_name,
                                         pcmk__node_search_cluster_member);

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -269,7 +269,7 @@ do_dc_release(long long action,
         crm_info("DC role released");
         if (pcmk_is_set(controld_globals.fsa_input_register, R_SHUTDOWN)) {
             xmlNode *update = NULL;
-            crm_node_t *node =
+            pcmk__node_status_t *node =
                 pcmk__get_node(0, controld_globals.our_nodename,
                                NULL, pcmk__node_search_cluster_member);
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -574,7 +574,7 @@ controld_query_executor_state(void)
     xmlNode *xml_state = NULL;
     xmlNode *xml_data = NULL;
     xmlNode *rsc_list = NULL;
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
     lrm_state_t *lrm_state = lrm_state_find(controld_globals.our_nodename);
 
     if (!lrm_state) {
@@ -1717,7 +1717,7 @@ controld_ack_event_directly(const char *to_host, const char *to_sys,
 {
     xmlNode *reply = NULL;
     xmlNode *update, *iter;
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
 
     CRM_CHECK(op != NULL, return);
     if (op->rsc_id == NULL) {

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -203,7 +203,7 @@ send_stonith_update(pcmk__graph_action_t *action, const char *target,
                     const char *uuid)
 {
     int rc = pcmk_ok;
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
 
     /* We (usually) rely on the membership layer to do node_update_cluster,
      * and the peer status callback to do node_update_peer, because the node
@@ -373,7 +373,7 @@ execute_stonith_cleanup(void)
 
     for (iter = stonith_cleanup_list; iter != NULL; iter = iter->next) {
         char *target = iter->data;
-        crm_node_t *target_node =
+        pcmk__node_status_t *target_node =
             pcmk__get_node(0, target, NULL, pcmk__node_search_cluster_member);
         const char *uuid = pcmk__cluster_node_uuid(target_node);
 
@@ -583,7 +583,8 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
         const uint32_t flags = pcmk__node_search_any
                                |pcmk__node_search_cluster_cib;
 
-        crm_node_t *peer = pcmk__search_node_caches(0, event->target, flags);
+        pcmk__node_status_t *peer = pcmk__search_node_caches(0, event->target,
+                                                             flags);
         const char *uuid = NULL;
 
         if (peer == NULL) {

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -34,8 +34,9 @@ update_dc_expected(const xmlNode *msg)
 {
     if ((controld_globals.dc_name != NULL)
         && pcmk__xe_attr_is_true(msg, PCMK__XA_DC_LEAVING)) {
-        crm_node_t *dc_node = pcmk__get_node(0, controld_globals.dc_name, NULL,
-                                             pcmk__node_search_cluster_member);
+        pcmk__node_status_t *dc_node =
+            pcmk__get_node(0, controld_globals.dc_name, NULL,
+                           pcmk__node_search_cluster_member);
 
         pcmk__update_peer_expected(__func__, dc_node, CRMD_JOINSTATE_DOWN);
     }
@@ -166,7 +167,7 @@ join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
 
     } else {
         xmlNode *reply = NULL;
-        const crm_node_t *dc_node =
+        const pcmk__node_status_t *dc_node =
             pcmk__get_node(0, controld_globals.dc_name, NULL,
                            pcmk__node_search_cluster_member);
 
@@ -229,7 +230,8 @@ update_conn_host_cache(xmlNode *node, void *userdata)
     const char *conn_host = crm_element_value(node, PCMK__XA_CONNECTION_HOST);
     const char *state = crm_element_value(node, PCMK__XA_NODE_STATE);
 
-    crm_node_t *remote_peer = pcmk__cluster_lookup_remote_node(remote);
+    pcmk__node_status_t *remote_peer =
+        pcmk__cluster_lookup_remote_node(remote);
 
     if (remote_peer == NULL) {
         return pcmk_rc_ok;
@@ -310,7 +312,7 @@ do_cl_join_finalize_respond(long long action,
         xmlNode *reply = create_request(CRM_OP_JOIN_CONFIRM, tmp1,
                                         controld_globals.dc_name, CRM_SYSTEM_DC,
                                         CRM_SYSTEM_CRMD, NULL);
-        const crm_node_t *dc_node =
+        const pcmk__node_status_t *dc_node =
             pcmk__get_node(0, controld_globals.dc_name, NULL,
                            pcmk__node_search_cluster_member);
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -1013,7 +1013,7 @@ do_dc_join_final(long long action,
                  enum crmd_fsa_input current_input, fsa_data_t * msg_data)
 {
     crm_debug("Ensuring DC, quorum and node attributes are up-to-date");
-    crm_update_quorum(crm_have_quorum, TRUE);
+    crm_update_quorum(pcmk__cluster_has_quorum(), TRUE);
 }
 
 int crmd_join_phase_count(enum crm_join_phase phase)

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -132,21 +132,21 @@ crm_update_peer_join(const char *source, crm_node_t * node, enum crm_join_phase 
     if(phase == last) {
         crm_trace("Node %s join-%d phase is still %s "
                   QB_XS " nodeid=%u source=%s",
-                  node->uname, current_join_id, crm_join_phase_str(last),
+                  node->uname, current_join_id, controld_join_phase_text(last),
                   node->id, source);
 
     } else if ((phase <= crm_join_none) || (phase == (last + 1))) {
         node->join = phase;
         crm_trace("Node %s join-%d phase is now %s (was %s) "
                   QB_XS " nodeid=%u source=%s",
-                 node->uname, current_join_id, crm_join_phase_str(phase),
-                 crm_join_phase_str(last), node->id, source);
+                 node->uname, current_join_id, controld_join_phase_text(phase),
+                 controld_join_phase_text(last), node->id, source);
 
     } else {
         crm_warn("Rejecting join-%d phase update for node %s because "
                  "can't go from %s to %s " QB_XS " nodeid=%u source=%s",
-                 current_join_id, node->uname, crm_join_phase_str(last),
-                 crm_join_phase_str(phase), node->id, source);
+                 current_join_id, node->uname, controld_join_phase_text(last),
+                 controld_join_phase_text(phase), node->id, source);
     }
 }
 
@@ -239,7 +239,7 @@ join_make_offer(gpointer key, gpointer value, gpointer user_data)
     if(user_data && member->join > crm_join_none) {
         crm_info("Not making join-%d offer to already known node %s (%s)",
                  current_join_id, member->uname,
-                 crm_join_phase_str(member->join));
+                 controld_join_phase_text(member->join));
         return;
     }
 
@@ -748,8 +748,8 @@ do_dc_join_ack(long long action,
     if (peer->join != crm_join_finalized) {
         crm_info("Ignoring out-of-sequence join-%d confirmation from %s "
                  "(currently %s not %s)",
-                 join_id, join_from, crm_join_phase_str(peer->join),
-                 crm_join_phase_str(crm_join_finalized));
+                 join_id, join_from, controld_join_phase_text(peer->join),
+                 controld_join_phase_text(crm_join_finalized));
         goto done;
     }
 
@@ -855,7 +855,8 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
         default:
             crm_trace("Not updating non-integrated and non-nacked node %s (%s) "
                       "for join-%d", join_to,
-                      crm_join_phase_str(join_node->join), current_join_id);
+                      controld_join_phase_text(join_node->join),
+                      current_join_id);
             return;
     }
 
@@ -1039,6 +1040,6 @@ void crmd_join_phase_log(int level)
     g_hash_table_iter_init(&iter, crm_peer_cache);
     while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &peer)) {
         do_crm_log(level, "join-%d: %s=%s", current_join_id, peer->uname,
-                   crm_join_phase_str(peer->join));
+                   controld_join_phase_text(peer->join));
     }
 }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -23,6 +23,37 @@ void post_cache_update(int instance);
 
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
+/*!
+ * \internal
+ * \brief Get log-friendly string equivalent of a controller group join phase
+ *
+ * \param[in] phase  Join phase
+ *
+ * \return Log-friendly string equivalent of \p phase
+ */
+const char *
+controld_join_phase_text(enum crm_join_phase phase)
+{
+    switch (phase) {
+        case crm_join_nack_quiet:
+            return "nack_quiet";
+        case crm_join_nack:
+            return "nack";
+        case crm_join_none:
+            return "none";
+        case crm_join_welcomed:
+            return "welcomed";
+        case crm_join_integrated:
+            return "integrated";
+        case crm_join_finalized:
+            return "finalized";
+        case crm_join_confirmed:
+            return "confirmed";
+        default:
+            return "invalid";
+    }
+}
+
 static void
 reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
 {

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -57,7 +57,7 @@ controld_join_phase_text(enum crm_join_phase phase)
 static void
 reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
 {
-    crm_node_t *node = value;
+    pcmk__node_status_t *node = value;
 
     if (!pcmk__cluster_is_node_active(node)) {
         crm_update_peer_join(__func__, node, crm_join_none);
@@ -151,8 +151,8 @@ crmd_node_update_complete(xmlNode * msg, int call_id, int rc, xmlNode * output, 
  * \return Pointer to created node state tag
  */
 xmlNode *
-create_node_state_update(crm_node_t *node, int flags, xmlNode *parent,
-                         const char *source)
+create_node_state_update(pcmk__node_status_t *node, int flags,
+                         xmlNode *parent, const char *source)
 {
     const char *value = NULL;
     xmlNode *node_state;
@@ -264,7 +264,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
         const char *node_uuid = NULL;
         const char *node_uname = NULL;
         GHashTableIter iter;
-        crm_node_t *node = NULL;
+        pcmk__node_status_t *node = NULL;
         gboolean known = FALSE;
 
         node_uuid = crm_element_value(node_xml, PCMK_XA_ID);
@@ -348,7 +348,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
 
     if (from_hashtable) {
         GHashTableIter iter;
-        crm_node_t *node = NULL;
+        pcmk__node_status_t *node = NULL;
         GString *xpath = NULL;
 
         g_hash_table_iter_init(&iter, crm_peer_cache);
@@ -398,7 +398,7 @@ populate_cib_nodes(enum node_update_flags flags, const char *source)
          * we've not seen valid membership data
          */
         GHashTableIter iter;
-        crm_node_t *node = NULL;
+        pcmk__node_status_t *node = NULL;
 
         pcmk__xml_free(node_list);
         node_list = pcmk__xe_create(NULL, PCMK_XE_STATUS);

--- a/daemons/controld/controld_membership.h
+++ b/daemons/controld/controld_membership.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the Pacemaker project contributors
+ * Copyright 2012-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -17,6 +17,7 @@ extern "C" {
 
 void post_cache_update(int instance);
 
+const char *controld_join_phase_text(enum crm_join_phase phase);
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
 void controld_destroy_failed_sync_table(void);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -342,7 +342,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
     const char *type = NULL;
     const char *task = NULL;
     const char *ref = NULL;
-    crm_node_t *node_to = NULL;
+    pcmk__node_status_t *node_to = NULL;
 
     CRM_CHECK(msg != NULL, return TRUE);
 
@@ -777,7 +777,7 @@ handle_remote_state(const xmlNode *msg)
 {
     const char *conn_host = NULL;
     const char *remote_uname = pcmk__xe_id(msg);
-    crm_node_t *remote_peer;
+    pcmk__node_status_t *remote_peer;
     bool remote_is_up = false;
     int rc = pcmk_rc_ok;
 
@@ -855,7 +855,7 @@ static enum crmd_fsa_input
 handle_node_list(const xmlNode *request)
 {
     GHashTableIter iter;
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
     xmlNode *reply = NULL;
     xmlNode *reply_data = NULL;
 
@@ -893,7 +893,7 @@ static enum crmd_fsa_input
 handle_node_info_request(const xmlNode *msg)
 {
     const char *value = NULL;
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
     int node_id = 0;
     xmlNode *reply = NULL;
     xmlNode *reply_data = NULL;
@@ -1045,7 +1045,7 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
 
     if (strcmp(op, CRM_OP_SHUTDOWN_REQ) == 0) {
         const char *from = crm_element_value(stored_msg, PCMK__XA_SRC);
-        crm_node_t *node =
+        pcmk__node_status_t *node =
             pcmk__search_node_caches(0, from, pcmk__node_search_cluster_member);
 
         pcmk__update_peer_expected(__func__, node, CRMD_JOINSTATE_DOWN);

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -193,10 +193,10 @@ start_delay_helper(gpointer data)
 }
 
 static bool
-should_purge_attributes(crm_node_t *node)
+should_purge_attributes(pcmk__node_status_t *node)
 {
     bool purge = true;
-    crm_node_t *conn_node = NULL;
+    pcmk__node_status_t *conn_node = NULL;
     lrm_state_t *connection_rsc = NULL;
 
     if (!node->conn_host) {
@@ -256,7 +256,7 @@ section_to_delete(bool purge)
 }
 
 static void
-purge_remote_node_attrs(int call_opt, crm_node_t *node)
+purge_remote_node_attrs(int call_opt, pcmk__node_status_t *node)
 {
     bool purge = should_purge_attributes(node);
     enum controld_section_e section = section_to_delete(purge);
@@ -280,7 +280,7 @@ remote_node_up(const char *node_name)
 {
     int call_opt;
     xmlNode *update, *state;
-    crm_node_t *node;
+    pcmk__node_status_t *node = NULL;
     lrm_state_t *connection_rsc = NULL;
 
     CRM_CHECK(node_name != NULL, return);
@@ -365,7 +365,7 @@ remote_node_down(const char *node_name, const enum down_opts opts)
 {
     xmlNode *update;
     int call_opt = crmd_cib_smart_opt();
-    crm_node_t *node;
+    pcmk__node_status_t *node = NULL;
 
     /* Purge node from attrd's memory */
     update_attrd_remote_node_removed(node_name, NULL);
@@ -422,7 +422,8 @@ check_remote_node_state(const remote_ra_cmd_t *cmd)
          * it hasn't been tracking the remote node, and other code relies on
          * the cache to distinguish remote nodes from unseen cluster nodes.
          */
-        crm_node_t *node = pcmk__cluster_lookup_remote_node(cmd->rsc_id);
+        pcmk__node_status_t *node =
+            pcmk__cluster_lookup_remote_node(cmd->rsc_id);
 
         CRM_CHECK(node != NULL, return);
         pcmk__update_peer_state(__func__, node, CRM_NODE_MEMBER, 0);
@@ -1391,7 +1392,7 @@ remote_ra_maintenance(lrm_state_t * lrm_state, gboolean maintenance)
 {
     xmlNode *update, *state;
     int call_opt;
-    crm_node_t *node;
+    pcmk__node_status_t *node = NULL;
 
     call_opt = crmd_cib_smart_opt();
     node = pcmk__cluster_lookup_remote_node(lrm_state->node_name);

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -489,7 +489,8 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     force_local_option(output, PCMK_OPT_HAVE_WATCHDOG, pcmk__btoa(watchdog));
 
     if (pcmk_is_set(controld_globals.flags, controld_ever_had_quorum)
-        && !crm_have_quorum) {
+        && !pcmk__cluster_has_quorum()) {
+
         crm_xml_add_int(output, PCMK_XA_NO_QUORUM_PANIC, 1);
     }
 

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -48,7 +48,7 @@ execute_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
     /* send to peers as well? */
     if (pcmk__str_eq(task, PCMK_ACTION_MAINTENANCE_NODES, pcmk__str_casei)) {
         GHashTableIter iter;
-        crm_node_t *node = NULL;
+        pcmk__node_status_t *node = NULL;
 
         g_hash_table_iter_init(&iter, crm_peer_cache);
         while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
@@ -112,7 +112,7 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     gboolean rc = TRUE;
     gboolean no_wait = FALSE;
 
-    const crm_node_t *node = NULL;
+    const pcmk__node_status_t *node = NULL;
 
     id = pcmk__xe_id(action->xml);
     CRM_CHECK(!pcmk__str_empty(id), return EPROTO);
@@ -159,8 +159,9 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
         return pcmk_rc_ok;
 
     } else if (pcmk__str_eq(task, PCMK_ACTION_DO_SHUTDOWN, pcmk__str_none)) {
-        crm_node_t *peer = pcmk__get_node(0, router_node, NULL,
-                                          pcmk__node_search_cluster_member);
+        pcmk__node_status_t *peer =
+            pcmk__get_node(0, router_node, NULL,
+                           pcmk__node_search_cluster_member);
 
         pcmk__update_peer_expected(__func__, peer, CRMD_JOINSTATE_DOWN);
     }
@@ -429,7 +430,7 @@ execute_rsc_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                       I_NULL, &msg);
 
     } else {
-        const crm_node_t *node =
+        const pcmk__node_status_t *node =
             pcmk__get_node(0, router_node, NULL,
                            pcmk__node_search_cluster_member);
 

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -120,7 +120,7 @@ fail_incompletable_actions(pcmk__graph_t *graph, const char *down_node)
                                             PCMK__META_ON_NODE_UUID);
             router = crm_element_value(action->xml, PCMK__XA_ROUTER_NODE);
             if (router) {
-                const crm_node_t *node =
+                const pcmk__node_status_t *node =
                     pcmk__get_node(0, router, NULL,
                                    pcmk__node_search_cluster_member);
 

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -205,7 +205,7 @@ node_pending_timer_popped(gpointer key)
 }
 
 static void
-init_node_pending_timer(const crm_node_t *node, guint timeout)
+init_node_pending_timer(const pcmk__node_status_t *node, guint timeout)
 {
     struct abort_timer_s *node_pending_timer = NULL;
     char *key = NULL;
@@ -255,7 +255,7 @@ remove_node_pending_timer(const char *node_uuid)
 }
 
 void
-controld_node_pending_timer(const crm_node_t *node)
+controld_node_pending_timer(const pcmk__node_status_t *node)
 {
     long long remaining_timeout = 0;
 

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -1,17 +1,21 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
  */
 
 #ifndef TENGINE__H
-#  define TENGINE__H
+#define TENGINE__H
 
-#  include <crm/common/mainloop.h>
-#  include <crm/stonith-ng.h>
-#  include <crm/services.h>
-#  include <pacemaker-internal.h>
+#include <glib.h>                   // gboolean
+#include <libxml/tree.h>            // xmlNode
+
+#include <crm/cluster/internal.h>   // pcmk__node_status_t
+#include <crm/common/mainloop.h>
+#include <crm/stonith-ng.h>
+#include <crm/services.h>
+#include <pacemaker-internal.h>
 
 /* tengine */
 pcmk__graph_action_t *match_down_event(const char *target);
@@ -48,7 +52,7 @@ void controld_destroy_transition_trigger(void);
 void controld_trigger_graph_as(const char *fn, int line);
 void abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
                        const char *abort_text, guint delay_ms);
-void controld_node_pending_timer(const crm_node_t *node);
+void controld_node_pending_timer(const pcmk__node_status_t *node);
 void controld_free_node_pending_timers(void);
 void abort_transition_graph(int abort_priority,
                             enum pcmk__graph_next abort_action,

--- a/daemons/controld/controld_utils.c
+++ b/daemons/controld/controld_utils.c
@@ -733,8 +733,9 @@ update_dc(xmlNode * msg)
         /* do nothing */
 
     } else if (controld_globals.dc_name != NULL) {
-        crm_node_t *dc_node = pcmk__get_node(0, controld_globals.dc_name, NULL,
-                                             pcmk__node_search_cluster_member);
+        pcmk__node_status_t *dc_node =
+            pcmk__get_node(0, controld_globals.dc_name, NULL,
+                           pcmk__node_search_cluster_member);
 
         crm_info("Set DC to %s (%s)",
                  controld_globals.dc_name,
@@ -749,7 +750,7 @@ update_dc(xmlNode * msg)
     return TRUE;
 }
 
-void crmd_peer_down(crm_node_t *peer, bool full) 
+void crmd_peer_down(pcmk__node_status_t *peer, bool full) 
 {
     if(full && peer->state == NULL) {
         pcmk__update_peer_state(__func__, peer, CRM_NODE_LOST, 0);

--- a/daemons/controld/controld_utils.h
+++ b/daemons/controld/controld_utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -8,10 +8,15 @@
  */
 
 #ifndef CRMD_UTILS__H
-#  define CRMD_UTILS__H
+#define CRMD_UTILS__H
 
-#  include <crm/crm.h>
-#  include <crm/common/xml.h>
+#include <glib.h>                   // gboolean
+#include <libxml/tree.h>            // xmlNode
+
+#include <crm/crm.h>
+#include <crm/cluster.h>            // enum crm_join_phase
+#include <crm/cluster/internal.h>   // pcmk__node_status_t
+#include <crm/common/xml.h>
 
 #  define FAKE_TE_ID	"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
@@ -36,8 +41,9 @@ void fsa_dump_actions(uint64_t action, const char *text);
 void fsa_dump_inputs(int log_level, const char *text, long long input_register);
 
 gboolean update_dc(xmlNode * msg);
-void crm_update_peer_join(const char *source, crm_node_t * node, enum crm_join_phase phase);
-xmlNode *create_node_state_update(crm_node_t *node, int flags,
+void crm_update_peer_join(const char *source, pcmk__node_status_t *node,
+                          enum crm_join_phase phase);
+xmlNode *create_node_state_update(pcmk__node_status_t *node, int flags,
                                   xmlNode *parent, const char *source);
 void populate_cib_nodes(enum node_update_flags flags, const char *source);
 void crm_update_quorum(gboolean quorum, gboolean force_update);
@@ -52,7 +58,7 @@ void update_attrd_clear_failures(const char *host, const char *rsc,
 int crmd_join_phase_count(enum crm_join_phase phase);
 void crmd_join_phase_log(int level);
 
-void crmd_peer_down(crm_node_t *peer, bool full);
+void crmd_peer_down(pcmk__node_status_t *peer, bool full);
 
 bool feature_set_compatible(const char *dc_version, const char *join_version);
 

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -644,8 +644,9 @@ schedule_stonith_command(async_command_t * cmd, stonith_device_t * device)
     }
 
     if (device->include_nodeid && (cmd->target != NULL)) {
-        crm_node_t *node = pcmk__get_node(0, cmd->target, NULL,
-                                          pcmk__node_search_cluster_member);
+        pcmk__node_status_t *node =
+            pcmk__get_node(0, cmd->target, NULL,
+                           pcmk__node_search_cluster_member);
 
         cmd->target_nodeid = node->id;
     }
@@ -2346,7 +2347,7 @@ stonith_send_reply(const xmlNode *reply, int call_options,
     if (remote_peer == NULL) {
         do_local_reply(reply, client, call_options);
     } else {
-        const crm_node_t *node =
+        const pcmk__node_status_t *node =
             pcmk__get_node(0, remote_peer, NULL,
                            pcmk__node_search_cluster_member);
 
@@ -2867,7 +2868,7 @@ fence_locally(xmlNode *msg, pcmk__action_result_t *result)
 
         if (pcmk_is_set(cmd->options, st_opt_cs_nodeid)) {
             int nodeid = 0;
-            crm_node_t *node = NULL;
+            pcmk__node_status_t *node = NULL;
 
             pcmk__scan_min_int(host, &nodeid, 0);
             node = pcmk__search_node_caches(nodeid, NULL,
@@ -2982,7 +2983,7 @@ construct_async_reply(const async_command_t *cmd,
     return reply;
 }
 
-bool fencing_peer_active(crm_node_t *peer)
+bool fencing_peer_active(pcmk__node_status_t *peer)
 {
     if (peer == NULL) {
         return FALSE;
@@ -3018,7 +3019,7 @@ check_alternate_host(const char *target)
 {
     if (pcmk__str_eq(target, stonith_our_uname, pcmk__str_casei)) {
         GHashTableIter gIter;
-        crm_node_t *entry = NULL;
+        pcmk__node_status_t *entry = NULL;
 
         g_hash_table_iter_init(&gIter, crm_peer_cache);
         while (g_hash_table_iter_next(&gIter, NULL, (void **)&entry)) {
@@ -3314,8 +3315,9 @@ handle_fence_request(pcmk__request_t *request)
         if (alternate_host != NULL) {
             const char *client_id = NULL;
             remote_fencing_op_t *op = NULL;
-            crm_node_t *node = pcmk__get_node(0, alternate_host, NULL,
-                                              pcmk__node_search_cluster_member);
+            pcmk__node_status_t *node =
+                pcmk__get_node(0, alternate_host, NULL,
+                               pcmk__node_search_cluster_member);
 
             if (request->ipc_client->id == 0) {
                 client_id = crm_element_value(request->xml,

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -483,7 +483,7 @@ stonith_fence_history(xmlNode *msg, xmlNode **output,
         target = crm_element_value(dev, PCMK__XA_ST_TARGET);
         if (target && (options & st_opt_cs_nodeid)) {
             int nodeid;
-            crm_node_t *node;
+            pcmk__node_status_t *node = NULL;
 
             pcmk__scan_min_int(target, &nodeid, 0);
             node = pcmk__search_node_caches(nodeid, NULL,

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1008,7 +1008,7 @@ merge_duplicates(remote_fencing_op_t *op)
     g_hash_table_iter_init(&iter, stonith_remote_op_list);
     while (g_hash_table_iter_next(&iter, NULL, (void **)&other)) {
         const char *other_action = op_requested_action(other);
-        crm_node_t *node = NULL;
+        pcmk__node_status_t *node = NULL;
 
         if (!strcmp(op->id, other->id)) {
             continue; // Don't compare against self
@@ -1084,7 +1084,7 @@ merge_duplicates(remote_fencing_op_t *op)
 static uint32_t fencing_active_peers(void)
 {
     uint32_t count = 0;
-    crm_node_t *entry;
+    pcmk__node_status_t *entry = NULL;
     GHashTableIter gIter;
 
     g_hash_table_iter_init(&gIter, crm_peer_cache);
@@ -1237,7 +1237,7 @@ create_remote_stonith_op(const char *client, xmlNode *request, gboolean peer)
 
     if (op->call_options & st_opt_cs_nodeid) {
         int nodeid;
-        crm_node_t *node;
+        pcmk__node_status_t *node = NULL;
 
         pcmk__scan_min_int(op->target, &nodeid, 0);
         node = pcmk__search_node_caches(nodeid, NULL,
@@ -1923,7 +1923,7 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
     if (peer) {
         int timeout_one = 0;
         xmlNode *remote_op = stonith_create_op(op->client_callid, op->id, STONITH_OP_FENCE, NULL, 0);
-        const crm_node_t *peer_node =
+        const pcmk__node_status_t *peer_node =
             pcmk__get_node(0, peer->host, NULL,
                            pcmk__node_search_cluster_member);
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -468,7 +468,8 @@ struct qb_ipcs_service_handlers ipc_callbacks = {
  * \param[in] data  Previous value of what changed
  */
 static void
-st_peer_update_callback(enum crm_status_type type, crm_node_t * node, const void *data)
+st_peer_update_callback(enum crm_status_type type, pcmk__node_status_t *node,
+                        const void *data)
 {
     if ((type != crm_status_processes)
         && !pcmk_is_set(node->flags, crm_remote_node)) {

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -272,7 +272,7 @@ void stonith_fence_history(xmlNode *msg, xmlNode **output,
 
 void stonith_fence_history_trim(void);
 
-bool fencing_peer_active(crm_node_t *peer);
+bool fencing_peer_active(pcmk__node_status_t *peer);
 
 void set_fencing_completed(remote_fencing_op_t * op);
 

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -48,8 +48,8 @@ extern unsigned long long crm_peer_seq;
 //!@{
 //! \deprecated Do not use (public access will be removed in a future release)
 enum crm_join_phase {
-    /* @COMPAT: crm_join_nack_quiet can be replaced by crm_node_t:user_data
-     *          at a compatibility break.
+    /* @COMPAT: crm_join_nack_quiet can be replaced by
+     * pcmk__node_status_t:user_data at a compatibility break
      */
     //! Not allowed to join, but don't send a nack message
     crm_join_nack_quiet = -2,
@@ -77,56 +77,8 @@ enum crm_node_flags {
 };
 //!@}
 
-// @COMPAT Make this internal when we can break API backward compatibility
-//!@{
 //! \deprecated Do not use (public access will be removed in a future release)
-typedef struct crm_peer_node_s {
-    char *uname;                // Node name as known to cluster
-
-    /* @COMPAT This is less than ideal since the value is not a valid XML ID
-     * (for Corosync, it's the string equivalent of the node's numeric node ID,
-     * but XML IDs can't start with a number) and the three elements should have
-     * different IDs.
-     *
-     * Ideally, we would use something like node-NODEID, node_state-NODEID, and
-     * transient_attributes-NODEID as the element IDs. Unfortunately changing it
-     * would be impractical due to backward compatibility; older nodes in a
-     * rolling upgrade will always write and expect the value in the old format.
-     *
-     * This is also named poorly, since the value is not a UUID, but at least
-     * that can be changed at an API compatibility break.
-     */
-    /*! Value of the PCMK_XA_ID XML attribute to use with the node's
-     * PCMK_XE_NODE, PCMK_XE_NODE_STATE, and PCMK_XE_TRANSIENT_ATTRIBUTES
-     * XML elements in the CIB
-     */
-    char *uuid;
-
-    char *state;                // @TODO change to enum
-    uint64_t flags;             // Bitmask of crm_node_flags
-    uint64_t last_seen;         // Only needed by cluster nodes
-    uint32_t processes;         // @TODO most not needed, merge into flags
-
-    /* @TODO When we can break public API compatibility, we can make the rest of
-     * these members separate structs and use void *cluster_data and
-     * void *user_data here instead, to abstract the cluster layer further.
-     */
-
-    // Currently only needed by corosync stack
-    uint32_t id;                // Node ID
-    time_t when_lost;           // When CPG membership was last lost
-
-    // Only used by controller
-    enum crm_join_phase join;
-    char *expected;
-
-    time_t peer_lost;
-    char *conn_host;
-
-    time_t when_member;         // Since when node has been a cluster member
-    time_t when_online;         // Since when peer has been online in CPG
-} crm_node_t;
-//!@}
+typedef struct pcmk__node_status crm_node_t;
 
 // Implementation of pcmk_cluster_t
 // @COMPAT Make this internal when we can break API backward compatibility

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -26,10 +26,6 @@ extern "C" {
 
 // @COMPAT Make this internal when we can break API backward compatibility
 //! \deprecated Do not use (public access will be removed in a future release)
-extern gboolean crm_have_quorum;
-
-// @COMPAT Make this internal when we can break API backward compatibility
-//! \deprecated Do not use (public access will be removed in a future release)
 extern GHashTable *crm_peer_cache;
 
 // @COMPAT Make this internal when we can break API backward compatibility

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -77,9 +77,6 @@ enum crm_node_flags {
 };
 //!@}
 
-//! \deprecated Do not use (public access will be removed in a future release)
-typedef struct pcmk__node_status crm_node_t;
-
 // Implementation of pcmk_cluster_t
 // @COMPAT Make this internal when we can break API backward compatibility
 //!@{

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -227,29 +227,6 @@ enum pcmk_cluster_layer {
 enum pcmk_cluster_layer pcmk_get_cluster_layer(void);
 const char *pcmk_cluster_layer_text(enum pcmk_cluster_layer layer);
 
-/*
- * \brief Get log-friendly string equivalent of a join phase
- *
- * \param[in] phase  Join phase
- *
- * \return Log-friendly string equivalent of \p phase
- */
-//! \deprecated Do not use (public access will be removed in a future release)
-static inline const char *
-crm_join_phase_str(enum crm_join_phase phase)
-{
-    switch (phase) {
-        case crm_join_nack_quiet:   return "nack_quiet";
-        case crm_join_nack:         return "nack";
-        case crm_join_none:         return "none";
-        case crm_join_welcomed:     return "welcomed";
-        case crm_join_integrated:   return "integrated";
-        case crm_join_finalized:    return "finalized";
-        case crm_join_confirmed:    return "confirmed";
-        default:                    return "invalid";
-    }
-}
-
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
 #include <crm/cluster/compat.h>
 #endif

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -166,6 +166,8 @@ bool pcmk__cluster_send_message(const crm_node_t *node,
 
 // Membership
 
+bool pcmk__cluster_has_quorum(void);
+
 void pcmk__cluster_init_node_caches(void);
 void pcmk__cluster_destroy_node_caches(void);
 

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -86,7 +86,7 @@ pcmk__cluster_parse_msg_type(const char *text)
  * \return Cluster-layer node UUID of \p node, or \c NULL if unknown
  */
 const char *
-pcmk__cluster_node_uuid(crm_node_t *node)
+pcmk__cluster_node_uuid(pcmk__node_status_t *node)
 {
     const enum pcmk_cluster_layer cluster_layer = pcmk_get_cluster_layer();
 
@@ -233,7 +233,7 @@ pcmk_cluster_set_destroy_fn(pcmk_cluster_t *cluster, void (*fn)(gpointer))
  * \return \c true on success, or \c false otherwise
  */
 bool
-pcmk__cluster_send_message(const crm_node_t *node,
+pcmk__cluster_send_message(const pcmk__node_status_t *node,
                            enum crm_ais_msg_types service, const xmlNode *data)
 {
     // @TODO Return standard Pacemaker return code
@@ -356,7 +356,7 @@ pcmk__node_name_from_uuid(const char *uuid)
      * the extent possible, likely with new helper functions.
      */
     GHashTableIter iter;
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
 
     CRM_CHECK(uuid != NULL, return NULL);
 

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -50,7 +50,7 @@ static gboolean (*quorum_app_callback)(unsigned long long seq,
  * \note It is the caller's responsibility to free the result with free().
  */
 char *
-pcmk__corosync_uuid(const crm_node_t *node)
+pcmk__corosync_uuid(const pcmk__node_status_t *node)
 {
     CRM_ASSERT(pcmk_get_cluster_layer() == pcmk_cluster_layer_corosync);
 
@@ -270,7 +270,7 @@ quorum_notification_cb(quorum_handle_t handle, uint32_t quorate,
 {
     int i;
     GHashTableIter iter;
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
     static gboolean init_phase = TRUE;
 
     bool is_quorate = (quorate != 0);
@@ -458,7 +458,7 @@ pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
 int
 pcmk__corosync_connect(pcmk_cluster_t *cluster)
 {
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
     const enum pcmk_cluster_layer cluster_layer = pcmk_get_cluster_layer();
     const char *cluster_layer_s = pcmk_cluster_layer_text(cluster_layer);
     int rc = pcmk_rc_ok;
@@ -529,7 +529,7 @@ pcmk__corosync_is_active(void)
  * \return \c true if \p node is an active Corosync peer, or \c false otherwise
  */
 bool
-pcmk__corosync_is_peer_active(const crm_node_t *node)
+pcmk__corosync_is_peer_active(const pcmk__node_status_t *node)
 {
     if (node == NULL) {
         crm_trace("Corosync peer inactive: NULL");
@@ -625,7 +625,7 @@ pcmk__corosync_add_nodes(xmlNode *xml_parent)
         name = pcmk__corosync_name(cmap_handle, nodeid);
         if (name != NULL) {
             GHashTableIter iter;
-            crm_node_t *node = NULL;
+            pcmk__node_status_t *node = NULL;
 
             g_hash_table_iter_init(&iter, crm_peer_cache);
             while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -460,7 +460,7 @@ pcmk__cpg_message_data(cpg_handle_t handle, uint32_t sender_id, uint32_t pid,
 
         msg->sender.id = sender_id;
         if (msg->sender.size == 0) {
-            const crm_node_t *peer =
+            const pcmk__node_status_t *peer =
                 pcmk__get_node(sender_id, NULL, NULL,
                                pcmk__node_search_cluster_member);
 
@@ -596,7 +596,7 @@ cpgreason2str(cpg_reason_t reason)
  * \return Node's uname, or readable string if not known
  */
 static inline const char *
-peer_name(const crm_node_t *peer)
+peer_name(const pcmk__node_status_t *peer)
 {
     if (peer == NULL) {
         return "unknown node";
@@ -624,7 +624,7 @@ node_left(const char *cpg_group_name, int event_counter,
           const struct cpg_address **sorted_member_list,
           size_t member_list_entries)
 {
-    crm_node_t *peer =
+    pcmk__node_status_t *peer =
         pcmk__search_node_caches(cpg_peer->nodeid, NULL,
                                  pcmk__node_search_cluster_member);
     const struct cpg_address **rival = NULL;
@@ -726,8 +726,9 @@ pcmk__cpg_confchg_cb(cpg_handle_t handle,
     }
 
     for (int i = 0; i < member_list_entries; i++) {
-        crm_node_t *peer = pcmk__get_node(member_list[i].nodeid, NULL, NULL,
-                                          pcmk__node_search_cluster_member);
+        pcmk__node_status_t *peer =
+            pcmk__get_node(member_list[i].nodeid, NULL, NULL,
+                           pcmk__node_search_cluster_member);
 
         if (member_list[i].nodeid == local_nodeid
                 && member_list[i].pid != getpid()) {
@@ -832,7 +833,7 @@ pcmk__cpg_connect(pcmk_cluster_t *cluster)
     int fd = -1;
     int retries = 0;
     uint32_t id = 0;
-    crm_node_t *peer = NULL;
+    pcmk__node_status_t *peer = NULL;
     cpg_handle_t handle = 0;
     const char *message_name = pcmk__message_name(crm_system_name);
     uid_t found_uid = 0;
@@ -956,7 +957,7 @@ pcmk__cpg_disconnect(pcmk_cluster_t *cluster)
  * \return \c true on success, or \c false otherwise
  */
 static bool
-send_cpg_text(const char *data, bool local, const crm_node_t *node,
+send_cpg_text(const char *data, bool local, const pcmk__node_status_t *node,
               enum crm_ais_msg_types dest)
 {
     // @COMPAT Drop local argument when send_cluster_text is dropped
@@ -1088,7 +1089,7 @@ send_cpg_text(const char *data, bool local, const crm_node_t *node,
  * \return TRUE on success, otherwise FALSE
  */
 bool
-pcmk__cpg_send_xml(const xmlNode *msg, const crm_node_t *node,
+pcmk__cpg_send_xml(const xmlNode *msg, const pcmk__node_status_t *node,
                    enum crm_ais_msg_types dest)
 {
     bool rc = true;

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -14,16 +14,18 @@
  * declared with G_GNUC_INTERNAL for efficiency.
  */
 
-#include <stdint.h>                // uint32_t, uint64_t
+#include <stdbool.h>                // bool
+#include <stdint.h>                 // uint32_t, uint64_t
 
-#include <glib.h>                  // G_GNUC_INTERNAL, gboolean
-#include <libxml/tree.h>           // xmlNode
+#include <glib.h>                   // G_GNUC_INTERNAL, gboolean
+#include <libxml/tree.h>            // xmlNode
 
 #if SUPPORT_COROSYNC
-#include <corosync/cpg.h>          // cpg_handle_t
+#include <corosync/cpg.h>           // cpg_handle_t
 #endif  // SUPPORT_COROSYNC
 
-#include <crm/cluster.h>           // crm_node_t
+#include <crm/cluster.h>            // pcmk_cluster_t
+#include <crm/cluster/internal.h>   // pcmk__node_status_t
 
 G_GNUC_INTERNAL
 void pcmk__cluster_set_quorum(bool quorate);
@@ -37,7 +39,7 @@ G_GNUC_INTERNAL
 bool pcmk__corosync_has_nodelist(void);
 
 G_GNUC_INTERNAL
-char *pcmk__corosync_uuid(const crm_node_t *peer);
+char *pcmk__corosync_uuid(const pcmk__node_status_t *peer);
 
 G_GNUC_INTERNAL
 char *pcmk__corosync_name(uint64_t /*cmap_handle_t */ cmap_handle,
@@ -50,7 +52,7 @@ G_GNUC_INTERNAL
 void pcmk__corosync_disconnect(pcmk_cluster_t *cluster);
 
 G_GNUC_INTERNAL
-bool pcmk__corosync_is_peer_active(const crm_node_t *node);
+bool pcmk__corosync_is_peer_active(const pcmk__node_status_t *node);
 
 G_GNUC_INTERNAL
 int pcmk__cpg_connect(pcmk_cluster_t *cluster);
@@ -62,7 +64,7 @@ G_GNUC_INTERNAL
 uint32_t pcmk__cpg_local_nodeid(cpg_handle_t handle);
 
 G_GNUC_INTERNAL
-bool pcmk__cpg_send_xml(const xmlNode *msg, const crm_node_t *node,
+bool pcmk__cpg_send_xml(const xmlNode *msg, const pcmk__node_status_t *node,
                         enum crm_ais_msg_types dest);
 
 #endif  // SUPPORT_COROSYNC

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -25,6 +25,9 @@
 
 #include <crm/cluster.h>           // crm_node_t
 
+G_GNUC_INTERNAL
+void pcmk__cluster_set_quorum(bool quorate);
+
 #if SUPPORT_COROSYNC
 
 G_GNUC_INTERNAL

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -25,6 +25,8 @@
 
 #include <crm/cluster.h>           // crm_node_t
 
+#if SUPPORT_COROSYNC
+
 G_GNUC_INTERNAL
 bool pcmk__corosync_is_active(void);
 
@@ -59,5 +61,7 @@ uint32_t pcmk__cpg_local_nodeid(cpg_handle_t handle);
 G_GNUC_INTERNAL
 bool pcmk__cpg_send_xml(const xmlNode *msg, const crm_node_t *node,
                         enum crm_ais_msg_types dest);
+
+#endif  // SUPPORT_COROSYNC
 
 #endif  // PCMK__CRMCLUSTER_PRIVATE__H

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -290,7 +290,7 @@ election_vote(election_t *e)
 {
     struct timeval age;
     xmlNode *vote = NULL;
-    crm_node_t *our_node;
+    pcmk__node_status_t *our_node = NULL;
 
     if (e == NULL) {
         crm_trace("Election vote requested, but no election available");
@@ -368,7 +368,7 @@ election_check(election_t *e)
         election_timeout_stop(e);
         if (voted_size > num_members) {
             GHashTableIter gIter;
-            const crm_node_t *node;
+            const pcmk__node_status_t *node = NULL;
             char *key = NULL;
 
             crm_warn("Received too many votes in %s", e->name);
@@ -498,7 +498,7 @@ record_vote(election_t *e, struct vote *vote)
 }
 
 static void
-send_no_vote(crm_node_t *peer, struct vote *vote)
+send_no_vote(pcmk__node_status_t *peer, struct vote *vote)
 {
     // @TODO probably shouldn't hardcode CRM_SYSTEM_CRMD and crm_msg_crmd
 
@@ -535,7 +535,8 @@ election_count_vote(election_t *e, const xmlNode *message, bool can_win)
     gboolean we_lose = FALSE;
     const char *reason = "unknown";
     bool we_are_owner = FALSE;
-    crm_node_t *our_node = NULL, *your_node = NULL;
+    pcmk__node_status_t *our_node = NULL;
+    pcmk__node_status_t *your_node = NULL;
     time_t tm_now = time(NULL);
     struct vote vote;
 

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -71,7 +71,7 @@ unsigned long long crm_peer_seq = 0;
 static bool autoreap = true;
 static bool has_quorum = false;
 
-// Flag setting and clearing for crm_node_t:flags
+// Flag setting and clearing for pcmk__node_status_t:flags
 
 #define set_peer_flags(peer, flags_to_set) do {                               \
         (peer)->flags = pcmk__set_flags_as(__func__, __LINE__, LOG_TRACE,     \
@@ -88,8 +88,9 @@ static bool has_quorum = false;
                                              #flags_to_clear);                \
     } while (0)
 
-static void update_peer_uname(crm_node_t *node, const char *uname);
-static crm_node_t *find_cib_cluster_node(const char *id, const char *uname);
+static void update_peer_uname(pcmk__node_status_t *node, const char *uname);
+static pcmk__node_status_t *find_cib_cluster_node(const char *id,
+                                                  const char *uname);
 
 /*!
  * \internal
@@ -145,10 +146,10 @@ pcmk__cluster_num_remote_nodes(void)
  * \note Because this can add and remove cache entries, callers should not
  *       assume any previously obtained cache entry pointers remain valid.
  */
-crm_node_t *
+pcmk__node_status_t *
 pcmk__cluster_lookup_remote_node(const char *node_name)
 {
-    crm_node_t *node;
+    pcmk__node_status_t *node = NULL;
     char *node_name_copy = NULL;
 
     if (node_name == NULL) {
@@ -184,7 +185,7 @@ pcmk__cluster_lookup_remote_node(const char *node_name)
     }
 
     /* Allocate a new entry */
-    node = calloc(1, sizeof(crm_node_t));
+    node = calloc(1, sizeof(pcmk__node_status_t));
     if (node == NULL) {
         free(node_name_copy);
         return NULL;
@@ -271,7 +272,7 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
     const struct refresh_data *data = user_data;
     const char *remote = crm_element_value(result, data->field);
     const char *state = NULL;
-    crm_node_t *node;
+    pcmk__node_status_t *node;
 
     CRM_CHECK(remote != NULL, return);
 
@@ -303,13 +304,13 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
 static void
 mark_dirty(gpointer key, gpointer value, gpointer user_data)
 {
-    set_peer_flags((crm_node_t *) value, crm_node_dirty);
+    set_peer_flags((pcmk__node_status_t *) value, crm_node_dirty);
 }
 
 static gboolean
 is_dirty(gpointer key, gpointer value, gpointer user_data)
 {
-    return pcmk_is_set(((crm_node_t*)value)->flags, crm_node_dirty);
+    return pcmk_is_set(((pcmk__node_status_t*)value)->flags, crm_node_dirty);
 }
 
 /*!
@@ -368,7 +369,7 @@ refresh_remote_nodes(xmlNode *cib)
  * \return \c true if the node is an active cluster node, or \c false otherwise
  */
 bool
-pcmk__cluster_is_node_active(const crm_node_t *node)
+pcmk__cluster_is_node_active(const pcmk__node_status_t *node)
 {
     const enum pcmk_cluster_layer cluster_layer = pcmk_get_cluster_layer();
 
@@ -397,8 +398,8 @@ pcmk__cluster_is_node_active(const crm_node_t *node)
  * \brief Check if a node's entry should be removed from the cluster node cache
  *
  * A node should be removed from the cache if it's inactive and matches another
- * \c crm_node_t (the search object). The node is considered a mismatch if any
- * of the following are true:
+ * \c pcmk__node_status_t (the search object). The node is considered a
+ * mismatch if any of the following are true:
  * * The search object is \c NULL.
  * * The search object has an ID set and the cached node's ID does not match it.
  * * The search object does not have an ID set, and the cached node's name does
@@ -411,8 +412,9 @@ pcmk__cluster_is_node_active(const crm_node_t *node)
  * ignored for matching purposes.
  *
  * \param[in] key        Ignored
- * \param[in] value      \c crm_node_t object from cluster node cache
- * \param[in] user_data  \c crm_node_t object to match against (search object)
+ * \param[in] value      \c pcmk__node_status_t object from cluster node cache
+ * \param[in] user_data  \c pcmk__node_status_t object to match against (search
+ *                       object)
  *
  * \return \c TRUE if the node entry should be removed from \c crm_peer_cache,
  *         or \c FALSE otherwise
@@ -420,8 +422,8 @@ pcmk__cluster_is_node_active(const crm_node_t *node)
 static gboolean
 should_forget_cluster_node(gpointer key, gpointer value, gpointer user_data)
 {
-    crm_node_t *node = value;
-    crm_node_t *search = user_data;
+    pcmk__node_status_t *node = value;
+    pcmk__node_status_t *search = user_data;
 
     if (search == NULL) {
         return FALSE;
@@ -465,7 +467,7 @@ should_forget_cluster_node(gpointer key, gpointer value, gpointer user_data)
 void
 pcmk__cluster_forget_cluster_node(uint32_t id, const char *node_name)
 {
-    crm_node_t search = { 0, };
+    pcmk__node_status_t search = { 0, };
     char *criterion = NULL; // For logging
     guint matches = 0;
 
@@ -511,7 +513,7 @@ static void
 count_peer(gpointer key, gpointer value, gpointer user_data)
 {
     unsigned int *count = user_data;
-    crm_node_t *node = value;
+    pcmk__node_status_t *node = value;
 
     if (pcmk__cluster_is_node_active(node)) {
         *count = *count + 1;
@@ -541,7 +543,7 @@ pcmk__cluster_num_active_nodes(void)
 static void
 destroy_crm_node(gpointer data)
 {
-    crm_node_t *node = data;
+    pcmk__node_status_t *node = data;
 
     crm_trace("Destroying entry for node %u: %s", node->id, node->uname);
 
@@ -602,7 +604,7 @@ pcmk__cluster_destroy_node_caches(void)
     }
 }
 
-static void (*peer_status_callback)(enum crm_status_type, crm_node_t *,
+static void (*peer_status_callback)(enum crm_status_type, pcmk__node_status_t *,
                                     const void *) = NULL;
 
 /*!
@@ -616,7 +618,8 @@ static void (*peer_status_callback)(enum crm_status_type, crm_node_t *,
  */
 void
 pcmk__cluster_set_status_callback(void (*dispatch)(enum crm_status_type,
-                                                   crm_node_t *, const void *))
+                                                   pcmk__node_status_t *,
+                                                   const void *))
 {
     // @TODO Improve documentation of peer_status_callback
     peer_status_callback = dispatch;
@@ -647,7 +650,7 @@ dump_peer_hash(int level, const char *caller)
 {
     GHashTableIter iter;
     const char *id = NULL;
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
 
     g_hash_table_iter_init(&iter, crm_peer_cache);
     while (g_hash_table_iter_next(&iter, (gpointer *) &id, (gpointer *) &node)) {
@@ -672,14 +675,14 @@ hash_find_by_data(gpointer key, gpointer value, gpointer user_data)
  *
  * \return Cluster node cache entry if found, otherwise NULL
  */
-static crm_node_t *
+static pcmk__node_status_t *
 search_cluster_member_cache(unsigned int id, const char *uname,
                             const char *uuid)
 {
     GHashTableIter iter;
-    crm_node_t *node = NULL;
-    crm_node_t *by_id = NULL;
-    crm_node_t *by_name = NULL;
+    pcmk__node_status_t *node = NULL;
+    pcmk__node_status_t *by_id = NULL;
+    pcmk__node_status_t *by_name = NULL;
 
     CRM_ASSERT(id > 0 || uname != NULL);
 
@@ -785,10 +788,10 @@ search_cluster_member_cache(unsigned int id, const char *uname,
  *
  * \return Node cache entry if found, otherwise NULL
  */
-crm_node_t *
+pcmk__node_status_t *
 pcmk__search_node_caches(unsigned int id, const char *uname, uint32_t flags)
 {
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
 
     CRM_ASSERT(id > 0 || uname != NULL);
 
@@ -856,11 +859,11 @@ pcmk__purge_node_from_cache(const char *node_name, uint32_t node_id)
 
 #if SUPPORT_COROSYNC
 static guint
-remove_conflicting_peer(crm_node_t *node)
+remove_conflicting_peer(pcmk__node_status_t *node)
 {
     int matches = 0;
     GHashTableIter iter;
-    crm_node_t *existing_node = NULL;
+    pcmk__node_status_t *existing_node = NULL;
 
     if (node->id == 0 || node->uname == NULL) {
         return 0;
@@ -910,11 +913,11 @@ remove_conflicting_peer(crm_node_t *node)
  * \return (Possibly newly created) cluster node cache entry
  */
 /* coverity[-alloc] Memory is referenced in one or both hashtables */
-crm_node_t *
+pcmk__node_status_t *
 pcmk__get_node(unsigned int id, const char *uname, const char *uuid,
                uint32_t flags)
 {
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
     char *uname_lookup = NULL;
 
     CRM_ASSERT(id > 0 || uname != NULL);
@@ -954,7 +957,7 @@ pcmk__get_node(unsigned int id, const char *uname, const char *uuid,
     if (node == NULL) {
         char *uniqueid = crm_generate_uuid();
 
-        node = pcmk__assert_alloc(1, sizeof(crm_node_t));
+        node = pcmk__assert_alloc(1, sizeof(pcmk__node_status_t));
 
         crm_info("Created entry %s/%p for node %s/%u (%d total)",
                  uniqueid, node, uname, id, 1 + g_hash_table_size(crm_peer_cache));
@@ -1003,7 +1006,7 @@ pcmk__get_node(unsigned int id, const char *uname, const char *uuid,
  *       which would invalidate the iterator.
  */
 static void
-update_peer_uname(crm_node_t *node, const char *uname)
+update_peer_uname(pcmk__node_status_t *node, const char *uname)
 {
     CRM_CHECK(uname != NULL,
               crm_err("Bug: can't update node name without name"); return);
@@ -1079,8 +1082,9 @@ proc2text(enum crm_proc_flag proc)
  *       called within a cache iteration if reaping is possible, otherwise
  *       reaping could invalidate the iterator.
  */
-crm_node_t *
-crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const char *status)
+pcmk__node_status_t *
+crm_update_peer_proc(const char *source, pcmk__node_status_t *node,
+                     uint32_t flag, const char *status)
 {
     uint32_t last = 0;
     gboolean changed = FALSE;
@@ -1174,7 +1178,7 @@ crm_update_peer_proc(const char *source, crm_node_t * node, uint32_t flag, const
  * \param[in]     expected  Node's new join state
  */
 void
-pcmk__update_peer_expected(const char *source, crm_node_t *node,
+pcmk__update_peer_expected(const char *source, pcmk__node_status_t *node,
                            const char *expected)
 {
     char *last = NULL;
@@ -1220,9 +1224,10 @@ pcmk__update_peer_expected(const char *source, crm_node_t *node,
  *       freed and should not be used again. This function may be called from
  *       within a peer cache iteration if the iterator is supplied.
  */
-static crm_node_t *
-update_peer_state_iter(const char *source, crm_node_t *node, const char *state,
-                       uint64_t membership, GHashTableIter *iter)
+static pcmk__node_status_t *
+update_peer_state_iter(const char *source, pcmk__node_status_t *node,
+                       const char *state, uint64_t membership,
+                       GHashTableIter *iter)
 {
     gboolean is_member;
 
@@ -1298,8 +1303,8 @@ update_peer_state_iter(const char *source, crm_node_t *node, const char *state,
  *       called within a cache iteration if reaping is possible,
  *       otherwise reaping could invalidate the iterator.
  */
-crm_node_t *
-pcmk__update_peer_state(const char *source, crm_node_t *node,
+pcmk__node_status_t *
+pcmk__update_peer_state(const char *source, pcmk__node_status_t *node,
                         const char *state, uint64_t membership)
 {
     return update_peer_state_iter(source, node, state, membership, NULL);
@@ -1315,7 +1320,7 @@ void
 pcmk__reap_unseen_nodes(uint64_t membership)
 {
     GHashTableIter iter;
-    crm_node_t *node = NULL;
+    pcmk__node_status_t *node = NULL;
 
     crm_trace("Reaping unseen nodes...");
     g_hash_table_iter_init(&iter, crm_peer_cache);
@@ -1338,13 +1343,13 @@ pcmk__reap_unseen_nodes(uint64_t membership)
     }
 }
 
-static crm_node_t *
+static pcmk__node_status_t *
 find_cib_cluster_node(const char *id, const char *uname)
 {
     GHashTableIter iter;
-    crm_node_t *node = NULL;
-    crm_node_t *by_id = NULL;
-    crm_node_t *by_name = NULL;
+    pcmk__node_status_t *node = NULL;
+    pcmk__node_status_t *by_id = NULL;
+    pcmk__node_status_t *by_name = NULL;
 
     if (uname) {
         g_hash_table_iter_init(&iter, cluster_node_cib_cache);
@@ -1421,7 +1426,7 @@ cluster_node_cib_cache_refresh_helper(xmlNode *xml_node, void *user_data)
 {
     const char *id = crm_element_value(xml_node, PCMK_XA_ID);
     const char *uname = crm_element_value(xml_node, PCMK_XA_UNAME);
-    crm_node_t * node =  NULL;
+    pcmk__node_status_t * node =  NULL;
 
     CRM_CHECK(id != NULL && uname !=NULL, return);
     node = find_cib_cluster_node(id, uname);
@@ -1429,7 +1434,7 @@ cluster_node_cib_cache_refresh_helper(xmlNode *xml_node, void *user_data)
     if (node == NULL) {
         char *uniqueid = crm_generate_uuid();
 
-        node = pcmk__assert_alloc(1, sizeof(crm_node_t));
+        node = pcmk__assert_alloc(1, sizeof(pcmk__node_status_t));
 
         node->uname = pcmk__str_copy(uname);
         node->uuid = pcmk__str_copy(id);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -14,12 +14,15 @@
 #endif
 
 #include <inttypes.h>                   // PRIu32
+#include <stdbool.h>                    // bool
+#include <stdio.h>
+#include <string.h>
 #include <sys/param.h>
 #include <sys/types.h>
-#include <stdio.h>
 #include <unistd.h>
-#include <string.h>
+
 #include <glib.h>
+
 #include <crm/common/ipc.h>
 #include <crm/common/xml_internal.h>
 #include <crm/cluster/internal.h>
@@ -65,8 +68,8 @@ GHashTable *crm_remote_peer_cache = NULL;
 static GHashTable *cluster_node_cib_cache = NULL;
 
 unsigned long long crm_peer_seq = 0;
-gboolean crm_have_quorum = FALSE;
 static bool autoreap = true;
+static bool has_quorum = false;
 
 // Flag setting and clearing for crm_node_t:flags
 
@@ -87,6 +90,30 @@ static bool autoreap = true;
 
 static void update_peer_uname(crm_node_t *node, const char *uname);
 static crm_node_t *find_cib_cluster_node(const char *id, const char *uname);
+
+/*!
+ * \internal
+ * \brief Check whether the cluster currently has quorum
+ *
+ * \return \c true if the cluster has quorum, or \c false otherwise
+ */
+bool
+pcmk__cluster_has_quorum(void)
+{
+    return has_quorum;
+}
+
+/*!
+ * \internal
+ * \brief Set whether the cluster currently has quorum
+ *
+ * \param[in] quorate  \c true if the cluster has quorum, or \c false otherwise
+ */
+void
+pcmk__cluster_set_quorum(bool quorate)
+{
+    has_quorum = quorate;
+}
 
 /*!
  * \internal

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -129,8 +129,8 @@ set_node_info_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
 
     /* Integer node_info.id is currently valid only for Corosync nodes.
      *
-     * @TODO: Improve handling after crm_node_t is refactored to handle layer-
-     * specific data better.
+     * @TODO: Improve handling after pcmk__node_status_t is refactored to handle
+     * layer-specific data better.
      */
     crm_element_value_int(msg_data, PCMK_XA_ID, &(data->data.node_info.id));
 


### PR DESCRIPTION
I thought I'd have a little bit more before opening this first PR, but this is where I wrapped up tonight. There's a lot more to be done for `crm_node_t`/`pcmk__cluster_member_t`, and I need to move `enum crm_join_phase` into the controller.

Still we can get started reviewing this and maybe merge it before moving on.

I'm open to using a different name instead of `pcmk__cluster_member_t`.
* I definitely want to avoid `pcmk__cluster_node_t` since this type is also used for remote nodes.
* I also want to move away from "peer" terminology. I find it non-obvious.
* Shorter options are `pcmk__member_node_t` (by 3 chars) and `pcmk__member_t` (by 8 chars). `pcmk__cluster_member_t` is clearer than both of those IMO, but brevity is nice too.