### PR TITLE
Organize server-related names

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -114,7 +114,7 @@ attrd_cib_connect(int max_retry)
         }
         attempts++;
         crm_debug("Connection attempt %d to the CIB manager", attempts);
-        rc = the_cib->cmds->signon(the_cib, PCMK__VALUE_ATTRD, cib_command);
+        rc = the_cib->cmds->signon(the_cib, crm_system_name, cib_command);
 
     } while ((rc != pcmk_ok) && (attempts < max_retry));
 

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -342,5 +342,5 @@ attrd_send_message(pcmk__node_status_t *node, xmlNode *data, bool confirm)
     }
 
     attrd_xml_add_writer(data);
-    return pcmk__cluster_send_message(node, pcmk__cluster_msg_attrd, data);
+    return pcmk__cluster_send_message(node, pcmk_ipc_attrd, data);
 }

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -331,7 +331,7 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
             cib_client->name = pcmk__itoa(cib_client->pid);
         } else {
             cib_client->name = pcmk__str_copy(value);
-            if (crm_is_daemon_name(value)) {
+            if (pcmk__parse_server(value) != pcmk_ipc_unknown) {
                 pcmk__set_client_flags(cib_client, cib_is_daemon);
             }
         }

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -383,7 +383,7 @@ cib_digester_cb(gpointer data)
         crm_xml_add(ping, PCMK__XA_CIB_PING_ID, buffer);
 
         crm_xml_add(ping, PCMK_XA_CRM_FEATURE_SET, CRM_FEATURE_SET);
-        pcmk__cluster_send_message(NULL, pcmk__cluster_msg_based, ping);
+        pcmk__cluster_send_message(NULL, pcmk_ipc_based, ping);
 
         pcmk__xml_free(ping);
     }
@@ -708,7 +708,7 @@ forward_request(xmlNode *request)
     if (host != NULL) {
         peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster_member);
     }
-    pcmk__cluster_send_message(peer, pcmk__cluster_msg_based, request);
+    pcmk__cluster_send_message(peer, pcmk_ipc_based, request);
 
     // Return the request to its original state
     pcmk__xe_remove_attr(request, PCMK__XA_CIB_DELEGATED_FROM);
@@ -729,7 +729,7 @@ send_peer_reply(xmlNode *msg, const char *originator)
 
     crm_trace("Sending request result to %s only", originator);
     crm_xml_add(msg, PCMK__XA_CIB_ISREPLYTO, originator);
-    pcmk__cluster_send_message(node, pcmk__cluster_msg_based, msg);
+    pcmk__cluster_send_message(node, pcmk_ipc_based, msg);
 }
 
 /*!
@@ -1252,7 +1252,7 @@ initiate_exit(void)
     crm_xml_add(leaving, PCMK__XA_T, PCMK__VALUE_CIB);
     crm_xml_add(leaving, PCMK__XA_CIB_OP, PCMK__CIB_REQUEST_SHUTDOWN);
 
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_based, leaving);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_based, leaving);
     pcmk__xml_free(leaving);
 
     g_timeout_add(EXIT_ESCALATION_MS, cib_force_exit, NULL);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -129,7 +129,7 @@ send_sync_request(const char *host)
     if (host != NULL) {
         peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster_member);
     }
-    pcmk__cluster_send_message(peer, pcmk__cluster_msg_based, sync_me);
+    pcmk__cluster_send_message(peer, pcmk_ipc_based, sync_me);
     pcmk__xml_free(sync_me);
 }
 
@@ -235,7 +235,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
             crm_xml_add(up, PCMK__XA_CIB_CALLOPT, call_opts);
             crm_xml_add(up, PCMK__XA_CIB_CALLID, call_id);
 
-            pcmk__cluster_send_message(NULL, pcmk__cluster_msg_based, up);
+            pcmk__cluster_send_message(NULL, pcmk_ipc_based, up);
 
             pcmk__xml_free(up);
 
@@ -265,8 +265,7 @@ cib_process_upgrade_server(const char *op, int options, const char *section, xml
                 crm_xml_add(up, PCMK__XA_CIB_CALLOPT, call_opts);
                 crm_xml_add(up, PCMK__XA_CIB_CALLID, call_id);
                 crm_xml_add_int(up, PCMK__XA_CIB_UPGRADE_RC, rc);
-                if (!pcmk__cluster_send_message(origin, pcmk__cluster_msg_based,
-                                                up)) {
+                if (!pcmk__cluster_send_message(origin, pcmk_ipc_based, up)) {
                     crm_warn("Could not send CIB upgrade result to %s", host);
                 }
                 pcmk__xml_free(up);
@@ -439,8 +438,7 @@ sync_our_cib(xmlNode * request, gboolean all)
     if (!all) {
         peer = pcmk__get_node(0, host, NULL, pcmk__node_search_cluster_member);
     }
-    if (!pcmk__cluster_send_message(peer, pcmk__cluster_msg_based,
-                                    replace_request)) {
+    if (!pcmk__cluster_send_message(peer, pcmk_ipc_based, replace_request)) {
         result = -ENOTCONN;
     }
     pcmk__xml_free(replace_request);

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -138,7 +138,7 @@ peer_update_callback(enum pcmk__node_update type, pcmk__node_status_t *node,
         crm_debug("Sending hello to node %" PRIu32 " so that it learns our "
                   "node name",
                   node->cluster_layer_id);
-        pcmk__cluster_send_message(node, pcmk__cluster_msg_controld, query);
+        pcmk__cluster_send_message(node, pcmk_ipc_controld, query);
 
         pcmk__xml_free(query);
     }

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -155,13 +155,13 @@ do_cib_control(long long action,
         return;
     }
 
-    rc = cib_conn->cmds->signon(cib_conn, CRM_SYSTEM_CRMD,
+    rc = cib_conn->cmds->signon(cib_conn, crm_system_name,
                                 cib_command_nonblocking);
 
     if (rc != pcmk_ok) {
         // A short wait that usually avoids stalling the FSA
         sleep(1);
-        rc = cib_conn->cmds->signon(cib_conn, CRM_SYSTEM_CRMD,
+        rc = cib_conn->cmds->signon(cib_conn, crm_system_name,
                                     cib_command_nonblocking);
     }
 

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -125,7 +125,7 @@ do_shutdown_req(long long action,
              pcmk__s(controld_globals.dc_name, "not set"));
     msg = create_request(CRM_OP_SHUTDOWN_REQ, NULL, NULL, CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
 
-    if (!pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, msg)) {
+    if (!pcmk__cluster_send_message(NULL, pcmk_ipc_controld, msg)) {
         register_fsa_error(C_FSA_INTERNAL, I_ERROR, NULL);
     }
     pcmk__xml_free(msg);

--- a/daemons/controld/controld_join_client.c
+++ b/daemons/controld/controld_join_client.c
@@ -56,7 +56,7 @@ do_cl_join_query(long long action,
     sleep(1);                   // Give the cluster layer time to propagate to the DC
     update_dc(NULL);            /* Unset any existing value so that the result is not discarded */
     crm_debug("Querying for a DC");
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, req);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_controld, req);
     pcmk__xml_free(req);
 }
 
