### PR TITLE
Refactor: daemons: Remove an unreachable block from controld.

### DIFF
--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -798,13 +798,6 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
         }
         cmd_handled = TRUE;
 
-    } else if ((op->type == lrmd_event_new_client)
-               && pcmk__str_eq(cmd->action, PCMK_ACTION_STOP,
-                               pcmk__str_casei)) {
-
-        handle_remote_ra_stop(lrm_state, cmd);
-        cmd_handled = TRUE;
-
     } else {
         crm_debug("Event did not match %s action", ra_data->cur_cmd->action);
     }


### PR DESCRIPTION
lrmd_event_new_client gets handled at the top of remote_lrm_op_callback and then the function returns, so there's no way for this block to be reached.