### PR TITLE
Perform gnutls handshake asynchronously

### DIFF
--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -94,6 +94,19 @@ int pcmk__read_handshake_data(const pcmk__client_t *client);
 
 /*!
  * \internal
+ * \brief Make a single attempt to perform the client TLS handshake
+ *
+ * \param[in,out] remote       Newly established remote connection
+ * \param[out]    gnutls_rc    If this is non-NULL, it will be set to the GnuTLS
+ *                             rc (for logging) if this function returns EPROTO,
+ *                             otherwise GNUTLS_E_SUCCESS
+ *
+ * \return Standard Pacemaker return code
+ */
+int pcmk__tls_client_try_handshake(pcmk__remote_t *remote, int *gnutls_rc);
+
+/*!
+ * \internal
  * \brief Perform client TLS handshake after establishing TCP socket
  *
  * \param[in,out] remote       Newly established remote connection

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -125,36 +125,52 @@ localized_remote_header(pcmk__remote_t *remote)
 }
 
 int
+pcmk__tls_client_try_handshake(pcmk__remote_t *remote, int *gnutls_rc)
+{
+    int rc = pcmk_rc_ok;
+
+    if (gnutls_rc != NULL) {
+        *gnutls_rc = GNUTLS_E_SUCCESS;
+    }
+
+    rc = gnutls_handshake(*remote->tls_session);
+
+    switch (rc) {
+        case GNUTLS_E_SUCCESS:
+            rc = pcmk_rc_ok;
+            break;
+
+        case GNUTLS_E_INTERRUPTED:
+        case GNUTLS_E_AGAIN:
+            rc = EAGAIN;
+            break;
+
+        default:
+            if (gnutls_rc != NULL) {
+                *gnutls_rc = rc;
+            }
+
+            rc = EPROTO;
+            break;
+    }
+
+    return rc;
+}
+
+int
 pcmk__tls_client_handshake(pcmk__remote_t *remote, int timeout_sec,
                            int *gnutls_rc)
 {
     const time_t time_limit = time(NULL) + timeout_sec;
 
-    if (gnutls_rc != NULL) {
-        *gnutls_rc = GNUTLS_E_SUCCESS;
-    }
     do {
-        int rc = gnutls_handshake(*remote->tls_session);
+        int rc = pcmk__tls_client_try_handshake(remote, gnutls_rc);
 
-        switch (rc) {
-            case GNUTLS_E_SUCCESS:
-                return pcmk_rc_ok;
-
-            case GNUTLS_E_INTERRUPTED:
-            case GNUTLS_E_AGAIN:
-                rc = pcmk__remote_ready(remote, 1000);
-                if ((rc != pcmk_rc_ok) && (rc != ETIME)) { // Fatal error
-                    return rc;
-                }
-                break;
-
-            default:
-                if (gnutls_rc != NULL) {
-                    *gnutls_rc = rc;
-                }
-                return EPROTO;
+        if (rc != EAGAIN) {
+            return rc;
         }
     } while (time(NULL) < time_limit);
+
     return ETIME;
 }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1321,6 +1321,8 @@ tls_handshake_failed(lrmd_t *lrmd, int tls_rc, int rc)
              "Pacemaker Remote server %s:%d failed: %s",
              native->server, native->port,
              (rc == EPROTO)? gnutls_strerror(tls_rc) : pcmk_rc_str(rc));
+    report_async_connection_result(lrmd, pcmk_rc2legacy(rc));
+
     gnutls_deinit(*native->remote->tls_session);
     gnutls_free(native->remote->tls_session);
     native->remote->tls_session = NULL;
@@ -1451,7 +1453,6 @@ lrmd_tcp_connect_cb(void *userdata, int rc, int sock)
     }
 
     if (tls_client_handshake(lrmd) != pcmk_rc_ok) {
-        report_async_connection_result(lrmd, -EKEYREJECTED);
         return;
     }
 
@@ -1578,10 +1579,6 @@ lrmd_api_connect_async(lrmd_t * lrmd, const char *name, int timeout)
             break;
         case pcmk__client_tls:
             rc = lrmd_tls_connect_async(lrmd, timeout);
-            if (rc) {
-                /* connection failed, report rc now */
-                report_async_connection_result(lrmd, rc);
-            }
             break;
         default:
             crm_err("Unsupported executor connection type (bug?): %d",

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -92,6 +92,7 @@ typedef struct lrmd_private_s {
     int expected_late_replies;
     GList *pending_notify;
     crm_trigger_t *process_notify;
+    crm_trigger_t *handshake_trigger;
 
     lrmd_event_callback callback;
 
@@ -607,6 +608,10 @@ lrmd_tls_connection_destroy(gpointer userdata)
     if (native->pending_notify) {
         g_list_free_full(native->pending_notify, lrmd_free_xml);
         native->pending_notify = NULL;
+    }
+    if (native->handshake_trigger != NULL) {
+        mainloop_destroy_trigger(native->handshake_trigger);
+        native->handshake_trigger = NULL;
     }
 
     free(native->remote->buffer);
@@ -1405,12 +1410,55 @@ add_tls_to_mainloop(lrmd_t *lrmd, bool do_handshake)
     return rc;
 }
 
+struct handshake_data_s {
+    lrmd_t *lrmd;
+    time_t start_time;
+    int timeout_sec;
+};
+
+static gboolean
+try_handshake_cb(gpointer user_data)
+{
+    struct handshake_data_s *hs = user_data;
+    lrmd_t *lrmd = hs->lrmd;
+    lrmd_private_t *native = lrmd->lrmd_private;
+    pcmk__remote_t *remote = native->remote;
+
+    int rc = pcmk_rc_ok;
+    int tls_rc = GNUTLS_E_SUCCESS;
+
+    if (time(NULL) >= hs->start_time + hs->timeout_sec) {
+        rc = ETIME;
+
+        tls_handshake_failed(lrmd, GNUTLS_E_TIMEDOUT, rc);
+        free(hs);
+        return 0;
+    }
+
+    rc = pcmk__tls_client_try_handshake(remote, &tls_rc);
+
+    if (rc == pcmk_rc_ok) {
+        tls_handshake_succeeded(lrmd);
+        free(hs);
+        return 0;
+    } else if (rc == EAGAIN) {
+        mainloop_set_trigger(native->handshake_trigger);
+        return 1;
+    } else {
+        rc = EKEYREJECTED;
+        tls_handshake_failed(lrmd, tls_rc, rc);
+        free(hs);
+        return 0;
+    }
+}
+
 static void
 lrmd_tcp_connect_cb(void *userdata, int rc, int sock)
 {
     lrmd_t *lrmd = userdata;
     lrmd_private_t *native = lrmd->lrmd_private;
     gnutls_datum_t psk_key = { NULL, 0 };
+    int tls_rc = GNUTLS_E_SUCCESS;
 
     native->async_timer = 0;
 
@@ -1423,9 +1471,7 @@ lrmd_tcp_connect_cb(void *userdata, int rc, int sock)
         return;
     }
 
-    /* The TCP connection was successful, so establish the TLS connection.
-     * @TODO make this async to avoid blocking code in client
-     */
+    /* The TCP connection was successful, so establish the TLS connection. */
 
     native->sock = sock;
 
@@ -1452,11 +1498,32 @@ lrmd_tcp_connect_cb(void *userdata, int rc, int sock)
         return;
     }
 
