### PR TITLE
Feature: API: Add pcmk_api_init.

### DIFF
--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -79,6 +79,17 @@ typedef struct {
 } pcmk_injections_t;
 
 /*!
+ * \brief Initialize the Pacemaker API
+ *
+ * This function should be called before any of the other functions in this
+ * public API.  It calls internal functions that set up the data structures
+ * needed for the public API to function properly.
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk_api_init(void);
+
+/*!
  * \brief Get and output controller status
  *
  * \param[in,out] xml                 Destination for the result, as an XML tree

--- a/lib/pacemaker/pcmk_setup.c
+++ b/lib/pacemaker/pcmk_setup.c
@@ -76,3 +76,11 @@ pcmk__setup_output_cib_sched(pcmk__output_t **out, cib_t **cib,
     pcmk__register_lib_messages(*out);
     return rc;
 }
+
+// Documented in pacemaker.h
+int
+pcmk_api_init(void)
+{
+    pcmk__xml_init();
+    return pcmk_rc_ok;
+}


### PR DESCRIPTION
This function should be called by any external users of the libpacemaker API before making any other calls.  For the moment, all it does is set up libxml the way pacemaker expects, but more stuff could be added to it if necessary.

Converting booth to use libpacemaker brought this problem up - if crm_xml_init is not called prior to using libxml, libpacemaker will crash.  However, crm_xml_init is deprecated and the replacement (pcmk__xml_init) is a private function.