### PR TITLE
High: libcrmcommon: Don't assert on failure to write errors.

### DIFF
--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -135,7 +135,6 @@ G_GNUC_PRINTF(2, 3)
 static void
 text_err(pcmk__output_t *out, const char *format, ...) {
     va_list ap;
-    int len = 0;
 
     pcmk__assert(out != NULL);
 
@@ -144,8 +143,7 @@ text_err(pcmk__output_t *out, const char *format, ...) {
     /* Informational output does not get indented, to separate it from other
      * potentially indented list output.
      */
-    len = vfprintf(stderr, format, ap);
-    pcmk__assert(len >= 0);
+    vfprintf(stderr, format, ap);
     va_end(ap);
 
     /* Add a newline. */
@@ -156,7 +154,6 @@ G_GNUC_PRINTF(2, 3)
 static int
 text_info(pcmk__output_t *out, const char *format, ...) {
     va_list ap;
-    int len = 0;
 
     pcmk__assert(out != NULL);
 
@@ -169,8 +166,7 @@ text_info(pcmk__output_t *out, const char *format, ...) {
     /* Informational output does not get indented, to separate it from other
      * potentially indented list output.
      */
-    len = vfprintf(out->dest, format, ap);
-    pcmk__assert(len >= 0);
+    vfprintf(out->dest, format, ap);
     va_end(ap);
 
     /* Add a newline. */
@@ -399,13 +395,9 @@ pcmk__output_text_set_fancy(pcmk__output_t *out, bool enabled)
 G_GNUC_PRINTF(2, 0)
 void
 pcmk__formatted_vprintf(pcmk__output_t *out, const char *format, va_list args) {
-    int len = 0;
-
     pcmk__assert(out != NULL);
     CRM_CHECK(pcmk__str_eq(out->fmt_name, "text", pcmk__str_none), return);
-
-    len = vfprintf(out->dest, format, args);
-    pcmk__assert(len >= 0);
+    vfprintf(out->dest, format, args);
 }
 
 G_GNUC_PRINTF(2, 3)


### PR DESCRIPTION
Only text output mode is affected by this - other output formats write to a buffer, so an error there is likely a memory problem and should be asserted on.  Additionally, there are other places in text output where we assert on writing to out->dest - these are not affected either because we only allow dest to be a filename (or "-", but see below).

Strangely, text_info does not appear to be affected despite doing basically the same thing but on stdout.  This is the same reason why --output-to=- is not a problem.

Fixes T891