### PR TITLE
Backport (most) recent integer parsing changes to 2.1 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,9 @@ pacemaker_*.info
 /maint/testcc_helper.cc
 /maint/testcc_*_h
 
+# Files built by main branch (helps when jumping back and forth in checkout)
+/cts/cts-schemas
+
 # Formerly built files (helps when jumping back and forth in checkout)
 /.ABI-build
 /Doxyfile

--- a/configure.ac
+++ b/configure.ac
@@ -680,9 +680,12 @@ AM_CONDITIONAL([BUILD_LEGACY_LINKS], [test $enable_legacy_links -ne $DISABLED])
 
 AS_IF([test x"$enable_nls" = x"yes"], [PCMK_FEATURES="$PCMK_FEATURES nls"])
 
-AC_DEFINE_UNQUOTED([PCMK__CONCURRENT_FENCING_DEFAULT],
-                   ["$with_concurrent_fencing_default"],
-                   [Default value for concurrent-fencing cluster option])
+AS_IF([test x"$with_concurrent_fencing_default" = x"true"],
+      [PCMK__CONCURRENT_FENCING_DEFAULT_TRUE="1"],
+      [PCMK__CONCURRENT_FENCING_DEFAULT_TRUE="0"])
+AC_DEFINE_UNQUOTED([PCMK__CONCURRENT_FENCING_DEFAULT_TRUE],
+                   [$PCMK__CONCURRENT_FENCING_DEFAULT_TRUE],
+                   [Whether concurrent-fencing cluster option default is true])
 
 AC_DEFINE_UNQUOTED([PCMK__SBD_SYNC_DEFAULT],
                    [$with_sbd_sync_default],

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -362,11 +362,7 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
     if (pcmk_is_set(cib_client->flags, cib_is_daemon)) {
         const char *qmax = cib_config_lookup(PCMK_OPT_CLUSTER_IPC_LIMIT);
 
-        if (pcmk__set_client_queue_max(cib_client, qmax)) {
-            crm_trace("IPC threshold for client %s[%u] is now %u",
-                      pcmk__client_name(cib_client), cib_client->pid,
-                      cib_client->queue_max);
-        }
+        pcmk__set_client_queue_max(cib_client, qmax);
     }
 
     crm_xml_add(op_request, PCMK__XA_CIB_CLIENTID, cib_client->id);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -426,8 +426,11 @@ process_ping_reply(xmlNode *reply)
 
     } else {
         long long seq_ll;
+        int rc = pcmk__scan_ll(seq_s, &seq_ll, 0LL);
 
-        if (pcmk__scan_ll(seq_s, &seq_ll, 0LL) != pcmk_rc_ok) {
+        if (rc != pcmk_rc_ok) {
+            crm_debug("Ignoring ping reply with invalid " PCMK__XA_CIB_PING_ID
+                      " '%s': %s", seq_s, pcmk_rc_str(rc));
             return;
         }
         seq = (uint64_t) seq_ll;

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -748,6 +748,7 @@ controld_record_pending_op(const char *node_name, const lrmd_rsc_info_t *rsc,
     }
 
     op->call_id = -1;
+    // coverity[store_truncates_time_t]
     op->t_run = time(NULL);
     op->t_rcchange = op->t_run;
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1026,6 +1026,7 @@ fake_op_status(lrm_state_t *lrm_state, lrmd_event_data_t *op, int op_status,
                enum ocf_exitcode op_exitcode, const char *exit_reason)
 {
     op->call_id = get_fake_call_id(lrm_state, op->rsc_id);
+    // coverity[store_truncates_time_t]
     op->t_run = time(NULL);
     op->t_rcchange = op->t_run;
     lrmd__set_result(op, op_exitcode, op_status, exit_reason);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -78,7 +78,9 @@ fail_pending_op(gpointer key, gpointer value, gpointer user_data)
     event.interval_ms = op->interval_ms;
     lrmd__set_result(&event, PCMK_OCF_UNKNOWN_ERROR, PCMK_EXEC_NOT_CONNECTED,
                      "Action was pending when executor connection was dropped");
+    // coverity[store_truncates_time_t]
     event.t_run = (unsigned int) op->start_time;
+    // coverity[store_truncates_time_t]
     event.t_rcchange = (unsigned int) op->start_time;
 
     event.call_id = op->call_id;

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -358,8 +358,19 @@ compare_int_fields(xmlNode * left, xmlNode * right, const char *field)
     long long int_elem_l;
     long long int_elem_r;
 
-    pcmk__scan_ll(elem_l, &int_elem_l, -1LL);
-    pcmk__scan_ll(elem_r, &int_elem_r, -1LL);
+    int rc = pcmk_rc_ok;
+
+    rc = pcmk__scan_ll(elem_l, &int_elem_l, -1LL);
+    if (rc != pcmk_rc_ok) { // Shouldn't be possible
+        crm_warn("Comparing current CIB %s as -1 "
+                 "because '%s' is not an integer", field, elem_l);
+    }
+
+    rc = pcmk__scan_ll(elem_r, &int_elem_r, -1LL);
+    if (rc != pcmk_rc_ok) { // Shouldn't be possible
+        crm_warn("Comparing joining node's CIB %s as -1 "
+                 "because '%s' is not an integer", field, elem_r);
+    }
 
     if (int_elem_l < int_elem_r) {
         return -1;

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -467,13 +467,16 @@ report_remote_ra_result(remote_ra_cmd_t * cmd)
     op.user_data = cmd->userdata;
     op.timeout = cmd->timeout;
     op.interval_ms = cmd->interval_ms;
+    // coverity[store_truncates_time_t]
     op.t_run = (unsigned int) cmd->start_time;
+    // coverity[store_truncates_time_t]
     op.t_rcchange = (unsigned int) cmd->start_time;
 
     lrmd__set_result(&op, cmd->result.exit_status, cmd->result.execution_status,
                      cmd->result.exit_reason);
 
     if (pcmk_is_set(cmd->status, cmd_reported_success) && !pcmk__result_ok(&(cmd->result))) {
+        // coverity[store_truncates_time_t]
         op.t_rcchange = (unsigned int) time(NULL);
         /* This edge case will likely never ever occur, but if it does the
          * result is that a failure will not be processed correctly. This is only
@@ -622,6 +625,7 @@ synthesize_lrmd_success(lrm_state_t *lrm_state, const char *rsc_id, const char *
     op.type = lrmd_event_exec_complete;
     op.rsc_id = rsc_id;
     op.op_type = op_type;
+    // coverity[store_truncates_time_t]
     op.t_run = (unsigned int) time(NULL);
     op.t_rcchange = op.t_run;
     op.call_id = generate_callid();

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -408,14 +408,25 @@ static void
 throttle_update_job_max(const char *preference)
 {
     long long max = 0LL;
+
+    // Per-node override
     const char *env_limit = pcmk__env_option(PCMK__ENV_NODE_ACTION_LIMIT);
 
     if (env_limit != NULL) {
-        preference = env_limit; // Per-node override
+        int rc = pcmk__scan_ll(env_limit, &max, 0LL);
+
+        if (rc != pcmk_rc_ok) {
+            crm_warn("Ignoring local option PCMK_" PCMK__ENV_NODE_ACTION_LIMIT
+                     " because '%s' is not a valid value: %s",
+                     env_limit, pcmk_rc_str(rc));
+            env_limit = NULL;
+        }
     }
-    if (preference != NULL) {
-        pcmk__scan_ll(preference, &max, 0LL);
+    if (env_limit == NULL) {
+        // Option validator should prevent invalid values
+        CRM_LOG_ASSERT(pcmk__scan_ll(preference, &max, 0LL) == pcmk_rc_ok);
     }
+
     if (max > 0) {
         throttle_job_max = (max >= INT_MAX)? INT_MAX : (int) max;
     } else {

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -383,6 +383,7 @@ controld_start_recheck_timer(void)
             // We're already past the desired time
             period_ms = 500;
         } else {
+            // coverity[store_truncates_time_t]
             period_ms = (guint) diff_seconds * 1000;
         }
 

--- a/doc/sphinx/Pacemaker_Explained/local-options.rst
+++ b/doc/sphinx/Pacemaker_Explained/local-options.rst
@@ -443,9 +443,10 @@ environment variables when Pacemaker daemons start up.
        PCMK_node_action_limit
      - :ref:`nonnegative integer <nonnegative_integer>`
      -
-     - Specify the maximum number of jobs that can be scheduled on this node. If
-       set, this overrides the :ref:`node-action-limit <node_action_limit>`
-       cluster option on this node.
+     - If set, this overrides the :ref:`node-action-limit <node_action_limit>`
+       cluster option on this node to specify the maximum number of jobs that
+       can be scheduled on this node (or 0 to use twice the number of CPU
+       cores).
 
    * - .. _pcmk_shutdown_delay:
 

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -161,10 +161,12 @@
 
 # PCMK_node_action_limit
 #
-# Specify the maximum number of jobs that can be scheduled on this node. If set,
-# this overrides the node-action-limit cluster property for this node.
+# If set, this overrides the node-action-limit cluster option for this node to
+# specify the maximum number of jobs that can be scheduled on this node (or 0
+# to use twice the number of CPU cores).
 #
-# Default: PCMK_node_action_limit=""
+# Default: unset
+# Example: PCMK_node_action_limit="1"
 
 
 ## Crash Handling

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -122,7 +122,7 @@ enum cib_call_options {
      *   value and \c X are parsed and added as scores.
      *
      * Scores are integer values capped at \c INFINITY and \c -INFINITY. Refer
-     * to Pacemaker Explained and to the \c char2score() function for more
+     * to Pacemaker Explained and to the \c pcmk_parse_score() function for more
      * details on scores, including how they're parsed and added.
      *
      * Note: This is implemented only for modify operations.

--- a/include/crm/common/health_internal.h
+++ b/include/crm/common/health_internal.h
@@ -10,6 +10,10 @@
 #ifndef PCMK__CRM_COMMON_HEALTH_INTERNAL__H
 #define PCMK__CRM_COMMON_HEALTH_INTERNAL__H
 
+#include <stdbool.h>                    // bool
+
+#include <crm/common/scheduler_types.h> // pcmk_scheduler_t
+ 
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,6 +36,8 @@ enum pcmk__health_strategy {
 bool pcmk__validate_health_strategy(const char *value);
 
 enum pcmk__health_strategy pcmk__parse_health_strategy(const char *value);
+
+int pcmk__health_score(const char *option, const pcmk_scheduler_t *scheduler);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -237,7 +237,7 @@ pcmk__client_t *pcmk__new_unauth_client(void *key);
 pcmk__client_t *pcmk__new_client(qb_ipcs_connection_t *c, uid_t uid, gid_t gid);
 void pcmk__free_client(pcmk__client_t *c);
 void pcmk__drop_all_clients(qb_ipcs_service_t *s);
-bool pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax);
+void pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax);
 
 xmlNode *pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
                                  const char *tag, const char *ver, crm_exit_t status);

--- a/include/crm/common/scores.h
+++ b/include/crm/common/scores.h
@@ -23,6 +23,7 @@ extern "C" {
 //! Integer score to use to represent "infinity"
 #define PCMK_SCORE_INFINITY 1000000
 
+int pcmk_parse_score(const char *score_s, int *score, int default_score);
 const char *pcmk_readable_score(int score);
 int char2score(const char *score);
 

--- a/include/crm/common/xml_internal.h
+++ b/include/crm/common/xml_internal.h
@@ -449,6 +449,9 @@ enum pcmk__xa_flags {
     pcmk__xaf_score_update  = (1U << 1),
 };
 
+int pcmk__xe_get_score(const xmlNode *xml, const char *name, int *score,
+                       int default_score);
+
 int pcmk__xe_copy_attrs(xmlNode *target, const xmlNode *src, uint32_t flags);
 
 /*!

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -325,7 +325,7 @@ void pe_fence_node(pcmk_scheduler_t *scheduler, pcmk_node_t *node,
                    const char *reason, bool priority_delay);
 
 pcmk_node_t *pe_create_node(const char *id, const char *uname, const char *type,
-                            const char *score, pcmk_scheduler_t *scheduler);
+                            int score, pcmk_scheduler_t *scheduler);
 
 //! \deprecated This function will be removed in a future release
 void common_print(pcmk_resource_t *rsc, const char *pre_text, const char *name,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -430,12 +430,4 @@ pe__health_strategy(pcmk_scheduler_t *scheduler)
     return pcmk__parse_health_strategy(strategy);
 }
 
-static inline int
-pe__health_score(const char *option, pcmk_scheduler_t *scheduler)
-{
-    const char *value = pcmk__cluster_option(scheduler->config_hash, option);
-
-    return char2score(value);
-}
-
 #endif

--- a/lib/common/health.c
+++ b/lib/common/health.c
@@ -9,6 +9,11 @@
 
 #include <crm_internal.h>
 
+#include <stdio.h>                          // NULL
+
+#include <crm/common/scheduler.h>           // pcmk_scheduler_t
+#include <crm/common/scheduler_internal.h>  // pcmk_scheduler_t private data
+
 /*!
  * \internal
  * \brief Ensure a health strategy value is allowed
@@ -62,4 +67,31 @@ pcmk__parse_health_strategy(const char *value)
                          value);
         return pcmk__health_strategy_none;
     }
+}
+
+/*!
+ * \internal
+ * \brief Parse a health score from a cluster option value
+ *
+ * \param[in] option     Name of option to parse
+ * \param[in] scheduler  Scheduler data
+ *
+ * \return Integer score parsed from \p option value (or 0 if invalid)
+ */
+int
+pcmk__health_score(const char *option, const pcmk_scheduler_t *scheduler)
+{
+    int score = 0;
+    int rc = pcmk_rc_ok;
+    const char *value = NULL;
+
+    CRM_CHECK((option != NULL) && (scheduler != NULL), return 0);
+
+    value = pcmk__cluster_option(scheduler->config_hash, option);
+    rc = pcmk_parse_score(value, &score, 0);
+    if (rc != pcmk_rc_ok) {
+        crm_warn("Using 0 for %s because '%s' is invalid: %s",
+                 option, value, pcmk_rc_str(rc));
+    }
+    return score;
 }

--- a/lib/common/ipc_pacemakerd.c
+++ b/lib/common/ipc_pacemakerd.c
@@ -203,8 +203,14 @@ dispatch(pcmk_ipc_api_t *api, xmlNode *reply)
 
     if (pcmk__xe_is(reply, PCMK__XE_ACK)) {
         long long int ack_status = 0;
-        pcmk__scan_ll(crm_element_value(reply, PCMK_XA_STATUS), &ack_status,
-                      CRM_EX_OK);
+        const char *status = crm_element_value(reply, PCMK_XA_STATUS);
+        int rc = pcmk__scan_ll(status, &ack_status, CRM_EX_OK);
+
+        if (rc != pcmk_rc_ok) {
+            crm_warn("Ack reply from %s has invalid " PCMK_XA_STATUS
+                     " '%s' (bug?)",
+                     pcmk_ipc_name(api, true), pcmk__s(status, ""));
+        }
         return ack_status == CRM_EX_INDETERMINATE;
     }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -335,23 +335,42 @@ pcmk__free_client(pcmk__client_t *c)
  * \brief Raise IPC eviction threshold for a client, if allowed
  *
  * \param[in,out] client     Client to modify
- * \param[in]     qmax       New threshold (as non-NULL string)
- *
- * \return true if change was allowed, false otherwise
+ * \param[in]     qmax       New threshold
  */
-bool
+void
 pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax)
 {
-    if (pcmk_is_set(client->flags, pcmk__client_privileged)) {
-        long long qmax_ll;
+    int rc = pcmk_rc_ok;
+    long long qmax_ll = 0LL;
+    unsigned int orig_value = 0U;
 
-        if ((pcmk__scan_ll(qmax, &qmax_ll, 0LL) == pcmk_rc_ok)
-            && (qmax_ll > 0LL) && (qmax_ll <= UINT_MAX)) {
-            client->queue_max = (unsigned int) qmax_ll;
-            return true;
+    CRM_CHECK(client != NULL, return);
+
+    orig_value = client->queue_max;
+
+    if (pcmk_is_set(client->flags, pcmk__client_privileged)) {
+        rc = pcmk__scan_ll(qmax, &qmax_ll, 0LL);
+        if (rc == pcmk_rc_ok) {
+            if ((qmax_ll <= 0LL) || (qmax_ll > UINT_MAX)) {
+                rc = ERANGE;
+            } else {
+                client->queue_max = (unsigned int) qmax_ll;
+            }
         }
+    } else {
+        rc = EACCES;
     }
-    return false;
+
+    if (rc != pcmk_rc_ok) {
+        crm_info("Could not set IPC threshold for client %s[%u] to %s: %s",
+                  pcmk__client_name(client), client->pid,
+                  pcmk__s(qmax, "default"), pcmk_rc_str(rc));
+
+    } else if (client->queue_max != orig_value) {
+        crm_debug("IPC threshold for client %s[%u] is now %u (was %u)",
+                  pcmk__client_name(client), client->pid,
+                  client->queue_max, orig_value);
+    }
 }
 
 int

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -317,7 +317,12 @@ static const pcmk__cluster_option_t cluster_options[] = {
     },
     {
         PCMK_OPT_CONCURRENT_FENCING, NULL, PCMK_VALUE_BOOLEAN, NULL,
-        PCMK__CONCURRENT_FENCING_DEFAULT, pcmk__valid_boolean,
+#if PCMK__CONCURRENT_FENCING_DEFAULT_TRUE
+        PCMK_VALUE_TRUE,
+#else
+        PCMK_VALUE_FALSE,
+#endif
+        pcmk__valid_boolean,
         pcmk__opt_schedulerd,
         N_("Allow performing fencing operations in parallel"),
         NULL,

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -270,8 +270,9 @@ pcmk__evaluate_date_spec(const xmlNode *date_spec, const crm_time_t *now)
         if (sub_rc != pcmk_rc_ok) {                                         \
             /* @COMPAT return sub_rc when we can break compatibility */     \
             pcmk__config_warn("Ignoring %s in " PCMK_XE_DURATION " %s "     \
-                              "because it is invalid",                      \
-                              pcmk__time_component_attr(component), id);    \
+                              "because it is invalid: %s",                  \
+                              pcmk__time_component_attr(component), id,     \
+                              pcmk_rc_str(sub_rc));                         \
             rc = sub_rc;                                                    \
         }                                                                   \
     } while (0)

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -1062,7 +1062,7 @@ apply_upgrade(const xmlNode *original_xml, int schema_index, gboolean to_logs)
     final = apply_transformation(xml, schema->transform, to_logs);
     if (upgrade != xml) {
         free_xml(upgrade);
-        upgrade = NULL;
+        /* upgrade = NULL; */ // Static analysis dislikes this, so be careful
     }
 
     if ((final != NULL) && transform_onleave) {

--- a/lib/common/tests/scores/Makefile.am
+++ b/lib/common/tests/scores/Makefile.am
@@ -13,6 +13,7 @@ include $(top_srcdir)/mk/unittest.mk
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = char2score_test 		\
 		 pcmk__add_scores_test		\
+		 pcmk_parse_score_test		\
 		 pcmk_readable_score_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/scores/pcmk_parse_score_test.c
+++ b/lib/common/tests/scores/pcmk_parse_score_test.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <limits.h>
+
+#include <crm/common/scores.h>
+#include <crm/common/unittest_internal.h>
+
+extern int pcmk__score_red;
+extern int pcmk__score_green;
+extern int pcmk__score_yellow;
+
+static int default_score = 99;
+
+static void
+assert_score(const char *score_s, int expected_rc, int expected_score)
+{
+    int score = 0;
+    int rc = pcmk_parse_score(score_s, &score, default_score);
+
+    assert_int_equal(rc, expected_rc);
+    assert_int_equal(score, expected_score);
+}
+
+static void
+null_score_string(void **state)
+{
+    assert_score(NULL, pcmk_rc_ok, default_score);
+
+    // Test out-of-bounds default score
+
+    default_score = -2000000;
+    assert_score(NULL, pcmk_rc_ok, -PCMK_SCORE_INFINITY);
+
+    default_score = 2000000;
+    assert_score(NULL, pcmk_rc_ok, PCMK_SCORE_INFINITY);
+
+    default_score = 99;
+}
+
+static void
+null_score(void **state)
+{
+    assert_int_equal(pcmk_parse_score(NULL, NULL, default_score), pcmk_rc_ok);
+    assert_int_equal(pcmk_parse_score("0", NULL, default_score), pcmk_rc_ok);
+    assert_int_equal(pcmk_parse_score("foo", NULL, default_score),
+                     EINVAL);
+}
+
+static void
+bad_input(void **state)
+{
+    assert_score("redder", EINVAL, default_score);
+    assert_score("3.141592", pcmk_rc_ok, 3);
+    assert_score("0xf00d", pcmk_rc_ok, 0);
+}
+
+static void
+special_values(void **state)
+{
+    assert_score("-INFINITY", pcmk_rc_ok, -PCMK_SCORE_INFINITY);
+    assert_score("INFINITY", pcmk_rc_ok, PCMK_SCORE_INFINITY);
+    assert_score("+INFINITY", pcmk_rc_ok, PCMK_SCORE_INFINITY);
+
+    pcmk__score_red = 10;
+    pcmk__score_green = 20;
+    pcmk__score_yellow = 30;
+
+    assert_score("red", pcmk_rc_ok, pcmk__score_red);
+    assert_score("green", pcmk_rc_ok, pcmk__score_green);
+    assert_score("yellow", pcmk_rc_ok, pcmk__score_yellow);
+
+    assert_score("ReD", pcmk_rc_ok, pcmk__score_red);
+    assert_score("GrEeN", pcmk_rc_ok, pcmk__score_green);
+    assert_score("yElLoW", pcmk_rc_ok, pcmk__score_yellow);
+}
+
+/* These ridiculous macros turn an integer constant into a string constant. */
+#define A(x) #x
+#define B(x) A(x)
+
+static void
+outside_limits(void **state)
+{
+    char *very_long = crm_strdup_printf(" %lld0", LLONG_MAX);
+
+    // Still within int range
+    assert_score(B(PCMK_SCORE_INFINITY) "00", pcmk_rc_ok, PCMK_SCORE_INFINITY);
+    assert_score("-" B(PCMK_SCORE_INFINITY) "00", pcmk_rc_ok,
+                 -PCMK_SCORE_INFINITY);
+
+    // Outside long long range
+    assert_score(very_long, pcmk_rc_ok, PCMK_SCORE_INFINITY);
+    very_long[0] = '-';
+    assert_score(very_long, pcmk_rc_ok, -PCMK_SCORE_INFINITY);
+    free(very_long);
+}
+
+static void
+inside_limits(void **state)
+{
+    assert_score("1234", pcmk_rc_ok, 1234);
+    assert_score("-1234", pcmk_rc_ok, -1234);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(null_score_string),
+                cmocka_unit_test(null_score),
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(special_values),
+                cmocka_unit_test(outside_limits),
+                cmocka_unit_test(inside_limits))

--- a/lib/common/tests/strings/pcmk__guint_from_hash_test.c
+++ b/lib/common/tests/strings/pcmk__guint_from_hash_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *

--- a/lib/common/tests/strings/pcmk__scan_min_int_test.c
+++ b/lib/common/tests/strings/pcmk__scan_min_int_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2024 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *

--- a/lib/common/tests/xml/Makefile.am
+++ b/lib/common/tests/xml/Makefile.am
@@ -16,6 +16,7 @@ check_PROGRAMS = crm_xml_init_test 		\
 		 pcmk__xe_copy_attrs_test	\
 		 pcmk__xe_first_child_test	\
 		 pcmk__xe_foreach_child_test 	\
+		 pcmk__xe_get_score_test	\
 		 pcmk__xe_set_score_test	\
 		 pcmk__xml_escape_test		\
 		 pcmk__xml_needs_escape_test	\

--- a/lib/common/tests/xml/pcmk__xe_get_score_test.c
+++ b/lib/common/tests/xml/pcmk__xe_get_score_test.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <limits.h>
+
+#include <crm/common/scores.h>
+#include <crm/common/unittest_internal.h>
+
+extern int pcmk__score_red;
+extern int pcmk__score_green;
+extern int pcmk__score_yellow;
+
+static int default_score = 99;
+
+static void
+assert_score(const char *score_s, int expected_rc, int expected_score)
+{
+    int score = 0;
+    int rc = pcmk_rc_ok;
+    xmlNode *xml = pcmk__xe_create(NULL, __func__);
+
+    crm_xml_add(xml, "test_attr", score_s);
+    rc = pcmk__xe_get_score(xml, "test_attr", &score, default_score);
+    assert_int_equal(rc, expected_rc);
+    assert_int_equal(score, expected_score);
+    free_xml(xml);
+}
+
+static void
+invalid_args(void **state)
+{
+    int score = 0;
+    xmlNode *xml = pcmk__xe_create(NULL, __func__);
+
+    assert_int_equal(pcmk__xe_get_score(NULL, NULL, &score, default_score),
+                     EINVAL);
+    assert_int_equal(pcmk__xe_get_score(xml, NULL, &score, default_score),
+                     EINVAL);
+    assert_int_equal(pcmk__xe_get_score(NULL, "test", &score, default_score),
+                     EINVAL);
+    free_xml(xml);
+}
+
+static void
+null_score_string(void **state)
+{
+    assert_score(NULL, pcmk_rc_ok, default_score);
+
+    // Test out-of-bounds default score
+
+    default_score = -2000000;
+    assert_score(NULL, pcmk_rc_ok, -PCMK_SCORE_INFINITY);
+
+    default_score = 2000000;
+    assert_score(NULL, pcmk_rc_ok, PCMK_SCORE_INFINITY);
+
+    default_score = 99;
+}
+
+static void
+null_score(void **state)
+{
+    xmlNode *xml = pcmk__xe_create(NULL, __func__);
+
+    assert_int_equal(pcmk__xe_get_score(xml, "test_attr", NULL, default_score),
+                     pcmk_rc_ok);
+
+    crm_xml_add(xml, "test_attr", "0");
+    assert_int_equal(pcmk__xe_get_score(xml, "test_attr", NULL, default_score),
+                     pcmk_rc_ok);
+
+    crm_xml_add(xml, "test_attr", "foo");
+    assert_int_equal(pcmk__xe_get_score(xml, "test_attr", NULL, default_score),
+                     EINVAL);
+
+    free_xml(xml);
+}
+
+static void
+bad_input(void **state)
+{
+    assert_score("redder", EINVAL, default_score);
+    assert_score("3.141592", pcmk_rc_ok, 3);
+    assert_score("0xf00d", pcmk_rc_ok, 0);
+}
+
+static void
+special_values(void **state)
+{
+    assert_score("-INFINITY", pcmk_rc_ok, -PCMK_SCORE_INFINITY);
+    assert_score("INFINITY", pcmk_rc_ok, PCMK_SCORE_INFINITY);
+    assert_score("+INFINITY", pcmk_rc_ok, PCMK_SCORE_INFINITY);
+
+    pcmk__score_red = 10;
+    pcmk__score_green = 20;
+    pcmk__score_yellow = 30;
+
+    assert_score("red", pcmk_rc_ok, pcmk__score_red);
+    assert_score("green", pcmk_rc_ok, pcmk__score_green);
+    assert_score("yellow", pcmk_rc_ok, pcmk__score_yellow);
+
+    assert_score("ReD", pcmk_rc_ok, pcmk__score_red);
+    assert_score("GrEeN", pcmk_rc_ok, pcmk__score_green);
+    assert_score("yElLoW", pcmk_rc_ok, pcmk__score_yellow);
+}
+
+/* These ridiculous macros turn an integer constant into a string constant. */
+#define A(x) #x
+#define B(x) A(x)
+
+static void
+outside_limits(void **state)
+{
+    char *very_long = crm_strdup_printf(" %lld0", LLONG_MAX);
+
+    // Still within int range
+    assert_score(B(PCMK_SCORE_INFINITY) "00", pcmk_rc_ok, PCMK_SCORE_INFINITY);
+    assert_score("-" B(PCMK_SCORE_INFINITY) "00", pcmk_rc_ok,
+                 -PCMK_SCORE_INFINITY);
+
+    // Outside long long range
+    assert_score(very_long, pcmk_rc_ok, PCMK_SCORE_INFINITY);
+    very_long[0] = '-';
+    assert_score(very_long, pcmk_rc_ok, -PCMK_SCORE_INFINITY);
+}
+
+static void
+inside_limits(void **state)
+{
+    assert_score("1234", pcmk_rc_ok, 1234);
+    assert_score("-1234", pcmk_rc_ok, -1234);
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(invalid_args),
+                cmocka_unit_test(null_score_string),
+                cmocka_unit_test(null_score),
+                cmocka_unit_test(bad_input),
+                cmocka_unit_test(special_values),
+                cmocka_unit_test(outside_limits),
+                cmocka_unit_test(inside_limits))

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -546,7 +546,7 @@ pcmk__xe_first_child(const xmlNode *parent, const char *node_name,
  * The original attribute value in \p target and the number in an assignment
  * expression in \p value are parsed and added as scores (that is, their values
  * are capped at \c INFINITY and \c -INFINITY). For more details, refer to
- * \c char2score().
+ * \c pcmk_parse_score().
  *
  * For example, suppose \p target has an attribute named \c "X" with value
  * \c "5", and that \p name is \c "X".
@@ -557,7 +557,8 @@ pcmk__xe_first_child(const xmlNode *parent, const char *node_name,
  *
  * \param[in,out] target  XML node whose attribute to set
  * \param[in]     name    Name of the attribute to set
- * \param[in]     value   New value of attribute to set
+ * \param[in]     value   New value of attribute to set (if NULL, initial value
+ *                        will be left unchanged)
  *
  * \return Standard Pacemaker return code (specifically, \c EINVAL on invalid
  *         argument, or \c pcmk_rc_ok otherwise)
@@ -570,6 +571,7 @@ pcmk__xe_set_score(xmlNode *target, const char *name, const char *value)
     CRM_CHECK((target != NULL) && (name != NULL), return EINVAL);
 
     if (value == NULL) {
+        // @TODO Maybe instead delete the attribute or set it to 0
         return pcmk_rc_ok;
     }
 
@@ -588,13 +590,31 @@ pcmk__xe_set_score(xmlNode *target, const char *name, const char *value)
             && (*v++ == '+')
             && ((*v == '+') || (*v == '='))) {
 
+            int add = 1;
+            int old_value_i = 0;
+            int rc = pcmk_rc_ok;
+
             // If we're expanding ourselves, no previous value was set; use 0
-            int old_value_i = (old_value != value)? char2score(old_value) : 0;
+            if (old_value != value) {
+                rc = pcmk_parse_score(old_value, &old_value_i, 0);
+                if (rc != pcmk_rc_ok) {
+                    // @TODO This is inconsistent with old_value==NULL
+                    crm_trace("Using 0 before incrementing %s because '%s' "
+                              "is not a score", name, old_value);
+                }
+            }
 
             /* value="X++": new value of X is old_value + 1
              * value="X+=Y": new value of X is old_value + Y (for some number Y)
              */
-            int add = (*v == '+')? 1 : char2score(++v);
+            if (*v != '+') {
+                rc = pcmk_parse_score(++v, &add, 0);
+                if (rc != pcmk_rc_ok) {
+                    // @TODO We should probably skip expansion instead
+                    crm_trace("Not incrementing %s because '%s' does not have "
+                              "a valid increment", name, value);
+                }
+            }
 
             crm_xml_add_int(target, name, pcmk__add_scores(old_value_i, add));
             return pcmk_rc_ok;

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -534,6 +534,30 @@ pcmk__xe_first_child(const xmlNode *parent, const char *node_name,
 
 /*!
  * \internal
+ * \brief Parse an integer score from an XML attribute
+ *
+ * \param[in]  xml            XML element with attribute to parse
+ * \param[in]  name           Name of attribute to parse
+ * \param[out] score          Where to store parsed score (can be NULL to
+ *                            just validate)
+ * \param[in]  default_score  What to return if the attribute value is not
+ *                            present or invalid
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__xe_get_score(const xmlNode *xml, const char *name, int *score,
+                   int default_score)
+{
+    const char *value = NULL;
+
+    CRM_CHECK((xml != NULL) && (name != NULL), return EINVAL);
+    value = crm_element_value(xml, name);
+    return pcmk_parse_score(value, score, default_score);
+}
+
+/*!
+ * \internal
  * \brief Set an XML attribute, expanding \c ++ and \c += where appropriate
  *
  * If \p target already has an attribute named \p name set to an integer value

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -315,9 +315,11 @@ lrmd_dispatch_internal(lrmd_t * lrmd, xmlNode * msg)
                               &event.rsc_deleted);
 
         crm_element_value_epoch(msg, PCMK__XA_LRMD_RUN_TIME, &epoch);
+        // coverity[store_truncates_time_t]
         event.t_run = (unsigned int) epoch;
 
         crm_element_value_epoch(msg, PCMK__XA_LRMD_RCCHANGE_TIME, &epoch);
+        // coverity[store_truncates_time_t]
         event.t_rcchange = (unsigned int) epoch;
 
         crm_element_value_int(msg, PCMK__XA_LRMD_EXEC_TIME, &exec_time);

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -860,6 +860,7 @@ pcmk__event_from_graph_action(const xmlNode *resource,
                         crm_element_value(action->xml, PCMK_XA_OPERATION),
                         action->interval_ms);
     lrmd__set_result(op, rc, status, exit_reason);
+    // coverity[store_truncates_time_t]
     op->t_run = time(NULL);
     op->t_rcchange = op->t_run;
     op->params = pcmk__strkey_table(free, free);

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -1005,6 +1005,7 @@ pcmk__create_graph(pcmk_scheduler_t *scheduler)
     const char *value = NULL;
     long long limit = 0LL;
     GHashTable *config_hash = scheduler->config_hash;
+    int rc = pcmk_rc_ok;
 
     transition_id++;
     crm_trace("Creating transition graph %d", transition_id);
@@ -1031,7 +1032,11 @@ pcmk__create_graph(pcmk_scheduler_t *scheduler)
     crm_xml_add_int(scheduler->graph, "transition_id", transition_id);
 
     value = pcmk__cluster_option(config_hash, PCMK_OPT_MIGRATION_LIMIT);
-    if ((pcmk__scan_ll(value, &limit, 0LL) == pcmk_rc_ok) && (limit > 0)) {
+    rc = pcmk__scan_ll(value, &limit, 0LL);
+    if (rc != pcmk_rc_ok) {
+        crm_warn("Ignoring invalid value '%s' for " PCMK_OPT_MIGRATION_LIMIT
+                 ": %s", value, pcmk_rc_str(rc));
+    } else if (limit > 0) {
         crm_xml_add(scheduler->graph, PCMK_OPT_MIGRATION_LIMIT, value);
     }
 

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -190,6 +190,7 @@ create_op(const xmlNode *cib_resource, const char *task, guint interval_ms,
     op = lrmd_new_event(pcmk__xe_id(cib_resource), task, interval_ms);
     lrmd__set_result(op, outcome, PCMK_EXEC_DONE, "Simulated action result");
     op->params = NULL; // Not needed for simulation purposes
+    // coverity[store_truncates_time_t]
     op->t_run = (unsigned int) time(NULL);
     op->t_rcchange = op->t_run;
 

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -374,7 +374,7 @@ pcmk__apply_node_health(pcmk_scheduler_t *scheduler)
 
     // The progressive strategy can use a base health score
     if (strategy == pcmk__health_strategy_progressive) {
-        base_health = pe__health_score(PCMK_OPT_NODE_HEALTH_BASE, scheduler);
+        base_health = pcmk__health_score(PCMK_OPT_NODE_HEALTH_BASE, scheduler);
     }
 
     for (GList *iter = scheduler->nodes; iter != NULL; iter = iter->next) {

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -83,8 +83,9 @@ get_ordering_type(const xmlNode *xml_obj)
 
         if (score) {
             // @COMPAT deprecated informally since 1.0.7, formally since 2.0.1
-            int score_i = char2score(score);
+            int score_i = 0;
 
+            (void) pcmk_parse_score(score, &score_i, 0);
             if (score_i == 0) {
                 kind_e = pe_order_kind_optional;
             }

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1583,9 +1583,14 @@ shutdown_time(pcmk_node_t *node)
 
     if (shutdown != NULL) {
         long long result_ll;
+        int rc = pcmk__scan_ll(shutdown, &result_ll, 0LL);
 
-        if (pcmk__scan_ll(shutdown, &result_ll, 0LL) == pcmk_rc_ok) {
+        if (rc == pcmk_rc_ok) {
             result = (time_t) result_ll;
+        } else {
+            crm_warn("Ignoring invalid value '%s' for %s "
+                     PCMK__NODE_ATTR_SHUTDOWN " attribute: %s",
+                     shutdown, pcmk__node_name(node), pcmk_rc_str(rc));
         }
     }
     return (result == 0)? get_effective_time(node->details->data_set) : result;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -665,6 +665,8 @@ static int
 promotion_score(const pcmk_resource_t *rsc, const pcmk_node_t *node,
                 bool *is_default)
 {
+    int score = 0;
+    int rc = pcmk_rc_ok;
     char *name = NULL;
     const char *attr_value = NULL;
 
@@ -732,7 +734,14 @@ promotion_score(const pcmk_resource_t *rsc, const pcmk_node_t *node,
     if (is_default != NULL) {
         *is_default = false;
     }
-    return char2score(attr_value);
+
+    rc = pcmk_parse_score(attr_value, &score, 0);
+    if (rc != pcmk_rc_ok) {
+        crm_warn("Using 0 as promotion score for %s on %s "
+                 "because '%s' is not a valid score",
+                 rsc->id, pcmk__node_name(node), attr_value);
+    }
+    return score;
 }
 
 /*!

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -735,7 +735,7 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
         node = pcmk_find_node(parent->cluster, uname);
         if (node == NULL) {
             node = pe_create_node(uname, uname, PCMK_VALUE_REMOTE,
-                                  PCMK_VALUE_MINUS_INFINITY, parent->cluster);
+                                  -PCMK_SCORE_INFINITY, parent->cluster);
         } else {
             node->weight = -PCMK_SCORE_INFINITY;
         }

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -641,6 +641,37 @@ unpack_priority(pcmk_resource_t *rsc)
 
 /*!
  * \internal
+ * \brief Parse resource stickiness from meta-attribute
+ *
+ * \param[in,out] rsc  Resource being unpacked
+ */
+static void
+unpack_stickiness(pcmk_resource_t *rsc)
+{
+    const char *value = g_hash_table_lookup(rsc->meta,
+                                            PCMK_META_RESOURCE_STICKINESS);
+
+    if (pcmk__str_eq(value, PCMK_VALUE_DEFAULT, pcmk__str_casei)) {
+        // @COMPAT Deprecated since 2.1.8
+        pcmk__config_warn("Support for setting "
+                          PCMK_META_RESOURCE_STICKINESS
+                          " to the explicit value '" PCMK_VALUE_DEFAULT
+                          "' is deprecated and will be removed in a "
+                          "future release (just leave it unset)");
+    } else {
+        int rc = pcmk_parse_score(value, &(rsc->stickiness), 0);
+
+        if (rc != pcmk_rc_ok) {
+            pcmk__config_warn("Using default (0) for resource %s "
+                              PCMK_META_RESOURCE_STICKINESS
+                              " because '%s' is not a valid value: %s",
+                              rsc->id, value, pcmk_rc_str(rc));
+        }
+    }
+}
+
+/*!
+ * \internal
  * \brief Unpack configuration XML for a given resource
  *
  * Unpack the XML object containing a resource's configuration into a new
@@ -888,19 +919,7 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
                         (*rsc)->id);
     }
 
-    value = g_hash_table_lookup((*rsc)->meta, PCMK_META_RESOURCE_STICKINESS);
-    if (value != NULL) {
-        if (pcmk__str_eq(PCMK_VALUE_DEFAULT, value, pcmk__str_casei)) {
-            // @COMPAT Deprecated since 2.1.8
-            pcmk__config_warn("Support for setting "
-                              PCMK_META_RESOURCE_STICKINESS
-                              " to the explicit value '" PCMK_VALUE_DEFAULT
-                              "' is deprecated and will be removed in a "
-                              "future release (just leave it unset)");
-        } else {
-            (*rsc)->stickiness = char2score(value);
-        }
-    }
+    unpack_stickiness(*rsc);
 
     value = g_hash_table_lookup((*rsc)->meta, PCMK_META_MIGRATION_THRESHOLD);
     if (value != NULL) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -620,6 +620,27 @@ warn_about_deprecated_classes(pcmk_resource_t *rsc)
 
 /*!
  * \internal
+ * \brief Parse resource priority from meta-attribute
+ *
+ * \param[in,out] rsc  Resource being unpacked
+ */
+static void
+unpack_priority(pcmk_resource_t *rsc)
+{
+    const char *value = g_hash_table_lookup(rsc->meta,
+                                            PCMK_META_PRIORITY);
+    int rc = pcmk_parse_score(value, &(rsc->priority), 0);
+
+    if (rc != pcmk_rc_ok) {
+        pcmk__config_warn("Using default (0) for resource %s "
+                          PCMK_META_PRIORITY
+                          " because '%s' is not a valid value: %s",
+                          rsc->id, value, pcmk_rc_str(rc));
+    }
+}
+
+/*!
+ * \internal
  * \brief Unpack configuration XML for a given resource
  *
  * Unpack the XML object containing a resource's configuration into a new
@@ -745,8 +766,7 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
     (*rsc)->migration_threshold = PCMK_SCORE_INFINITY;
     (*rsc)->failure_timeout = 0;
 
-    value = g_hash_table_lookup((*rsc)->meta, PCMK_META_PRIORITY);
-    (*rsc)->priority = char2score(value);
+    unpack_priority(*rsc);
 
     value = g_hash_table_lookup((*rsc)->meta, PCMK_META_CRITICAL);
     if ((value == NULL) || crm_is_true(value)) {

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -313,11 +313,14 @@ update_failcount_for_attr(gpointer key, gpointer value, gpointer user_data)
     if (regexec(&(fc_data->lastfailure_re), (const char *) key, 0, NULL,
                 0) == 0) {
         long long last_ll;
+        int rc = pcmk__scan_ll(value, &last_ll, 0LL);
 
-        if (pcmk__scan_ll(value, &last_ll, 0LL) == pcmk_rc_ok) {
-            fc_data->last_failure = (time_t) QB_MAX(fc_data->last_failure,
-                                                    last_ll);
+        if (rc != pcmk_rc_ok) {
+            crm_info("Ignoring invalid value '%s' for %s: %s",
+                     (const char *) value, (const char *) key, pcmk_rc_str(rc));
+            return;
         }
+        fc_data->last_failure = (time_t) QB_MAX(fc_data->last_failure, last_ll);
     }
 }
 

--- a/lib/pengine/pe_health.c
+++ b/lib/pengine/pe_health.c
@@ -43,12 +43,12 @@ pe__unpack_node_health_scores(pcmk_scheduler_t *scheduler)
             break;
 
         default: // progressive or custom
-            pcmk__score_red = pe__health_score(PCMK_OPT_NODE_HEALTH_RED,
-                                               scheduler);
-            pcmk__score_green = pe__health_score(PCMK_OPT_NODE_HEALTH_GREEN,
+            pcmk__score_red = pcmk__health_score(PCMK_OPT_NODE_HEALTH_RED,
                                                  scheduler);
-            pcmk__score_yellow = pe__health_score(PCMK_OPT_NODE_HEALTH_YELLOW,
-                                                  scheduler);
+            pcmk__score_green = pcmk__health_score(PCMK_OPT_NODE_HEALTH_GREEN,
+                                                   scheduler);
+            pcmk__score_yellow = pcmk__health_score(PCMK_OPT_NODE_HEALTH_YELLOW,
+                                                    scheduler);
             break;
     }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -3240,7 +3240,7 @@ ticket_default(pcmk__output_t *out, va_list args) {
                 char *epoch_str = NULL;
                 long long time_ll;
 
-                pcmk__scan_ll(value, &time_ll, 0);
+                (void) pcmk__scan_ll(value, &time_ll, 0);
                 epoch_str = pcmk__epoch2str((const time_t *) &time_ll, 0);
                 pcmk__g_strcat(detail_str, epoch_str, NULL);
                 free(epoch_str);

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -69,9 +69,9 @@ sort_pairs(gconstpointer a, gconstpointer b, gpointer user_data)
     const xmlNode *pair_b = b;
     pcmk__nvpair_unpack_t *unpack_data = user_data;
 
-    const char *score = NULL;
     int score_a = 0;
     int score_b = 0;
+    int rc = pcmk_rc_ok;
 
     if (a == NULL && b == NULL) {
         return 0;
@@ -90,11 +90,23 @@ sort_pairs(gconstpointer a, gconstpointer b, gpointer user_data)
         return 1;
     }
 
-    score = crm_element_value(pair_a, PCMK_XA_SCORE);
-    score_a = char2score(score);
+    rc = pcmk__xe_get_score(pair_a, PCMK_XA_SCORE, &score_a, 0);
+    if (rc != pcmk_rc_ok) { // Not possible with schema validation enabled
+        pcmk__config_warn("Using 0 as %s score because '%s' "
+                          "is not a valid score: %s",
+                          pcmk__xe_id(pair_a),
+                          crm_element_value(pair_a, PCMK_XA_SCORE),
+                          pcmk_rc_str(rc));
+    }
 
-    score = crm_element_value(pair_b, PCMK_XA_SCORE);
-    score_b = char2score(score);
+    rc = pcmk__xe_get_score(pair_b, PCMK_XA_SCORE, &score_b, 0);
+    if (rc != pcmk_rc_ok) { // Not possible with schema validation enabled
+        pcmk__config_warn("Using 0 as %s score because '%s' "
+                          "is not a valid score: %s",
+                          pcmk__xe_id(pair_b),
+                          crm_element_value(pair_b, PCMK_XA_SCORE),
+                          pcmk_rc_str(rc));
+    }
 
     /* If we're overwriting values, we want lowest score first, so the highest
      * score is processed last; if we're not overwriting values, we want highest

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -419,11 +419,11 @@ set_working_set_defaults(pcmk_scheduler_t *scheduler)
 
     pcmk__set_scheduler_flags(scheduler,
                               pcmk_sched_symmetric_cluster
+#if PCMK__CONCURRENT_FENCING_DEFAULT_TRUE
+                              |pcmk_sched_concurrent_fencing
+#endif
                               |pcmk_sched_stop_removed_resources
                               |pcmk_sched_cancel_removed_actions);
-    if (!strcmp(PCMK__CONCURRENT_FENCING_DEFAULT, PCMK_VALUE_TRUE)) {
-        pcmk__set_scheduler_flags(scheduler, pcmk_sched_concurrent_fencing);
-    }
 }
 
 pcmk_resource_t *

--- a/lib/pengine/tests/status/set_working_set_defaults_test.c
+++ b/lib/pengine/tests/status/set_working_set_defaults_test.c
@@ -26,13 +26,11 @@ check_defaults(void **state) {
     set_working_set_defaults(scheduler);
 
     flags = pcmk_sched_symmetric_cluster
+#if PCMK__CONCURRENT_FENCING_DEFAULT_TRUE
+            |pcmk_sched_concurrent_fencing
+#endif
             |pcmk_sched_stop_removed_resources
             |pcmk_sched_cancel_removed_actions;
-
-    if (!strcmp(PCMK__CONCURRENT_FENCING_DEFAULT, PCMK_VALUE_TRUE)) {
-        flags |= pcmk_sched_concurrent_fencing;
-    }
-
 
     assert_null(scheduler->priv);
     assert_int_equal(scheduler->order_id, 1);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -452,9 +452,23 @@ unpack_config(xmlNode *config, pcmk_scheduler_t *scheduler)
     return TRUE;
 }
 
+/*!
+ * \internal
+ * \brief Create a new node object in scheduler data
+ *
+ * \param[in]     id         ID of new node
+ * \param[in]     uname      Name of new node
+ * \param[in]     type       Type of new node
+ * \param[in]     score      Score of new node
+ * \param[in,out] scheduler  Scheduler data
+ *
+ * \return Newly created node object
+ * \note The returned object is part of the scheduler data and should not be
+ *       freed separately.
+ */
 pcmk_node_t *
 pe_create_node(const char *id, const char *uname, const char *type,
-               const char *score, pcmk_scheduler_t *scheduler)
+               int score, pcmk_scheduler_t *scheduler)
 {
     pcmk_node_t *new_node = NULL;
 
@@ -468,7 +482,7 @@ pe_create_node(const char *id, const char *uname, const char *type,
         return NULL;
     }
 
-    new_node->weight = char2score(score);
+    new_node->weight = score;
     new_node->details = calloc(1, sizeof(struct pe_node_shared_s));
 
     if (new_node->details == NULL) {
@@ -647,7 +661,8 @@ unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *scheduler)
                                  "> entry in configuration without id");
                 continue;
             }
-            new_node = pe_create_node(id, uname, type, score, scheduler);
+            new_node = pe_create_node(id, uname, type, char2score(score),
+                                      scheduler);
 
             if (new_node == NULL) {
                 return FALSE;
@@ -726,7 +741,7 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
                 crm_trace("Found remote node %s defined by resource %s",
                           new_node_id, pcmk__xe_id(xml_obj));
                 pe_create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
-                               NULL, scheduler);
+                               0, scheduler);
             }
             continue;
         }
@@ -746,7 +761,7 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
                 crm_trace("Found guest node %s in resource %s",
                           new_node_id, pcmk__xe_id(xml_obj));
                 pe_create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
-                               NULL, scheduler);
+                               0, scheduler);
             }
             continue;
         }
