### PR TITLE
Low: tools: Don't skip formatting if running crm_simulate interactively.

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -8043,58 +8043,70 @@ export overcloud-rabbit-2=overcloud-rabbit-2
 =#=#=#= Begin test: Show utilization with crm_simulate =#=#=#=
 4 of 32 resource instances DISABLED and 0 BLOCKED from further action due to failure
 
-[ cluster01 cluster02 ]
-[ httpd-bundle-0 httpd-bundle-1 ]
+Current cluster status:
+  * Node List:
+    * Online: [ cluster01 cluster02 ]
+    * GuestOnline: [ httpd-bundle-0 httpd-bundle-1 ]
 
-Started: [ cluster01 cluster02 ]
-Fencing	(stonith:fence_xvm):	 Started cluster01
-dummy	(ocf:pacemaker:Dummy):	 Started cluster02
-Stopped (disabled): [ cluster01 cluster02 ]
-inactive-dummy-1	(ocf:pacemaker:Dummy):	 Stopped (disabled)
-inactive-dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled)
-httpd-bundle-0 (192.168.122.131)	(ocf:heartbeat:apache):	 Started cluster01
-httpd-bundle-1 (192.168.122.132)	(ocf:heartbeat:apache):	 Started cluster02
-httpd-bundle-2 (192.168.122.133)	(ocf:heartbeat:apache):	 Stopped
-Public-IP	(ocf:heartbeat:IPaddr):	 Started cluster02
-Email	(lsb:exim):	 Started cluster02
-Started: [ cluster01 cluster02 ]
-Promoted: [ cluster02 ]
-Unpromoted: [ cluster01 ]
+  * Full List of Resources:
+    * Clone Set: ping-clone [ping]:
+      * Started: [ cluster01 cluster02 ]
+    * Fencing	(stonith:fence_xvm):	 Started cluster01
+    * dummy	(ocf:pacemaker:Dummy):	 Started cluster02
+    * Clone Set: inactive-clone [inactive-dhcpd] (disabled):
+      * Stopped (disabled): [ cluster01 cluster02 ]
+    * Resource Group: inactive-group (disabled):
+      * inactive-dummy-1	(ocf:pacemaker:Dummy):	 Stopped (disabled)
+      * inactive-dummy-2	(ocf:pacemaker:Dummy):	 Stopped (disabled)
+    * Container bundle set: httpd-bundle [pcmk:http]:
+      * httpd-bundle-0 (192.168.122.131)	(ocf:heartbeat:apache):	 Started cluster01
+      * httpd-bundle-1 (192.168.122.132)	(ocf:heartbeat:apache):	 Started cluster02
+      * httpd-bundle-2 (192.168.122.133)	(ocf:heartbeat:apache):	 Stopped
+    * Resource Group: exim-group:
+      * Public-IP	(ocf:heartbeat:IPaddr):	 Started cluster02
+      * Email	(lsb:exim):	 Started cluster02
+    * Clone Set: mysql-clone-group [mysql-group]:
+      * Started: [ cluster01 cluster02 ]
+    * Clone Set: promotable-clone [promotable-rsc] (promotable):
+      * Promoted: [ cluster02 ]
+      * Unpromoted: [ cluster01 ]
 
+Utilization Information:
 Only 'private' parameters to 1m-interval monitor for dummy on cluster02 changed: 0:0;16:2:0:4a9e64d6-e1dd-4395-917c-1596312eafe4