@@ -85,7 +85,7 @@ do_cl_join_announce(long long action,
 
         crm_debug("Announcing availability");
         update_dc(NULL);
-        pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, req);
+        pcmk__cluster_send_message(NULL, pcmk_ipc_controld, req);
         pcmk__xml_free(req);
 
     } else {
@@ -181,7 +181,7 @@ join_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
 
         crm_xml_add(reply, PCMK__XA_JOIN_ID, join_id);
         crm_xml_add(reply, PCMK_XA_CRM_FEATURE_SET, CRM_FEATURE_SET);
-        pcmk__cluster_send_message(dc_node, pcmk__cluster_msg_controld, reply);
+        pcmk__cluster_send_message(dc_node, pcmk_ipc_controld, reply);
         pcmk__xml_free(reply);
     }
 
@@ -343,7 +343,7 @@ do_cl_join_finalize_respond(long long action,
             }
         }
 
-        pcmk__cluster_send_message(dc_node, pcmk__cluster_msg_controld, reply);
+        pcmk__cluster_send_message(dc_node, pcmk_ipc_controld, reply);
         pcmk__xml_free(reply);
 
         if (AM_I_DC == FALSE) {

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -302,7 +302,7 @@ join_make_offer(gpointer key, gpointer value, gpointer user_data)
     crm_xml_add(offer, PCMK_XA_CRM_FEATURE_SET, CRM_FEATURE_SET);
 
     crm_info("Sending join-%d offer to %s", current_join_id, member->name);
-    pcmk__cluster_send_message(member, pcmk__cluster_msg_controld, offer);
+    pcmk__cluster_send_message(member, pcmk_ipc_controld, offer);
     pcmk__xml_free(offer);
 
     crm_update_peer_join(__func__, member, controld_join_welcomed);
@@ -966,7 +966,7 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
             }
         }
     }
