### PR TITLE
Tests: cts: Add non-XML tests to cts-attrd.

### DIFF
--- a/cts/cts-attrd.in
+++ b/cts/cts-attrd.in
@@ -115,6 +115,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name AAA -U 111 --output-as=xml")
         test.add_cmd("attrd_updater", args="--name AAA -Q --output-as=xml",
                      stdout_match='name="AAA" value="111"')
+        test.add_cmd("attrd_updater", args="--name AAA -Q",
+                     stdout_match='name="AAA" host="[^"]+" value="111"',
+                     validate=False)
         test.add_log_pattern(r"Setting AAA\[.*\] in instance_attributes: \(unset\) -> 111",
                              regex=True)
 
@@ -131,6 +134,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name AAA -B 111 -d 5 --output-as=xml")
         test.add_cmd("attrd_updater", args="--name AAA -Q --output-as=xml",
                      stdout_match='name="AAA" value="111"')
+        test.add_cmd("attrd_updater", args="--name AAA -Q",
+                     stdout_match='name="AAA" host="[^"]+" value="111"',
+                     validate=False)
         test.add_log_pattern(r"Setting AAA\[.*\] in instance_attributes: \(unset\) -> 111 \| from .* with 5s write delay",
                              regex=True)
 
@@ -139,6 +145,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name BBB -U 999 -d 10 --output-as=xml")
         test.add_cmd("attrd_updater", args="--name BBB -Q --output-as=xml",
                      stdout_match='name="BBB" value="999"')
+        test.add_cmd("attrd_updater", args="--name BBB -Q",
+                     stdout_match='name="BBB" host="[^"]+" value="999"',
+                     validate=False)
         test.add_log_pattern(r"Setting BBB\[.*\] in instance_attributes: \(unset\) -> 999 \| from .* with 10s write delay",
                              regex=True)
 
@@ -148,6 +157,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name BBB -U 333 --output-as=xml")
         test.add_cmd("attrd_updater", args="--name BBB -Q --output-as=xml",
                      stdout_match='name="BBB" value="333"')
