### PR TITLE
Feature: libpe_status: Drop support for ping nodes

### DIFF
--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -32,7 +32,6 @@ enum pcmk__warnings {
     pcmk__wo_require_all    = (1 << 4),
     pcmk__wo_order_score    = (1 << 5),
     pcmk__wo_remove_after   = (1 << 7),
-    pcmk__wo_ping_node      = (1 << 8),
     pcmk__wo_group_order    = (1 << 11),
     pcmk__wo_group_coloc    = (1 << 12),
     pcmk__wo_set_ordering   = (1 << 15),

--- a/include/crm/common/nodes_internal.h
+++ b/include/crm/common/nodes_internal.h
@@ -34,7 +34,6 @@ extern "C" {
 #define PCMK__NODE_ATTR_RESOURCE_DISCOVERY_ENABLED  "resource-discovery-enabled"
 
 enum pcmk__node_variant { // Possible node types
-    pcmk__node_variant_ping     = 0,    // deprecated
     pcmk__node_variant_cluster  = 1,    // Cluster layer node
     pcmk__node_variant_remote   = 2,    // Pacemaker Remote node
 };

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -220,7 +220,6 @@ bool pcmk__valid_stonith_watchdog_timeout(const char *value);
 #define PCMK__VALUE_MAINT                   "maint"
 #define PCMK__VALUE_OUTPUT                  "output"
 #define PCMK__VALUE_PASSWORD                "password"
-#define PCMK__VALUE_PING                    "ping"
 #define PCMK__VALUE_PRIMITIVE               "primitive"
 #define PCMK__VALUE_REFRESH                 "refresh"
 #define PCMK__VALUE_REQUEST                 "request"

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -2026,7 +2026,6 @@ health_text(int health)
  *
  * \retval \c PCMK_VALUE_MEMBER if \p node_type is \c pcmk__node_variant_cluster
  * \retval \c PCMK_VALUE_REMOTE if \p node_type is \c pcmk__node_variant_remote
- * \retval \c PCMK__VALUE_PING if \p node_type is \c pcmk__node_variant_ping
  * \retval \c PCMK_VALUE_UNKNOWN otherwise
  */
 static const char *
@@ -2037,9 +2036,6 @@ node_variant_text(enum pcmk__node_variant variant)
             return PCMK_VALUE_MEMBER;
         case pcmk__node_variant_remote:
             return PCMK_VALUE_REMOTE;
-        case pcmk__node_variant_ping:
-            // @COMPAT Not possible with schema validation enabled
-            return PCMK__VALUE_PING;
         default:
             return PCMK_VALUE_UNKNOWN;
     }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -480,14 +480,6 @@ pe_create_node(const char *id, const char *uname, const char *type,
     } else if (pcmk__str_eq(type, PCMK_VALUE_REMOTE, pcmk__str_casei)) {
         variant = pcmk__node_variant_remote;
 
-    } else if (pcmk__str_eq(type, PCMK__VALUE_PING, pcmk__str_casei)) {
-        pcmk__warn_once(pcmk__wo_ping_node,
-                        "Support for nodes of type '" PCMK__VALUE_PING "' "
-                        "(such as %s) is deprecated and will be removed in a "
-                        "future release",
-                        pcmk__s(uname, "unnamed node"));
-        variant = pcmk__node_variant_ping;
-
     } else {
         pcmk__config_err("Ignoring node %s with unrecognized type '%s'",
                          pcmk__s(uname, "without name"), type);
@@ -1889,15 +1881,7 @@ determine_online_status(const xmlNode *node_state, pcmk_node_t *this_node,
         pcmk__set_node_flags(this_node, pcmk__node_expected_up);
     }
 
-    if (this_node->priv->variant == pcmk__node_variant_ping) {
-        // @COMPAT Not possible with schema validation enabled
-        this_node->details->unclean = FALSE;
-        online = FALSE;         /* As far as resource management is concerned,
-                                 * the node is safely offline.
-                                 * Anyone caught abusing this logic will be shot
-                                 */
-
-    } else if (!pcmk_is_set(scheduler->flags, pcmk__sched_fencing_enabled)) {
+    if (!pcmk_is_set(scheduler->flags, pcmk__sched_fencing_enabled)) {
         online = determine_online_status_no_fencing(scheduler, node_state,
                                                     this_node);
 
@@ -1919,11 +1903,7 @@ determine_online_status(const xmlNode *node_state, pcmk_node_t *this_node,
         this_node->assign->score = -PCMK_SCORE_INFINITY;
     }
 
-    if (this_node->priv->variant == pcmk__node_variant_ping) {
-        // @COMPAT Not possible with schema validation enabled
-        crm_info("%s is not a Pacemaker node", pcmk__node_name(this_node));
-
-    } else if (this_node->details->unclean) {
+    if (this_node->details->unclean) {
         pcmk__sched_warn(scheduler, "%s is unclean",
                          pcmk__node_name(this_node));
 


### PR DESCRIPTION
Ping nodes have been deprecated since 2.1.3. See commit 1478ee54 for more details.

This is already disallowed by the schema.

Closes T302