### PR TITLE
Fix: tools: CIB clients retry signon upon an EAGAIN error

### DIFF
--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -292,6 +292,9 @@ cib_callback_client_t* cib__lookup_id (int call_id);
  */
 int cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object);
 
+int cib__signon_attempts(cib_t *cib, const char *name, enum cib_conn_type type,
+                         int attempts);
+
 int cib__clean_up_connection(cib_t **cib);
 
 int cib__update_node_attr(pcmk__output_t *out, cib_t *cib, int call_options,

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -957,6 +957,33 @@ done:
 }
 
 int
+cib__signon_attempts(cib_t *cib, const char *name, enum cib_conn_type type,
+                     int attempts)
+{
+    int rc = pcmk_rc_ok;
+
+    crm_trace("Attempting connection to CIB manager (up to %d time%s)",
+              attempts, pcmk__plural_s(attempts));
+
+    for (int remaining = attempts - 1; remaining >= 0; --remaining) {
+        rc = cib->cmds->signon(cib, name, type);
+
+        if ((rc == pcmk_rc_ok)
+            || (remaining == 0)
+            || ((errno != EAGAIN) && (errno != EALREADY))) {
+            break;
+        }
+
+        // Retry after soft error (interrupted by signal, etc.)
+        pcmk__sleep_ms((attempts - remaining) * 500);
+        crm_debug("Re-attempting connection to CIB manager (%d attempt%s remaining)",
+                  remaining, pcmk__plural_s(remaining));
+    }
+
+    return rc;
+}
+
+int
 cib__clean_up_connection(cib_t **cib)
 {
     int rc;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -924,7 +924,7 @@ do_init(void)
     int rc = pcmk_ok;
 
     the_cib = cib_new();
-    rc = the_cib->cmds->signon(the_cib, crm_system_name, cib_command);
+    rc = cib__signon_attempts(the_cib, crm_system_name, cib_command, 5);
     if (rc != pcmk_ok) {
         crm_err("Could not connect to the CIB: %s", pcmk_strerror(rc));
         fprintf(stderr, "Could not connect to the CIB: %s\n",

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -818,7 +818,7 @@ main(int argc, char **argv)
     }
 
     the_cib = cib_new();
-    rc = the_cib->cmds->signon(the_cib, crm_system_name, cib_command);
+    rc = cib__signon_attempts(the_cib, crm_system_name, cib_command, 5);
     rc = pcmk_legacy2rc(rc);
 
     if (rc != pcmk_rc_ok) {

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -579,7 +579,7 @@ purge_node_from_cib(const char *node_name, long node_id)
     if (cib == NULL) {
         return ENOTCONN;
     }
-    rc = cib->cmds->signon(cib, crm_system_name, cib_command);
+    rc = cib__signon_attempts(cib, crm_system_name, cib_command, 5);
     if (rc == pcmk_ok) {
         rc = cib->cmds->init_transaction(cib);
     }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1701,7 +1701,7 @@ main(int argc, char **argv)
                         _("Could not create CIB connection"));
             goto done;
         }
-        rc = cib_conn->cmds->signon(cib_conn, crm_system_name, cib_command);
+        rc = cib__signon_attempts(cib_conn, crm_system_name, cib_command, 5);
         rc = pcmk_legacy2rc(rc);
         if (rc != pcmk_rc_ok) {
             exit_code = pcmk_rc2exitc(rc);

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -455,7 +455,7 @@ connect_real_cib(cib_t **real_cib, GError **error)
         return rc;
     }
 
-    rc = (*real_cib)->cmds->signon(*real_cib, crm_system_name, cib_command);
+    rc = cib__signon_attempts(*real_cib, crm_system_name, cib_command, 5);
     rc = pcmk_legacy2rc(rc);
     if (rc != pcmk_rc_ok) {
         exit_code = pcmk_rc2exitc(rc);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -405,7 +405,7 @@ main(int argc, char **argv)
         goto done;
     }
 
-    rc = cib_conn->cmds->signon(cib_conn, crm_system_name, cib_command);
+    rc = cib__signon_attempts(cib_conn, crm_system_name, cib_command, 5);
     rc = pcmk_legacy2rc(rc);
 
     if (rc != pcmk_rc_ok) {


### PR DESCRIPTION
... up to 5 times.

Previously CIB clients wouldn't retry signon upon an EAGAIN and directly return a connection error, which made them not resilient enough.

A new function cib__signon_attempts() is added for the purpose. It's similar to how it's done in pcmk__connect_ipc().

Apparently there's a plan on converting CIB manager to use pcmk_ipc_api_t as client interface
https://projects.clusterlabs.org/T143

But I think it still makes sense to make the current code base deal with such a situation.

Let's take a look if it makes sense. I'll ask the user to try it out as well.