+        test.add_cmd("attrd_updater", args="--name BBB -Q",
+                     stdout_match='name="BBB" host="[^"]+" value="333"',
+                     validate=False)
         test.add_log_pattern(r"Setting BBB\[.*\] in instance_attributes: \(unset\) -> 222",
                              regex=True)
         test.add_log_pattern(r"Setting BBB\[.*\] in instance_attributes: 222 -> 333",
@@ -201,6 +213,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name DDD -U 555 --set=foo --output-as=xml")
         test.add_cmd("attrd_updater", args="--name DDD -Q --output-as=xml",
                      stdout_match='name="DDD" value="555"')
+        test.add_cmd("attrd_updater", args="--name DDD -Q",
+                     stdout_match='name="DDD" host="[^"]+" value="555"',
+                     validate=False)
         test.add_log_pattern("Processed 1 private change for DDD (set foo)")
 
     def build_multiple_query_tests(self):
@@ -215,19 +230,37 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name AAA -U 222 --node cluster2 --output-as=xml")
         test.add_cmd("attrd_updater", args="--name AAA -QA --output-as=xml",
                      stdout_match=r'<attribute name="AAA" value="111" host="cluster1"/>\n.*<attribute name="AAA" value="222" host="cluster2"/>')
+        test.add_cmd("attrd_updater", args="--name AAA -QA",
+                     stdout_match='name="AAA" host="cluster1" value="111"\nname="AAA" host="cluster2" value="222"',
+                     validate=False)
         test.add_cmd("attrd_updater", args="--name AAA -Q --node=cluster1 --output-as=xml",
                      stdout_match='<attribute name="AAA" value="111" host="cluster1"/>')
+        test.add_cmd("attrd_updater", args="--name AAA -Q --node=cluster1",
+                     stdout_match='name="AAA" host="cluster1" value="111"',
+                     validate=False)
         test.add_cmd("attrd_updater", args="--name AAA -Q --node=cluster2 --output-as=xml",
                      stdout_match='<attribute name="AAA" value="222" host="cluster2"/>')
+        test.add_cmd("attrd_updater", args="--name AAA -Q --node=cluster2",
+                     stdout_match='name="AAA" host="cluster2" value="222"',
+                     validate=False)
         test.add_cmd("attrd_updater", args="--name AAA -QA --output-as=xml",
                      stdout_match=r'<attribute name="AAA" value="111" host="cluster1"/>\n.*<attribute name="AAA" value="222" host="cluster2"/>',
                      env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
+        test.add_cmd("attrd_updater", args="--name AAA -QA",
+                     stdout_match='name="AAA" host="cluster1" value="111"\nname="AAA" host="cluster2" value="222"',
+                     validate=False, env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
         test.add_cmd("attrd_updater", args="--name AAA -Q --output-as=xml",
                      stdout_match='<attribute name="AAA" value="111" host="cluster1"/>',
                      env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
+        test.add_cmd("attrd_updater", args="--name AAA -Q",
+                     stdout_match='name="AAA" host="cluster1" value="111"',
+                     validate=False, env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
         test.add_cmd("attrd_updater", args="--name AAA -Q --node=cluster2 --output-as=xml",
                      stdout_match='<attribute name="AAA" value="222" host="cluster2"/>',
                      env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
+        test.add_cmd("attrd_updater", args="--name AAA -Q --node=cluster2",
+                     stdout_match='name="AAA" host="cluster2" value="222"',
+                     validate=False, env={"OCF_RESKEY_CRM_meta_on_node": "cluster1"})
 
     def build_regex_tests(self):
         """Add tests that use regexes."""
@@ -240,6 +273,12 @@ class AttributeTests(Tests):
                      stdout_match='name="AAA" value="333"')
         test.add_cmd("attrd_updater", args="--name ABB -Q --output-as=xml",
                      stdout_match='name="ABB" value="333"')
+        test.add_cmd("attrd_updater", args="--name AAA -Q",
+                     stdout_match='name="AAA" host="[^"]+" value="333"',
+                     validate=False)
+        test.add_cmd("attrd_updater", args="--name ABB -Q",
+                     stdout_match='name="ABB" host="[^"]+" value="333"',
+                     validate=False)
         test.add_log_pattern(r"Setting AAA\[.*\] in instance_attributes: \(unset\) -> 111",
                              regex=True)
         test.add_log_pattern(r"Setting ABB\[.*\] in instance_attributes: \(unset\) -> 222",
@@ -270,6 +309,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name AAA -U ABC -z --output-as=xml")
         test.add_cmd("attrd_updater", args="--name AAA -Q --output-as=xml",
                      stdout_match='name="AAA" value="ABC"')
+        test.add_cmd("attrd_updater", args="--name AAA -Q",
+                     stdout_match='name="AAA" host="[^"]+" value="ABC"',
+                     validate=False)
         test.add_log_pattern(r"Setting AAA\[.*\] in utilization: \(unset\) -> ABC",
                              regex=True)
 
@@ -280,6 +322,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name AAA -U 123 --wait=local --output-as=xml")
         test.add_cmd("attrd_updater", args="--name AAA -Q --output-as=xml",
                      stdout_match='name="AAA" value="123"')
+        test.add_cmd("attrd_updater", args="--name AAA -Q",
+                     stdout_match='name="AAA" host="[^"]+" value="123"',
+                     validate=False)
         test.add_log_pattern(r"Alerting client .* for reached local sync point",
                              regex=True)
 
@@ -288,6 +333,9 @@ class AttributeTests(Tests):
         test.add_cmd("attrd_updater", args="--name BBB -U 456 --wait=cluster --output-as=xml")
         test.add_cmd("attrd_updater", args="--name BBB -Q --output-as=xml",
                      stdout_match='name="BBB" value="456"')
+        test.add_cmd("attrd_updater", args="--name BBB -Q",
+                     stdout_match='name="BBB" host="[^"]+" value="456"',
+                     validate=False)
         test.add_log_pattern(r"Alerting client .* for reached cluster sync point",
                              regex=True)
 


### PR DESCRIPTION
The bug introduced by 8d12f32efa06878778c86045fb01ee2d0bbe05ab was not caught by cts-attrd because it only occurred in text output mode, and cts-attrd only uses XML output mode.  This tests duplicates various existing queries in text mode.  While it's unlikely we will have that exact problem again in the future, it seems like a good idea to test the text output code as well.