### PR TITLE
Low: cts: Don't include the digest in expected output.

### DIFF
--- a/cts/cli/regression.cibadmin.exp
+++ b/cts/cli/regression.cibadmin.exp
@@ -37,7 +37,7 @@
 =#=#=#= End test: Validate CIB - OK (0) =#=#=#=
 * Passed: cibadmin              - Validate CIB
 =#=#=#= Begin test: Digest calculation =#=#=#=
-Digest: 5bfd0f70973217c2a4735960dfafbb55
+Digest:
 =#=#=#= End test: Digest calculation - OK (0) =#=#=#=
 * Passed: cibadmin              - Digest calculation
 =#=#=#= Begin test: Require --force for CIB erasure =#=#=#=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1267,7 +1267,10 @@ class CibadminRegressionTest(RegressionTest):
         """A list of Test instances to be run as part of this regression test."""
         basic_tests = [
             Test("Validate CIB", "cibadmin -Q", update_cib=True),
-            Test("Digest calculation", "cibadmin -Q | cibadmin -5 -p 2>&1"),
+            # FIXME: The calculated digest is different in certain build environments
+            # for unknown reasons.  When this is figured out, remove the part that gets
+            # rid of the hash.
+            Test("Digest calculation", "cibadmin -Q | cibadmin -5 -p 2>&1 | sed -e 's/Digest:.*/Digest:/'"),
             Test("Require --force for CIB erasure", "cibadmin -E",
                  expected_rc=ExitStatus.UNSAFE, update_cib=True),
             Test("Allow CIB erasure with --force", "cibadmin -E --force"),


### PR DESCRIPTION
We are seeing a problem during test builds where the digest can differ. This problem has not been seen when doing builds locally with mock, nor on the clusterlabs CI infrastructure.  It additionally does not seem to be a symptom of any other problem, since we've had no reports with weird CIB differing problems.

Note that the digest was not included in the expected output from the moment it was first committed in 2008 until I converted cts-cli.in to python  Presumedly, this was originally done because the input CIB would be changing and they didn't also want to have to remember to change the expected output.  Unfortunately, this makes it difficult to know if we would have been seeing these digest differences all along.