-    pcmk__cluster_send_message(join_node, pcmk__cluster_msg_controld, acknak);
+    pcmk__cluster_send_message(join_node, pcmk_ipc_controld, acknak);
     pcmk__xml_free(acknak);
     return;
 }

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -86,7 +86,7 @@ post_cache_update(int instance)
      */
     no_op = create_request(CRM_OP_NOOP, NULL, NULL, CRM_SYSTEM_CRMD,
                            AM_I_DC ? CRM_SYSTEM_DC : CRM_SYSTEM_CRMD, NULL);
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, no_op);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_controld, no_op);
     pcmk__xml_free(no_op);
 }
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -328,7 +328,7 @@ route_message(enum crmd_fsa_cause cause, xmlNode * input)
 gboolean
 relay_message(xmlNode * msg, gboolean originated_locally)
 {
-    enum pcmk__cluster_msg dest = pcmk__cluster_msg_unknown;
+    enum pcmk_ipc_server dest = pcmk_ipc_unknown;
     bool is_for_dc = false;
     bool is_for_dcib = false;
     bool is_for_te = false;
@@ -386,12 +386,12 @@ relay_message(xmlNode * msg, gboolean originated_locally)
     // Get the message type appropriate to the destination subsystem
     if (pcmk_get_cluster_layer() == pcmk_cluster_layer_corosync) {
         dest = pcmk__cluster_parse_msg_type(sys_to);
-        if (dest == pcmk__cluster_msg_unknown) {
+        if (dest == pcmk_ipc_unknown) {
             /* Unrecognized value, use a sane default
              *
              * @TODO Maybe we should bail instead
              */
-            dest = pcmk__cluster_msg_controld;
+            dest = pcmk_ipc_controld;
         }
     }
 
@@ -1160,8 +1160,7 @@ handle_request(xmlNode *stored_msg, enum crmd_fsa_cause cause)
 
         if(cause == C_IPC_MESSAGE) {
             msg = create_request(CRM_OP_RM_NODE_CACHE, NULL, NULL, CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
-            if (!pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld,
-                                            msg)) {
+            if (!pcmk__cluster_send_message(NULL, pcmk_ipc_controld, msg)) {
                 crm_err("Could not instruct peers to remove references to node %s/%u", name, id);
             } else {
                 crm_notice("Instructing peers to remove references to node %s/%u", name, id);
@@ -1359,7 +1358,7 @@ broadcast_remote_state_message(const char *node_name, bool node_up)
                     controld_globals.our_nodename);
     }
 
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, msg);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_controld, msg);
     pcmk__xml_free(msg);
 }
 

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -385,7 +385,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
 
     // Get the message type appropriate to the destination subsystem
     if (pcmk_get_cluster_layer() == pcmk_cluster_layer_corosync) {
-        dest = pcmk__cluster_parse_msg_type(sys_to);
+        dest = pcmk__parse_server(sys_to);
         if (dest == pcmk_ipc_unknown) {
             /* Unrecognized value, use a sane default
              *

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -61,7 +61,7 @@ execute_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
 
             cmd = create_request(task, pseudo->xml, node->name,
                                  CRM_SYSTEM_CRMD, CRM_SYSTEM_TENGINE, NULL);
-            pcmk__cluster_send_message(node, pcmk__cluster_msg_controld, cmd);
+            pcmk__cluster_send_message(node, pcmk_ipc_controld, cmd);
             pcmk__xml_free(cmd);
         }
 
@@ -175,7 +175,7 @@ execute_cluster_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
 
     node = pcmk__get_node(0, router_node, NULL,
                           pcmk__node_search_cluster_member);
-    rc = pcmk__cluster_send_message(node, pcmk__cluster_msg_controld, cmd);
+    rc = pcmk__cluster_send_message(node, pcmk_ipc_controld, cmd);
     free(counter);
     pcmk__xml_free(cmd);
 
@@ -434,7 +434,7 @@ execute_rsc_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
             pcmk__get_node(0, router_node, NULL,
                            pcmk__node_search_cluster_member);
 
-        rc = pcmk__cluster_send_message(node, pcmk__cluster_msg_execd, cmd);
+        rc = pcmk__cluster_send_message(node, pcmk_ipc_execd, cmd);
     }
 
     free(counter);

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -371,7 +371,7 @@ throttle_send_command(enum throttle_state_e mode)
         crm_xml_add_int(xml, PCMK__XA_CRM_LIMIT_MODE, mode);
         crm_xml_add_int(xml, PCMK__XA_CRM_LIMIT_MAX, throttle_job_max);
 
-        pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, xml);
+        pcmk__cluster_send_message(NULL, pcmk_ipc_controld, xml);
         pcmk__xml_free(xml);
     }
 }

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -591,7 +591,7 @@ setup_cib(void)
 
     do {
         sleep(retries);
-        rc = cib_api->cmds->signon(cib_api, CRM_SYSTEM_STONITHD, cib_command);
+        rc = cib_api->cmds->signon(cib_api, crm_system_name, cib_command);
     } while (rc == -ENOTCONN && ++retries < 5);
 
     if (rc != pcmk_ok) {

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2353,7 +2353,7 @@ stonith_send_reply(const xmlNode *reply, int call_options,
             pcmk__get_node(0, remote_peer, NULL,
                            pcmk__node_search_cluster_member);
 
-        pcmk__cluster_send_message(node, pcmk__cluster_msg_fenced, reply);
+        pcmk__cluster_send_message(node, pcmk_ipc_fenced, reply);
     }
 }
 
@@ -2599,7 +2599,7 @@ send_async_reply(const async_command_t *cmd, const pcmk__action_result_t *result
                   cmd->action, cmd->target);
         crm_xml_add(reply, PCMK__XA_SUBT, PCMK__VALUE_BROADCAST);
         crm_xml_add(reply, PCMK__XA_ST_OP, STONITH_OP_NOTIFY);
-        pcmk__cluster_send_message(NULL, pcmk__cluster_msg_fenced, reply);
+        pcmk__cluster_send_message(NULL, pcmk_ipc_fenced, reply);
     } else {
         // Reply only to the originator
         stonith_send_reply(reply, cmd->options, cmd->origin, client);
@@ -3334,8 +3334,7 @@ handle_fence_request(pcmk__request_t *request)
             crm_xml_add(request->xml, PCMK__XA_ST_CLIENTID,
                         request->ipc_client->id);
             crm_xml_add(request->xml, PCMK__XA_ST_REMOTE_OP, op->id);
-            pcmk__cluster_send_message(node, pcmk__cluster_msg_fenced,
-                                       request->xml);
+            pcmk__cluster_send_message(node, pcmk_ipc_fenced, request->xml);
             pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_PENDING,
                              NULL);
 

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -55,7 +55,7 @@ stonith_send_broadcast_history(xmlNode *history,
         crm_xml_add(call_data, PCMK__XA_ST_TARGET, target);
     }
 
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_fenced, bcast);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_fenced, bcast);
 
     pcmk__xml_free(bcast);
 }

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -422,7 +422,7 @@ fenced_broadcast_op_result(const remote_fencing_op_t *op, bool op_merged)
     notify_data = fencing_result2xml(wrapper, op);
     stonith__xe_set_result(notify_data, &op->result);
 
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_fenced, bcast);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_fenced, bcast);
     pcmk__xml_free(bcast);
 
     return;
@@ -1352,7 +1352,7 @@ initiate_remote_stonith_op(const pcmk__client_t *client, xmlNode *request,
         }
     }
 
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_fenced, query);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_fenced, query);
     pcmk__xml_free(query);
 
     query_timeout = op->base_timeout * TIMEOUT_MULTIPLY_FACTOR;
@@ -1740,7 +1740,7 @@ report_timeout_period(remote_fencing_op_t * op, int op_timeout)
 
     pcmk__cluster_send_message(pcmk__get_node(0, client_node, NULL,
                                               pcmk__node_search_cluster_member),
-                               pcmk__cluster_msg_fenced, update);
+                               pcmk_ipc_fenced, update);
 
     pcmk__xml_free(update);
 
@@ -1995,8 +1995,7 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
             op->op_timer_one = g_timeout_add((1000 * timeout_one), remote_op_timeout_one, op);
         }
 
-        pcmk__cluster_send_message(peer_node, pcmk__cluster_msg_fenced,
-                                   remote_op);
+        pcmk__cluster_send_message(peer_node, pcmk_ipc_fenced, remote_op);
         peer->tried = TRUE;
         pcmk__xml_free(remote_op);
         return;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -113,7 +113,7 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         crm_xml_add(request, PCMK__XA_ST_CLIENTNAME, pcmk__client_name(c));
         crm_xml_add(request, PCMK__XA_ST_CLIENTNODE, fenced_get_local_node());
 
-        pcmk__cluster_send_message(NULL, pcmk__cluster_msg_fenced, request);
+        pcmk__cluster_send_message(NULL, pcmk_ipc_fenced, request);
         pcmk__xml_free(request);
         return 0;
     }
@@ -477,7 +477,7 @@ st_peer_update_callback(enum pcmk__node_update type, pcmk__node_status_t *node,
 
         crm_debug("Broadcasting our uname because of node %" PRIu32,
                   node->cluster_layer_id);
-        pcmk__cluster_send_message(NULL, pcmk__cluster_msg_fenced, query);
+        pcmk__cluster_send_message(NULL, pcmk_ipc_fenced, query);
 
         pcmk__xml_free(query);
     }

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -120,6 +120,7 @@ typedef struct cib_s cib_t;
 
 typedef struct cib_api_operations_s {
     // NOTE: sbd (as of at least 1.5.2) uses this
+    // @COMPAT At compatibility break, drop name (always use crm_system_name)
     int (*signon) (cib_t *cib, const char *name, enum cib_conn_type type);
 
     //! \deprecated This method will be removed and should not be used

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -292,8 +292,7 @@ cib_callback_client_t* cib__lookup_id (int call_id);
  */
 int cib__signon_query(pcmk__output_t *out, cib_t **cib, xmlNode **cib_object);
 
-int cib__signon_attempts(cib_t *cib, const char *name, enum cib_conn_type type,
-                         int attempts);
+int cib__signon_attempts(cib_t *cib, enum cib_conn_type type, int attempts);
 
 int cib__clean_up_connection(cib_t **cib);
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -13,6 +13,7 @@
 #include <crm/cib.h>
 #include <crm/common/ipc_internal.h>
 #include <crm/common/output_internal.h>
+#include <crm/common/servers_internal.h>
 #include <crm/common/strings_internal.h>
 
 #ifdef __cplusplus
@@ -161,7 +162,7 @@ cib_t *cib_new_variant(void);
 static inline bool
 cib__client_triggers_refresh(const char *name)
 {
-    return !crm_is_daemon_name(name)
+    return (pcmk__parse_server(name) == pcmk_ipc_unknown)
            && !pcmk__str_any_of(name,
                                 "attrd_updater",
                                 "crm_attribute",

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -279,7 +279,6 @@ void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
                                                         gboolean),
                                    void (*destroy) (gpointer));
 
-enum pcmk_ipc_server pcmk__cluster_parse_msg_type(const char *text);
 bool pcmk__cluster_send_message(const pcmk__node_status_t *node,
                                 enum pcmk_ipc_server service,
                                 const xmlNode *data);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -16,6 +16,7 @@
 #include <glib.h>           // gboolean
 #include <libxml/tree.h>    // xmlNode
 
+#include <crm/common/ipc.h> // enum crm_ipc_server
 #include <crm/cluster.h>
 
 #if SUPPORT_COROSYNC
@@ -25,20 +26,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/*!
- * \internal
- * \enum pcmk__cluster_msg
- * \brief Types of message sent via the cluster layer
- */
-enum pcmk__cluster_msg {
-    pcmk__cluster_msg_unknown,
-    pcmk__cluster_msg_attrd,
-    pcmk__cluster_msg_based,
-    pcmk__cluster_msg_controld,
-    pcmk__cluster_msg_execd,
-    pcmk__cluster_msg_fenced,
-};
 
 enum crm_proc_flag {
     /* @COMPAT When pcmk__node_status_t:processes is made internal, we can merge
@@ -292,9 +279,9 @@ void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
                                                         gboolean),
                                    void (*destroy) (gpointer));
 
-enum pcmk__cluster_msg pcmk__cluster_parse_msg_type(const char *text);
+enum pcmk_ipc_server pcmk__cluster_parse_msg_type(const char *text);
 bool pcmk__cluster_send_message(const pcmk__node_status_t *node,
-                                enum pcmk__cluster_msg service,
+                                enum pcmk_ipc_server service,
                                 const xmlNode *data);
 
 // Membership

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -73,6 +73,9 @@ xmlNode *create_request_adv(const char *task, xmlNode *xml_data,
  * Pacemaker daemon IPC
  */
 
+/* @COMPAT This is also used internally for cluster message types, but it's not
+ * worth the hassle of redefining this public API just to change the name.
+ */
 //! Available IPC interfaces
 enum pcmk_ipc_server {
     pcmk_ipc_unknown,       //!< Unknown or invalid

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -75,6 +75,7 @@ xmlNode *create_request_adv(const char *task, xmlNode *xml_data,
 
 //! Available IPC interfaces
 enum pcmk_ipc_server {
+    pcmk_ipc_unknown,       //!< Unknown or invalid
     pcmk_ipc_attrd,         //!< Attribute manager
     pcmk_ipc_based,         //!< CIB manager
     pcmk_ipc_controld,      //!< Controller

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -31,12 +31,6 @@
 extern "C" {
 #endif
 
-/*
- * XML attribute names used only by internal code
- */
-
-#define PCMK__XA_IPC_PROTO_VERSION  "ipc-protocol-version"
-
 /* denotes "non yieldable PID" on FreeBSD, or actual PID1 in scenarios that
    require a delicate handling anyway (socket-based activation with systemd);
    we can be reasonably sure that this PID is never possessed by the actual

--- a/include/crm/common/messages_internal.h
+++ b/include/crm/common/messages_internal.h
@@ -77,7 +77,6 @@ typedef struct {
     xmlNode *(*handler)(pcmk__request_t *request);
 } pcmk__server_command_t;
 
-const char *pcmk__message_name(const char *name);
 GHashTable *pcmk__register_handlers(const pcmk__server_command_t handlers[]);
 xmlNode *pcmk__process_request(pcmk__request_t *request, GHashTable *handlers);
 void pcmk__reset_request(pcmk__request_t *request);

--- a/include/crm/common/servers_internal.h
+++ b/include/crm/common/servers_internal.h
@@ -18,6 +18,7 @@ extern "C" {
 
 const char *pcmk__server_log_name(enum pcmk_ipc_server server);
 const char *pcmk__server_ipc_name(enum pcmk_ipc_server server);
+const char *pcmk__server_message_type(enum pcmk_ipc_server server);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/servers_internal.h
+++ b/include/crm/common/servers_internal.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 
 const char *pcmk__server_log_name(enum pcmk_ipc_server server);
+const char *pcmk__server_ipc_name(enum pcmk_ipc_server server);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/servers_internal.h
+++ b/include/crm/common/servers_internal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__CRM_COMMON_SERVERS_INTERNAL__H
+#define PCMK__CRM_COMMON_SERVERS_INTERNAL__H
+
+#include <crm/common/ipc.h>     // enum pcmk_ipc_server
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *pcmk__server_log_name(enum pcmk_ipc_server server);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__CRM_COMMON_SERVERS_INTERNAL__H

--- a/include/crm/common/servers_internal.h
+++ b/include/crm/common/servers_internal.h
@@ -19,6 +19,7 @@ extern "C" {
 const char *pcmk__server_log_name(enum pcmk_ipc_server server);
 const char *pcmk__server_ipc_name(enum pcmk_ipc_server server);
 const char *pcmk__server_message_type(enum pcmk_ipc_server server);
+enum pcmk_ipc_server pcmk__parse_server(const char *text);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -103,9 +103,6 @@ char *crm_md5sum(const char *buffer);
 
 char *crm_generate_uuid(void);
 
-// This belongs in ipc.h but is here for backward compatibility
-bool crm_is_daemon_name(const char *name);
-
 int crm_user_lookup(const char *name, uid_t * uid, gid_t * gid);
 int pcmk_daemon_user(uid_t *uid, gid_t *gid);
 

--- a/include/crm/common/util_compat.h
+++ b/include/crm/common/util_compat.h
@@ -10,7 +10,8 @@
 #ifndef PCMK__CRM_COMMON_UTIL_COMPAT__H
 #define PCMK__CRM_COMMON_UTIL_COMPAT__H
 
-#include <glib.h>   // gboolean
+#include <stdbool.h>    // bool
+#include <glib.h>       // gboolean
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,6 +25,9 @@ extern "C" {
  *             header, and the header itself, will be removed in a future
  *             release.
  */
+
+//! \deprecated Do not use (will be dropped in a future release)
+bool crm_is_daemon_name(const char *name);
 
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use pcmk_is_set() or pcmk_all_flags_set() instead

--- a/include/crm/common/xml_names_internal.h
+++ b/include/crm/common/xml_names_internal.h
@@ -163,6 +163,7 @@ extern "C" {
 #define PCMK__XA_HIDDEN                 "hidden"
 #define PCMK__XA_HTTP_EQUIV             "http-equiv"
 #define PCMK__XA_IN_CCM                 "in_ccm"
+#define PCMK__XA_IPC_PROTO_VERSION      "ipc-protocol-version"
 #define PCMK__XA_JOIN                   "join"
 #define PCMK__XA_JOIN_ID                "join_id"
 #define PCMK__XA_LINE                   "line"

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -85,7 +85,6 @@ extern char *crm_system_name;
 #  define CRM_SYSTEM_LRMD		"lrmd"
 #  define CRM_SYSTEM_PENGINE	"pengine"
 #  define CRM_SYSTEM_TENGINE	"tengine"
-#  define CRM_SYSTEM_STONITHD	"stonithd"
 #  define CRM_SYSTEM_MCP	"pacemakerd"
 
 // Names of internally generated node attributes

--- a/include/crm/crm_compat.h
+++ b/include/crm/crm_compat.h
@@ -27,6 +27,9 @@ extern "C" {
  *             release.
  */
 
+//! \deprecated Do not use (will be removed in a future release)
+#define CRM_SYSTEM_STONITHD "stonithd"
+
 // NOTE: sbd (as of at least 1.5.2) uses this
 //! \deprecated Use PCMK_SCORE_INFINITY instead
 #define CRM_SCORE_INFINITY PCMK_SCORE_INFINITY

--- a/include/crm_internal.h
+++ b/include/crm_internal.h
@@ -44,6 +44,7 @@
 #include <crm/common/output_internal.h>
 #include <crm/common/scheduler_internal.h>
 #include <crm/common/schemas_internal.h>
+#include <crm/common/servers_internal.h>
 #include <crm/common/xml_internal.h>
 #include <crm/common/xml_io_internal.h>
 #include <crm/common/xml_names_internal.h>

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -423,14 +423,15 @@ cib_file_signon(cib_t *cib, const char *name, enum cib_conn_type type)
 
     if (rc == pcmk_ok) {
         crm_debug("Opened connection to local file '%s' for %s",
-                  private->filename, name);
+                  private->filename, pcmk__s(name, "client"));
         cib->state = cib_connected_command;
         cib->type = cib_command;
         register_client(cib);
 
     } else {
         crm_info("Connection to local file '%s' for %s (client %s) failed: %s",
-                 private->filename, name, private->id, pcmk_strerror(rc));
+                 private->filename, pcmk__s(name, "client"), private->id,
+                 pcmk_strerror(rc));
     }
     return rc;
 }

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -274,6 +274,10 @@ cib_native_signon_raw(cib_t *cib, const char *name, enum cib_conn_type type,
         .destroy = cib_native_destroy
     };
 
+    if (name == NULL) {
+        name = pcmk__s(crm_system_name, "client");
+    }
+
     cib->call_timeout = PCMK__IPC_TIMEOUT;
 
     if (type == cib_command) {

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -432,6 +432,10 @@ cib_remote_signon(cib_t *cib, const char *name, enum cib_conn_type type)
     cib_remote_opaque_t *private = cib->variant_opaque;
     xmlNode *hello = NULL;
 
+    if (name == NULL) {
+        name = pcmk__s(crm_system_name, "client");
+    }
+
     if (private->passwd == NULL) {
         if (private->out == NULL) {
             /* If no pcmk__output_t is set, just assume that a text prompt

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -957,8 +957,7 @@ done:
 }
 
 int
-cib__signon_attempts(cib_t *cib, const char *name, enum cib_conn_type type,
-                     int attempts)
+cib__signon_attempts(cib_t *cib, enum cib_conn_type type, int attempts)
 {
     int rc = pcmk_rc_ok;
 
@@ -966,7 +965,7 @@ cib__signon_attempts(cib_t *cib, const char *name, enum cib_conn_type type,
               attempts, pcmk__plural_s(attempts));
 
     for (int remaining = attempts - 1; remaining >= 0; --remaining) {
-        rc = cib->cmds->signon(cib, name, type);
+        rc = cib->cmds->signon(cib, crm_system_name, type);
 
         if ((rc == pcmk_rc_ok)
             || (remaining == 0)

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -34,41 +34,6 @@ CRM_TRACE_INIT_DATA(cluster);
 
 /*!
  * \internal
- * \brief Get the message type equivalent of a string
- *
- * \param[in] text  String of message type
- *
- * \return Message type equivalent of \p text
- */
-enum pcmk_ipc_server
-pcmk__cluster_parse_msg_type(const char *text)
-{
-    CRM_CHECK(text != NULL, return pcmk_ipc_unknown);
-
-    text = pcmk__message_name(text);
-
-    if (pcmk__str_eq(text, "attrd", pcmk__str_none)) {
-        return pcmk_ipc_attrd;
-
-    } else if (pcmk__str_eq(text, CRM_SYSTEM_CIB, pcmk__str_none)) {
-        return pcmk_ipc_based;
-
-    } else if (pcmk__str_any_of(text, CRM_SYSTEM_CRMD, CRM_SYSTEM_DC, NULL)) {
-        return pcmk_ipc_controld;
-
-    } else if (pcmk__str_eq(text, CRM_SYSTEM_LRMD, pcmk__str_none)) {
-        return pcmk_ipc_execd;
-
-    } else if (pcmk__str_eq(text, "stonith-ng", pcmk__str_none)) {
-        return pcmk_ipc_fenced;
-
-    } else {
-        return pcmk_ipc_unknown;
-    }
-}
-
-/*!
- * \internal
  * \brief Get a node's cluster-layer UUID, setting it if not already set
  *
  * \param[in,out] node  Node to check

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -40,30 +40,30 @@ CRM_TRACE_INIT_DATA(cluster);
  *
  * \return Message type equivalent of \p text
  */
-enum pcmk__cluster_msg
+enum pcmk_ipc_server
 pcmk__cluster_parse_msg_type(const char *text)
 {
-    CRM_CHECK(text != NULL, return pcmk__cluster_msg_unknown);
+    CRM_CHECK(text != NULL, return pcmk_ipc_unknown);
 
     text = pcmk__message_name(text);
 
     if (pcmk__str_eq(text, "attrd", pcmk__str_none)) {
-        return pcmk__cluster_msg_attrd;
+        return pcmk_ipc_attrd;
 
     } else if (pcmk__str_eq(text, CRM_SYSTEM_CIB, pcmk__str_none)) {
-        return pcmk__cluster_msg_based;
+        return pcmk_ipc_based;
 
     } else if (pcmk__str_any_of(text, CRM_SYSTEM_CRMD, CRM_SYSTEM_DC, NULL)) {
-        return pcmk__cluster_msg_controld;
+        return pcmk_ipc_controld;
 
     } else if (pcmk__str_eq(text, CRM_SYSTEM_LRMD, pcmk__str_none)) {
-        return pcmk__cluster_msg_execd;
+        return pcmk_ipc_execd;
 
     } else if (pcmk__str_eq(text, "stonith-ng", pcmk__str_none)) {
-        return pcmk__cluster_msg_fenced;
+        return pcmk_ipc_fenced;
 
     } else {
-        return pcmk__cluster_msg_unknown;
+        return pcmk_ipc_unknown;
     }
 }
 
@@ -231,7 +231,7 @@ pcmk_cluster_set_destroy_fn(pcmk_cluster_t *cluster, void (*fn)(gpointer))
  */
 bool
 pcmk__cluster_send_message(const pcmk__node_status_t *node,
-                           enum pcmk__cluster_msg service, const xmlNode *data)
+                           enum pcmk_ipc_server service, const xmlNode *data)
 {
     // @TODO Return standard Pacemaker return code
     switch (pcmk_get_cluster_layer()) {

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -293,20 +293,9 @@ ais_dest(const pcmk__cpg_host_t *host)
 static inline const char *
 msg_type2text(enum pcmk_ipc_server type)
 {
-    switch (type) {
-        case pcmk_ipc_attrd:
-            return "attrd";
-        case pcmk_ipc_based:
-            return "cib";
-        case pcmk_ipc_controld:
-            return "crmd";
-        case pcmk_ipc_execd:
-            return "lrmd";
-        case pcmk_ipc_fenced:
-            return "stonith-ng";
-        default:
-            return "unknown";
-    }
+    const char *name = pcmk__server_message_type(type);
+
+    return pcmk__s(name, "unknown");
 }
 
 /*!

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -960,7 +960,7 @@ send_cpg_text(const char *data, const pcmk__node_status_t *node,
     }
 
     msg->sender.id = 0;
-    msg->sender.type = pcmk__cluster_parse_msg_type(crm_system_name);
+    msg->sender.type = pcmk__parse_server(crm_system_name);
     msg->sender.pid = local_pid;
     msg->sender.size = local_name_len;
     memset(msg->sender.uname, 0, MAX_NAME);

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -49,7 +49,7 @@ static int cs_message_timer = 0;
 struct pcmk__cpg_host_s {
     uint32_t id;
     uint32_t pid;
-    enum pcmk__cluster_msg type;
+    enum pcmk_ipc_server type;  // For logging only
     uint32_t size;
     char uname[MAX_NAME];
 } __attribute__ ((packed));
@@ -291,18 +291,18 @@ ais_dest(const pcmk__cpg_host_t *host)
 }
 
 static inline const char *
-msg_type2text(enum pcmk__cluster_msg type)
+msg_type2text(enum pcmk_ipc_server type)
 {
     switch (type) {
-        case pcmk__cluster_msg_attrd:
+        case pcmk_ipc_attrd:
             return "attrd";
-        case pcmk__cluster_msg_based:
+        case pcmk_ipc_based:
             return "cib";
-        case pcmk__cluster_msg_controld:
+        case pcmk_ipc_controld:
             return "crmd";
-        case pcmk__cluster_msg_execd:
+        case pcmk_ipc_execd:
             return "lrmd";
-        case pcmk__cluster_msg_fenced:
+        case pcmk_ipc_fenced:
             return "stonith-ng";
         default:
             return "unknown";
@@ -920,7 +920,7 @@ pcmk__cpg_disconnect(pcmk_cluster_t *cluster)
  */
 static bool
 send_cpg_text(const char *data, const pcmk__node_status_t *node,
-              enum pcmk__cluster_msg dest)
+              enum pcmk_ipc_server dest)
 {
     static int msg_id = 0;
     static int local_pid = 0;
@@ -1047,7 +1047,7 @@ send_cpg_text(const char *data, const pcmk__node_status_t *node,
  */
 bool
 pcmk__cpg_send_xml(const xmlNode *msg, const pcmk__node_status_t *node,
-                   enum pcmk__cluster_msg dest)
+                   enum pcmk_ipc_server dest)
 {
     bool rc = true;
     GString *data = g_string_sized_new(1024);

--- a/lib/cluster/crmcluster_private.h
+++ b/lib/cluster/crmcluster_private.h
@@ -69,7 +69,7 @@ uint32_t pcmk__cpg_local_nodeid(cpg_handle_t handle);
 
 G_GNUC_INTERNAL
 bool pcmk__cpg_send_xml(const xmlNode *msg, const pcmk__node_status_t *node,
-                        enum pcmk__cluster_msg dest);
+                        enum pcmk_ipc_server dest);
 
 #endif  // SUPPORT_COROSYNC
 

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -318,7 +318,7 @@ election_vote(election_t *e)
     crm_xml_add_timeval(vote, PCMK__XA_ELECTION_AGE_SEC,
                         PCMK__XA_ELECTION_AGE_NANO_SEC, &age);
 
-    pcmk__cluster_send_message(NULL, pcmk__cluster_msg_controld, vote);
+    pcmk__cluster_send_message(NULL, pcmk_ipc_controld, vote);
     pcmk__xml_free(vote);
 
     crm_debug("Started %s round %d", e->name, e->count);
@@ -500,9 +500,7 @@ record_vote(election_t *e, struct vote *vote)
 static void
 send_no_vote(pcmk__node_status_t *peer, struct vote *vote)
 {
-    /* @TODO probably shouldn't hardcode CRM_SYSTEM_CRMD and
-     * pcmk__cluster_msg_controld
-     */
+    // @TODO probably shouldn't hardcode CRM_SYSTEM_CRMD and pcmk_ipc_controld
 
     xmlNode *novote = create_request(CRM_OP_NOVOTE, NULL, vote->from,
                                      CRM_SYSTEM_CRMD, CRM_SYSTEM_CRMD, NULL);
@@ -510,7 +508,7 @@ send_no_vote(pcmk__node_status_t *peer, struct vote *vote)
     crm_xml_add(novote, PCMK__XA_ELECTION_OWNER, vote->election_owner);
     crm_xml_add_int(novote, PCMK__XA_ELECTION_ID, vote->election_id);
 
-    pcmk__cluster_send_message(peer, pcmk__cluster_msg_controld, novote);
+    pcmk__cluster_send_message(peer, pcmk_ipc_controld, novote);
     pcmk__xml_free(novote);
 }
 

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -99,6 +99,7 @@ libcrmcommon_la_SOURCES	+= rules.c
 libcrmcommon_la_SOURCES	+= scheduler.c
 libcrmcommon_la_SOURCES	+= schemas.c
 libcrmcommon_la_SOURCES	+= scores.c
+libcrmcommon_la_SOURCES	+= servers.c
 libcrmcommon_la_SOURCES	+= strings.c
 libcrmcommon_la_SOURCES	+= utils.c
 libcrmcommon_la_SOURCES	+= watchdog.c

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -249,30 +249,35 @@ pcmk_ipc_name(const pcmk_ipc_api_t *api, bool for_log)
     if (api == NULL) {
         return for_log? "Pacemaker" : NULL;
     }
+    if (for_log) {
+        const char *name = pcmk__server_log_name(api->server);
+
+        return pcmk__s(name, "Pacemaker");
+    }
     switch (api->server) {
         case pcmk_ipc_attrd:
-            return for_log? "attribute manager" : PCMK__VALUE_ATTRD;
+            return PCMK__VALUE_ATTRD;
 
         case pcmk_ipc_based:
-            return for_log? "CIB manager" : NULL /* PCMK__SERVER_BASED_RW */;
+            return NULL /* PCMK__SERVER_BASED_RW */;
 
         case pcmk_ipc_controld:
-            return for_log? "controller" : CRM_SYSTEM_CRMD;
+            return CRM_SYSTEM_CRMD;
 
         case pcmk_ipc_execd:
-            return for_log? "executor" : NULL /* CRM_SYSTEM_LRMD */;
+            return NULL /* CRM_SYSTEM_LRMD */;
 
         case pcmk_ipc_fenced:
-            return for_log? "fencer" : NULL /* "stonith-ng" */;
+            return NULL /* "stonith-ng" */;
 
         case pcmk_ipc_pacemakerd:
-            return for_log? "launcher" : CRM_SYSTEM_MCP;
+            return CRM_SYSTEM_MCP;
 
         case pcmk_ipc_schedulerd:
-            return for_log? "scheduler" : CRM_SYSTEM_PENGINE;
+            return CRM_SYSTEM_PENGINE;
 
         default:
-            return for_log? "Pacemaker" : NULL;
+            return NULL;
     }
 }
 

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -92,6 +92,11 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
             // @TODO max_size could vary by client, maybe take as argument?
             (*api)->ipc_size_max = 5 * 1024 * 1024; // 5MB
             break;
+
+        default: // pcmk_ipc_unknown
+            pcmk_free_ipc_api(*api);
+            *api = NULL;
+            return EINVAL;
     }
     if ((*api)->cmds == NULL) {
         pcmk_free_ipc_api(*api);
@@ -773,6 +778,9 @@ create_purge_node_request(const pcmk_ipc_api_t *api, const char *node_name,
         case pcmk_ipc_execd:
         case pcmk_ipc_schedulerd:
             break;
+
+        default: // pcmk_ipc_unknown (shouldn't be possible)
+            return NULL;
     }
     return request;
 }

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -255,29 +255,14 @@ pcmk_ipc_name(const pcmk_ipc_api_t *api, bool for_log)
         return pcmk__s(name, "Pacemaker");
     }
     switch (api->server) {
-        case pcmk_ipc_attrd:
-            return PCMK__VALUE_ATTRD;
-
+        // These servers do not have pcmk_ipc_api_t implementations yet
         case pcmk_ipc_based:
-            return NULL /* PCMK__SERVER_BASED_RW */;
-
-        case pcmk_ipc_controld:
-            return CRM_SYSTEM_CRMD;
-
         case pcmk_ipc_execd:
-            return NULL /* CRM_SYSTEM_LRMD */;
-
         case pcmk_ipc_fenced:
-            return NULL /* "stonith-ng" */;
-
-        case pcmk_ipc_pacemakerd:
-            return CRM_SYSTEM_MCP;
-
-        case pcmk_ipc_schedulerd:
-            return CRM_SYSTEM_PENGINE;
+            return NULL;
 
         default:
-            return NULL;
+            return pcmk__server_ipc_name(api->server);
     }
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -986,31 +986,3 @@ pcmk__serve_schedulerd_ipc(struct qb_ipcs_service_handlers *cb)
 {
     return mainloop_add_ipc_server(CRM_SYSTEM_PENGINE, QB_IPC_NATIVE, cb);
 }
-
-/*!
- * \brief Check whether string represents a client name used by cluster daemons
- *
- * \param[in] name  String to check
- *
- * \return true if name is standard client name used by daemons, false otherwise
- *
- * \note This is provided by the client, and so cannot be used by itself as a
- *       secure means of authentication.
- */
-bool
-crm_is_daemon_name(const char *name)
-{
-    return pcmk__str_any_of(pcmk__message_name(name),
-                            "attrd",
-                            CRM_SYSTEM_CIB,
-                            CRM_SYSTEM_CRMD,
-                            CRM_SYSTEM_DC,
-                            CRM_SYSTEM_LRMD,
-                            CRM_SYSTEM_MCP,
-                            CRM_SYSTEM_PENGINE,
-                            CRM_SYSTEM_STONITHD,
-                            CRM_SYSTEM_TENGINE,
-                            "pacemaker-remoted",
-                            "stonith-ng",
-                            NULL);
-}

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -159,46 +159,6 @@ create_reply_adv(const xmlNode *original_request, xmlNode *xml_response_data,
 }
 
 /*!
- * \brief Get name to be used as identifier for cluster messages
- *
- * \param[in] name  Actual system name to check
- *
- * \return Non-NULL cluster message identifier corresponding to name
- *
- * \note The Pacemaker daemons were renamed in version 2.0.0, but the old names
- *       must continue to be used as the identifier for cluster messages, so
- *       that mixed-version clusters are possible during a rolling upgrade.
- */
-const char *
-pcmk__message_name(const char *name)
-{
-    if (name == NULL) {
-        return "unknown";
-
-    } else if (!strcmp(name, "pacemaker-attrd")) {
-        return "attrd";
-
-    } else if (!strcmp(name, "pacemaker-based")) {
-        return CRM_SYSTEM_CIB;
-
-    } else if (!strcmp(name, "pacemaker-controld")) {
-        return CRM_SYSTEM_CRMD;
-
-    } else if (!strcmp(name, "pacemaker-execd")) {
-        return CRM_SYSTEM_LRMD;
-
-    } else if (!strcmp(name, "pacemaker-fenced")) {
-        return "stonith-ng";
-
-    } else if (!strcmp(name, "pacemaker-schedulerd")) {
-        return CRM_SYSTEM_PENGINE;
-
-    } else {
-        return name;
-    }
-}
-
-/*!
  * \internal
  * \brief Register handlers for server commands
  *

--- a/lib/common/servers.c
+++ b/lib/common/servers.c
@@ -141,3 +141,47 @@ pcmk__server_message_type(enum pcmk_ipc_server server)
               return NULL);
     return server_info[server].message_types[0];
 }
+
+/*!
+ * \internal
+ * \brief Get the server corresponding to a name
+ *
+ * \param[in] text  A system name, IPC endpoint name, or message type
+ *
+ * \return Server corresponding to \p text
+ */
+enum pcmk_ipc_server
+pcmk__parse_server(const char *text)
+{
+    if (text == NULL) {
+        return pcmk_ipc_unknown;
+    }
+    for (enum pcmk_ipc_server server = pcmk_ipc_attrd;
+         server <= pcmk_ipc_schedulerd; ++server) {
+
+        int name;
+
+        for (name = 0;
+             (name < 2) && (server_info[server].system_names[name] != NULL);
+             ++name) {
+            if (strcmp(text, server_info[server].system_names[name]) == 0) {
+                return server;
+            }
+        }
+        for (name = 0;
+             (name < 3) && (server_info[server].ipc_names[name] != NULL);
+             ++name) {
+            if (strcmp(text, server_info[server].ipc_names[name]) == 0) {
+                return server;
+            }
+        }
+        for (name = 0;
+             (name < 3) && (server_info[server].message_types[name] != NULL);
+             ++name) {
+            if (strcmp(text, server_info[server].message_types[name]) == 0) {
+                return server;
+            }
+        }
+    }
+    return pcmk_ipc_unknown;
+}

--- a/lib/common/servers.c
+++ b/lib/common/servers.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdio.h>      // NULL
+
+#include <crm/crm.h>
+
+/* Each Pacemaker subdaemon offers an IPC interface, and most exchange cluster
+ * messages as well. Particular names need to be used for logging, connecting
+ * IPC, and IPC/cluster message types.
+ *
+ * This array is indexed by enum pcmk_ipc_server and gathers all those names for
+ * easier mapping. Most members are lists with the first value listed being the
+ * "main" one returned if another value is mapped to it.
+ *
+ * @COMPAT Ideally, we'd use a single string (such as the server's
+ * crm_system_name) as the sole IPC name and sole message type for each server,
+ * making most of this unnecessary. However, backward compatiblity with older
+ * nodes involved in a rolling upgrade or Pacemaker Remote connection would
+ * be a nightmare: we'd have to add duplicate message attributes, struct
+ * members, and libqb IPC server endpoints for both the old and new names, and
+ * could drop the old names only after we no longer supported connections with
+ * older nodes.
+ */
+static struct {
+    const char *log_name;         // Readable server name for use in logs
+    const char *system_names[2];  // crm_system_name values (subdaemon names)
+    const char *ipc_names[3];     // libqb IPC names used to contact server
+    const char *message_types[3]; // IPC/cluster message types sent to server
+} server_info[] = {
+    [pcmk_ipc_unknown] = {
+        NULL,
+        { NULL, NULL, },
+        { NULL, NULL, NULL, },
+        { NULL, NULL, NULL, },
+    },
+
+    [pcmk_ipc_attrd] = {
+        "attribute manager",
+        { "pacemaker-attrd", NULL, },
+        { PCMK__VALUE_ATTRD, NULL, NULL, },
+        { PCMK__VALUE_ATTRD, NULL, NULL, },
+    },
+
+    [pcmk_ipc_based] = {
+        "CIB manager",
+        { "pacemaker-based", NULL, },
+        { PCMK__SERVER_BASED_RW, PCMK__SERVER_BASED_RO,
+          PCMK__SERVER_BASED_SHM, },
+        { CRM_SYSTEM_CIB, NULL, NULL, },
+    },
+
+    [pcmk_ipc_controld] = {
+        "controller",
+        { "pacemaker-controld", NULL, },
+        { PCMK__VALUE_CRMD, NULL, NULL, },
+        { PCMK__VALUE_CRMD, CRM_SYSTEM_DC, CRM_SYSTEM_TENGINE, },
+    },
+
+    [pcmk_ipc_execd] = {
+        "executor",
+        { "pacemaker-execd", "pacemaker-remoted", },
+        { PCMK__VALUE_LRMD, NULL, NULL, },
+        { PCMK__VALUE_LRMD, NULL, NULL, },
+    },
+
+    [pcmk_ipc_fenced] = {
+        "fencer",
+        { "pacemaker-fenced", NULL, },
+        { PCMK__VALUE_STONITH_NG, NULL, NULL, },
+        { PCMK__VALUE_STONITH_NG, NULL, NULL, },
+    },
+
+    [pcmk_ipc_pacemakerd] = {
+        "launcher",
+        { "pacemakerd", NULL, },
+        { CRM_SYSTEM_MCP, NULL, NULL, },
+        { CRM_SYSTEM_MCP, NULL, NULL, },
+    },
+
+    [pcmk_ipc_schedulerd] = {
+        "scheduler",
+        { "pacemaker-schedulerd", NULL, },
+        { CRM_SYSTEM_PENGINE, NULL, NULL, },
+        { CRM_SYSTEM_PENGINE, NULL, NULL, },
+    },
+};
+
+/*!
+ * \internal
+ * \brief Return a readable description of server for logging
+ *
+ * \param[in] server  Server to get log name for
+ *
+ * \return Log name for server (or NULL if invalid)
+ */
+const char *
+pcmk__server_log_name(enum pcmk_ipc_server server)
+{
+    CRM_CHECK((server > 0) && (server < PCMK__NELEM(server_info)),
+              return NULL);
+    return server_info[server].log_name;
+}

--- a/lib/common/servers.c
+++ b/lib/common/servers.c
@@ -125,3 +125,19 @@ pcmk__server_ipc_name(enum pcmk_ipc_server server)
               return NULL);
     return server_info[server].ipc_names[0];
 }
+
+/*!
+ * \internal
+ * \brief Return the (primary) message type for a server
+ *
+ * \param[in] server  Server to get message type for
+ *
+ * \return Message type for server (or NULL if invalid)
+ */
+const char *
+pcmk__server_message_type(enum pcmk_ipc_server server)
+{
+    CRM_CHECK((server > 0) && (server < PCMK__NELEM(server_info)),
+              return NULL);
+    return server_info[server].message_types[0];
+}

--- a/lib/common/servers.c
+++ b/lib/common/servers.c
@@ -109,3 +109,19 @@ pcmk__server_log_name(enum pcmk_ipc_server server)
               return NULL);
     return server_info[server].log_name;
 }
+
+/*!
+ * \internal
+ * \brief Return the (primary) IPC endpoint name for a server
+ *
+ * \param[in] server  Server to get IPC endpoint for
+ *
+ * \return IPC endpoint for server (or NULL if invalid)
+ */
+const char *
+pcmk__server_ipc_name(enum pcmk_ipc_server server)
+{
+    CRM_CHECK((server > 0) && (server < PCMK__NELEM(server_info)),
+              return NULL);
+    return server_info[server].ipc_names[0];
+}

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -523,7 +523,6 @@ crm_is_daemon_name(const char *name)
                             CRM_SYSTEM_LRMD,
                             CRM_SYSTEM_MCP,
                             CRM_SYSTEM_PENGINE,
-                            CRM_SYSTEM_STONITHD,
                             CRM_SYSTEM_TENGINE,
                             "pacemaker-attrd",
                             "pacemaker-based",
@@ -533,6 +532,7 @@ crm_is_daemon_name(const char *name)
                             "pacemaker-remoted",
                             "pacemaker-schedulerd",
                             "stonith-ng",
+                            "stonithd",
                             NULL);
 }
 

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -496,3 +496,45 @@ pcmk__sleep_ms(unsigned int ms)
     }
 #endif
 }
