### PR TITLE
Feature: libpe_rules: Drop support for multiple top-level location rules

### DIFF
--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -41,7 +41,6 @@ enum pcmk__warnings {
     pcmk__wo_set_ordering   = (1 << 15),
     pcmk__wo_rdisc_enabled  = (1 << 16),
     pcmk__wo_rkt            = (1 << 17),
-    pcmk__wo_location_rules = (1 << 18),
     pcmk__wo_op_attr_expr   = (1 << 19),
     pcmk__wo_instance_defaults  = (1 << 20),
     pcmk__wo_multiple_rules     = (1 << 21),


### PR DESCRIPTION
Instead, create multiple constraints or use a nested rule with boolean-op="or" in the top-level rule.

The schema already disallows multiple top-level location constraint rules.

Now, we ignore any top-level rules after the first one.