### PR TITLE
Low: schemas: Add additional node types to the crmadmin schema.

### DIFF
--- a/xml/api/crmadmin-2.25.rng
+++ b/xml/api/crmadmin-2.25.rng
@@ -51,6 +51,8 @@
                     <value>member</value>
                     <value>remote</value>
                     <value>ping</value>
+                    <value>cluster</value>
+                    <value>guest</value>
                 </choice>
             </attribute>
 

--- a/xml/api/crmadmin-2.4.rng
+++ b/xml/api/crmadmin-2.4.rng
@@ -58,6 +58,8 @@
                     <value>member</value>
                     <value>remote</value>
                     <value>ping</value>
+                    <value>cluster</value>
+                    <value>guest</value>
                 </choice>
             </attribute>
 


### PR DESCRIPTION
I think these always should have been present as options in the schema. Without them, crmadmin output does not validate.