### PR TITLE
Low: CTS: Fix argument handling for certain scheduler tests.

### DIFF
--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1666,6 +1666,17 @@ class CtsScheduler(object):
                 shutil.rmtree(self.failed_dir)
         return ExitStatus.ERROR
 
+    def find_test(self, name):
+        if platform.architecture()[0] == "64bit":
+            TESTS.extend(TESTS_64BIT)
+
+        for group in TESTS:
+            for test in group.tests:
+                if test.name == name:
+                    return test
+
+        return None
+
     def run(self):
         """ Run test(s) as specified """
 
@@ -1687,7 +1698,21 @@ class CtsScheduler(object):
             self.failed_file.close()
             rc = self._test_results()
         else:
-            rc = self.run_one(self.args.run, "Single shot", self.single_test_args)
+            # Find the test we were asked to run
+            test = self.find_test(self.args.run)
+
+            if test is None:
+                print("No test named %s" % self.args.run)
+                return ExitStatus.INVALID_PARAM
+
+            # If no arguments were given on the command line, default to the ones
+            # contained in the test
+            if self.single_test_args:
+                args = self.single_test_args
+            else:
+                args = test.args
+
+            rc = self.run_one(test.name, test.desc, args)
             self.failed_file.close()
             if self.num_failed > 0:
               print("\nFailures:\nThese have also been written to: " + self.failed_filename + "\n")


### PR DESCRIPTION
A couple date-related scheduler regression tests accept arguments. When running all the tests in one go, the regression test grabs the arguments out of the SchedulerTest object automatically.

If you run these tests individually (using --run), it is expected that you will provide the command line arguments yourself.  If you don't, the tests will fail.  Instead, it should default to grabbing the arguments out of the SchedulerTest object if you don't provide any on the command line.

Fixes T835