### PR TITLE
Make the lrmd API handshake async

### DIFF
--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -63,7 +63,7 @@ gnutls_psk_client_credentials_t psk_cred_s;
 static void lrmd_tls_disconnect(lrmd_t * lrmd);
 static int global_remote_msg_id = 0;
 static void lrmd_tls_connection_destroy(gpointer userdata);
-static int add_tls_to_mainloop(lrmd_t *lrmd, bool do_handshake);
+static int add_tls_to_mainloop(lrmd_t *lrmd, bool do_api_handshake);
 
 typedef struct lrmd_private_s {
     uint64_t type;
@@ -1391,13 +1391,13 @@ tls_client_handshake(lrmd_t *lrmd)
  * \internal
  * \brief Add trigger and file descriptor mainloop sources for TLS
  *
- * \param[in,out] lrmd          API connection with established TLS session
- * \param[in]     do_handshake  Whether to perform executor handshake
+ * \param[in,out] lrmd              API connection with established TLS session
+ * \param[in]     do_api_handshake  Whether to perform executor handshake
  *
  * \return Standard Pacemaker return code
  */
 static int
-add_tls_to_mainloop(lrmd_t *lrmd, bool do_handshake)
+add_tls_to_mainloop(lrmd_t *lrmd, bool do_api_handshake)
 {
     lrmd_private_t *native = lrmd->lrmd_private;
     int rc = pcmk_rc_ok;
@@ -1421,7 +1421,7 @@ add_tls_to_mainloop(lrmd_t *lrmd, bool do_handshake)
      * @TODO Keep track of the caller-provided name. Perhaps we should be using
      * that name in this function instead of generating one anyway.
      */
-    if (do_handshake) {
+    if (do_api_handshake) {
         rc = lrmd_handshake(lrmd, name);
         rc = pcmk_legacy2rc(rc);
     }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -878,15 +878,15 @@ lrmd_api_is_connected(lrmd_t * lrmd)
  *                              standard vs. pacemaker remote);
  *                              also propagated to the command XML
  * \param[in]     call_options  Call options to pass to server when sending
- * \param[in]     expect_reply  If TRUE, wait for a reply from the server;
- *                              must be TRUE for IPC (as opposed to TLS) clients
+ * \param[in]     expect_reply  If true, wait for a reply from the server;
+ *                              must be true for IPC (as opposed to TLS) clients
  *
  * \return pcmk_ok on success, -errno on error
  */
 static int
 lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
                   xmlNode **output_data, int timeout,
-                  enum lrmd_call_options options, gboolean expect_reply)
+                  enum lrmd_call_options options, bool expect_reply)
 {
     int rc = pcmk_ok;
     lrmd_private_t *native = lrmd->lrmd_private;
@@ -1786,7 +1786,7 @@ lrmd_api_register_rsc(lrmd_t * lrmd,
     crm_xml_add(data, PCMK__XA_LRMD_CLASS, class);
     crm_xml_add(data, PCMK__XA_LRMD_PROVIDER, provider);
     crm_xml_add(data, PCMK__XA_LRMD_TYPE, type);
-    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_REG, data, NULL, 0, options, TRUE);
+    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_REG, data, NULL, 0, options, true);
     pcmk__xml_free(data);
 
     return rc;
@@ -1800,7 +1800,7 @@ lrmd_api_unregister_rsc(lrmd_t * lrmd, const char *rsc_id, enum lrmd_call_option
 
     crm_xml_add(data, PCMK__XA_LRMD_ORIGIN, __func__);
     crm_xml_add(data, PCMK__XA_LRMD_RSC_ID, rsc_id);
-    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_UNREG, data, NULL, 0, options, TRUE);
+    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_UNREG, data, NULL, 0, options, true);
     pcmk__xml_free(data);
 
     return rc;
@@ -1851,7 +1851,7 @@ lrmd_api_get_rsc_info(lrmd_t * lrmd, const char *rsc_id, enum lrmd_call_options 
 
     crm_xml_add(data, PCMK__XA_LRMD_ORIGIN, __func__);
     crm_xml_add(data, PCMK__XA_LRMD_RSC_ID, rsc_id);
-    lrmd_send_command(lrmd, LRMD_OP_RSC_INFO, data, &output, 0, options, TRUE);
+    lrmd_send_command(lrmd, LRMD_OP_RSC_INFO, data, &output, 0, options, true);
     pcmk__xml_free(data);
 
     if (!output) {
@@ -1908,7 +1908,7 @@ lrmd_api_get_recurring_ops(lrmd_t *lrmd, const char *rsc_id, int timeout_ms,
         crm_xml_add(data, PCMK__XA_LRMD_RSC_ID, rsc_id);
     }
     rc = lrmd_send_command(lrmd, LRMD_OP_GET_RECURRING, data, &output_xml,
-                           timeout_ms, options, TRUE);
+                           timeout_ms, options, true);
     if (data) {
         pcmk__xml_free(data);
     }
@@ -2104,7 +2104,7 @@ lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
         hash2smartfield((gpointer) tmp->key, (gpointer) tmp->value, args);
     }
 
-    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_EXEC, data, NULL, timeout, options, TRUE);
+    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_EXEC, data, NULL, timeout, options, true);
     pcmk__xml_free(data);
 
     lrmd_key_value_freeall(params);
@@ -2131,7 +2131,7 @@ lrmd_api_exec_alert(lrmd_t *lrmd, const char *alert_id, const char *alert_path,
     }
 
     rc = lrmd_send_command(lrmd, LRMD_OP_ALERT_EXEC, data, NULL, timeout,
-                           lrmd_opt_notify_orig_only, TRUE);
+                           lrmd_opt_notify_orig_only, true);
     pcmk__xml_free(data);
 
     lrmd_key_value_freeall(params);
@@ -2149,7 +2149,7 @@ lrmd_api_cancel(lrmd_t *lrmd, const char *rsc_id, const char *action,
     crm_xml_add(data, PCMK__XA_LRMD_RSC_ACTION, action);
     crm_xml_add(data, PCMK__XA_LRMD_RSC_ID, rsc_id);
     crm_xml_add_ms(data, PCMK__XA_LRMD_RSC_INTERVAL, interval_ms);
-    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_CANCEL, data, NULL, 0, 0, TRUE);
+    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_CANCEL, data, NULL, 0, 0, true);
     pcmk__xml_free(data);
     return rc;
 }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -902,8 +902,7 @@ lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
         return -EINVAL;
     }
 
-    CRM_CHECK(native->token != NULL,;
-        );
+    CRM_LOG_ASSERT(native->token != NULL);
     crm_trace("Sending %s op to executor", op);
 
     op_msg = lrmd_create_op(native->token, op, data, timeout, options);
@@ -923,7 +922,7 @@ lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
         crm_perror(LOG_ERR, "Couldn't perform %s operation (timeout=%d): %d", op, timeout, rc);
         goto done;
 
-    } else if(op_reply == NULL) {
+    } else if (op_reply == NULL) {
         rc = -ENOMSG;
         goto done;
     }


### PR DESCRIPTION
Previous patches only dealt with the TLS handshake.  This one - I *think* - makes the API handshake async as well.  I initially also had a patch to use standard Pacemaker return codes in lrmd_send_command, but something about that wasn't working.  I could give it another try if necessary.