@@ -768,7 +783,7 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
                               new_node_id, pcmk__xe_id(xml_obj2),
                               pcmk__xe_id(xml_obj));
                     pe_create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
-                                   NULL, scheduler);
+                                   0, scheduler);
                 }
             }
         }
@@ -2019,7 +2034,7 @@ create_fake_resource(const char *rsc_id, const xmlNode *rsc_entry,
         crm_debug("Detected orphaned remote node %s", rsc_id);
         node = pcmk_find_node(scheduler, rsc_id);
         if (node == NULL) {
-            node = pe_create_node(rsc_id, rsc_id, PCMK_VALUE_REMOTE, NULL,
+            node = pe_create_node(rsc_id, rsc_id, PCMK_VALUE_REMOTE, 0,
                                   scheduler);
         }
         link_rsc2remotenode(scheduler, rsc);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -642,18 +642,19 @@ unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *scheduler)
     const char *id = NULL;
     const char *uname = NULL;
     const char *type = NULL;
-    const char *score = NULL;
 
     for (xml_obj = pcmk__xe_first_child(xml_nodes, NULL, NULL, NULL);
          xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {
 
         if (pcmk__xe_is(xml_obj, PCMK_XE_NODE)) {
+            int score = 0;
+            int rc = pcmk__xe_get_score(xml_obj, PCMK_XA_SCORE, &score, 0);
+
             new_node = NULL;
 
             id = crm_element_value(xml_obj, PCMK_XA_ID);
             uname = crm_element_value(xml_obj, PCMK_XA_UNAME);
             type = crm_element_value(xml_obj, PCMK_XA_TYPE);
-            score = crm_element_value(xml_obj, PCMK_XA_SCORE);
             crm_trace("Processing node %s/%s", uname, id);
 
             if (id == NULL) {
@@ -661,8 +662,15 @@ unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *scheduler)
                                  "> entry in configuration without id");
                 continue;
             }
-            new_node = pe_create_node(id, uname, type, char2score(score),
-                                      scheduler);
+            if (rc != pcmk_rc_ok) {
+                // Not possible with schema validation enabled
+                pcmk__config_warn("Using 0 as score for node %s "
+                                  "because '%s' is not a valid score: %s",
+                                  pcmk__s(uname, "without name"),
+                                  crm_element_value(xml_obj, PCMK_XA_SCORE),
+                                  pcmk_rc_str(rc));
+            }
+            new_node = pe_create_node(id, uname, type, score, scheduler);
 
             if (new_node == NULL) {
                 return FALSE;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1042,9 +1042,15 @@ unpack_ticket_state(xmlNode *xml_ticket, pcmk_scheduler_t *scheduler)
 
     last_granted = g_hash_table_lookup(ticket->state, PCMK_XA_LAST_GRANTED);
     if (last_granted) {
-        long long last_granted_ll;
+        long long last_granted_ll = 0LL;
+        int rc = pcmk__scan_ll(last_granted, &last_granted_ll, 0LL);
 
-        pcmk__scan_ll(last_granted, &last_granted_ll, 0LL);
+        if (rc != pcmk_rc_ok) {
+            crm_warn("Using %lld instead of invalid " PCMK_XA_LAST_GRANTED
+                     " value '%s' in state for ticket %s: %s",
+                     last_granted_ll, last_granted, ticket->id,
+                     pcmk_rc_str(rc));
+        }
         ticket->last_granted = (time_t) last_granted_ll;
     }
 
@@ -1569,6 +1575,7 @@ unpack_node_terminate(const pcmk_node_t *node, const xmlNode *node_state)
 {
     long long value = 0LL;
     int value_i = 0;
+    int rc = pcmk_rc_ok;
     const char *value_s = pcmk__node_attr(node, PCMK_NODE_ATTR_TERMINATE,
                                           NULL, pcmk__rsc_node_current);
 
@@ -1576,11 +1583,13 @@ unpack_node_terminate(const pcmk_node_t *node, const xmlNode *node_state)
     if (crm_str_to_boolean(value_s, &value_i) == 1) {
         return (value_i != 0);
     }
-    if (pcmk__scan_ll(value_s, &value, 0LL) == pcmk_rc_ok) {
+    rc = pcmk__scan_ll(value_s, &value, 0LL);
+    if (rc == pcmk_rc_ok) {
         return (value > 0);
     }
     crm_warn("Ignoring unrecognized value '%s' for " PCMK_NODE_ATTR_TERMINATE
-             "node attribute for %s", value_s, pcmk__node_name(node));
+             "node attribute for %s: %s",
+             value_s, pcmk__node_name(node), pcmk_rc_str(rc));
     return false;
 }
 


### PR DESCRIPTION
This backports #3643 except for the Low/Feature commits (which change behavior incompatibly) and `char2score()` deprecation. The `scan_ll()` return code change from `EINVAL` to `pcmk_rc_bad_input` was skipped to avoid changing behavior.