### PR TITLE
Drop deprecated crm_mon options

### DIFF
--- a/include/pcmki/pcmki_status.h
+++ b/include/pcmki/pcmki_status.h
@@ -22,39 +22,19 @@
 extern "C" {
 #endif
 
-/*!
- * \internal
- * \brief Print one-line status suitable for use with monitoring software
- *
- * \param[in,out] out        Output object
- * \param[in]     scheduler  Scheduler data
- *
- * \return Standard Pacemaker return code
- *
- * \note This function's output should conform to
- *       https://www.monitoring-plugins.org/doc/guidelines.html
- *
- * \note This function is planned to be deprecated and then removed in the
- *       future.  It should only be called from crm_mon, and no additional
- *       callers should be added.
- */
-int pcmk__output_simple_status(pcmk__output_t *out,
-                               const pcmk_scheduler_t *scheduler);
-
 int pcmk__output_cluster_status(pcmk__output_t *out, stonith_t *stonith,
                                 cib_t *cib, xmlNode *current_cib,
                                 enum pcmk_pacemakerd_state pcmkd_state,
                                 enum pcmk__fence_history fence_history,
                                 uint32_t show, uint32_t show_opts,
                                 const char *only_node, const char *only_rsc,
-                                const char *neg_location_prefix,
-                                bool simple_output);
+                                const char *neg_location_prefix);
 
 int pcmk__status(pcmk__output_t *out, cib_t *cib,
                  enum pcmk__fence_history fence_history, uint32_t show,
                  uint32_t show_opts, const char *only_node,
                  const char *only_rsc, const char *neg_location_prefix,
-                 bool simple_output, unsigned int timeout_ms);
+                 unsigned int timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -436,15 +436,6 @@ as_cgi_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 }
 
 static gboolean
-as_html_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    pcmk__str_update(&args->output_dest, optarg);
-    pcmk__str_update(&args->output_ty, "html");
-    output_format = mon_output_html;
-    umask(S_IWGRP | S_IWOTH);   // World-readable HTML
-    return TRUE;
-}
-
-static gboolean
 as_simple_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     pcmk__str_update(&args->output_ty, "text");
     output_format = mon_output_monitor;
@@ -763,11 +754,6 @@ static GOptionEntry display_entries[] = {
 };
 
 static GOptionEntry deprecated_entries[] = {
-    { "as-html", 'h', G_OPTION_FLAG_FILENAME, G_OPTION_ARG_CALLBACK, as_html_cb,
-      "Write cluster status to the named HTML file.\n"
-      INDENT "Use --output-as=html --output-to=FILE instead.",
-      "FILE" },
-
     { "as-xml", 'X', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, as_xml_cb,
       "Write cluster status as XML to stdout. This will enable one-shot mode.\n"
       INDENT "Use --output-as=xml instead.",
@@ -1346,13 +1332,13 @@ add_output_args(void) {
 
 /*!
  * \internal
- * \brief Set output format based on \p --output-as arguments and mode arguments
+ * \brief Set output format based on \c --output-as arguments and mode arguments
  *
- * When the deprecated output format arguments (\p --as-cgi, \p --as-html,
- * \p --simple-status, \p --as-xml) are parsed, callback functions set
- * \p output_format (and the umask if appropriate). If none of the deprecated
- * arguments were specified, this function does the same based on the current
- * \p --output-as arguments and the \p --one-shot and \p --daemonize arguments.
+ * When the deprecated output format arguments (\c --as-cgi, \c --simple-status,
+ * \c --as-xml) are parsed, callback functions set \c output_format (and the
+ * umask if appropriate). If none of the deprecated arguments were specified,
+ * this function does the same based on the current \c --output-as arguments and
+ * the \c --one-shot and \c --daemonize arguments.
  *
  * \param[in,out] args  Command line arguments
  */
@@ -1508,7 +1494,7 @@ main(int argc, char **argv)
         options.exec_mode = mon_exec_one_shot;
     }
 
-    processed_args = pcmk__cmdline_preproc(argv, "ehimpxEILU");
+    processed_args = pcmk__cmdline_preproc(argv, "eimpxEILU");
 
     fence_history_cb("--fence-history", "1", NULL, NULL);
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -489,13 +489,6 @@ inactive_resources_cb(const gchar *option_name, const gchar *optarg, gpointer da
 }
 
 static gboolean
-no_curses_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
-    pcmk__str_update(&args->output_ty, "text");
-    output_format = mon_output_plain;
-    return TRUE;
-}
-
-static gboolean
 print_brief_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
     show_opts |= pcmk_show_brief;
     return TRUE;
@@ -740,11 +733,6 @@ static GOptionEntry deprecated_entries[] = {
     { "as-xml", 'X', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, as_xml_cb,
       "Write cluster status as XML to stdout. This will enable one-shot mode.\n"
       INDENT "Use --output-as=xml instead.",
-      NULL },
-
-    { "disable-ncurses", 'N', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, no_curses_cb,
-      "Disable the use of ncurses.\n"
-      INDENT "Use --output-as=text instead.",
       NULL },
 
     { "web-cgi", 'w', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, as_cgi_cb,

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the Pacemaker project contributors
+ * Copyright 2019-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -46,7 +46,6 @@
 typedef enum mon_output_format_e {
     mon_output_unset,
     mon_output_none,
-    mon_output_monitor,
     mon_output_plain,
     mon_output_console,
     mon_output_xml,

--- a/tools/crm_mon.h
+++ b/tools/crm_mon.h
@@ -51,7 +51,6 @@ typedef enum mon_output_format_e {
     mon_output_xml,
     mon_output_legacy_xml,
     mon_output_html,
-    mon_output_cgi
 } mon_output_format_t;
 
 enum mon_exec_mode {


### PR DESCRIPTION
I stumbled across this task while dropping support for Nagios resources (the `--simple-status` machinery is for Nagios, but unrelated to resources).

Closes T707