-    if (tls_client_handshake(lrmd) != pcmk_rc_ok) {
-        return;
-    }
+    /* If the TLS handshake immediately succeeds or fails, we can handle that
+     * now without having to deal with mainloops and retries.  Otherwise, add a
+     * trigger to keep trying until we get a result (or it times out).
+     */
+    rc = pcmk__tls_client_try_handshake(native->remote, &tls_rc);
+    if (rc == EAGAIN) {
+        struct handshake_data_s *hs = NULL;
 
-    tls_handshake_succeeded(lrmd);
+        if (native->handshake_trigger != NULL) {
+            return;
+        }
+
+        hs = pcmk__assert_alloc(1, sizeof(struct handshake_data_s));
+        hs->lrmd = lrmd;
+        hs->start_time = time(NULL);
+        hs->timeout_sec = TLS_HANDSHAKE_TIMEOUT;
+
+        native->handshake_trigger = mainloop_add_trigger(G_PRIORITY_LOW, try_handshake_cb, hs);
+        mainloop_set_trigger(native->handshake_trigger);
+
+    } else if (rc == pcmk_rc_ok) {
+        tls_handshake_succeeded(lrmd);
+
+    } else {
+        tls_handshake_failed(lrmd, tls_rc, rc);
+    }
 }
 
 static int


### PR DESCRIPTION
I can't convince myself that this is completely correct.  My testing still shows the two remote connection resources starting serially, but I am wondering if it's because handle_remote_ra_exec is getting called several seconds apart for the two resources.  I'm not seeing anywhere in my patches where I'm still doing something in a blocking manner, however.