### PR TITLE
Fix: executor: avoid use-after-free upon shutdown

### DIFF
--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -290,11 +290,12 @@ exit_executor(void)
 #endif
 
     pcmk__client_cleanup();
-    g_hash_table_destroy(rsc_list);
 
     if (mainloop) {
         lrmd_drain_alerts(mainloop);
     }
+
+    g_hash_table_destroy(rsc_list);
 
     crm_exit(CRM_EX_OK);
 }


### PR DESCRIPTION
Upon shutdown of executor, lrmd_drain_alerts() calls pcmk_drain_main_loop() which calls g_main_context_iteration(). If there's a pending SIGCHLD signal, it will be processed by crm_signal_dispatch() -> child_death_dispatch() -> child_waitpid() -> services__finalize_async_op() -> action_complete(), which accesses the hash table "rsc_list".

Previously "rsc_list" was destroyed before lrmd_drain_alerts(), which would cause use-after-free.