### PR TITLE
Fix: crmadmin: return error if DC is not elected #2902 #3606

### DIFF
--- a/cts/cli/regression.error_codes.exp
+++ b/cts/cli/regression.error_codes.exp
@@ -404,6 +404,7 @@ CRM_EX_ERROR - Error occurred
   111: Requested item is not yet in effect
   112: Could not determine status
   113: Not applicable under current conditions
+  114: DC is not yet elected
   124: Timeout occurred
   190: Service is active but might fail soon
   191: Service is promoted but might fail soon
@@ -451,6 +452,7 @@ CRM_EX_ERROR - Error occurred
   <result-code code="111" description="Requested item is not yet in effect"/>
   <result-code code="112" description="Could not determine status"/>
   <result-code code="113" description="Not applicable under current conditions"/>
+  <result-code code="114" description="DC is not yet elected"/>
   <result-code code="124" description="Timeout occurred"/>
   <result-code code="190" description="Service is active but might fail soon"/>
   <result-code code="191" description="Service is promoted but might fail soon"/>
@@ -499,6 +501,7 @@ CRM_EX_ERROR - Error occurred
   111: CRM_EX_NOT_YET_IN_EFFECT    Requested item is not yet in effect
   112: CRM_EX_INDETERMINATE        Could not determine status
   113: CRM_EX_UNSATISFIED          Not applicable under current conditions
+  114: CRM_EX_NO_DC                DC is not yet elected
   124: CRM_EX_TIMEOUT              Timeout occurred
   190: CRM_EX_DEGRADED             Service is active but might fail soon
   191: CRM_EX_DEGRADED_PROMOTED    Service is promoted but might fail soon
@@ -546,6 +549,7 @@ CRM_EX_ERROR - Error occurred
   <result-code code="111" name="CRM_EX_NOT_YET_IN_EFFECT" description="Requested item is not yet in effect"/>
   <result-code code="112" name="CRM_EX_INDETERMINATE" description="Could not determine status"/>
   <result-code code="113" name="CRM_EX_UNSATISFIED" description="Not applicable under current conditions"/>
+  <result-code code="114" name="CRM_EX_NO_DC" description="DC is not yet elected"/>
   <result-code code="124" name="CRM_EX_TIMEOUT" description="Timeout occurred"/>
   <result-code code="190" name="CRM_EX_DEGRADED" description="Service is active but might fail soon"/>
   <result-code code="191" name="CRM_EX_DEGRADED_PROMOTED" description="Service is promoted but might fail soon"/>

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -111,6 +111,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_no_dc               = -1040,
     pcmk_rc_compression         = -1039,
     pcmk_rc_ns_resolution       = -1038,
     pcmk_rc_no_transaction      = -1037,
@@ -273,6 +274,7 @@ typedef enum crm_exit_e {
     CRM_EX_NOT_YET_IN_EFFECT    = 111, //!< Requested item is not in effect
     CRM_EX_INDETERMINATE        = 112, //!< Could not determine status
     CRM_EX_UNSATISFIED          = 113, //!< Requested item does not satisfy constraints
+    CRM_EX_NO_DC                = 114, //!< DC is not yet elected, e.g. right after cluster restart
 
     // Other
     CRM_EX_TIMEOUT              = 124, //!< Convention from timeout(1)

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -734,6 +734,7 @@ crm_exit_name(crm_exit_t exit_code)
         case CRM_EX_NOT_YET_IN_EFFECT: return "CRM_EX_NOT_YET_IN_EFFECT";
         case CRM_EX_INDETERMINATE: return "CRM_EX_INDETERMINATE";
         case CRM_EX_UNSATISFIED: return "CRM_EX_UNSATISFIED";
+        case CRM_EX_NO_DC: return "CRM_EX_NO_DC";
         case CRM_EX_OLD: return "CRM_EX_OLD";
         case CRM_EX_TIMEOUT: return "CRM_EX_TIMEOUT";
         case CRM_EX_DEGRADED: return "CRM_EX_DEGRADED";
@@ -786,6 +787,7 @@ crm_exit_str(crm_exit_t exit_code)
         case CRM_EX_NOT_YET_IN_EFFECT: return "Requested item is not yet in effect";
         case CRM_EX_INDETERMINATE: return "Could not determine status";
         case CRM_EX_UNSATISFIED: return "Not applicable under current conditions";
+        case CRM_EX_NO_DC: return "DC is not yet elected";
         case CRM_EX_OLD: return "Update was older than existing configuration";
         case CRM_EX_TIMEOUT: return "Timeout occurred";
         case CRM_EX_DEGRADED: return "Service is active but might fail soon";
@@ -921,6 +923,9 @@ pcmk_rc2exitc(int rc)
         case pcmk_rc_bad_input:
         case pcmk_rc_bad_xml_patch:
             return CRM_EX_DATAERR;
+
+        case pcmk_rc_no_dc:
+            return CRM_EX_NO_DC;
 
         default:
             return CRM_EX_ERROR;

--- a/lib/pacemaker/pcmk_cluster_queries.c
+++ b/lib/pacemaker/pcmk_cluster_queries.c
@@ -235,7 +235,7 @@ designated_controller_event_cb(pcmk_ipc_api_t *controld_api,
 
     reply = (const pcmk_controld_api_reply_t *) event_data;
     out->message(out, "dc", reply->host_from);
-    data->rc = pcmk_rc_ok;
+    data->rc = reply->host_from ? pcmk_rc_ok : pcmk_rc_no_dc;
 }
 
 /*!


### PR DESCRIPTION
If the DC is not yet elected, the crmadmin will return an error. (This change complements #3606).