### PR TITLE
Med: libcrmcommon: Disable FIPS mode when running md5sum check.

### DIFF
--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -241,7 +241,9 @@ crm_md5sum(const char *buffer)
 
     raw_digest = pcmk__assert_alloc(dlen, sizeof(unsigned char));
 
+    GNUTLS_FIPS140_SET_LAX_MODE();
     rc = gnutls_hash_fast(GNUTLS_DIG_MD5, buffer, strlen(buffer), raw_digest);
+    GNUTLS_FIPS140_SET_STRICT_MODE();
 
     if (rc < 0) {
         free(raw_digest);


### PR DESCRIPTION
MD5 is not a supported algorithm when FIPS is enabled.  Luckily, we are not using it for any security purposes - only for calculating hashes of XML blobs.  In order to use the MD5 algorithm, we have to temporarily disable and then re-enable the FIPS check in gnutls which provides macros for this purpose.

We were previously not seeing this problem because we were using gnulib, which is not FIPS aware.  The switch to gnutls causes the problem.

Tested by running "make check" on a system that was installed with the fips=1 kernel command line parameter, which resulted in a segfault.  The addition of this patch causes the check to succeed.