### PR TITLE
Treat misconfigured rules as not passing

### DIFF
--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -77,8 +77,10 @@ enum pcmk__warnings {
         }                                                               \
     } while (0)
 
-typedef void (*pcmk__config_error_func) (void *ctx, const char *msg, ...);
-typedef void (*pcmk__config_warning_func) (void *ctx, const char *msg, ...);
+typedef void (*pcmk__config_error_func) (void *ctx, const char *msg, ...)
+        G_GNUC_PRINTF(2, 3);
+typedef void (*pcmk__config_warning_func) (void *ctx, const char *msg, ...)
+        G_GNUC_PRINTF(2, 3);
 
 extern pcmk__config_error_func pcmk__config_error_handler;
 extern pcmk__config_warning_func pcmk__config_warning_handler;

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -1177,11 +1177,9 @@ pcmk__evaluate_rsc_expression(const xmlNode *rsc_expression,
     id = pcmk__xe_id(rsc_expression);
     if (pcmk__str_empty(id)) {
         // Not possible with schema validation enabled
-        /* @COMPAT When we can break behavioral backward compatibility,
-         * fail the expression
-         */
-        pcmk__config_warn(PCMK_XE_RSC_EXPRESSION " has no " PCMK_XA_ID);
-        id = "without ID"; // for logging
+        pcmk__config_err("Treating " PCMK_XE_RSC_EXPRESSION " without "
+                         PCMK_XA_ID " as not passing");
+        return pcmk_rc_unpack_error;
     }
 
     // Compare resource standard

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -1245,27 +1245,26 @@ pcmk__evaluate_op_expression(const xmlNode *op_expression,
     // Get operation expression ID (for logging)
     id = pcmk__xe_id(op_expression);
     if (pcmk__str_empty(id)) { // Not possible with schema validation enabled
-        /* @COMPAT When we can break behavioral backward compatibility,
-         * return pcmk_rc_op_unsatisfied
-         */
-        pcmk__config_warn(PCMK_XE_OP_EXPRESSION " element has no " PCMK_XA_ID);
-        id = "without ID"; // for logging
+        pcmk__config_err("Treating " PCMK_XE_OP_EXPRESSION " without "
+                         PCMK_XA_ID " as not passing");
+        return pcmk_rc_unpack_error;
     }
 
     // Validate operation name
     name = crm_element_value(op_expression, PCMK_XA_NAME);
     if (name == NULL) { // Not possible with schema validation enabled
-        pcmk__config_warn("Treating " PCMK_XE_OP_EXPRESSION " %s as not "
-                          "passing because it has no " PCMK_XA_NAME, id);
+        pcmk__config_err("Treating " PCMK_XE_OP_EXPRESSION " %s as not "
+                         "passing because it has no " PCMK_XA_NAME, id);
         return pcmk_rc_unpack_error;
     }
 
     // Validate operation interval
     interval_s = crm_element_value(op_expression, PCMK_META_INTERVAL);
     if (pcmk_parse_interval_spec(interval_s, &interval_ms) != pcmk_rc_ok) {
-        pcmk__config_warn("Treating " PCMK_XE_OP_EXPRESSION " %s as not "
-                          "passing because '%s' is not a valid interval",
-                          id, interval_s);
+        pcmk__config_err("Treating " PCMK_XE_OP_EXPRESSION " %s as not "
+                         "passing because '%s' is not a valid "
+                         PCMK_META_INTERVAL,
+                         id, interval_s);
         return pcmk_rc_unpack_error;
     }
 

--- a/lib/common/tests/rules/pcmk__evaluate_attr_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_attr_expression_test.c
@@ -130,8 +130,7 @@ null_invalid(void **state)
 static void
 id_missing(void **state)
 {
-    // Currently acceptable
-    assert_attr_expression(EXPR_ID_MISSING, pcmk_rc_ok);
+    assert_attr_expression(EXPR_ID_MISSING, pcmk_rc_unpack_error);
 }
 
 
@@ -200,8 +199,7 @@ source_missing(void **state)
 static void
 source_invalid(void **state)
 {
-    // Currently treated as literal
-    assert_attr_expression(EXPR_SOURCE_INVALID, pcmk_rc_ok);
+    assert_attr_expression(EXPR_SOURCE_INVALID, pcmk_rc_unpack_error);
 }
 
 static void
@@ -720,8 +718,7 @@ op_defined_fails(void **state)
 static void
 op_defined_with_value(void **state)
 {
-    // Ill-formed but currently accepted
-    assert_attr_expression(EXPR_OP_DEFINED_WITH_VALUE, pcmk_rc_ok);
+    assert_attr_expression(EXPR_OP_DEFINED_WITH_VALUE, pcmk_rc_unpack_error);
 }
 
 #define EXPR_OP_UNDEFINED_PASSES                        \
@@ -762,16 +759,15 @@ value_missing_defined_ok(void **state)
     assert_attr_expression(EXPR_VALUE_MISSING_DEFINED_OK, pcmk_rc_ok);
 }
 
-#define EXPR_VALUE_MISSING_EQ_OK                        \
+#define EXPR_VALUE_MISSING_EQ_FAILS                     \
         "<" PCMK_XE_EXPRESSION " " PCMK_XA_ID "='e' "   \
         PCMK_XA_ATTRIBUTE "='not-an-attr' "             \
         PCMK_XA_OPERATION "='" PCMK_VALUE_EQ "' />"
 
 static void
-value_missing_eq_ok(void **state)
+value_missing_eq_fails(void **state)
 {
-    // Currently treated as NULL reference value
-    assert_attr_expression(EXPR_VALUE_MISSING_EQ_OK, pcmk_rc_ok);
+    assert_attr_expression(EXPR_VALUE_MISSING_EQ_FAILS, pcmk_rc_unpack_error);
 }
 
 
@@ -828,4 +824,4 @@ PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
                 expr_test(op_undefined_passes),
                 expr_test(op_undefined_fails),
                 expr_test(value_missing_defined_ok),
-                expr_test(value_missing_eq_ok))
+                expr_test(value_missing_eq_fails))

