### PR TITLE
[2.1] Fix: tools: crm_resource returns error on failed schema upgrade

### DIFF
--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1303,7 +1303,7 @@ update_scheduler_input(pcmk_scheduler_t *scheduler, xmlNode **xml)
         scheduler->input = *xml;
         scheduler->now = crm_time_new(NULL);
     }
-    return pcmk_rc_ok;
+    return rc;
 }
 
 /*!


### PR DESCRIPTION
This fixes a regression introduced by 05e8f1b9 in 2.1.8.