### PR TITLE
Low: python: Fix sloppy XML in ctslab

### DIFF
--- a/python/pacemaker/_cts/clustermanager.py
+++ b/python/pacemaker/_cts/clustermanager.py
@@ -877,7 +877,7 @@ class ClusterManager(UserDict):
         rsc_xml = """ '<resources>
                 <primitive class=\"ocf\" id=\"%s\" provider=\"pacemaker\" type=\"Dummy\">
                     <operations>
-                        <op id=\"%s-interval-10s\" interval=\"10s\" name=\"monitor\"/
+                        <op id=\"%s-interval-10s\" interval=\"10s\" name=\"monitor\"/>
                     </operations>
                 </primitive>
             </resources>'""" % (rid, rid)

--- a/python/pacemaker/_cts/tests/reattach.py
+++ b/python/pacemaker/_cts/tests/reattach.py
@@ -79,7 +79,7 @@ class Reattach(CTSTest):
     def _enable_incompatible_rscs(self, node):
         """Re-enable resources that were incompatible with this test."""
         self.debug("Re-enable incompatible resources")
-        xml = """<meta_attributes id="cts-lab-Reattach-meta">"""
+        xml = """<meta_attributes id="cts-lab-Reattach-meta"/>"""
         return self._rsh(node, """cibadmin --delete --xml-text '%s'""" % xml)
 
     def _reprobe(self, node):


### PR DESCRIPTION
This has been broken since being introduced in 4b03268ade7.  Something in XML handling must have changed to cause it to start being a problem, but I don't see what.