### PR TITLE
Med: Build: Update gnutls build requirements.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,6 +24,9 @@ Also:
 * make must be GNU (or compatible) (setting MAKE=gmake might also work but is
   untested)
 * GNU (or compatible) getopt must be somewhere on the PATH
+* If built with gnutls >= 3.3.0 and <= 3.6.1, Pacemaker will not be usable in
+  FIPS mode.  Before 3.3.0, gnutls did not support FIPS and after 3.6.1, gnutls
+  includes a function to temporarily disable FIPS.
 
 ### Cluster Stack Dependencies
 

--- a/configure.ac
+++ b/configure.ac
@@ -1647,6 +1647,8 @@ PKG_CHECK_MODULES(GNUTLS, [gnutls >= 2.12.0],
                   [CPPFLAGS="${CPPFLAGS} ${GNUTLS_CFLAGS}"
                    LIBS="${LIBS} ${GNUTLS_LIBS}"])
 
+AC_CHECK_FUNCS([gnutls_fips140_set_mode])
+
 # --- ASAN/UBSAN/TSAN (see man gcc) ---
 # when using SANitizers, we need to pass the -fsanitize..
 # to both CFLAGS and LDFLAGS. The CFLAGS/LDFLAGS must be

--- a/include/portability.h
+++ b/include/portability.h
@@ -71,4 +71,32 @@
 #    define EKEYREJECTED 200
 #  endif
 
+// Replacements for libgnutls FIPS macros
+
+#  include <gnutls/gnutls.h>
+
+#  ifndef GNUTLS_FIPS140_SET_LAX_MODE
+#    ifdef HAVE_GNUTLS_FIPS140_SET_MODE
+#      define GNUTLS_FIPS140_SET_LAX_MODE() \
+        do { \
+            if (gnutls_fips140_mode_enabled()) \
+                gnutls_fips140_set_mode(GNUTLS_FIPS140_LAX, GNUTLS_FIPS140_SET_MODE_THREAD); \
+        } while(0)
+#    else
+#      define GNUTLS_FIPS140_SET_LAX_MODE()
+#    endif
+#  endif
+
+#  ifndef GNUTLS_FIPS140_SET_STRICT_MODE
+#    ifdef HAVE_GNUTLS_FIPS140_SET_MODE
+#      define GNUTLS_FIPS140_SET_STRICT_MODE() \
+        do { \
+            if (gnutls_fips140_mode_enabled()) \
+                gnutls_fips140_set_mode(GNUTLS_FIPS140_STRICT, GNUTLS_FIPS140_SET_MODE_THREAD); \
+        } while(0)
+#    else
+#      define GNUTLS_FIPS140_SET_STRICT_MODE()
+#    endif
+#  endif
+
 #endif // PCMK__PORTABILITY__H


### PR DESCRIPTION
The macros needed to enable/disable FIPS mode were not introduced until 3.6.2.  Pacemaker supports building on systems as late as Ubuntu 18, which has 3.5.18.

So, make 3.5.18 the required version and add a note that we really do prefer 3.6.2.  Then, add a configure test and compability macros to handle the gap between the minimum required version and the preferred version.

This means that anyone with gnutls >= 3.5.18 and < 3.6.2 cannot run Pacemaker in FIPS mode.  In practice, this should not be a problem because it only affects the following people:

* Ubuntu 18 users - The commits that switched us to using gnutls were only on the main (Pacemaker 3) branch, and we do not expect that Ubuntu will backport Pacemaker 3 to that release.

* People building from source - No one that cares about FIPS mode will be building from source.