### PR TITLE
Fix: controld: leave xml-src attribute empty when no DC selected #2902 #3606

### DIFF
--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -23,11 +23,12 @@
 
 static enum crmd_fsa_input handle_message(xmlNode *msg,
                                           enum crmd_fsa_cause cause);
+static xmlNode* create_ping_reply(const xmlNode *msg);
 static void handle_response(xmlNode *stored_msg);
 static enum crmd_fsa_input handle_request(xmlNode *stored_msg,
                                           enum crmd_fsa_cause cause);
 static enum crmd_fsa_input handle_shutdown_request(xmlNode *stored_msg);
-static void send_msg_via_ipc(xmlNode * msg, const char *sys);
+static void send_msg_via_ipc(xmlNode * msg, const char *sys, const char *src);
 
 /* debug only, can wrap all it likes */
 static int last_data_id = 0;
@@ -440,6 +441,18 @@ relay_message(xmlNode * msg, gboolean originated_locally)
         }
     }
 
+    // If is for DC and DC is not yet selected
+    if (is_for_dc && pcmk__str_eq(task, CRM_OP_PING, pcmk__str_casei)
+        && (controld_globals.dc_name == NULL)) {
+
+        xmlNode *reply = create_ping_reply(msg);
+        sys_to = crm_element_value(reply, PCMK__XA_CRM_SYS_TO);
+        // Explicitly leave src empty. It indicates that dc is "not yet selected"
+        send_msg_via_ipc(reply, sys_to, NULL);
+        free_xml(reply);
+        return TRUE;
+    }
+
     // Check whether message should be relayed
 
     if (is_for_dc || is_for_dcib || is_for_te) {
@@ -448,7 +461,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
                 crm_trace("Route message %s locally as transition request",
                           ref);
                 crm_log_xml_trace(msg, sys_to);
-                send_msg_via_ipc(msg, sys_to);
+                send_msg_via_ipc(msg, sys_to, controld_globals.our_nodename);
                 return TRUE; // No further processing of message is needed
             }
             crm_trace("Route message %s locally as DC request", ref);
@@ -484,7 +497,7 @@ relay_message(xmlNode * msg, gboolean originated_locally)
         }
         crm_trace("Relay message %s locally to %s", ref, sys_to);
         crm_log_xml_trace(msg, "IPC-relay");
-        send_msg_via_ipc(msg, sys_to);
+        send_msg_via_ipc(msg, sys_to, controld_globals.our_nodename);
         return TRUE;
     }
 
@@ -810,8 +823,8 @@ handle_remote_state(const xmlNode *msg)
  *
  * \return Next FSA input
  */
-static enum crmd_fsa_input
-handle_ping(const xmlNode *msg)
+static xmlNode*
+create_ping_reply(const xmlNode *msg)
 {
     const char *value = NULL;
     xmlNode *ping = NULL;
@@ -832,9 +845,15 @@ handle_ping(const xmlNode *msg)
     // @TODO maybe do some checks to determine meaningful status
     crm_xml_add(ping, PCMK_XA_RESULT, "ok");
 
-    // Send reply
     reply = create_reply(msg, ping);
     free_xml(ping);
+    return reply;
+}
+
+static enum crmd_fsa_input
+handle_ping(const xmlNode *msg)
+{
+    xmlNode *reply = create_ping_reply(msg);
     if (reply != NULL) {
         (void) relay_message(reply, TRUE);
         free_xml(reply);
@@ -1270,7 +1289,7 @@ handle_shutdown_request(xmlNode * stored_msg)
 }
 
 static void
-send_msg_via_ipc(xmlNode * msg, const char *sys)
+send_msg_via_ipc(xmlNode * msg, const char *sys, const char *src)
 {
     pcmk__client_t *client_channel = NULL;
 
@@ -1279,7 +1298,7 @@ send_msg_via_ipc(xmlNode * msg, const char *sys)
     client_channel = pcmk__find_client_by_id(sys);
 
     if (crm_element_value(msg, PCMK__XA_SRC) == NULL) {
-        crm_xml_add(msg, PCMK__XA_SRC, controld_globals.our_nodename);
+        crm_xml_add(msg, PCMK__XA_SRC, src);
     }
 
     if (client_channel != NULL) {


### PR DESCRIPTION
Right after starting the cluster the DC is offline for short time, and if you call `crmadmin --dc_lookup` during this time, it would hang. This change leaves the xml-src attribute that the crmadmin receives from the pacemaker-controld empty, so that crmadmin knows the DC was not selected.
ref: https://projects.clusterlabs.org/T735