--- a/lib/common/tests/rules/pcmk__evaluate_attr_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_attr_expression_test.c
@@ -345,6 +345,19 @@ type_default_int(void **state)
     assert_attr_expression(EXPR_TYPE_DEFAULT_INT, pcmk_rc_ok);
 }
 
+#define EXPR_TYPE_INVALID                               \
+        "<" PCMK_XE_EXPRESSION " " PCMK_XA_ID "='e' "   \
+        PCMK_XA_TYPE "='not-a-value' "                  \
+        PCMK_XA_OPERATION "='" PCMK_VALUE_EQ "' "       \
+        PCMK_XA_ATTRIBUTE "='foo' "                     \
+        PCMK_XA_VALUE "='bar' />"
+
+static void
+type_invalid(void **state)
+{
+    assert_attr_expression(EXPR_TYPE_INVALID, pcmk_rc_unpack_error);
+}
+
 #define EXPR_TYPE_STRING_PASSES                         \
         "<" PCMK_XE_EXPRESSION " " PCMK_XA_ID "='e' "   \
         PCMK_XA_TYPE "='" PCMK_VALUE_STRING "' "        \
@@ -792,6 +805,7 @@ PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
                 expr_test(source_meta_fails),
                 expr_test(type_default_number),
                 expr_test(type_default_int),
+                expr_test(type_invalid),
                 expr_test(type_string_passes),
                 expr_test(type_string_fails),
                 expr_test(type_integer_passes),

