### PR TITLE
Minor fixes

### DIFF
--- a/doc/sphinx/Pacemaker_Explained/local-options.rst
+++ b/doc/sphinx/Pacemaker_Explained/local-options.rst
@@ -43,7 +43,8 @@ of the following types:
           pair: type; duration
 
        duration
-     - A time duration, specified either like a :ref:`timeout <timeout>` or an
+     - A nonnegative time duration, specified either like a
+       :ref:`timeout <timeout>` or an
        `ISO 8601 duration <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_.
        A duration may be up to approximately 49 days but is intended for much
        smaller time periods.

--- a/lib/cib/Makefile.am
+++ b/lib/cib/Makefile.am
@@ -20,7 +20,7 @@ libcib_la_SOURCES	+= cib_ops.c
 libcib_la_SOURCES	+= cib_remote.c
 libcib_la_SOURCES	+= cib_utils.c
 
-libcib_la_LDFLAGS	= -version-info 33:0:6
+libcib_la_LDFLAGS	= -version-info 33:1:6
 libcib_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
 
 libcib_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)

--- a/lib/cluster/Makefile.am
+++ b/lib/cluster/Makefile.am
@@ -15,7 +15,7 @@ noinst_HEADERS	= crmcluster_private.h
 ## libraries
 lib_LTLIBRARIES	= libcrmcluster.la 
 
-libcrmcluster_la_LDFLAGS = -version-info 32:0:3
+libcrmcluster_la_LDFLAGS = -version-info 32:1:3
 
 libcrmcluster_la_CFLAGS  = $(CFLAGS_HARDENED_LIB)
 libcrmcluster_la_LDFLAGS += $(LDFLAGS_HARDENED_LIB)

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -30,7 +30,7 @@ SUBDIRS = . tests
 noinst_HEADERS		= crmcommon_private.h \
 			  mock_private.h
 
-libcrmcommon_la_LDFLAGS	= -version-info 47:0:13
+libcrmcommon_la_LDFLAGS	= -version-info 47:1:13
 
 libcrmcommon_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libcrmcommon_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1765,18 +1765,23 @@ crm_time_compare(const crm_time_t *a, const crm_time_t *b)
 void
 crm_time_add_seconds(crm_time_t *a_time, int extra)
 {
-    int days = 0;
+    int days = extra / DAY_SECONDS;
 
-    crm_trace("Adding %d seconds to %d (max=%d)",
-              extra, a_time->seconds, DAY_SECONDS);
-    a_time->seconds += extra;
-    days = a_time->seconds / DAY_SECONDS;
-    a_time->seconds %= DAY_SECONDS;
+    pcmk__assert(a_time != NULL);
 
-    // Don't have negative seconds
-    if (a_time->seconds < 0) {
-        a_time->seconds += DAY_SECONDS;
+    crm_trace("Adding %d seconds (including %d whole day%s) to %d",
+              extra, days, pcmk__plural_s(days), a_time->seconds);
+
+    a_time->seconds += extra % DAY_SECONDS;
+
+    // Check whether the addition crossed a day boundary
+    if (a_time->seconds > DAY_SECONDS) {
+        ++days;
+        a_time->seconds -= DAY_SECONDS;
+
+    } else if (a_time->seconds < 0) {
         --days;
+        a_time->seconds += DAY_SECONDS;
     }
 
     crm_time_add_days(a_time, days);

--- a/lib/common/tests/iso8601/Makefile.am
+++ b/lib/common/tests/iso8601/Makefile.am
@@ -13,6 +13,7 @@ include $(top_srcdir)/mk/unittest.mk
 
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = crm_time_add_days_test			\
+		 crm_time_add_seconds_test		\
 		 crm_time_add_years_test		\
 		 crm_time_parse_duration_test		\
 		 pcmk__add_time_from_xml_test		\

--- a/lib/common/tests/iso8601/crm_time_add_seconds_test.c
+++ b/lib/common/tests/iso8601/crm_time_add_seconds_test.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdio.h>      // NULL
+#include <limits.h>     // INT_MAX
+
+#include <crm/common/unittest_internal.h>
+
+#include <crm/common/iso8601.h>
+
+static void
+assert_add_seconds(const char *orig_date_time, int seconds,
+                 const char *expected_date_time)
+{
+    crm_time_t *orig = crm_time_new(orig_date_time);
+    crm_time_t *expected = crm_time_new(expected_date_time);
+
+    assert_non_null(orig);
+    assert_non_null(expected);
+
+    crm_time_add_seconds(orig, seconds);
+    assert_int_equal(crm_time_compare(orig, expected), 0);
+
+    crm_time_free(orig);
+    crm_time_free(expected);
+}
+
+static void
+invalid_argument(void **state)
+{
+    pcmk__assert_asserts(crm_time_add_seconds(NULL, 1));
+}
+
+static void
+add_zero(void **state)
+{
+    assert_add_seconds("2024-01-01 00:30:00 +01:00", 0,
+                       "2024-01-01 00:30:00 +01:00");
+}
+
+static void
+add_less_than_one_day(void **state)
+{
+    // Minute boundary not crossed
+    assert_add_seconds("2024-01-01 00:30:00 +01:00", 1,
+                       "2024-01-01 00:30:01 +01:00");
+    assert_add_seconds("2024-01-01 00:30:00 +01:00", 59,
+                       "2024-01-01 00:30:59 +01:00");
+
+    // Minute boundary crossed
+    assert_add_seconds("2024-01-01 00:30:59 +02:00", 1,
+                       "2024-01-01 00:31:00 +02:00");
+    assert_add_seconds("2024-01-01 00:44:30 +02:00", 60,
+                       "2024-01-01 00:45:30 +02:00");
+    assert_add_seconds("2024-01-01 00:44:30 +02:00", 125,
+                       "2024-01-01 00:46:35 +02:00");
+
+    // Hour boundary crossed
+    assert_add_seconds("2024-01-01 00:59:59 -03:00", 1,
+                       "2024-01-01 01:00:00 -03:00");
+    assert_add_seconds("2024-01-01 00:23:34 -03:00", 3600,
+                       "2024-01-01 01:23:34 -03:00");
+    assert_add_seconds("2024-01-01 00:23:34 -03:00", 7210,
+                       "2024-01-01 02:23:44 -03:00");
+
+    // Day boundary crossed
+    assert_add_seconds("2024-01-01 23:59:59 +04:00", 1,
+                       "2024-01-02 00:00:00 +04:00");
+    assert_add_seconds("2024-02-28 00:05:00 +04:00", 86200,
+                       "2024-02-29 00:01:40 +04:00");
+
+    // Month boundary crossed
+    assert_add_seconds("2023-02-28 00:05:00 -05:00", 86200,
+                       "2023-03-01 00:01:40 -05:00");
+    assert_add_seconds("2024-02-29 23:59:00 -05:00", 60,
+                       "2024-03-01 00:00:00 -05:00");
+
+    // Year boundary crossed
+    assert_add_seconds("2024-12-31 23:59:59 +06:00", 1,
+                       "2025-01-01 00:00:00 +06:00");
+}
+
+static void
+add_more_than_one_day(void **state)
+{
+    // Month boundary not crossed
+    assert_add_seconds("2024-01-01 00:00:00 +01:00", 86400 * 2,
+                       "2024-01-03 00:00:00 +01:00");
+    assert_add_seconds("2024-02-27 23:59:59 +01:00", 86400 * 2,
+                       "2024-02-29 23:59:59 +01:00");
+
+    // Month boundary crossed
+    assert_add_seconds("2023-02-26 23:59:59 -02:00", 86400 * 2 + 1,
+                       "2023-03-01 00:00:00 -02:00");
+    assert_add_seconds("2024-02-27 23:59:59 -02:00", 86400 * 2 + 1,
+                       "2024-03-01 00:00:00 -02:00");
+
+    // Year boundary crossed
+    assert_add_seconds("2024-12-01 00:00:00 +06:00", 86400 * 31,
+                       "2025-01-01 00:00:00 +06:00");
+}
+
+static void
+subtract_less_than_one_day(void **state)
+{
+    // Minute boundary not crossed
+    assert_add_seconds("2024-01-01 00:30:01 +01:00", -1,
+                       "2024-01-01 00:30:00 +01:00");
+    assert_add_seconds("2024-01-01 00:30:30 +01:00", -5,
+                       "2024-01-01 00:30:25 +01:00");
+    assert_add_seconds("2024-01-01 00:30:59 +01:00", -59,
+                       "2024-01-01 00:30:00 +01:00");
+
+    // Minute boundary crossed
+    assert_add_seconds("2024-01-01 00:30:00 +02:00", -1,
+                       "2024-01-01 00:29:59 +02:00");
+    assert_add_seconds("2024-01-01 00:44:30 +02:00", -60,
+                       "2024-01-01 00:43:30 +02:00");
+    assert_add_seconds("2024-01-01 00:14:30 +02:00", -125,
+                       "2024-01-01 00:12:25 +02:00");
+
+    // Hour boundary crossed
+    assert_add_seconds("2024-01-01 01:00:00 -03:00", -1,
+                       "2024-01-01 00:59:59 -03:00");
+    assert_add_seconds("2024-01-01 01:23:34 -03:00", -3600,
+                       "2024-01-01 00:23:34 -03:00");
+    assert_add_seconds("2024-01-01 02:23:34 -03:00", -7210,
+                       "2024-01-01 00:23:24 -03:00");
+
+    // Day boundary crossed
+    assert_add_seconds("2024-01-02 00:00:00 +04:00", -1,
+                       "2024-01-01 23:59:59 +04:00");
+    assert_add_seconds("2024-02-29 00:01:40 +04:00", -86200,
+                       "2024-02-28 00:05:00 +04:00");
+
+    // Month boundary crossed
+    assert_add_seconds("2023-03-01 00:01:40 -05:00", -86200,
+                       "2023-02-28 00:05:00 -05:00");
+    assert_add_seconds("2024-03-01 00:00:00 -05:00", -60,
+                       "2024-02-29 23:59:00 -05:00");
+
+    // Year boundary crossed
+    assert_add_seconds("2025-01-01 00:00:00 +06:00", -1,
+                       "2024-12-31 23:59:59 +06:00");
+}
+
+static void
+subtract_more_than_one_day(void **state)
+{
+    // Month boundary not crossed
+    assert_add_seconds("2024-01-03 00:00:00 +01:00", 86400 * -2,
+                       "2024-01-01 00:00:00 +01:00");
+    assert_add_seconds("2024-02-29 23:59:59 +01:00", 86400 * -2,
+                       "2024-02-27 23:59:59 +01:00");
+
+    // Month boundary crossed
+    assert_add_seconds("2023-03-03 00:00:00 -02:00", 86400 * -2 - 1,
+                       "2023-02-28 23:59:59 -02:00");
+    assert_add_seconds("2024-03-03 00:00:00 -02:00", 86400 * -2 - 1,
+                       "2024-02-29 23:59:59 -02:00");
+
+    // Year boundary crossed
+    assert_add_seconds("2025-01-01 00:00:00 +06:00", 86400 * -31,
+                       "2024-12-01 00:00:00 +06:00");
+}
+
+PCMK__UNIT_TEST(NULL, NULL,
+                cmocka_unit_test(invalid_argument),
+                cmocka_unit_test(add_zero),
+                cmocka_unit_test(add_less_than_one_day),
+                cmocka_unit_test(add_more_than_one_day),
+                cmocka_unit_test(subtract_less_than_one_day),
+                cmocka_unit_test(subtract_more_than_one_day));

--- a/lib/fencing/Makefile.am
+++ b/lib/fencing/Makefile.am
@@ -14,7 +14,7 @@ noinst_HEADERS		= fencing_private.h
 
 lib_LTLIBRARIES		= libstonithd.la
 
-libstonithd_la_LDFLAGS	= -version-info 34:5:8
+libstonithd_la_LDFLAGS	= -version-info 35:0:9
 
 libstonithd_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libstonithd_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/lrmd/Makefile.am
+++ b/lib/lrmd/Makefile.am
@@ -10,7 +10,7 @@ include $(top_srcdir)/mk/common.mk
 
 lib_LTLIBRARIES		= liblrmd.la
 
-liblrmd_la_LDFLAGS	= -version-info 31:0:3
+liblrmd_la_LDFLAGS	= -version-info 31:1:3
 
 liblrmd_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 liblrmd_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/pacemaker/Makefile.am
+++ b/lib/pacemaker/Makefile.am
@@ -16,7 +16,7 @@ noinst_HEADERS  = libpacemaker_private.h
 ## libraries
 lib_LTLIBRARIES	= libpacemaker.la
 
-libpacemaker_la_LDFLAGS	= -version-info 9:0:8
+libpacemaker_la_LDFLAGS	= -version-info 9:1:8
 
 libpacemaker_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libpacemaker_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/pengine/Makefile.am
+++ b/lib/pengine/Makefile.am
@@ -21,7 +21,7 @@ check_LTLIBRARIES 	= libpe_status_test.la
 
 noinst_HEADERS		= pe_status_private.h
 
-libpe_rules_la_LDFLAGS	= -version-info 30:2:4
+libpe_rules_la_LDFLAGS	= -version-info 30:3:4
 
 libpe_rules_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libpe_rules_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)
@@ -32,7 +32,7 @@ libpe_rules_la_LIBADD	= $(top_builddir)/lib/common/libcrmcommon.la
 libpe_rules_la_SOURCES	= rules.c
 libpe_rules_la_SOURCES	+= rules_alerts.c
 
-libpe_status_la_LDFLAGS	= -version-info 35:1:7
+libpe_status_la_LDFLAGS	= -version-info 35:2:7
 
 libpe_status_la_CFLAGS	= $(CFLAGS_HARDENED_LIB)
 libpe_status_la_LDFLAGS	+= $(LDFLAGS_HARDENED_LIB)

--- a/lib/services/Makefile.am
+++ b/lib/services/Makefile.am
@@ -11,7 +11,7 @@ include $(top_srcdir)/mk/common.mk
 lib_LTLIBRARIES			= libcrmservice.la
 noinst_HEADERS			= $(wildcard *.h)
 
-libcrmservice_la_LDFLAGS	= -version-info 32:1:4
+libcrmservice_la_LDFLAGS	= -version-info 32:2:4
 libcrmservice_la_CFLAGS		=
 
 libcrmservice_la_CFLAGS		+= $(CFLAGS_HARDENED_LIB)

--- a/m4/version.m4
+++ b/m4/version.m4
@@ -1,2 +1,2 @@
-m4_define([VERSION_NUMBER], [2.1.8])
+m4_define([VERSION_NUMBER], [2.1.9])
 m4_define([PCMK_URL], [https://ClusterLabs.org/pacemaker/])


### PR DESCRIPTION
The first two (release info) commits are forward-ports from 2.1.9-rc1, to make it clear that 3.0.0 will contain everything in 2.1.9. (Once 3.0.0 is released, 2.1 release info will no longer be forward-ported.)

The rest are trivial issues found recently. They will be backported to 2.1 for 2.1.9-rc2.