### PR TITLE
[WIP] Fix when monitor of systemd resource continues to be pending.

### DIFF
--- a/include/crm/common/xml_names.h
+++ b/include/crm/common/xml_names.h
@@ -454,6 +454,7 @@ extern "C" {
 #define PCMK_XA_XPATH                       "xpath"
 #define PCMK_XA_YEARDAYS                    "yeardays"
 #define PCMK_XA_YEARS                       "years"
+#define PCMK_XA_USE_MONITOR_PENDING_TIMEOUT   "use-monitor-pending-timeout"
 
 
 #ifdef __cplusplus

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -677,7 +677,20 @@ systemd_unit_exists(const char *name)
     "  <" PCMK_XE_SHORTDESC " " PCMK_XA_LANG "=\"" PCMK__VALUE_EN "\">"        \
         "systemd unit file for %s"                                             \
       "</" PCMK_XE_SHORTDESC ">\n"                                             \
-    "  <" PCMK_XE_PARAMETERS "/>\n"                                            \
+    "  <" PCMK_XE_PARAMETERS ">\n"                                             \
+    "  <" PCMK_XE_PARAMETER " " PCMK_XA_NAME "=\""                             \
+        PCMK_XA_USE_MONITOR_PENDING_TIMEOUT "\""                               \
+        " " PCMK_XA_UNIQUE "=\"0\">\n"                                         \
+    "  <" PCMK_XE_LONGDESC " " PCMK_XA_LANG "=\"" PCMK__VALUE_EN "\">"         \
+        "It specifies whether a timeout will be triggered when the monitor"    \
+        " remains in a pending state.\n"                                       \
+    "  </" PCMK_XE_LONGDESC ">\n"                                              \
+    "  <" PCMK_XE_SHORTDESC " " PCMK_XA_LANG "=\"" PCMK__VALUE_EN "\">"        \
+        "Enables timeout when monitor is pending.</" PCMK_XE_SHORTDESC ">\n"   \
+    "  <" PCMK_XE_CONTENT " type=\"boolean\""                                  \
+        " " PCMK_XA_DEFAULT "=\"false\" />\n"                                  \
+    "  </" PCMK_XE_PARAMETER ">\n"                                             \
+    "  </" PCMK_XE_PARAMETERS ">\n"                                            \
     "  <" PCMK_XE_ACTIONS ">\n"                                                \
     "    <" PCMK_XE_ACTION " " PCMK_XA_NAME "=\"" PCMK_ACTION_START "\""       \
                            " " PCMK_META_TIMEOUT "=\"100s\" />\n"              \


### PR DESCRIPTION
Hi All,

If a systemd resource fails and continues to return pending, detection of the failure will be delayed until the recheck-timer, and the service will be stopped until failover occurs.

This issue was confirmed by our user when using Zabbix 6.0 resources with systemd.

 * The problem occurred when a user killed a process to simulate a failure.
 * This did not occur in previous Zabbix versions.

To control this, we have added the use-monitor-pending-timeout parameter and made a correction so that if the pending state continues until the monitor timeout, it will be treated as an error.

---
* Use the parameter use-monitor-pending-timeout, but it may be better to use a shorter parameter.
* It may be better to use it commonly with sysetmd resources, but to maintain compatibility, we have introduced the use-monitor-pending-timeout parameter.
* Considered controlling it on the controld side, but decided to control it on the execd side.
* Parameter passing to systemd resources was enabled.
 * Perhaps it would be sufficient to only pass it in the use-monitor-pending-timeout case.
* Only run the monitor until the timeout within the range of the monitor interval, and managed it only by continuing the deactivation.
 * Did not adopt the same fix as the follow up monitor. This is because there are monitors in progress, so management would be complicated. Also, we thought that if the monitor timeout is long, running the follow up monitor could cause a high load.
---

Please let me know your thoughts on the proposed amendments.

Best Regards,
Hideo Yamauchi.