### PR TITLE
Fix: tools: Don't double-free XML in crm_verify after schema update

### DIFF
--- a/include/pcmki/pcmki_verify.h
+++ b/include/pcmki/pcmki_verify.h
@@ -44,11 +44,12 @@ int pcmk__parse_cib(pcmk__output_t *out, const char *cib_source, xmlNodePtr *cib
  *
  * \param[in,out] scheduler    Scheduler data
  * \param[in]     out          Output to use for logging and printing results
- * \param[in]     cib_object   The parsed CIB object
+ * \param[in,out] cib_object   The parsed CIB object
  *
  * \return Standard Pacemaker return code
  */
-int pcmk__verify(pcmk_scheduler_t *scheduler, pcmk__output_t *out, xmlNode *cib_object);
+int pcmk__verify(pcmk_scheduler_t *scheduler, pcmk__output_t *out,
+                 xmlNode **cib_object);
 
 #ifdef __cplusplus
 }

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -255,7 +255,7 @@ main(int argc, char **argv)
 
     scheduler->priv->out = out;
 
-    rc = pcmk__verify(scheduler, out, cib_object);
+    rc = pcmk__verify(scheduler, out, &cib_object);
 
     if (rc == pcmk_rc_schema_validation) {
         if (crm_config_error) {


### PR DESCRIPTION
Currently, if an updated schema is acceptable, the old CIB XML is freed by pcmk_update_configured_schema() and then again by crm_verify.c:main(). Here we fix this by passing a pointer-to-pointer into pcmk__verify(), so that crm_verify gets a pointer to the new XML object instead of to the freed one.

This fixes a regression introduced by a744f1a8.