### PR TITLE
[2.1] Fix: libcrmcommon: Detect newly created alerts section

### DIFF
--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -160,7 +160,7 @@ element_in_patchset_v2(const xmlNode *patchset, const char *element)
                                                       NULL, NULL);
          change != NULL; change = pcmk__xe_next_same(change)) {
 
-        const char *op = crm_element_value(change, PCMK__XA_CIB_OP);
+        const char *op = crm_element_value(change, PCMK_XA_OPERATION);
         const char *diff_xpath = crm_element_value(change, PCMK_XA_PATH);
 
         if (pcmk__str_eq(diff_xpath, element_regex, pcmk__str_regex)) {


### PR DESCRIPTION
I'd prefer not to backport the unit tests or the move to libcrmcommon from #3624.

This fixes a regression introduced by 20ad1a9.

If the CIB does not already contain an alerts element, creating a new alert requires creating the alerts element. This is included in the patchset as a create operation. (Adding a new alert to an existing alerts element is a modify operation.)

Prior to this commit, we were checking whether cib_op="create". We should be checking whether operation="create".

As a result, if a new alert was created in a CIB that did not previously contain an alerts element, the controller would not detect the change and would not process the new alert.

Fixes T865
Fixes RHEL-55458