--- a/lib/common/tests/rules/pcmk__evaluate_date_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_date_expression_test.c
@@ -582,10 +582,9 @@ spec_missing(void **state)
 static void
 spec_invalid(void **state)
 {
-    // Currently treated as date_spec with no ranges (which passes)
     xmlNodePtr xml = pcmk__xml_parse(EXPR_SPEC_INVALID);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_ok);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -632,26 +631,10 @@ spec_valid(void **state)
 static void
 spec_missing_id(void **state)
 {
-    // Currently acceptable; date_spec does not currently support next_change
     xmlNodePtr xml = pcmk__xml_parse(EXPR_SPEC_MISSING_ID);
 
-    // Now is just before spec start
     assert_date_expression(xml, "2024-01-01 23:59:59", NULL, NULL,
-                           pcmk_rc_before_range);
-
-    // Now matches spec start
-    assert_date_expression(xml, "2024-02-01 00:00:00", NULL, NULL, pcmk_rc_ok);
-
-    // Now is within spec range
-    assert_date_expression(xml, "2024-02-22 22:22:22", NULL, NULL, pcmk_rc_ok);
-
-    // Now matches spec end
-    assert_date_expression(xml, "2024-02-29 23:59:59", NULL, NULL, pcmk_rc_ok);
-
-    // Now is just past spec end
-    assert_date_expression(xml, "2024-03-01 00:00:00", NULL, NULL,
-                           pcmk_rc_after_range);
-
+                           pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/rules/pcmk__evaluate_date_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_date_expression_test.c
@@ -94,10 +94,9 @@ null_next_change_ok(void **state)
 static void
 id_missing(void **state)
 {
-    // Currently acceptable
     xmlNodePtr xml = pcmk__xml_parse(EXPR_ID_MISSING);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_within_range);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -110,7 +109,7 @@ op_invalid(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_OP_INVALID);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -123,7 +122,7 @@ lt_missing_end(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_LT_MISSING_END);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -137,7 +136,7 @@ lt_invalid_end(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_LT_INVALID_END);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -174,7 +173,7 @@ gt_missing_start(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_GT_MISSING_START);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -188,7 +187,7 @@ gt_invalid_start(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_GT_INVALID_START);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -236,7 +235,7 @@ range_missing(void **state)
     crm_time_t *t = crm_time_new("2024-01-01");
 
     assert_int_equal(pcmk__evaluate_date_expression(xml, t, NULL),
-                     pcmk_rc_undetermined);
+                     pcmk_rc_unpack_error);
 
     crm_time_free(t);
     pcmk__xml_free(xml);
