### PR TITLE
Feature: tools: Define behavior of attrd_updater -Q without -N

### DIFF
--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -284,6 +284,8 @@ pcmk__attrd_api_query(pcmk_ipc_api_t *api, const char *node, const char *name,
 
         if (target != NULL) {
             node = target;
+        } else if (node == NULL) {
+            node = "localhost";
         }
     }
 

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -171,7 +171,10 @@ static GOptionEntry command_entries[] = {
       NULL },
 
     { "query", 'Q', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, command_cb,
-      "Query the attribute's value from the attribute manager",
+      "Query the attribute's value from the attribute manager. By default\n"
+      INDENT "this will query the value of the attribute on the local node.\n"
+      INDENT "Use -N/--node for the value on a given node, or -A/--all for the\n"
+      INDENT "value on all nodes.",
       NULL },
 
     { "delete", 'D', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, command_cb,
@@ -199,7 +202,8 @@ static GOptionEntry addl_entries[] = {
       "SET" },
 
     { "node", 'N', 0, G_OPTION_ARG_STRING, &options.attr_node,
-      "Set the attribute for the named node (instead of the local one)",
+      "Use the named node for setting and querying the attribute (instead\n"
+      INDENT "of the local one)",
       "NODE" },
 
     { "all", 'A', 0, G_OPTION_ARG_NONE, &options.query_all,


### PR DESCRIPTION
Before, `attrd_updater -Q` would query all nodes when called by a user and the local node when called by a resource agent.  Now, the same command line will query only the local node when called by a user.  This can be modified by using -N to specify a node, or --all to specify all nodes.

Fixes T630