### PR TITLE
Move sort_pairs() to libcrmcommon

### DIFF
--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -39,6 +39,9 @@ typedef struct unpack_data_s {
     crm_time_t *next_change;
 } pcmk__nvpair_unpack_t;
 
+gint pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b,
+                             gpointer user_data);
+
 /*!
  * \internal
  * \brief Insert a meta-attribute into a hash table

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -453,7 +453,7 @@ crm_meta_value(GHashTable *meta, const char *attr_name)
  * \param[in] user_data  pcmk__nvpair_unpack_t with first_id (whether a
  *                       particular XML ID should have priority) and overwrite
  *                       (whether later-processed blocks will overwrite values
- *                       from earlier ones) set as desired; must be non-NULL
+ *                       from earlier ones) set as desired
  *
  * \return Standard comparison return code (a negative value if \p a should sort
  *         first, a positive value if \p b should sort first, and 0 if they
@@ -476,7 +476,8 @@ pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
      * lower-priority ones. If we're not overwriting values, we want to process
      * from highest priority to lowest.
      */
-    const gint a_is_higher = unpack_data->overwrite? 1 : -1;
+    const gint a_is_higher = ((unpack_data != NULL)
+                              && unpack_data->overwrite)? 1 : -1;
     const gint b_is_higher = -a_is_higher;
 
     /* NULL values have lowest priority, regardless of the other's score
@@ -494,7 +495,7 @@ pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
      * from having the same ID, so we can ignore handling that case
      * specifically)
      */