@@ -253,7 +252,7 @@ range_invalid_start_invalid_end(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_RANGE_INVALID_START_INVALID_END);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -267,7 +266,7 @@ range_invalid_start_only(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_RANGE_INVALID_START_ONLY);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -310,7 +309,7 @@ range_invalid_end_only(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_RANGE_INVALID_END_ONLY);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -352,25 +351,10 @@ range_valid_end_only(void **state)
 static void
 range_valid_start_invalid_end(void **state)
 {
-    // Currently treated same as start without end
     xmlNodePtr xml = pcmk__xml_parse(EXPR_RANGE_VALID_START_INVALID_END);
 
-    // Now and next change are before start
-    assert_date_expression(xml, "2024-01-01 04:30:05", "2024-01-01 11:00:00",
-                           "2024-01-01 11:00:00", pcmk_rc_before_range);
-
-    // Now is before start, next change is after start
-    assert_date_expression(xml, "2024-02-01 11:59:59", "2024-02-01 18:00:00",
-                           "2024-02-01 12:00:00", pcmk_rc_before_range);
-
-    // Now is equal to start, next change is after start
-    assert_date_expression(xml, "2024-02-01 12:00:00", "2024-02-01 18:00:00",
-                           "2024-02-01 18:00:00", pcmk_rc_within_range);
-
-    // Now and next change are after start
-    assert_date_expression(xml, "2024-03-01 05:03:11", "2024-04-04 04:04:04",
-                           "2024-04-04 04:04:04", pcmk_rc_within_range);
-
+    assert_date_expression(xml, "2024-01-01 04:30:05", NULL, NULL,
+                           pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -383,25 +367,10 @@ range_valid_start_invalid_end(void **state)
 static void
 range_invalid_start_valid_end(void **state)
 {
-    // Currently treated same as end without start
     xmlNodePtr xml = pcmk__xml_parse(EXPR_RANGE_INVALID_START_VALID_END);
 
-    // Now and next change are before end
-    assert_date_expression(xml, "2024-01-01 04:30:05", "2024-01-01 11:00:00",
-                           "2024-01-01 11:00:00", pcmk_rc_within_range);
-
-    // Now is before end, next change is after end
-    assert_date_expression(xml, "2024-02-01 14:59:59", "2024-02-01 18:00:00",
-                           "2024-02-01 15:00:01", pcmk_rc_within_range);
-
-    // Now is equal to end, next change is after end
-    assert_date_expression(xml, "2024-02-01 15:00:00", "2024-02-01 18:00:00",
-                           "2024-02-01 15:00:01", pcmk_rc_within_range);
-
-    // Now and next change are after end
-    assert_date_expression(xml, "2024-02-01 15:00:01", "2024-04-04 04:04:04",
-                           "2024-04-04 04:04:04", pcmk_rc_after_range);
-
+    assert_date_expression(xml, "2024-01-01 04:30:05", NULL, NULL,
+                           pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -529,7 +498,7 @@ spec_missing(void **state)
 {
     xmlNodePtr xml = pcmk__xml_parse(EXPR_SPEC_MISSING);
 
-    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_undetermined);
+    assert_date_expression(xml, "2024-01-01", NULL, NULL, pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/rules/pcmk__evaluate_date_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_date_expression_test.c
@@ -454,25 +454,10 @@ range_valid_start_valid_end(void **state)
 static void
 range_valid_start_invalid_duration(void **state)
 {
-    // Currently treated same as end equals start
     xmlNodePtr xml = pcmk__xml_parse(EXPR_RANGE_VALID_START_INVALID_DURATION);
 
-    // Now and next change are before start
-    assert_date_expression(xml, "2024-02-01 04:30:05", "2024-01-01 11:00:00",
-                           "2024-01-01 11:00:00", pcmk_rc_before_range);
-
-    // Now is before start, next change is after start
-    assert_date_expression(xml, "2024-02-01 11:59:59", "2024-02-01 18:00:00",
-                           "2024-02-01 12:00:00", pcmk_rc_before_range);
-
-    // Now is equal to start, next change is after start
-    assert_date_expression(xml, "2024-02-01 12:00:00", "2024-02-01 14:30:00",
-                           "2024-02-01 12:00:01", pcmk_rc_within_range);
-
-    // Now and next change are after start
-    assert_date_expression(xml, "2024-02-01 12:00:01", "2024-02-01 14:30:00",
-                           "2024-02-01 14:30:00", pcmk_rc_after_range);
-
+    assert_date_expression(xml, "2024-02-01 04:30:05", NULL, NULL,
+                           pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 
@@ -517,45 +502,21 @@ range_valid_start_valid_duration(void **state)
 }
 
 #define EXPR_RANGE_VALID_START_DURATION_MISSING_ID      \
-    "<" PCMK_XE_DATE_EXPRESSION " "                     \
+    "<" PCMK_XE_DATE_EXPRESSION " " PCMK_XA_ID "='d' "  \
     PCMK_XA_OPERATION "='" PCMK_VALUE_IN_RANGE "' "     \
     PCMK_XA_START "='2024-02-01 12:00:00'>"             \
-    "<" PCMK_XE_DURATION " " PCMK_XA_ID "='d' "         \
-    PCMK_XA_HOURS "='3' />"                             \
+    "<" PCMK_XE_DURATION " " PCMK_XA_HOURS "='3' />"    \
     "</" PCMK_XE_DATE_EXPRESSION ">"
 
 static void
 range_valid_start_duration_missing_id(void **state)
 {
-    // Currently acceptable
     xmlNodePtr xml = NULL;
 
     xml = pcmk__xml_parse(EXPR_RANGE_VALID_START_DURATION_MISSING_ID);
 
-    // Now and next change are before start
-    assert_date_expression(xml, "2024-01-01 04:30:05", "2024-01-01 11:00:00",
-                           "2024-01-01 11:00:00", pcmk_rc_before_range);
-
-    // Now is before start, next change is between start and end
-    assert_date_expression(xml, "2024-02-01 11:59:59", "2024-02-01 14:00:00",
-                           "2024-02-01 12:00:00", pcmk_rc_before_range);
-
-    // Now is equal to start, next change is between start and end
-    assert_date_expression(xml, "2024-02-01 12:00:00", "2024-02-01 14:30:00",
-                           "2024-02-01 14:30:00", pcmk_rc_within_range);
-
-    // Now is between start and end, next change is after end
-    assert_date_expression(xml, "2024-02-01 14:03:11", "2024-04-04 04:04:04",
-                           "2024-02-01 15:00:01", pcmk_rc_within_range);
-
-    // Now is equal to end, next change is after end
-    assert_date_expression(xml, "2024-02-01 15:00:00", "2028-04-04 04:04:04",
-                           "2024-02-01 15:00:01", pcmk_rc_within_range);
-
-    // Now and next change are after end
-    assert_date_expression(xml, "2024-02-01 15:00:01", "2028-04-04 04:04:04",
-                           "2028-04-04 04:04:04", pcmk_rc_after_range);
-
+    assert_date_expression(xml, "2024-02-01 04:30:05", NULL, NULL,
+                           pcmk_rc_unpack_error);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/rules/pcmk__evaluate_date_spec_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_date_spec_test.c
@@ -48,16 +48,15 @@ null_invalid(void **state)
 static void
 spec_id_missing(void **state)
 {
-    // Currently acceptable
-    run_one_test("2020-01-01", "<date_spec years='2020'/>", pcmk_rc_ok);
+    run_one_test("2020-01-01", "<date_spec years='2020'/>",
+                 pcmk_rc_unpack_error);
 }
 
 static void
 invalid_range(void **state)
 {
-    // Currently acceptable
     run_one_test("2020-01-01", "<date_spec years='not-a-year' months='1'/>",
-                 pcmk_rc_ok);
+                 pcmk_rc_unpack_error);
 }
 
 static void

--- a/lib/common/tests/rules/pcmk__evaluate_op_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_op_expression_test.c
@@ -86,9 +86,8 @@ null_invalid(void **state)
 static void
 id_missing(void **state)
 {
-    // Currently acceptable
-    assert_op_expression(EXPR_ID_MISSING, pcmk_rc_ok);
-    assert_op_expression(EXPR_ID_EMPTY, pcmk_rc_ok);
+    assert_op_expression(EXPR_ID_MISSING, pcmk_rc_unpack_error);
+    assert_op_expression(EXPR_ID_EMPTY, pcmk_rc_unpack_error);
 }
 
 

--- a/lib/common/tests/rules/pcmk__evaluate_rsc_expression_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_rsc_expression_test.c
@@ -90,9 +90,8 @@ null_invalid(void **state)
 static void
 id_missing(void **state)
 {
-    // Currently acceptable
-    assert_rsc_expression(EXPR_ID_MISSING, pcmk_rc_ok);
-    assert_rsc_expression(EXPR_ID_EMPTY, pcmk_rc_ok);
+    assert_rsc_expression(EXPR_ID_MISSING, pcmk_rc_unpack_error);
+    assert_rsc_expression(EXPR_ID_EMPTY, pcmk_rc_unpack_error);
 }
 
 

--- a/lib/common/tests/rules/pcmk__unpack_duration_test.c
+++ b/lib/common/tests/rules/pcmk__unpack_duration_test.c
@@ -66,14 +66,12 @@ no_id(void **state)
     xmlNode *duration = pcmk__xml_parse(NO_ID);
     crm_time_t *start = crm_time_new("2024-01-01 15:00:00");
     crm_time_t *end = NULL;
-    crm_time_t *reference = crm_time_new("2025-03-21 16:01:01");
 
-    assert_int_equal(pcmk__unpack_duration(duration, start, &end), pcmk_rc_ok);
-    assert_int_equal(crm_time_compare(end, reference), 0);
+    assert_int_equal(pcmk__unpack_duration(duration, start, &end),
+                     pcmk_rc_unpack_error);
+    assert_null(end);
 
     crm_time_free(start);
-    crm_time_free(end);
-    crm_time_free(reference);
     pcmk__xml_free(duration);
 }
 
@@ -83,15 +81,12 @@ years_invalid(void **state)
     xmlNode *duration = pcmk__xml_parse(YEARS_INVALID);
     crm_time_t *start = crm_time_new("2024-01-01 15:00:00");
     crm_time_t *end = NULL;
-    crm_time_t *reference = crm_time_new("2024-03-21 16:01:01");
 
     assert_int_equal(pcmk__unpack_duration(duration, start, &end),
                      pcmk_rc_unpack_error);
-    assert_int_equal(crm_time_compare(end, reference), 0);
+    assert_null(end);
 
     crm_time_free(start);
-    crm_time_free(end);
-    crm_time_free(reference);
     pcmk__xml_free(duration);
 }
 

--- a/lib/common/tests/rules/pcmk_evaluate_rule_test.c
+++ b/lib/common/tests/rules/pcmk_evaluate_rule_test.c
@@ -69,12 +69,11 @@ null_invalid(void **state)
 static void
 id_missing(void **state)
 {
-    // Currently acceptable
     xmlNode *xml = pcmk__xml_parse(RULE_OP_MISSING_ID);
     crm_time_t *next_change = crm_time_new_undefined();
 
     assert_int_equal(pcmk_evaluate_rule(xml, &rule_input, next_change),
-                     pcmk_rc_ok);
+                     pcmk_rc_unpack_error);
 
     crm_time_free(next_change);
     pcmk__xml_free(xml);
@@ -149,11 +148,10 @@ empty_and(void **state)
 static void
 empty_or(void **state)
 {
-    // Currently treated as unsatisfied
     xmlNode *xml = pcmk__xml_parse(RULE_EMPTY_OR);
 
     assert_int_equal(pcmk_evaluate_rule(xml, &rule_input, NULL),
-                     pcmk_rc_op_unsatisfied);
+                     pcmk_rc_ok);
 
     pcmk__xml_free(xml);
 }
@@ -192,11 +190,10 @@ default_boolean_op(void **state)
 static void
 invalid_boolean_op(void **state)
 {
-    // Currently defaults to PCMK_VALUE_AND
     xmlNode *xml = pcmk__xml_parse(RULE_INVALID_BOOLEAN_OP);
 
     assert_int_equal(pcmk_evaluate_rule(xml, &rule_input, NULL),
-                     pcmk_rc_op_unsatisfied);
+                     pcmk_rc_unpack_error);
 
     pcmk__xml_free(xml);
 }

--- a/lib/pacemaker/pcmk_rule.c
+++ b/lib/pacemaker/pcmk_rule.c
@@ -138,7 +138,8 @@ eval_rule(pcmk_scheduler_t *scheduler, const char *rule_id, const char **error)
     CRM_ASSERT(pcmk__condition_type(match) == pcmk__condition_datetime);
 
     rc = pcmk__evaluate_date_expression(match, scheduler->priv->now, NULL);
-    if (rc == pcmk_rc_undetermined) { // Malformed or missing
+    if ((rc != pcmk_rc_ok) && (rc != pcmk_rc_within_range)) {
+        // Malformed or missing
         *error = "Error parsing rule";
     }
 

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -841,7 +841,7 @@ unpack_simple_colocation(xmlNode *xml_obj, const char *id,
         if (primary == NULL) {
             pcmk__config_warn("Ignoring constraint '%s' because resource '%s' "
                               "does not have an instance '%s'",
-                              "'%s'", id, primary_id, primary_instance);
+                              id, primary_id, primary_instance);
             return;
         }
     }

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -353,7 +353,7 @@ unpack_simple_rsc_ticket(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
         if (rsc == NULL) {
             pcmk__config_warn("Ignoring constraint '%s' because resource '%s' "
                               "does not have an instance '%s'",
-                              "'%s'", id, rsc_id, instance);
+                              id, rsc_id, instance);
             return;
         }
     }

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -32,7 +32,7 @@ utilization_value(const char *s)
 
     if ((s != NULL) && (pcmk__scan_min_int(s, &value, INT_MIN) == EINVAL)) {
         pcmk__config_warn("Using 0 for utilization instead of "
-                          "invalid value '%s'", value);
+                          "invalid value '%s'", s);
         value = 0;
     }
     return value;

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -473,12 +473,13 @@ cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, int cib_options,
 
         /* And then finally, see if the date expression is expired.  If so,
          * clear the constraint.
-         *
-         * @COMPAT Check for error once we are rejecting rules with invalid end
          */
         rc = pcmk__xe_get_datetime(date_expr_node, PCMK_XA_END, &end);
         if (rc != pcmk_rc_ok) {
-            crm_trace("Invalid " PCMK_XA_END ": %s", pcmk_rc_str(rc));
+            crm_trace("Date expression %s has invalid " PCMK_XA_END ": %s",
+                      pcmk__s(pcmk__xe_id(date_expr_node), "without ID"),
+                      pcmk_rc_str(rc));
+            continue; // Treat as unexpired
         }
 
         if (crm_time_compare(now, end) == 1) {


### PR DESCRIPTION
This breaks behavioral backward compatibility and so will not be backported to the 2.1 branch