-Original: cluster01 capacity:
-Original: cluster02 capacity:
-Original: httpd-bundle-0 capacity:
-Original: httpd-bundle-1 capacity:
-Original: httpd-bundle-2 capacity:
-pcmk__assign_resource: ping:0 utilization on cluster02:
-pcmk__assign_resource: ping:1 utilization on cluster01:
-pcmk__assign_resource: Fencing utilization on cluster01:
-pcmk__assign_resource: dummy utilization on cluster02:
-pcmk__assign_resource: httpd-bundle-docker-0 utilization on cluster01:
-pcmk__assign_resource: httpd-bundle-docker-1 utilization on cluster02:
-pcmk__assign_resource: httpd-bundle-ip-192.168.122.131 utilization on cluster01:
-pcmk__assign_resource: httpd-bundle-0 utilization on cluster01:
-pcmk__assign_resource: httpd:0 utilization on httpd-bundle-0:
-pcmk__assign_resource: httpd-bundle-ip-192.168.122.132 utilization on cluster02:
-pcmk__assign_resource: httpd-bundle-1 utilization on cluster02:
-pcmk__assign_resource: httpd:1 utilization on httpd-bundle-1:
-pcmk__assign_resource: httpd-bundle-2 utilization on cluster01:
-pcmk__assign_resource: httpd:2 utilization on httpd-bundle-2:
-pcmk__assign_resource: Public-IP utilization on cluster02:
-pcmk__assign_resource: Email utilization on cluster02:
-pcmk__assign_resource: mysql-proxy:0 utilization on cluster02:
-pcmk__assign_resource: mysql-proxy:1 utilization on cluster01:
-pcmk__assign_resource: promotable-rsc:0 utilization on cluster02:
-pcmk__assign_resource: promotable-rsc:1 utilization on cluster01:
-Remaining: cluster01 capacity:
-Remaining: cluster02 capacity:
-Remaining: httpd-bundle-0 capacity:
-Remaining: httpd-bundle-1 capacity:
-Remaining: httpd-bundle-2 capacity:
+  * Original: cluster01 capacity:
+  * Original: cluster02 capacity:
+  * Original: httpd-bundle-0 capacity:
+  * Original: httpd-bundle-1 capacity:
+  * Original: httpd-bundle-2 capacity:
+  * pcmk__assign_resource: ping:0 utilization on cluster02:
+  * pcmk__assign_resource: ping:1 utilization on cluster01:
+  * pcmk__assign_resource: Fencing utilization on cluster01:
+  * pcmk__assign_resource: dummy utilization on cluster02:
+  * pcmk__assign_resource: httpd-bundle-docker-0 utilization on cluster01:
+  * pcmk__assign_resource: httpd-bundle-docker-1 utilization on cluster02:
+  * pcmk__assign_resource: httpd-bundle-ip-192.168.122.131 utilization on cluster01:
+  * pcmk__assign_resource: httpd-bundle-0 utilization on cluster01:
+  * pcmk__assign_resource: httpd:0 utilization on httpd-bundle-0:
+  * pcmk__assign_resource: httpd-bundle-ip-192.168.122.132 utilization on cluster02:
+  * pcmk__assign_resource: httpd-bundle-1 utilization on cluster02:
+  * pcmk__assign_resource: httpd:1 utilization on httpd-bundle-1:
+  * pcmk__assign_resource: httpd-bundle-2 utilization on cluster01:
+  * pcmk__assign_resource: httpd:2 utilization on httpd-bundle-2:
+  * pcmk__assign_resource: Public-IP utilization on cluster02:
+  * pcmk__assign_resource: Email utilization on cluster02:
+  * pcmk__assign_resource: mysql-proxy:0 utilization on cluster02:
+  * pcmk__assign_resource: mysql-proxy:1 utilization on cluster01:
+  * pcmk__assign_resource: promotable-rsc:0 utilization on cluster02:
+  * pcmk__assign_resource: promotable-rsc:1 utilization on cluster01:
+  * Remaining: cluster01 capacity:
+  * Remaining: cluster02 capacity:
+  * Remaining: httpd-bundle-0 capacity:
+  * Remaining: httpd-bundle-1 capacity:
+  * Remaining: httpd-bundle-2 capacity:
 
-Start      httpd-bundle-2     (      cluster01 )  due to unrunnable httpd-bundle-docker-2 start (blocked)
-Start      httpd:2            ( httpd-bundle-2 )  due to unrunnable httpd-bundle-docker-2 start (blocked)
+Transition Summary:
+  * Start      httpd-bundle-2     (      cluster01 )  due to unrunnable httpd-bundle-docker-2 start (blocked)
+  * Start      httpd:2            ( httpd-bundle-2 )  due to unrunnable httpd-bundle-docker-2 start (blocked)
 =#=#=#= End test: Show utilization with crm_simulate - OK (0) =#=#=#=
 * Passed: crm_simulate   - Show utilization with crm_simulate
 =#=#=#= Begin test: Simulate injecting a failure =#=#=#=

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -492,9 +492,7 @@ main(int argc, char **argv)
     }
 
     if (pcmk__str_eq(args->output_ty, "text", pcmk__str_null_matches) &&
-        !pcmk_is_set(options.flags, pcmk_sim_show_scores) &&
-        !pcmk_is_set(options.flags, pcmk_sim_show_utilization)) {
-
+        !(pcmk_is_set(options.flags, pcmk_sim_show_scores) && args->quiet)) {
         pcmk__output_text_set_fancy(out, true);
     }
 


### PR DESCRIPTION
Somewhere along the line, we changed the interactive behavior of crm_simulate to not enable fancy text formatting.  This is necessary for non-interactive use (like when running cts-scheduler), but for interactive use, it is hard to read.

Change the conditional on when fancy text is enabled to be always, as long as we are not showing scores in quiet mode.  This seems to be the combination that differentiates interactive use from regression test use.

Fixes T833