### PR TITLE
Fix: libcrmcommon: Detect newly created alerts section

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -81,7 +81,8 @@ attrd_cib_updated_cb(const char *event, xmlNode *msg)
         return;
     }
 
-    if (status_changed || pcmk__cib_element_in_patchset(patchset, PCMK_XE_NODES)) {
+    if (status_changed
+        || pcmk__cib_element_in_patchset(patchset, PCMK_XE_NODES)) {
         /* An unsafe client modified the PCMK_XE_NODES or PCMK_XE_STATUS
          * section. Write transient attributes to ensure they're up-to-date in
          * the CIB.

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -602,7 +602,8 @@ pcmk__map_element_name(const xmlNode *xml)
  *
  * \return \c true if \p element was modified, or \c false otherwise
  */
-bool pcmk__cib_element_in_patchset(const xmlNode *patchset, const char *element);
+bool pcmk__cib_element_in_patchset(const xmlNode *patchset,
+                                   const char *element);
 
 #ifdef __cplusplus
 }

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -866,7 +866,7 @@ pcmk__cib_element_in_patchset(const xmlNode *patchset, const char *element)
                                                       NULL, NULL);
          change != NULL; change = pcmk__xe_next_same(change)) {
 
-        const char *op = crm_element_value(change, PCMK__XA_CIB_OP);
+        const char *op = crm_element_value(change, PCMK_XA_OPERATION);
         const char *diff_xpath = crm_element_value(change, PCMK_XA_PATH);
 
         if (pcmk__str_eq(diff_xpath, element_regex, pcmk__str_regex)) {

--- a/lib/common/tests/patchset/pcmk__cib_element_in_patchset_test.c
+++ b/lib/common/tests/patchset/pcmk__cib_element_in_patchset_test.c
@@ -13,16 +13,231 @@
 #include <crm/common/xml.h>
 #include <crm/common/xml_internal.h>
 
+#define ORIG_CIB                                                            \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"0\">"                       \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES ">"                                               \
+          "<" PCMK_XE_NODE " " PCMK_XA_ID "=\"1\""                          \
+                           " " PCMK_XA_UNAME "=\"node-1\"/>"                \
+        "</" PCMK_XE_NODES ">"                                              \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
 static void
-empty_arguments(void **state) {
-    xmlNode *missing = NULL;
+assert_in_patchset(const char *source_s, const char *target_s,
+                   const char *element, bool reference)
+{
+    xmlNode *source = pcmk__xml_parse(source_s);
+    xmlNode *target = pcmk__xml_parse(target_s);
+    xmlNode *patchset = NULL;
 
+    xml_track_changes(target, NULL, NULL, false);
+    xml_calculate_significant_changes(source, target);
+    patchset = xml_create_patchset(2, source, target, NULL, false);
+
+    if (reference) {
+        assert_true(pcmk__cib_element_in_patchset(patchset, element));
+    } else {
+        assert_false(pcmk__cib_element_in_patchset(patchset, element));
+    }
+
+    pcmk__xml_free(source);
+    pcmk__xml_free(target);
+    pcmk__xml_free(patchset);
+}
+
+static void
+null_patchset_asserts(void **state)
+{
+    pcmk__assert_asserts(pcmk__cib_element_in_patchset(NULL, NULL));
     pcmk__assert_asserts(pcmk__cib_element_in_patchset(NULL, PCMK_XE_NODES));
+}
 
-    missing = pcmk__xml_parse("<diff format=\"2\"/>");
-    assert_false(pcmk__cib_element_in_patchset(missing, NULL));
-    pcmk__xml_free(missing);
+// PCMK_XE_ALERTS element has been created relative to ORIG_CIB
+#define CREATE_CIB                                                          \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"0\">"                       \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES ">"                                               \
+          "<" PCMK_XE_NODE " " PCMK_XA_ID "=\"1\""                          \
+                           " " PCMK_XA_UNAME "=\"node-1\"/>"                \
+        "</" PCMK_XE_NODES ">"                                              \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+        "<" PCMK_XE_ALERTS "/>"                                             \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
+static void
+create_op(void **state)
+{
+    // Requested element was created
+    assert_in_patchset(ORIG_CIB, CREATE_CIB, PCMK_XE_ALERTS, true);
+
+    // Requested element's descendant was created
+    assert_in_patchset(ORIG_CIB, CREATE_CIB, PCMK_XE_CONFIGURATION, true);
+    assert_in_patchset(ORIG_CIB, CREATE_CIB, NULL, true);
+
+    // Requested element was not changed
+    assert_in_patchset(ORIG_CIB, CREATE_CIB, PCMK_XE_STATUS, false);
+}
+
+static void
+delete_op(void **state)
+{
+    // Requested element was deleted
+    assert_in_patchset(CREATE_CIB, ORIG_CIB, PCMK_XE_ALERTS, true);
+
+    // Requested element's descendant was deleted
+    assert_in_patchset(CREATE_CIB, ORIG_CIB, PCMK_XE_CONFIGURATION, true);
+    assert_in_patchset(CREATE_CIB, ORIG_CIB, NULL, true);
+
+    // Requested element was not changed
+    assert_in_patchset(CREATE_CIB, ORIG_CIB, PCMK_XE_STATUS, false);
+}
+
+// PCMK_XE_CIB XML attribute was added relative to ORIG_CIB
+#define MODIFY_ADD_CIB                                                      \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"0\""                        \
+                    " " PCMK_XA_CRM_FEATURE_SET "=\"3.19.7\">"              \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES ">"                                               \
+          "<" PCMK_XE_NODE " " PCMK_XA_ID "=\"1\""                          \
+                           " " PCMK_XA_UNAME "=\"node-1\"/>"                \
+        "</" PCMK_XE_NODES ">"                                              \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
+// PCMK_XE_CIB XML attribute was updated relative to ORIG_CIB
+#define MODIFY_UPDATE_CIB                                                   \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"1\">"                       \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES ">"                                               \
+          "<" PCMK_XE_NODE " " PCMK_XA_ID "=\"1\""                          \
+                           " " PCMK_XA_UNAME "=\"node-1\"/>"                \
+        "</" PCMK_XE_NODES ">"                                              \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
+// PCMK_XE_NODE XML attribute was added relative to ORIG_CIB
+#define MODIFY_ADD_NODE_CIB                                                 \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"0\">"                       \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES ">"                                               \
+          "<" PCMK_XE_NODE " " PCMK_XA_ID "=\"1\""                          \
+                           " " PCMK_XA_UNAME "=\"node-1\""                  \
+                           " " PCMK_XA_TYPE "=\"member\"/>"                 \
+        "</" PCMK_XE_NODES ">"                                              \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
+// PCMK_XE_NODE XML attribute was updated relative to ORIG_CIB
+#define MODIFY_UPDATE_NODE_CIB                                              \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"0\">"                       \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES ">"                                               \
+          "<" PCMK_XE_NODE " " PCMK_XA_ID "=\"1\""                          \
+                           " " PCMK_XA_UNAME "=\"node-2\"/>"                \
+        "</" PCMK_XE_NODES ">"                                              \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
+static void
+modify_op(void **state)
+{
+    // Requested element was modified (attribute added)
+    assert_in_patchset(ORIG_CIB, MODIFY_ADD_CIB, PCMK_XE_CIB, true);
+
+    // Requested element was modified (attribute updated)
+    assert_in_patchset(ORIG_CIB, MODIFY_UPDATE_CIB, PCMK_XE_CIB, true);
+
+    // Requested element was modified (attribute deleted)
+    assert_in_patchset(MODIFY_ADD_CIB, ORIG_CIB, PCMK_XE_CIB, true);
+
+    // Requested element's descendant was modified (attribute added)
+    assert_in_patchset(ORIG_CIB, MODIFY_ADD_NODE_CIB, PCMK_XE_CIB, true);
+    assert_in_patchset(ORIG_CIB, MODIFY_ADD_NODE_CIB, NULL, true);
+
+    // Requested element's descendant was modified (attribute updated)
+    assert_in_patchset(ORIG_CIB, MODIFY_UPDATE_NODE_CIB, PCMK_XE_CIB, true);
+    assert_in_patchset(ORIG_CIB, MODIFY_UPDATE_NODE_CIB, NULL, true);
+
+    // Requested element's descenant was modified (attribute deleted)
+    assert_in_patchset(MODIFY_ADD_NODE_CIB, ORIG_CIB, PCMK_XE_CIB, true);
+    assert_in_patchset(MODIFY_ADD_NODE_CIB, ORIG_CIB, NULL, true);
+
+    // Requested element was not changed
+    assert_in_patchset(ORIG_CIB, MODIFY_ADD_CIB, PCMK_XE_STATUS, false);
+    assert_in_patchset(ORIG_CIB, MODIFY_UPDATE_CIB, PCMK_XE_STATUS, false);
+    assert_in_patchset(ORIG_CIB, MODIFY_ADD_NODE_CIB, PCMK_XE_STATUS, false);
+    assert_in_patchset(ORIG_CIB, MODIFY_UPDATE_NODE_CIB, PCMK_XE_STATUS, false);
+}
+
+// PCMK_XE_RESOURCES and PCMK_XE_CONSTRAINTS are swapped relative to ORIG_CIB
+#define MOVE_CIB                                                            \
+    "<" PCMK_XE_CIB " " PCMK_XA_ADMIN_EPOCH "=\"0\""                        \
+                    " " PCMK_XA_EPOCH "=\"0\""                              \
+                    " " PCMK_XA_NUM_UPDATES "=\"0\">"                       \
+      "<" PCMK_XE_CONFIGURATION ">"                                         \
+        "<" PCMK_XE_CRM_CONFIG "/>"                                         \
+        "<" PCMK_XE_NODES "/>"                                              \
+        "<" PCMK_XE_CONSTRAINTS "/>"                                        \
+        "<" PCMK_XE_RESOURCES "/>"                                          \
+      "</" PCMK_XE_CONFIGURATION ">"                                        \
+      "<" PCMK_XE_STATUS "/>"                                               \
+    "</" PCMK_XE_CIB ">"
+
+static void
+move_op(void **state)
+{
+    // Requested element was moved
+    assert_in_patchset(ORIG_CIB, MOVE_CIB, PCMK_XE_RESOURCES, true);
+    assert_in_patchset(ORIG_CIB, MOVE_CIB, PCMK_XE_CONSTRAINTS, true);
+
+    // Requested element's descendant was moved
+    assert_in_patchset(ORIG_CIB, MOVE_CIB, PCMK_XE_CONFIGURATION, true);
+    assert_in_patchset(ORIG_CIB, MOVE_CIB, NULL, true);
+
+    // Requested element was not changed
+    assert_in_patchset(ORIG_CIB, MOVE_CIB, PCMK_XE_STATUS, false);
 }
 
 PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
-                cmocka_unit_test(empty_arguments))
+                cmocka_unit_test(null_patchset_asserts),
+                cmocka_unit_test(create_op),
+                cmocka_unit_test(delete_op),
+                cmocka_unit_test(modify_op),
+                cmocka_unit_test(move_op))

--- a/lib/common/tests/patchset/pcmk__cib_element_in_patchset_test.c
+++ b/lib/common/tests/patchset/pcmk__cib_element_in_patchset_test.c
@@ -21,8 +21,8 @@ empty_arguments(void **state) {
 
     missing = pcmk__xml_parse("<diff format=\"2\"/>");
     assert_false(pcmk__cib_element_in_patchset(missing, NULL));
-    xmlFreeNode(missing);
+    pcmk__xml_free(missing);
 }
 
-PCMK__UNIT_TEST(NULL, NULL,
+PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
                 cmocka_unit_test(empty_arguments))


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/ClusterLabs/pacemaker/commit/20ad1a974d5dff9f9e1a84c01fd329596c6691f9.

If the CIB does not already contain an alerts element, creating a new alert requires creating the alerts element. This is included in the patchset as a create operation. (Adding a new alert to an existing alerts element is a modify operation.)

Prior to this commit, we were checking whether `cib_op="create"`. We should be checking whether `operation="create"`.

As a result, if a new alert was created in a CIB that did not previously contain an alerts element, the controller would not detect the change and would not process the new alert.

Fixes T865
Fixes RHEL-55458