### PR TITLE
Doc: libcrmcommon: remove stray declaration

### DIFF
--- a/include/crm/common/util.h
+++ b/include/crm/common/util.h
@@ -51,8 +51,6 @@ int crm_str_to_boolean(const char *s, int *ret);
 // NOTE: sbd (as of at least 1.5.2) uses this
 long long crm_get_msec(const char *input);
 
-char * crm_strip_trailing_newline(char *str);
-
 // NOTE: sbd (as of at least 1.5.2) uses this
 char *crm_strdup_printf(char const *format, ...) G_GNUC_PRINTF(1, 2);
 


### PR DESCRIPTION
... so the one marked "deprecated" in util_compat.h is used