### PR TITLE
Remove undocumented Pacemaker Remote key handling behavior

### DIFF
--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -53,7 +53,6 @@ typedef struct lrmd_key_value_s {
 
 /* *INDENT-OFF* */
 #define DEFAULT_REMOTE_KEY_LOCATION PACEMAKER_CONFIG_DIR "/authkey"
-#define ALT_REMOTE_KEY_LOCATION "/etc/corosync/authkey"
 #define DEFAULT_REMOTE_PORT 3121
 #define DEFAULT_REMOTE_USERNAME "lrmd"
 


### PR DESCRIPTION
We previously deprecated this behavior for pacemaker-2, this removes it from master.