### PR TITLE
Perform remote CIB operations asynchronously

### DIFF
--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -428,12 +428,7 @@ cib_remote_msg(gpointer data)
     xmlNode *command = NULL;
     pcmk__client_t *client = data;
     int rc;
-    int timeout = 1000;
     const char *client_name = pcmk__client_name(client);
-
-    if (pcmk_is_set(client->flags, pcmk__client_authenticated)) {
-        timeout = -1;
-    }
 
     crm_trace("Remote %s message received for client %s",
               pcmk__client_type_str(PCMK__CLIENT_TYPE(client)), client_name);
@@ -465,7 +460,20 @@ cib_remote_msg(gpointer data)
         return 0;
     }
 
-    rc = pcmk__read_remote_message(client->remote, timeout);
+    rc = pcmk__read_available_remote_data(client->remote);
+    switch (rc) {
+        case pcmk_rc_ok:
+            break;
+
+        case EAGAIN:
+            /* We haven't read the whole message yet */
+            return 0;
+
+        default:
+            /* Error */
+            crm_trace("Error reading from remote client: %s", pcmk_rc_str(rc));
+            return -1;
+    }
 
     /* must pass auth before we will process anything else */
     if (!pcmk_is_set(client->flags, pcmk__client_authenticated)) {
@@ -507,12 +515,6 @@ cib_remote_msg(gpointer data)
         cib_handle_remote_msg(client, command);
         pcmk__xml_free(command);
         command = pcmk__remote_message_xml(client->remote);
-    }
-
-    if (rc == ENOTCONN) {
-        crm_trace("Remote CIB client %s disconnected while reading from it",
-                  client_name);
-        return -1;
     }
 
     return 0;

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -510,11 +510,10 @@ cib_remote_msg(gpointer data)
     }
 
     command = pcmk__remote_message_xml(client->remote);
-    while (command) {
+    if (command != NULL) {
         crm_trace("Remote message received from client %s", client_name);
         cib_handle_remote_msg(client, command);
         pcmk__xml_free(command);
-        command = pcmk__remote_message_xml(client->remote);
     }
 
     return 0;

--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -31,6 +31,7 @@ typedef struct pcmk__remote_s pcmk__remote_t;
 
 int pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg);
 int pcmk__remote_ready(const pcmk__remote_t *remote, int timeout_ms);
+int pcmk__read_available_remote_data(pcmk__remote_t *remote);
 int pcmk__read_remote_message(pcmk__remote_t *remote, int timeout_ms);
 xmlNode *pcmk__remote_message_xml(pcmk__remote_t *remote);
 int pcmk__connect_remote(const char *host, int port, int timeout_ms,

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -47,6 +47,8 @@ typedef struct cib_remote_opaque_s {
     pcmk__remote_t command;
     pcmk__remote_t callback;
     pcmk__output_t *out;
+    time_t start_time;
+    int timeout_sec;
 } cib_remote_opaque_t;
 
 static int
@@ -204,9 +206,37 @@ cib_remote_callback_dispatch(gpointer user_data)
 
     xmlNode *msg = NULL;
 
-    crm_info("Message on callback channel");
+    /* If start time is 0, we've previously handled a complete message and this
+     * connection is being reused for a new message.  Reset the start_time,
+     * giving this new message timeout_sec from now to complete.
+     */
+    if (private->start_time == 0) {
+        private->start_time = time(NULL);
+    }
 
-    rc = pcmk__read_remote_message(&private->callback, -1);
+    rc = pcmk__read_available_remote_data(&private->callback);
+    switch (rc) {
+        case pcmk_rc_ok:
+            /* We have the whole message so process it */
+            break;
+
+        case EAGAIN:
+            /* Have we timed out? */
+            if (time(NULL) >= private->start_time + private->timeout_sec) {
+                crm_info("Error reading from CIB manager connection: %s",
+                         pcmk_rc_str(ETIME));
+                return -1;
+            }
+
+            /* We haven't read the whole message yet */
+            return 0;
+
+        default:
+            /* Error */
+            crm_info("Error reading from CIB manager connection: %s",
+                     pcmk_rc_str(rc));
+            return -1;
+    }
 
     msg = pcmk__remote_message_xml(&private->callback);
     while (msg) {
@@ -228,10 +258,7 @@ cib_remote_callback_dispatch(gpointer user_data)
         msg = pcmk__remote_message_xml(&private->callback);
     }
 
-    if (rc == ENOTCONN) {
-        return -1;
-    }
-
+    private->start_time = 0;
     return 0;
 }
 
@@ -242,15 +269,35 @@ cib_remote_command_dispatch(gpointer user_data)
     cib_t *cib = user_data;
     cib_remote_opaque_t *private = cib->variant_opaque;
 
-    rc = pcmk__read_remote_message(&private->command, -1);
+    /* See cib_remote_callback_dispatch */
+    if (private->start_time == 0) {
+        private->start_time = time(NULL);
+    }
+
+    rc = pcmk__read_available_remote_data(&private->command);
+    if (rc == EAGAIN) {
+        /* Have we timed out? */
+        if (time(NULL) >= private->start_time + private->timeout_sec) {
+            crm_info("Error reading from CIB manager connection: %s",
+                     pcmk_rc_str(ETIME));
+            return -1;
+        }
+
+        /* We haven't read the whole message yet */
+        return 0;
+    }
 
     free(private->command.buffer);
     private->command.buffer = NULL;
     crm_err("received late reply for remote cib connection, discarding");
 
-    if (rc == ENOTCONN) {
+    if (rc != pcmk_rc_ok) {
+        crm_info("Error reading from CIB manager connection: %s",
+                 pcmk_rc_str(rc));
         return -1;
     }
+
+    private->start_time = 0;
     return 0;
 }
 
@@ -412,6 +459,7 @@ cib_tls_signon(cib_t *cib, pcmk__remote_t *connection, gboolean event_channel)
     }
 
     crm_trace("remote client connection established");
+    private->timeout_sec = 60;
     connection->source = mainloop_add_fd("cib-remote", G_PRIORITY_HIGH,
                                          connection->tcp_socket, cib,
                                          &cib_fd_callbacks);

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -656,8 +656,8 @@ pcmk__remote_ready(const pcmk__remote_t *remote, int timeout_ms)
  * \note This function will return when the socket read buffer is empty or an
  *       error is encountered.
  */
-static int
-read_available_remote_data(pcmk__remote_t *remote)
+int
+pcmk__read_available_remote_data(pcmk__remote_t *remote)
 {
     int rc = pcmk_rc_ok;
     size_t read_len = sizeof(struct remote_header_v0);
@@ -790,7 +790,7 @@ pcmk__read_remote_message(pcmk__remote_t *remote, int timeout_ms)
                       QB_XS " rc=%d", pcmk_rc_str(rc), rc);
 
         } else {
-            rc = read_available_remote_data(remote);
+            rc = pcmk__read_available_remote_data(remote);
             if (rc == pcmk_rc_ok) {
                 return rc;
             } else if (rc == EAGAIN) {

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -573,6 +573,7 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
         crm_err("Couldn't parse: '%.120s'", remote->buffer + header->payload_offset);
     }
 
+    crm_log_xml_trace(xml, "[remote msg]");
     return xml;
 }
 


### PR DESCRIPTION
This breaks a bunch of patches out of #3633 since the remote CIB stuff seems to be a lot less sensitive.  I've tested this by running things as normal, and additionally by inserting a line into cib_remote_msg where pcmk__read_available_remote_data always returns EAGAIN.  The result of the latter test is that pacemaker-based logs other things happening in between the client starting authentication and that authentication eventually timing out.