-    if (unpack_data->first_id != NULL) {
+    if ((unpack_data != NULL) && (unpack_data->first_id != NULL)) {
         if (pcmk__str_eq(pcmk__xe_id(pair_a), unpack_data->first_id,
                          pcmk__str_none)) {
             return a_is_higher;

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -494,13 +494,15 @@ pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
      * from having the same ID, so we can ignore handling that case
      * specifically)
      */
-    if (pcmk__str_eq(pcmk__xe_id(pair_a), unpack_data->first_id,
-                     pcmk__str_none)) {
-        return a_is_higher;
+    if (unpack_data->first_id != NULL) {
+        if (pcmk__str_eq(pcmk__xe_id(pair_a), unpack_data->first_id,
+                         pcmk__str_none)) {
+            return a_is_higher;
 
-    } else if (pcmk__str_eq(pcmk__xe_id(pair_b), unpack_data->first_id,
-                            pcmk__str_none)) {
-        return b_is_higher;
+        } else if (pcmk__str_eq(pcmk__xe_id(pair_b), unpack_data->first_id,
+                                pcmk__str_none)) {
+            return b_is_higher;
+        }
     }
 
     // Otherwise, check the scores

--- a/lib/common/tests/nvpair/Makefile.am
+++ b/lib/common/tests/nvpair/Makefile.am
@@ -14,6 +14,7 @@ include $(top_srcdir)/mk/unittest.mk
 # Add "_test" to the end of all test program names to simplify .gitignore.
 check_PROGRAMS = crm_meta_name_test		\
 		 crm_meta_value_test		\
+		 pcmk__cmp_nvpair_blocks_test	\
 		 pcmk__xe_attr_is_true_test 	\
 		 pcmk__xe_get_bool_attr_test 	\
 		 pcmk__xe_get_datetime_test	\

--- a/lib/common/tests/nvpair/pcmk__cmp_nvpair_blocks_test.c
+++ b/lib/common/tests/nvpair/pcmk__cmp_nvpair_blocks_test.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/unittest_internal.h>
+#include <crm/common/xml_internal.h>
+
+#define FIRST_ID "foo"
+
+#define XML_FIRST_ID "<block " PCMK_XA_ID "=\"" FIRST_ID "\" "  \
+                               PCMK_XA_SCORE "=\"0\" />"
+#define XML_NO_ID "<block " PCMK_XA_SCORE "=\"5\" />"
+#define XML_LOW   "<block " PCMK_XA_ID "=\"low\"  " PCMK_XA_SCORE "=\"1\"   />"
+#define XML_HIGH  "<block " PCMK_XA_ID "=\"high\" " PCMK_XA_SCORE "=\"100\" />"
+#define XML_BAD   "<block " PCMK_XA_ID "=\"high\" " PCMK_XA_SCORE "=\"x\"   />"
+
+static pcmk__nvpair_unpack_t unpack_data = {
+    .first_id = FIRST_ID,
+};
+
+static void
+null_lowest(void **state)
+{
+    xmlNode *block = pcmk__xml_parse(XML_LOW);
+
+    assert_non_null(block);
+
+    assert_int_equal(pcmk__cmp_nvpair_blocks(NULL, block, NULL), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(block, NULL, NULL), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(NULL, NULL, NULL), 0);
+
+    unpack_data.overwrite = false;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(NULL, block, &unpack_data), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(block, NULL, &unpack_data), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(NULL, NULL, &unpack_data), 0);
+
+    unpack_data.overwrite = true;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(NULL, block, &unpack_data), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(block, NULL, &unpack_data), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(NULL, NULL, &unpack_data), 0);
+
+    pcmk__xml_free(block);
+}
+
+static void
+special_id_highest(void **state)
+{
+    xmlNode *first_id = pcmk__xml_parse(XML_FIRST_ID);
+    xmlNode *not_first_id = pcmk__xml_parse(XML_HIGH);
+    xmlNode *no_id = pcmk__xml_parse(XML_NO_ID);
+
+    assert_non_null(first_id);
+    assert_non_null(not_first_id);
+    assert_non_null(no_id);
+
+    unpack_data.overwrite = false;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(first_id, not_first_id,
+                                             &unpack_data), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(not_first_id, first_id,
+                                             &unpack_data), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(first_id, no_id,
+                                             &unpack_data), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(no_id, first_id,
+                                             &unpack_data), 1);
+
+    unpack_data.overwrite = true;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(first_id, not_first_id,
+                                             &unpack_data), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(not_first_id, first_id,
+                                             &unpack_data), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(first_id, no_id,
+                                             &unpack_data), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(no_id, first_id,
+                                             &unpack_data), -1);
+
+    pcmk__xml_free(first_id);
+    pcmk__xml_free(not_first_id);
+    pcmk__xml_free(no_id);
+}
+
+static void
+null_special_id_ignored(void **state)
+{
+    xmlNode *no_id = pcmk__xml_parse(XML_NO_ID);
+    xmlNode *high = pcmk__xml_parse(XML_HIGH);
+
+    assert_non_null(no_id);
+    assert_non_null(high);
+
+    unpack_data.first_id = NULL;
+
+    unpack_data.overwrite = false;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(no_id, high, &unpack_data), 1);
+
+    unpack_data.overwrite = true;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(no_id, high, &unpack_data), -1);
+
+    unpack_data.first_id = FIRST_ID;
+
+    pcmk__xml_free(no_id);
+    pcmk__xml_free(high);
+}
+
+static void
+highest_score_wins(void **state)
+{
+    xmlNode *low = pcmk__xml_parse(XML_LOW);
+    xmlNode *low2 = pcmk__xml_parse(XML_LOW);
+    xmlNode *high = pcmk__xml_parse(XML_HIGH);
+
+    assert_non_null(low);
+    assert_non_null(high);
+
+    unpack_data.overwrite = false;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(low, high, &unpack_data), 1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(low, low2, &unpack_data), 0);
+
+    unpack_data.overwrite = true;
+    assert_int_equal(pcmk__cmp_nvpair_blocks(low, high, &unpack_data), -1);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(low, low2, &unpack_data), 0);
+
+    pcmk__xml_free(low);
+    pcmk__xml_free(high);
+}
+
+static void
+invalid_score_is_0(void **state)
+{
+    xmlNode *zero = pcmk__xml_parse(XML_FIRST_ID);
+    xmlNode *bad = pcmk__xml_parse(XML_BAD);
+
+    assert_non_null(zero);
+    assert_non_null(bad);
+
+    assert_int_equal(pcmk__cmp_nvpair_blocks(zero, bad, NULL), 0);
+    assert_int_equal(pcmk__cmp_nvpair_blocks(bad, zero, NULL), 0);
+
+    pcmk__xml_free(zero);
+    pcmk__xml_free(bad);
+}
+
+PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
+                cmocka_unit_test(null_lowest),
+                cmocka_unit_test(special_id_highest),
+                cmocka_unit_test(null_special_id_ignored),
+                cmocka_unit_test(highest_score_wins),
+                cmocka_unit_test(invalid_score_is_0))


### PR DESCRIPTION
This is part of a larger project to move the functionality of libpe_rules into libcrmcommon and bring the code up to current guidelines.