### PR TITLE
[2.1] Fix: tools: crm_verify distinguishes configuration warnings and errors

### DIFF
--- a/cts/cli/regression.tools.exp
+++ b/cts/cli/regression.tools.exp
@@ -10274,9 +10274,9 @@ Errors found during check: config not valid
 * Passed: crm_verify     - Verify a file-specified invalid configuration (text output)
 =#=#=#= Begin test: Verify a file-specified invalid configuration (verbose text output) =#=#=#=
 unpack_config 	warning: Blind faith: not fencing unseen nodes
-Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource
-Ignoring <clone> resource 'test2-clone' because configuration is invalid
-CIB did not pass schema validation
+error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource
+error: Ignoring <clone> resource 'test2-clone' because configuration is invalid
+error: CIB did not pass schema validation
 Errors found during check: config not valid
 =#=#=#= End test: Verify a file-specified invalid configuration (verbose text output) - Invalid configuration (78) =#=#=#=
 * Passed: crm_verify     - Verify a file-specified invalid configuration (verbose text output)
@@ -10287,9 +10287,9 @@ Errors found during check: config not valid
 <pacemaker-result api-version="X" request="crm_verify_invalid_bz.xml --output-as=xml">
   <status code="78" message="Invalid configuration">
     <errors>
-      <error>Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
-      <error>Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
-      <error>CIB did not pass schema validation</error>
+      <error>error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
+      <error>error: Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
+      <error>error: CIB did not pass schema validation</error>
       <error>Errors found during check: config not valid</error>
     </errors>
   </status>
@@ -10301,9 +10301,9 @@ unpack_config 	warning: Blind faith: not fencing unseen nodes
 <pacemaker-result api-version="X" request="crm_verify_invalid_bz.xml --output-as=xml --verbose">
   <status code="78" message="Invalid configuration">
     <errors>
-      <error>Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
-      <error>Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
-      <error>CIB did not pass schema validation</error>
+      <error>error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
+      <error>error: Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
+      <error>error: CIB did not pass schema validation</error>
       <error>Errors found during check: config not valid</error>
     </errors>
   </status>
@@ -10314,9 +10314,9 @@ unpack_config 	warning: Blind faith: not fencing unseen nodes
 <pacemaker-result api-version="X" request="crm_verify_invalid_bz.xml --output-as=xml --quiet">
   <status code="78" message="Invalid configuration">
     <errors>
-      <error>Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
-      <error>Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
-      <error>CIB did not pass schema validation</error>
+      <error>error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
+      <error>error: Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
+      <error>error: CIB did not pass schema validation</error>
     </errors>
   </status>
 </pacemaker-result>
@@ -10326,12 +10326,12 @@ unpack_config 	warning: Blind faith: not fencing unseen nodes
 <pacemaker-result api-version="X" request="crm_verify_invalid_no_stonith.xml --output-as=xml">
   <status code="78" message="Invalid configuration">
     <errors>
-      <error>Resource start-up disabled since no STONITH resources have been defined</error>
-      <error>Either configure some or disable STONITH with the stonith-enabled option</error>
-      <error>NOTE: Clusters with shared data need STONITH to ensure data integrity</error>
-      <error>Node pcmk-1 is unclean but cannot be fenced</error>
-      <error>Node pcmk-2 is unclean but cannot be fenced</error>
-      <error>CIB did not pass schema validation</error>
+      <error>error: Resource start-up disabled since no STONITH resources have been defined</error>
+      <error>error: Either configure some or disable STONITH with the stonith-enabled option</error>
+      <error>error: NOTE: Clusters with shared data need STONITH to ensure data integrity</error>
+      <error>warning: Node pcmk-1 is unclean but cannot be fenced</error>
+      <error>warning: Node pcmk-2 is unclean but cannot be fenced</error>
+      <error>error: CIB did not pass schema validation</error>
       <error>Errors found during check: config not valid</error>
     </errors>
   </status>

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -114,7 +114,7 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
 
 /*!
  * \internal
- * \brief Output a configuration issue
+ * \brief Output a configuration error
  *
  * \param[in] ctx  Output object
  * \param[in] msg  printf(3)-style format string
@@ -122,7 +122,7 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
  */
 G_GNUC_PRINTF(2, 3)
 static void
-output_config_issue(void *ctx, const char *msg, ...)
+output_config_error(void *ctx, const char *msg, ...)
 {
     va_list ap;
     char *buf = NULL;
@@ -131,7 +131,31 @@ output_config_issue(void *ctx, const char *msg, ...)
     va_start(ap, msg);
     CRM_ASSERT(vasprintf(&buf, msg, ap) > 0);
     if (options.verbosity > 0) {
-        out->err(out, "%s", buf);
+        out->err(out, "error: %s", buf);
+    }
+    va_end(ap);
+}
+
+/*!
+ * \internal
+ * \brief Output a configuration warning
+ *
+ * \param[in] ctx  Output object
+ * \param[in] msg  printf(3)-style format string
+ * \param[in] ...  Format string arguments
+ */
+G_GNUC_PRINTF(2, 3)
+static void
+output_config_warning(void *ctx, const char *msg, ...)
+{
+    va_list ap;
+    char *buf = NULL;
+    pcmk__output_t *out = ctx;
+
+    va_start(ap, msg);
+    CRM_ASSERT(vasprintf(&buf, msg, ap) > 0);
+    if (options.verbosity > 0) {
+        out->err(out, "warning: %s", buf);
     }
     va_end(ap);
 }
@@ -187,8 +211,8 @@ main(int argc, char **argv)
 
     pcmk__register_lib_messages(out);
 
-    pcmk__set_config_error_handler(output_config_issue, out);
-    pcmk__set_config_warning_handler(output_config_issue, out);
+    pcmk__set_config_error_handler(output_config_error, out);
+    pcmk__set_config_warning_handler(output_config_warning, out);
 
     if (pcmk__str_eq(args->output_ty, "xml", pcmk__str_none)) {
         args->verbosity = 1;


### PR DESCRIPTION
Backport https://github.com/ClusterLabs/pacemaker/pull/3538 to 2.1

The output of crm_verify no longer distinguished configuration warnings from errors as brought up from:
https://github.com/ClusterLabs/pacemaker/pull/3266#discussion_r1636411072

Regression introduced in 2.1.7 by 0c5a32624a

This commit fixes it by splitting output_config_issue() into separate error and warning handlers, and add the "warning:" or "error:" prefix to the message.

Fixes T834