+
+// Deprecated functions kept only for backward API compatibility
+// LCOV_EXCL_START
+
+#include <crm/common/util_compat.h>
+
+/*!
+ * \brief Check whether string represents a client name used by cluster daemons
+ *
+ * \param[in] name  String to check
+ *
+ * \return true if name is standard client name used by daemons, false otherwise
+ *
+ * \note This is provided by the client, and so cannot be used by itself as a
+ *       secure means of authentication.
+ */
+bool
+crm_is_daemon_name(const char *name)
+{
+    return pcmk__str_any_of(name,
+                            "attrd",
+                            CRM_SYSTEM_CIB,
+                            CRM_SYSTEM_CRMD,
+                            CRM_SYSTEM_DC,
+                            CRM_SYSTEM_LRMD,
+                            CRM_SYSTEM_MCP,
+                            CRM_SYSTEM_PENGINE,
+                            CRM_SYSTEM_STONITHD,
+                            CRM_SYSTEM_TENGINE,
+                            "pacemaker-attrd",
+                            "pacemaker-based",
+                            "pacemaker-controld",
+                            "pacemaker-execd",
+                            "pacemaker-fenced",
+                            "pacemaker-remoted",
+                            "pacemaker-schedulerd",
+                            "stonith-ng",
+                            NULL);
+}
+
+// LCOV_EXCL_STOP
+// End deprecated API

