### PR TITLE
Refactor: libpe_status: Best practices for pcmk__unpack_fencing_topology

### DIFF
--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -88,8 +88,7 @@ gboolean unpack_resources(const xmlNode *xml_resources,
                           pcmk_scheduler_t *scheduler);
 
 G_GNUC_INTERNAL
-void pcmk__unpack_fencing_topology(const xmlNode *xml_fencing_topology,
-                                 pcmk_scheduler_t *scheduler);
+void pcmk__validate_fencing_topology(const xmlNode *xml);
 
 G_GNUC_INTERNAL
 gboolean unpack_config(xmlNode *config, pcmk_scheduler_t *scheduler);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -167,7 +167,7 @@ cluster_status(pcmk_scheduler_t * scheduler)
 
     section = get_xpath_object("//" PCMK_XE_FENCING_TOPOLOGY, scheduler->input,
                                LOG_TRACE);
-    pcmk__unpack_fencing_topology(section, scheduler);
+    pcmk__validate_fencing_topology(section);
 
     section = get_xpath_object("//" PCMK_XE_TAGS, scheduler->input, LOG_NEVER);
     unpack_tags(section, scheduler);

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -886,37 +886,42 @@ unpack_resources(const xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
 
 /*!
  * \internal
- * \brief Parse configuration XML for fencing topology information
+ * \brief Validate the levels in a fencing topology
  *
- * \param[in]     xml_fencing_topology  Top of fencing topology configuration XML
- * \param[in,out] scheduler             Scheduler data
- *
- * \return void
+ * \param[in] xml  \c PCMK_XE_FENCING_TOPOLOGY element
  */
 void
-pcmk__unpack_fencing_topology(const xmlNode *xml_fencing_topology, pcmk_scheduler_t *scheduler)
+pcmk__validate_fencing_topology(const xmlNode *xml)
 {
-    xmlNode *xml_obj = NULL;
-    int id = 0;
+    if (xml == NULL) {
+        return;
+    }
 
-    for (xml_obj = pcmk__xe_first_child(xml_fencing_topology, PCMK_XE_FENCING_LEVEL, NULL, NULL);
-         xml_obj != NULL; xml_obj = pcmk__xe_next_same(xml_obj)) {
+    CRM_CHECK(pcmk__xe_is(xml, PCMK_XE_FENCING_TOPOLOGY), return);
 
-        crm_element_value_int(xml_obj, PCMK_XA_INDEX, &id);
+    for (const xmlNode *level = pcmk__xe_first_child(xml, PCMK_XE_FENCING_LEVEL,
+                                                     NULL, NULL);
+         level != NULL; level = pcmk__xe_next_same(level)) {
 
-        // Ensure an ID was given
-        if (pcmk__str_empty(pcmk__xe_id(xml_obj))) {
-            pcmk__config_warn("Ignoring registration for topology level without ID");
+        const char *id = pcmk__xe_id(level);
+        int index = 0;
+
+        if (pcmk__str_empty(id)) {
+            pcmk__config_err("Ignoring fencing level without ID");
             continue;
         }
 
-        // Ensure level ID is in allowed range
-        if ((id < ST__LEVEL_MIN) || (id > ST__LEVEL_MAX)) {
-            pcmk__config_warn("Ignoring topology registration with invalid level %d",
-                               id);
+        if (crm_element_value_int(level, PCMK_XA_INDEX, &index) != 0) {
+            pcmk__config_err("Ignoring fencing level %s with invalid index",
+                             id);
             continue;
         }
 
+        if ((index < ST__LEVEL_MIN) || (index > ST__LEVEL_MAX)) {
+            pcmk__config_err("Ignoring fencing level %s with out-of-range "
+                             "index %d",
+                             id, index);
+        }
     }
 }
 


### PR DESCRIPTION
Rename to pcmk__validate_fencing_topology() and drop the scheduler argument, since we're not truly unpacking anything. Throw an error instead of a warning upon configuration error. Improve error messages. Check separately for unparsable integer.