### PR TITLE
Test: test-headers.sh: Modify the C++ check again.

### DIFF
--- a/tests/test-headers.sh
+++ b/tests/test-headers.sh
@@ -41,7 +41,7 @@ EOF
         rm -f "$TESTFILE"
         exit 1
     fi
-    if [ -n "$CXX" ]
+    if [ -n "$CXX" ] && [ command -v "$CXX" >/dev/null 2>&1 ]
     then
         ${CXX} ${CXXFLAGS} ${CPPFLAGS} ${LIBS} \
             -I "${SRCDIR}/include" -I"${SRCDIR}/lib" "$TESTFILE" -o /dev/null


### PR DESCRIPTION
When building under mock, CXX is always set even though the program is not present in the build root because we do not BuildRequires it.  So, we additionally need to check that the program exists.