--- a/lib/lrmd/proxy_common.c
+++ b/lib/lrmd/proxy_common.c
@@ -191,8 +191,8 @@ remote_proxy_new(lrmd_t *lrmd, struct ipc_client_callbacks *proxy_callbacks,
     proxy->session_id = strdup(session_id);
     proxy->lrm = lrmd;
 
-    if (!strcmp(pcmk__message_name(crm_system_name), CRM_SYSTEM_CRMD)
-        && !strcmp(pcmk__message_name(channel), CRM_SYSTEM_CRMD)) {
+    if ((pcmk__parse_server(crm_system_name) == pcmk_ipc_controld)
+        && (pcmk__parse_server(channel) == pcmk_ipc_controld)) {
         // The controller doesn't need to connect to itself
         proxy->is_local = TRUE;
 

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -924,7 +924,7 @@ do_init(void)
     int rc = pcmk_ok;
 
     the_cib = cib_new();
-    rc = cib__signon_attempts(the_cib, crm_system_name, cib_command, 5);
+    rc = cib__signon_attempts(the_cib, cib_command, 5);
     if (rc != pcmk_ok) {
         crm_err("Could not connect to the CIB: %s", pcmk_strerror(rc));
         fprintf(stderr, "Could not connect to the CIB: %s\n",

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -818,7 +818,7 @@ main(int argc, char **argv)
     }
 
     the_cib = cib_new();
-    rc = cib__signon_attempts(the_cib, crm_system_name, cib_command, 5);
+    rc = cib__signon_attempts(the_cib, cib_command, 5);
     rc = pcmk_legacy2rc(rc);
 
     if (rc != pcmk_rc_ok) {

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -579,7 +579,7 @@ purge_node_from_cib(const char *node_name, long node_id)
     if (cib == NULL) {
         return ENOTCONN;
     }
-    rc = cib__signon_attempts(cib, crm_system_name, cib_command, 5);
+    rc = cib__signon_attempts(cib, cib_command, 5);
     if (rc == pcmk_ok) {
         rc = cib->cmds->init_transaction(cib);
     }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1699,7 +1699,7 @@ main(int argc, char **argv)
                         _("Could not create CIB connection"));
             goto done;
         }
-        rc = cib__signon_attempts(cib_conn, crm_system_name, cib_command, 5);
+        rc = cib__signon_attempts(cib_conn, cib_command, 5);
         rc = pcmk_legacy2rc(rc);
         if (rc != pcmk_rc_ok) {
             exit_code = pcmk_rc2exitc(rc);

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -455,7 +455,7 @@ connect_real_cib(cib_t **real_cib, GError **error)
         return rc;
     }
 
-    rc = cib__signon_attempts(*real_cib, crm_system_name, cib_command, 5);
+    rc = cib__signon_attempts(*real_cib, cib_command, 5);
     rc = pcmk_legacy2rc(rc);
     if (rc != pcmk_rc_ok) {
         exit_code = pcmk_rc2exitc(rc);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -404,7 +404,7 @@ main(int argc, char **argv)
         goto done;
     }
 
-    rc = cib__signon_attempts(cib_conn, crm_system_name, cib_command, 5);
+    rc = cib__signon_attempts(cib_conn, cib_command, 5);
     rc = pcmk_legacy2rc(rc);
 
     if (rc != pcmk_rc_ok) {


### PR DESCRIPTION
While preparing to drop deprecated IPC-related APIs, I ran into a rats' nest of server-related names. There is the server executable name, the friendly name/description used for logging, the IPC endpoint (or three in the case of pacemaker-based), and message types (arbitrary strings used with IPC and CPG messages as a sort of high-level protocol name). These were scattered throughout the code base.

This brings them all together in a new server_info struct.