### PR TITLE
Prepare for 2.1.8-rc3 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,21 @@
+* Tue Jun 11 2024 Ken Gaillot <kgaillot@redhat.com> Pacemaker-2.1.8-rc2
+- 38 commits with 23 files changed, 600 insertions(+), 283 deletions(-)
+
+- Features added since Pacemaker-2.1.8-rc1
+  + libcrmcommon: support PCMK_panic_action="off" or "sync-off"
+
+- Fixes since Pacemaker-2.1.8-rc1
+  + libcrmcommon: avoid possible buffer overflows when parsing date/times
+  + libpacemaker: correctly retrieve any existing fail-count for increment
+                  (regression introduced in 2.1.8-rc1)
+  + libstonithd: avoid double free when invalid replies are received
+  + libstonithd: avoid use-after-free when retrieving metadata of Linux-HA fence agents
+                 (regression introduced in 2.1.8-rc1)
+  + libstonithd: free escaped metadata descriptions with g_free()
+                 (regression introduced in 2.1.8-rc1)
+  + tools: restore whitespace to attrd_updater query output
+           (regression introduced in 2.1.8-rc1)
+
 * Wed May 15 2024 Ken Gaillot <kgaillot@redhat.com> Pacemaker-2.1.8-rc1
 - 2480 commits with 507 files changed, 45891 insertions(+), 22991 deletions(-)
 

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -258,7 +258,7 @@
 # Default: PCMK_tls_priorities="@PCMK_GNUTLS_PRIORITIES@"
 # Example: PCMK_tls_priorities="SECURE128:+SECURE192:-VERS-ALL:+VERS-TLS1.2"
 
-# PCMK_dh_min_bits (Advanced Use Only)
+# PCMK_dh_min_bits (DEPRECATED; Advanced Use Only)
 #
 # Set a lower bound on the bit length of the prime number generated for
 # Diffie-Hellman parameters needed by TLS connections. The default is no
@@ -276,6 +276,8 @@
 # the value must be lowered in order for the client's GnuTLS library to accept
 # a connection to an older server.
 # 
+# This variable is deprecated and will be ignored by Pacemaker 3.0.0 and later.
+#
 # Default: PCMK_dh_min_bits="0" (no minimum)
 
 # PCMK_dh_max_bits (Advanced Use Only)

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -153,6 +153,10 @@ gchar *pcmk__quote_cmdline(gchar **argv);
  * \param[in] argv    The command line arguments.
  * \param[in] special Single-letter command line arguments that take a value.
  *                    These letters will all have pre-processing applied.
+ *
+ * \note @COMPAT We should drop this at a new major or minor release series
+ *       after we no longer support building with Booth <1.2, which invokes
+ *       Pacemaker CLI tools using the getopt syntax.
  */
 gchar **
 pcmk__cmdline_preproc(char *const *argv, const char *special);

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -179,6 +179,9 @@ set_minimum_dh_bits(const gnutls_session_t *session)
     if (dh_min_bits > 0) {
         crm_info("Requiring server use a Diffie-Hellman prime of at least %d bits",
                  dh_min_bits);
+        crm_warn("Support for the " PCMK__ENV_DH_MIN_BITS " "
+                 "environment variable is deprecated and will be removed "
+                 "in a future release");
         gnutls_dh_set_prime_bits(*session, dh_min_bits);
     }
 }


### PR DESCRIPTION
The ChangeLog update for rc2 was accidentally applied to the 2.1 branch first, so forward-port it here. Also address a couple of compatibility issues ahead of the 3.0.0 release.