### PR TITLE
Combine "next XML element" functions

### DIFF
--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -496,7 +496,7 @@ attrd_peer_sync_response(const pcmk__node_status_t *peer, bool peer_won,
 
     // Process each attribute update in the sync response
     for (xmlNode *child = pcmk__xe_first_child(xml, NULL, NULL, NULL);
-         child != NULL; child = pcmk__xe_next(child)) {
+         child != NULL; child = pcmk__xe_next(child, NULL)) {
 
         attrd_peer_update(peer, child,
                           crm_element_value(child, PCMK__XA_ATTR_HOST), true);
@@ -584,7 +584,7 @@ attrd_peer_update(const pcmk__node_status_t *peer, xmlNode *xml,
     CRM_CHECK((peer != NULL) && (xml != NULL), return);
     if (xml->children != NULL) {
         for (xmlNode *child = pcmk__xe_first_child(xml, PCMK_XE_OP, NULL, NULL);
-             child != NULL; child = pcmk__xe_next_same(child)) {
+             child != NULL; child = pcmk__xe_next(child, PCMK_XE_OP)) {
 
             pcmk__xe_copy_attrs(child, xml, pcmk__xaf_no_overwrite);
             attrd_peer_update_one(peer, child, filter);

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -410,7 +410,7 @@ attrd_client_update(pcmk__request_t *request)
              */
             for (xmlNode *child = pcmk__xe_first_child(xml, PCMK_XE_OP, NULL,
                                                        NULL);
-                 child != NULL; child = pcmk__xe_next_same(child)) {
+                 child != NULL; child = pcmk__xe_next(child, PCMK_XE_OP)) {
 
                 attr = crm_element_value(child, PCMK__XA_ATTR_NAME);
                 value = crm_element_value(child, PCMK__XA_ATTR_VALUE);

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -58,7 +58,8 @@ process_transaction_requests(xmlNodePtr transaction,
     for (xmlNode *request = pcmk__xe_first_child(transaction,
                                                  PCMK__XE_CIB_COMMAND, NULL,
                                                  NULL);
-         request != NULL; request = pcmk__xe_next_same(request)) {
+         request != NULL;
+         request = pcmk__xe_next(request, PCMK__XE_CIB_COMMAND)) {
 
         const char *op = crm_element_value(request, PCMK__XA_CIB_OP);
         const char *host = crm_element_value(request, PCMK__XA_CIB_HOST);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -232,7 +232,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
         node_xml = pcmk__xe_first_child(output, PCMK_XE_NODE, NULL, NULL);
     }
 
-    for (; node_xml != NULL; node_xml = pcmk__xe_next_same(node_xml)) {
+    for (; node_xml != NULL; node_xml = pcmk__xe_next(node_xml, PCMK_XE_NODE)) {
         const char *node_uuid = NULL;
         const char *node_uname = NULL;
         GHashTableIter iter;

--- a/daemons/controld/controld_metadata.c
+++ b/daemons/controld/controld_metadata.c
@@ -159,7 +159,7 @@ controld_cache_metadata(GHashTable *mdc, const lrmd_rsc_info_t *rsc,
     // Check supported actions
     match = pcmk__xe_first_child(metadata, PCMK_XE_ACTIONS, NULL, NULL);
     for (match = pcmk__xe_first_child(match, PCMK_XE_ACTION, NULL, NULL);
-         match != NULL; match = pcmk__xe_next_same(match)) {
+         match != NULL; match = pcmk__xe_next(match, PCMK_XE_ACTION)) {
 
         const char *action_name = crm_element_value(match, PCMK_XA_NAME);
 
@@ -181,7 +181,7 @@ controld_cache_metadata(GHashTable *mdc, const lrmd_rsc_info_t *rsc,
     // Build a parameter list
     match = pcmk__xe_first_child(metadata, PCMK_XE_PARAMETERS, NULL, NULL);
     for (match = pcmk__xe_first_child(match, PCMK_XE_PARAMETER, NULL, NULL);
-         match != NULL; match = pcmk__xe_next_same(match)) {
+         match != NULL; match = pcmk__xe_next(match, PCMK_XE_PARAMETER)) {
 
         const char *param_name = crm_element_value(match, PCMK_XA_NAME);
 

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1432,7 +1432,7 @@ remote_ra_process_maintenance_nodes(xmlNode *xml)
 
         for (node = pcmk__xe_first_child(getXpathResult(search, 0),
                                          PCMK_XE_NODE, NULL, NULL);
-             node != NULL; node = pcmk__xe_next_same(node)) {
+             node != NULL; node = pcmk__xe_next(node, PCMK_XE_NODE)) {
 
             lrm_state_t *lrm_state = NULL;
             const char *id = pcmk__xe_id(node);

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -32,7 +32,7 @@ static void
 process_lrm_resource_diff(xmlNode *lrm_resource, const char *node)
 {
     for (xmlNode *rsc_op = pcmk__xe_first_child(lrm_resource, NULL, NULL, NULL);
-         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op)) {
+         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, NULL)) {
         process_graph_event(rsc_op, node);
     }
     if (shutdown_lock_cleared(lrm_resource)) {
@@ -81,7 +81,7 @@ process_resource_updates(const char *node, xmlNode *xml, xmlNode *change,
     }
 
     for (rsc = pcmk__xe_first_child(xml, NULL, NULL, NULL); rsc != NULL;
-         rsc = pcmk__xe_next(rsc)) {
+         rsc = pcmk__xe_next(rsc, NULL)) {
         crm_trace("Processing %s", pcmk__xe_id(rsc));
         process_lrm_resource_diff(rsc, node);
     }
@@ -206,7 +206,7 @@ process_status_diff(xmlNode *status, xmlNode *change, const char *op,
                     const char *xpath)
 {
     for (xmlNode *state = pcmk__xe_first_child(status, NULL, NULL, NULL);
-         state != NULL; state = pcmk__xe_next(state)) {
+         state != NULL; state = pcmk__xe_next(state, NULL)) {
 
         process_node_state_diff(state, change, op, xpath);
     }

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -245,7 +245,7 @@ update_cib_stonith_devices(const char *event, xmlNode * msg)
     }
 
     for (xmlNode *change = pcmk__xe_first_child(patchset, NULL, NULL, NULL);
-         change != NULL; change = pcmk__xe_next(change)) {
+         change != NULL; change = pcmk__xe_next(change, NULL)) {
 
         const char *op = crm_element_value(change, PCMK_XA_OPERATION);
         const char *xpath = crm_element_value(change, PCMK_XA_PATH);
@@ -388,7 +388,7 @@ update_fencing_topology(const char *event, xmlNode *msg)
     xml_patch_versions(patchset, add, del);
 
     for (xmlNode *change = pcmk__xe_first_child(patchset, NULL, NULL, NULL);
-         change != NULL; change = pcmk__xe_next(change)) {
+         change != NULL; change = pcmk__xe_next(change, NULL)) {
 
         const char *op = crm_element_value(change, PCMK_XA_OPERATION);
         const char *xpath = crm_element_value(change, PCMK_XA_PATH);

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -242,7 +242,7 @@ stonith_xml_history_to_list(const xmlNode *history)
     CRM_LOG_ASSERT(rv != NULL);
 
     for (xml_op = pcmk__xe_first_child(history, NULL, NULL, NULL);
-         xml_op != NULL; xml_op = pcmk__xe_next(xml_op)) {
+         xml_op != NULL; xml_op = pcmk__xe_next(xml_op, NULL)) {
 
         remote_fencing_op_t *op = NULL;
         char *id = crm_element_value_copy(xml_op, PCMK__XA_ST_REMOTE_OP);

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -2253,7 +2253,7 @@ add_device_properties(const xmlNode *xml, remote_fencing_op_t *op,
     parse_action_specific(xml, peer->host, device, op_requested_action(op),
                           op, st_phase_requested, props);
     for (child = pcmk__xe_first_child(xml, NULL, NULL, NULL); child != NULL;
-         child = pcmk__xe_next(child)) {
+         child = pcmk__xe_next(child, NULL)) {
         /* Replies for "reboot" operations will include the action-specific
          * values for "off" and "on" in child elements, just in case the reboot
          * winds up getting remapped.
@@ -2294,7 +2294,7 @@ add_result(remote_fencing_op_t *op, const char *host, int ndevices,
 
     /* Each child element describes one capable device available to the peer */
     for (child = pcmk__xe_first_child(xml, NULL, NULL, NULL); child != NULL;
-         child = pcmk__xe_next(child)) {
+         child = pcmk__xe_next(child, NULL)) {
         const char *device = pcmk__xe_id(child);
 
         if (device) {

--- a/include/crm/common/xml_element_internal.h
+++ b/include/crm/common/xml_element_internal.h
@@ -74,27 +74,8 @@ pcmk__xe_is(const xmlNode *xml, const char *name)
            && (strcmp((const char *) xml->name, name) == 0);
 }
 
-/*!
- * \internal
- * \brief Return next non-text sibling element of an XML element
- *
- * \param[in] child  XML element to check
- *
- * \return Next sibling element of \p child (or NULL if none)
- */
-static inline xmlNode *
-pcmk__xe_next(const xmlNode *child)
-{
-    xmlNode *next = child? child->next : NULL;
-
-    while (next && (next->type != XML_ELEMENT_NODE)) {
-        next = next->next;
-    }
-    return next;
-}
-
 xmlNode *pcmk__xe_create(xmlNode *parent, const char *name);
-xmlNode *pcmk__xe_next_same(const xmlNode *node);
+xmlNode *pcmk__xe_next(const xmlNode *node, const char *element_name);
 
 void pcmk__xe_set_content(xmlNode *node, const char *format, ...)
     G_GNUC_PRINTF(2, 3);

--- a/include/crm/common/xml_names_internal.h
+++ b/include/crm/common/xml_names_internal.h
@@ -36,6 +36,7 @@ extern "C" {
 #define PCMK__XE_EXIT_NOTIFICATION      "exit-notification"
 #define PCMK__XE_FAILED_UPDATE          "failed_update"
 #define PCMK__XE_GENERATION_TUPLE       "generation_tuple"
+#define PCMK__XE_INPUTS                 "inputs"
 #define PCMK__XE_LRM                    "lrm"
 #define PCMK__XE_LRM_RESOURCE           "lrm_resource"
 #define PCMK__XE_LRM_RESOURCES          "lrm_resources"

--- a/include/crm/common/xml_names_internal.h
+++ b/include/crm/common/xml_names_internal.h
@@ -73,6 +73,7 @@ extern "C" {
 #define PCMK__XE_ST_NOTIFY_FENCE        "st_notify_fence"
 #define PCMK__XE_ST_REPLY               "st-reply"
 #define PCMK__XE_STONITH_COMMAND        "stonith_command"
+#define PCMK__XE_SYNAPSE                "synapse"
 #define PCMK__XE_TICKET_STATE           "ticket_state"
 #define PCMK__XE_TRANSIENT_ATTRIBUTES   "transient_attributes"
 #define PCMK__XE_TRANSITION_GRAPH       "transition_graph"

--- a/include/crm/common/xml_names_internal.h
+++ b/include/crm/common/xml_names_internal.h
@@ -76,6 +76,7 @@ extern "C" {
 #define PCMK__XE_TICKET_STATE           "ticket_state"
 #define PCMK__XE_TRANSIENT_ATTRIBUTES   "transient_attributes"
 #define PCMK__XE_TRANSITION_GRAPH       "transition_graph"
+#define PCMK__XE_TRIGGER                "trigger"
 #define PCMK__XE_XPATH_QUERY            "xpath-query"
 #define PCMK__XE_XPATH_QUERY_PATH       "xpath-query-path"
 

--- a/include/crm/common/xml_names_internal.h
+++ b/include/crm/common/xml_names_internal.h
@@ -19,6 +19,7 @@ extern "C" {
  */
 
 #define PCMK__XE_ACK                    "ack"
+#define PCMK__XE_ACTION_SET             "action_set"
 #define PCMK__XE_ATTRIBUTES             "attributes"
 #define PCMK__XE_CIB_CALLBACK           "cib-callback"
 #define PCMK__XE_CIB_CALLDATA           "cib_calldata"

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -1063,7 +1063,8 @@ cib_file_process_transaction_requests(cib_t *cib, xmlNode *transaction)
     for (xmlNode *request = pcmk__xe_first_child(transaction,
                                                  PCMK__XE_CIB_COMMAND, NULL,
                                                  NULL);
-         request != NULL; request = pcmk__xe_next_same(request)) {
+         request != NULL;
+         request = pcmk__xe_next(request, PCMK__XE_CIB_COMMAND)) {
 
         xmlNode *output = NULL;
         const char *op = crm_element_value(request, PCMK__XA_CIB_OP);

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -116,7 +116,7 @@ parse_acl_entry(const xmlNode *acl_top, const xmlNode *acl_entry, GList *acls)
 {
     for (const xmlNode *child = pcmk__xe_first_child(acl_entry, NULL, NULL,
                                                      NULL);
-         child != NULL; child = pcmk__xe_next(child)) {
+         child != NULL; child = pcmk__xe_next(child, NULL)) {
 
         if (pcmk__xe_is(child, PCMK_XE_ACL_PERMISSION)) {
             const char *kind = crm_element_value(child, PCMK_XA_KIND);
@@ -150,7 +150,7 @@ parse_acl_entry(const xmlNode *acl_top, const xmlNode *acl_entry, GList *acls)
 
             for (xmlNode *role = pcmk__xe_first_child(acl_top, NULL, NULL,
                                                       NULL);
-                 role != NULL; role = pcmk__xe_next(role)) {
+                 role != NULL; role = pcmk__xe_next(role, NULL)) {
 
                 const char *role_id = NULL;
 
@@ -292,7 +292,7 @@ pcmk__unpack_acl(xmlNode *source, xmlNode *target, const char *user)
             xmlNode *child = NULL;
 
             for (child = pcmk__xe_first_child(acls, NULL, NULL, NULL);
-                 child != NULL; child = pcmk__xe_next(child)) {
+                 child != NULL; child = pcmk__xe_next(child, NULL)) {
 
                 if (pcmk__xe_is(child, PCMK_XE_ACL_TARGET)) {
                     const char *id = crm_element_value(child, PCMK_XA_NAME);

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -28,7 +28,7 @@ set_pairs_data(pcmk__attrd_api_reply_t *data, xmlNode *msg_data)
 
     for (xmlNode *node = pcmk__xe_first_child(msg_data, PCMK_XE_NODE, NULL,
                                               NULL);
-         node != NULL; node = pcmk__xe_next_same(node)) {
+         node != NULL; node = pcmk__xe_next(node, PCMK_XE_NODE)) {
 
         pair = pcmk__assert_alloc(1, sizeof(pcmk__attrd_query_pair_t));
 

--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -168,7 +168,7 @@ set_nodes_data(pcmk_controld_api_reply_t *data, xmlNode *msg_data)
     data->reply_type = pcmk_controld_reply_nodes;
     for (xmlNode *node = pcmk__xe_first_child(msg_data, PCMK_XE_NODE, NULL,
                                               NULL);
-         node != NULL; node = pcmk__xe_next_same(node)) {
+         node != NULL; node = pcmk__xe_next(node, PCMK_XE_NODE)) {
 
         long long id_ll = 0;
 

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -376,7 +376,7 @@ xml2list(const xmlNode *parent)
     }
 
     for (child = pcmk__xe_first_child(nvpair_list, PCMK__XE_PARAM, NULL, NULL);
-         child != NULL; child = pcmk__xe_next_same(child)) {
+         child != NULL; child = pcmk__xe_next(child, PCMK__XE_PARAM)) {
 
         const char *key = crm_element_value(child, PCMK_XA_NAME);
         const char *value = crm_element_value(child, PCMK_XA_VALUE);

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -853,7 +853,7 @@ pcmk__cib_element_in_patchset(const xmlNode *patchset, const char *element)
 
     for (const xmlNode *change = pcmk__xe_first_child(patchset, PCMK_XE_CHANGE,
                                                       NULL, NULL);
-         change != NULL; change = pcmk__xe_next_same(change)) {
+         change != NULL; change = pcmk__xe_next(change, PCMK_XE_CHANGE)) {
 
         const char *op = crm_element_value(change, PCMK_XA_OPERATION);
         const char *diff_xpath = crm_element_value(change, PCMK_XA_PATH);

--- a/lib/common/patchset_display.c
+++ b/lib/common/patchset_display.c
@@ -84,7 +84,7 @@ xml_show_patchset(pcmk__output_t *out, const xmlNode *patchset)
 
     for (const xmlNode *change = pcmk__xe_first_child(patchset, NULL, NULL,
                                                       NULL);
-         change != NULL; change = pcmk__xe_next(change)) {
+         change != NULL; change = pcmk__xe_next(change, NULL)) {
 
         const char *op = crm_element_value(change, PCMK_XA_OPERATION);
         const char *xpath = crm_element_value(change, PCMK_XA_PATH);
@@ -129,7 +129,7 @@ xml_show_patchset(pcmk__output_t *out, const xmlNode *patchset)
 
             for (const xmlNode *child = pcmk__xe_first_child(clist, NULL, NULL,
                                                              NULL);
-                 child != NULL; child = pcmk__xe_next(child)) {
+                 child != NULL; child = pcmk__xe_next(child, NULL)) {
 
                 const char *name = crm_element_value(child, PCMK_XA_NAME);
 

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -1348,7 +1348,7 @@ pcmk_evaluate_rule(xmlNode *rule, const pcmk_rule_input_t *rule_input,
 
     // Evaluate each condition
     for (xmlNode *condition = pcmk__xe_first_child(rule, NULL, NULL, NULL);
-         condition != NULL; condition = pcmk__xe_next(condition)) {
+         condition != NULL; condition = pcmk__xe_next(condition, NULL)) {
 
         empty = false;
         if (pcmk__evaluate_condition(condition, rule_input,

--- a/lib/common/tests/schemas/pcmk__build_schema_xml_node_test.c
+++ b/lib/common/tests/schemas/pcmk__build_schema_xml_node_test.c
@@ -93,7 +93,7 @@ single_schema(void **state)
                             crm_element_value(file_node, PCMK_XA_PATH));
         assert_int_equal(pcmk__xml_first_child(file_node)->type, XML_CDATA_SECTION_NODE);
 
-        file_node = pcmk__xe_next(file_node);
+        file_node = pcmk__xe_next(file_node, NULL);
         i++;
     }
 
@@ -129,11 +129,11 @@ multiple_schemas(void **state)
                             crm_element_value(file_node, PCMK_XA_PATH));
         assert_int_equal(pcmk__xml_first_child(file_node)->type, XML_CDATA_SECTION_NODE);
 
-        file_node = pcmk__xe_next(file_node);
+        file_node = pcmk__xe_next(file_node, NULL);
         i++;
     }
 
-    schema_node = pcmk__xe_next(schema_node);
+    schema_node = pcmk__xe_next(schema_node, NULL);
     assert_string_equal("pacemaker-2.1",
                         crm_element_value(schema_node, PCMK_XA_VERSION));
 
@@ -145,7 +145,7 @@ multiple_schemas(void **state)
                             crm_element_value(file_node, PCMK_XA_PATH));
         assert_int_equal(pcmk__xml_first_child(file_node)->type, XML_CDATA_SECTION_NODE);
 
-        file_node = pcmk__xe_next(file_node);
+        file_node = pcmk__xe_next(file_node, NULL);
         i++;
     }
 

--- a/lib/common/tests/xml_element/Makefile.am
+++ b/lib/common/tests/xml_element/Makefile.am
@@ -17,6 +17,7 @@ check_PROGRAMS = \
 		 pcmk__xe_first_child_test	\
 		 pcmk__xe_foreach_child_test 	\
 		 pcmk__xe_get_score_test	\
+		 pcmk__xe_next_test		\
 		 pcmk__xe_set_id_test		\
 		 pcmk__xe_set_score_test	\
 		 pcmk__xe_sort_attrs_test

--- a/lib/common/tests/xml_element/pcmk__xe_next_test.c
+++ b/lib/common/tests/xml_element/pcmk__xe_next_test.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU General Public License version 2
+ * or later (GPLv2+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <crm/common/xml.h>
+#include <crm/common/unittest_internal.h>
+#include <crm/common/xml_internal.h>
+
+static void
+null_xml(void **state)
+{
+    assert_null(pcmk__xe_next(NULL, NULL));
+    assert_null(pcmk__xe_next(NULL, "test"));
+}
+
+
+#define XML_NO_SIBLINGS             \
+    "<xml>\n"                       \
+    "  <!-- comment -->"            \
+    "  <foo id='child1'>text</foo>" \
+    "  <!-- another comment -->"    \
+    "</xml>"
+
+static void
+no_siblings(void **state)
+{
+    xmlNode *xml = pcmk__xml_parse(XML_NO_SIBLINGS);
+    xmlNode *child = NULL;
+
+    assert_non_null(xml);
+
+    child = pcmk__xe_first_child(xml, NULL, NULL, NULL);
+    assert_non_null(child);
+    assert_string_equal(pcmk__xe_id(child), "child1");
+
+    assert_null(pcmk__xe_next(child, NULL));
+    assert_null(pcmk__xe_next(child, "foo"));
+
+    pcmk__xml_free(xml);
+}
+
+#define XML_SIBLINGS                    \
+    "<xml>\n"                           \
+    "  <!-- comment -->"                \
+    "  <foo id='child1'>text</foo>"     \
+    "  <!-- another comment -->"        \
+    "  <bar id='child2'>text</bar>"     \
+    "  <!-- yet another comment -->"    \
+    "  <foo id='child3'>text</foo>"     \
+    "</xml>"
+
+static void
+with_siblings(void **state)
+{
+    xmlNode *xml = pcmk__xml_parse(XML_SIBLINGS);
+    xmlNode *child = NULL;
+    xmlNode *next = NULL;
+
+    assert_non_null(xml);
+
+    child = pcmk__xe_first_child(xml, NULL, NULL, NULL);
+    assert_non_null(child);
+    assert_string_equal(pcmk__xe_id(child), "child1");
+
+    next = pcmk__xe_next(child, NULL);
+    assert_non_null(next);
+    assert_string_equal(pcmk__xe_id(next), "child2");
+
+    next = pcmk__xe_next(child, "bar");
+    assert_non_null(next);
+    assert_string_equal(pcmk__xe_id(next), "child2");
+
+    next = pcmk__xe_next(child, "foo");
+    assert_non_null(next);
+    assert_string_equal(pcmk__xe_id(next), "child3");
+
+    next = pcmk__xe_next(child, "foobar");
+    assert_null(next);
+
+    pcmk__xml_free(xml);
+}
+
+PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
+                cmocka_unit_test(null_xml),
+                cmocka_unit_test(no_siblings),
+                cmocka_unit_test(with_siblings));

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -727,7 +727,7 @@ stonith_api_history(stonith_t * stonith, int call_options, const char *node,
                                           LOG_NEVER);
 
         for (op = pcmk__xe_first_child(reply, NULL, NULL, NULL); op != NULL;
-             op = pcmk__xe_next(op)) {
+             op = pcmk__xe_next(op, NULL)) {
             stonith_history_t *kvp;
             long long completed;
             long long completed_nsec = 0L;

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1973,7 +1973,7 @@ lrmd_api_get_recurring_ops(lrmd_t *lrmd, const char *rsc_id, int timeout_ms,
                                                        PCMK__XE_LRMD_RSC, NULL,
                                                        NULL);
          (rsc_xml != NULL) && (rc == pcmk_ok);
-         rsc_xml = pcmk__xe_next_same(rsc_xml)) {
+         rsc_xml = pcmk__xe_next(rsc_xml, PCMK__XE_LRMD_RSC)) {
 
         rsc_id = crm_element_value(rsc_xml, PCMK__XA_LRMD_RSC_ID);
         if (rsc_id == NULL) {
@@ -1983,7 +1983,8 @@ lrmd_api_get_recurring_ops(lrmd_t *lrmd, const char *rsc_id, int timeout_ms,
         for (const xmlNode *op_xml = pcmk__xe_first_child(rsc_xml,
                                                           PCMK__XE_LRMD_RSC_OP,
                                                           NULL, NULL);
-             op_xml != NULL; op_xml = pcmk__xe_next_same(op_xml)) {
+             op_xml != NULL;
+             op_xml = pcmk__xe_next(op_xml, PCMK__XE_LRMD_RSC_OP)) {
 
             lrmd_op_info_t *op_info = calloc(1, sizeof(lrmd_op_info_t));
 

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -666,9 +666,10 @@ unpack_synapse(pcmk__graph_t *new_graph, const xmlNode *xml_synapse)
                                                 NULL, NULL);
          inputs != NULL; inputs = pcmk__xe_next(inputs, PCMK__XE_INPUTS)) {
 
-        for (xmlNode *trigger = pcmk__xe_first_child(inputs, "trigger", NULL,
-                                                     NULL);
-             trigger != NULL; trigger = pcmk__xe_next(trigger, "trigger")) {
+        for (xmlNode *trigger = pcmk__xe_first_child(inputs, PCMK__XE_TRIGGER,
+                                                     NULL, NULL);
+             trigger != NULL;
+             trigger = pcmk__xe_next(trigger, PCMK__XE_TRIGGER)) {
 
             for (xmlNode *input = pcmk__xe_first_child(trigger, NULL, NULL,
                                                        NULL);

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -662,9 +662,9 @@ unpack_synapse(pcmk__graph_t *new_graph, const xmlNode *xml_synapse)
 
     crm_trace("Unpacking synapse %s inputs", pcmk__xe_id(xml_synapse));
 
-    for (xmlNode *inputs = pcmk__xe_first_child(xml_synapse, "inputs", NULL,
-                                                NULL);
-         inputs != NULL; inputs = pcmk__xe_next(inputs, "inputs")) {
+    for (xmlNode *inputs = pcmk__xe_first_child(xml_synapse, PCMK__XE_INPUTS,
+                                                NULL, NULL);
+         inputs != NULL; inputs = pcmk__xe_next(inputs, PCMK__XE_INPUTS)) {
 
         for (xmlNode *trigger = pcmk__xe_first_child(inputs, "trigger", NULL,
                                                      NULL);

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -781,10 +781,10 @@ pcmk__unpack_graph(const xmlNode *xml_graph, const char *reference)
 
     // Unpack each child <synapse> element
     for (const xmlNode *synapse_xml = pcmk__xe_first_child(xml_graph,
-                                                           "synapse", NULL,
-                                                           NULL);
+                                                           PCMK__XE_SYNAPSE,
+                                                           NULL, NULL);
          synapse_xml != NULL;
-         synapse_xml = pcmk__xe_next(synapse_xml, "synapse")) {
+         synapse_xml = pcmk__xe_next(synapse_xml, PCMK__XE_SYNAPSE)) {
 
         pcmk__graph_synapse_t *new_synapse = unpack_synapse(new_graph,
                                                             synapse_xml);

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -638,11 +638,12 @@ unpack_synapse(pcmk__graph_t *new_graph, const xmlNode *xml_synapse)
 
     for (action_set = pcmk__xe_first_child(xml_synapse, "action_set", NULL,
                                            NULL);
-         action_set != NULL; action_set = pcmk__xe_next_same(action_set)) {
+         action_set != NULL;
+         action_set = pcmk__xe_next(action_set, "action_set")) {
 
         for (xmlNode *action = pcmk__xe_first_child(action_set, NULL, NULL,
                                                     NULL);
-             action != NULL; action = pcmk__xe_next(action)) {
+             action != NULL; action = pcmk__xe_next(action, NULL)) {
 
             pcmk__graph_action_t *new_action = unpack_action(new_synapse,
                                                              action);
@@ -663,15 +664,15 @@ unpack_synapse(pcmk__graph_t *new_graph, const xmlNode *xml_synapse)
 
     for (xmlNode *inputs = pcmk__xe_first_child(xml_synapse, "inputs", NULL,
                                                 NULL);
-         inputs != NULL; inputs = pcmk__xe_next_same(inputs)) {
+         inputs != NULL; inputs = pcmk__xe_next(inputs, "inputs")) {
 
         for (xmlNode *trigger = pcmk__xe_first_child(inputs, "trigger", NULL,
                                                      NULL);
-             trigger != NULL; trigger = pcmk__xe_next_same(trigger)) {
+             trigger != NULL; trigger = pcmk__xe_next(trigger, "trigger")) {
 
             for (xmlNode *input = pcmk__xe_first_child(trigger, NULL, NULL,
                                                        NULL);
-                 input != NULL; input = pcmk__xe_next(input)) {
+                 input != NULL; input = pcmk__xe_next(input, NULL)) {
 
                 pcmk__graph_action_t *new_input = unpack_action(new_synapse,
                                                                 input);
@@ -781,7 +782,8 @@ pcmk__unpack_graph(const xmlNode *xml_graph, const char *reference)
     for (const xmlNode *synapse_xml = pcmk__xe_first_child(xml_graph,
                                                            "synapse", NULL,
                                                            NULL);
-         synapse_xml != NULL; synapse_xml = pcmk__xe_next_same(synapse_xml)) {
+         synapse_xml != NULL;
+         synapse_xml = pcmk__xe_next(synapse_xml, "synapse")) {
 
         pcmk__graph_synapse_t *new_synapse = unpack_synapse(new_graph,
                                                             synapse_xml);
@@ -849,7 +851,7 @@ pcmk__event_from_graph_action(const xmlNode *resource,
     }
 
     for (xmlNode *xop = pcmk__xe_first_child(resource, NULL, NULL, NULL);
-         xop != NULL; xop = pcmk__xe_next(xop)) {
+         xop != NULL; xop = pcmk__xe_next(xop, NULL)) {
 
         int tmp = 0;
 

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -636,10 +636,10 @@ unpack_synapse(pcmk__graph_t *new_graph, const xmlNode *xml_synapse)
     crm_trace("Unpacking synapse %s action sets",
               crm_element_value(xml_synapse, PCMK_XA_ID));
 
-    for (action_set = pcmk__xe_first_child(xml_synapse, "action_set", NULL,
-                                           NULL);
+    for (action_set = pcmk__xe_first_child(xml_synapse, PCMK__XE_ACTION_SET,
+                                           NULL, NULL);
          action_set != NULL;
-         action_set = pcmk__xe_next(action_set, "action_set")) {
+         action_set = pcmk__xe_next(action_set, PCMK__XE_ACTION_SET)) {
 
         for (xmlNode *action = pcmk__xe_first_child(action_set, NULL, NULL,
                                                     NULL);

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -849,7 +849,7 @@ static xmlNode *
 create_graph_synapse(const pcmk_action_t *action, pcmk_scheduler_t *scheduler)
 {
     int synapse_priority = 0;
-    xmlNode *syn = pcmk__xe_create(scheduler->priv->graph, "synapse");
+    xmlNode *syn = pcmk__xe_create(scheduler->priv->graph, PCMK__XE_SYNAPSE);
 
     crm_xml_add_int(syn, PCMK_XA_ID, scheduler->priv->synapse_count++);
 

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -921,7 +921,7 @@ add_action_to_graph(gpointer data, gpointer user_data)
         pcmk__related_action_t *input = lpc->data;
 
         if (should_add_input_to_graph(action, input)) {
-            xmlNode *input_xml = pcmk__xe_create(in, "trigger");
+            xmlNode *input_xml = pcmk__xe_create(in, PCMK__XE_TRIGGER);
 
             input->graphed = true;
             create_graph_action(input_xml, input->action, true, scheduler);

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -912,7 +912,7 @@ add_action_to_graph(gpointer data, gpointer user_data)
               ((action->node == NULL)? "" : action->node->priv->name));
 
     syn = create_graph_synapse(action, scheduler);
-    set = pcmk__xe_create(syn, "action_set");
+    set = pcmk__xe_create(syn, PCMK__XE_ACTION_SET);
     in = pcmk__xe_create(syn, "inputs");
 
     create_graph_action(set, action, false, scheduler);

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -913,7 +913,7 @@ add_action_to_graph(gpointer data, gpointer user_data)
 
     syn = create_graph_synapse(action, scheduler);
     set = pcmk__xe_create(syn, PCMK__XE_ACTION_SET);
-    in = pcmk__xe_create(syn, "inputs");
+    in = pcmk__xe_create(syn, PCMK__XE_INPUTS);
 
     create_graph_action(set, action, false, scheduler);
 

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -195,7 +195,7 @@ create_op(const xmlNode *cib_resource, const char *task, guint interval_ms,
     // Use a call ID higher than any existing history entries
     op->call_id = 0;
     for (xop = pcmk__xe_first_child(cib_resource, NULL, NULL, NULL);
-         xop != NULL; xop = pcmk__xe_next(xop)) {
+         xop != NULL; xop = pcmk__xe_next(xop, NULL)) {
 
         int tmp = 0;
 

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -2479,7 +2479,7 @@ ticket_constraints_default(pcmk__output_t *out, va_list args)
             out->output_xml(out, PCMK_XE_CONSTRAINT, buf->str);
             g_string_free(buf, TRUE);
 
-            child = pcmk__xe_next(child);
+            child = pcmk__xe_next(child, NULL);
         } while (child != NULL);
     } else {
         GString *buf = g_string_sized_new(1024);

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -49,7 +49,8 @@ best_op(const pcmk_resource_t *rsc, const pcmk_node_t *node)
     for (xmlNode *lrm_rsc_op = pcmk__xe_first_child(history,
                                                     PCMK__XE_LRM_RSC_OP, NULL,
                                                     NULL);
-         lrm_rsc_op != NULL; lrm_rsc_op = pcmk__xe_next_same(lrm_rsc_op)) {
+         lrm_rsc_op != NULL;
+         lrm_rsc_op = pcmk__xe_next(lrm_rsc_op, PCMK__XE_LRM_RSC_OP)) {
 
         const char *digest = crm_element_value(lrm_rsc_op,
                                                PCMK__XA_OP_RESTART_DIGEST);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1730,7 +1730,7 @@ rsc_history_as_list(const xmlNode *rsc_entry, int *start_index, int *stop_index)
 
     for (xmlNode *rsc_op = pcmk__xe_first_child(rsc_entry, PCMK__XE_LRM_RSC_OP,
                                                 NULL, NULL);
-         rsc_op != NULL; rsc_op = pcmk__xe_next_same(rsc_op)) {
+         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, PCMK__XE_LRM_RSC_OP)) {
 
         ops = g_list_prepend(ops, rsc_op);
     }
@@ -1873,7 +1873,8 @@ process_node_history(pcmk_node_t *node, const xmlNode *lrm_rscs)
     for (const xmlNode *rsc_entry = pcmk__xe_first_child(lrm_rscs,
                                                          PCMK__XE_LRM_RESOURCE,
                                                          NULL, NULL);
-         rsc_entry != NULL; rsc_entry = pcmk__xe_next_same(rsc_entry)) {
+         rsc_entry != NULL;
+         rsc_entry = pcmk__xe_next(rsc_entry, PCMK__XE_LRM_RESOURCE)) {
 
         if (rsc_entry->children != NULL) {
             GList *result = pcmk__rscs_matching_id(pcmk__xe_id(rsc_entry),

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -531,7 +531,8 @@ unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
     if (local_score > 0) {
         for (xml_rsc = pcmk__xe_first_child(set, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             xml_rsc_id = pcmk__xe_id(xml_rsc);
             resource =
@@ -569,7 +570,8 @@ unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
 
         for (xml_rsc = pcmk__xe_first_child(set, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             xmlNode *xml_rsc_with = NULL;
 
@@ -588,7 +590,8 @@ unpack_colocation_set(xmlNode *set, int score, const char *coloc_id,
             for (xml_rsc_with = pcmk__xe_first_child(set, PCMK_XE_RESOURCE_REF,
                                                      NULL, NULL);
                  xml_rsc_with != NULL;
-                 xml_rsc_with = pcmk__xe_next_same(xml_rsc_with)) {
+                 xml_rsc_with = pcmk__xe_next(xml_rsc_with,
+                                              PCMK_XE_RESOURCE_REF)) {
 
                 xml_rsc_id = pcmk__xe_id(xml_rsc_with);
                 if (pcmk__str_eq(resource->id, xml_rsc_id, pcmk__str_none)) {
@@ -665,7 +668,8 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
         // Get the last one
         for (xml_rsc = pcmk__xe_first_child(set2, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             xml_rsc_id = pcmk__xe_id(xml_rsc);
         }
@@ -689,7 +693,8 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
         flags = pcmk__coloc_explicit | unpack_influence(id, rsc_1, influence_s);
         for (xml_rsc = pcmk__xe_first_child(set2, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             xml_rsc_id = pcmk__xe_id(xml_rsc);
             rsc_2 = pcmk__find_constraint_resource(scheduler->priv->resources,
@@ -709,7 +714,8 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
     } else if (rsc_2 != NULL) { // Only set2 is sequential
         for (xml_rsc = pcmk__xe_first_child(set1, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             xml_rsc_id = pcmk__xe_id(xml_rsc);
             rsc_1 = pcmk__find_constraint_resource(scheduler->priv->resources,
@@ -731,7 +737,8 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
     } else { // Neither set is sequential
         for (xml_rsc = pcmk__xe_first_child(set1, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             xmlNode *xml_rsc_2 = NULL;
 
@@ -751,7 +758,8 @@ colocate_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
                     | unpack_influence(id, rsc_1, influence_s);
             for (xml_rsc_2 = pcmk__xe_first_child(set2, PCMK_XE_RESOURCE_REF,
                                                   NULL, NULL);
-                 xml_rsc_2 != NULL; xml_rsc_2 = pcmk__xe_next_same(xml_rsc_2)) {
+                 xml_rsc_2 != NULL;
+                 xml_rsc_2 = pcmk__xe_next(xml_rsc_2, PCMK_XE_RESOURCE_REF)) {
 
                 xml_rsc_id = pcmk__xe_id(xml_rsc_2);
                 rsc_2 =
@@ -1003,7 +1011,7 @@ pcmk__unpack_colocation(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
     influence_s = crm_element_value(xml_obj, PCMK_XA_INFLUENCE);
 
     for (set = pcmk__xe_first_child(xml_obj, PCMK_XE_RESOURCE_SET, NULL, NULL);
-         set != NULL; set = pcmk__xe_next_same(set)) {
+         set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
         set = pcmk__xe_resolve_idref(set, scheduler->input);
         if (set == NULL) { // Configuration error, message already logged

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -44,7 +44,7 @@ pcmk__unpack_constraints(pcmk_scheduler_t *scheduler)
 
     for (xmlNode *xml_obj = pcmk__xe_first_child(xml_constraints, NULL, NULL,
                                                  NULL);
-         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {
+         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj, NULL)) {
 
         const char *id = crm_element_value(xml_obj, PCMK_XA_ID);
         const char *tag = (const char *) xml_obj->name;
@@ -243,14 +243,15 @@ pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pcmk_scheduler_t *scheduler)
 
     for (xmlNode *set = pcmk__xe_first_child(new_xml, PCMK_XE_RESOURCE_SET,
                                              NULL, NULL);
-         set != NULL; set = pcmk__xe_next_same(set)) {
+         set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
         GList *tag_refs = NULL;
         GList *iter = NULL;
 
         for (xmlNode *xml_rsc = pcmk__xe_first_child(set, PCMK_XE_RESOURCE_REF,
                                                      NULL, NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             pcmk_resource_t *rsc = NULL;
             pcmk__idref_t *tag = NULL;

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -562,7 +562,8 @@ unpack_location_set(xmlNode *location, xmlNode *set,
     local_score = crm_element_value(set, PCMK_XA_SCORE);
 
     for (xml_rsc = pcmk__xe_first_child(set, PCMK_XE_RESOURCE_REF, NULL, NULL);
-         xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+         xml_rsc != NULL;
+         xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
         resource = pcmk__find_constraint_resource(scheduler->priv->resources,
                                                   pcmk__xe_id(xml_rsc));
@@ -598,7 +599,7 @@ pcmk__unpack_location(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
     }
 
     for (set = pcmk__xe_first_child(xml_obj, PCMK_XE_RESOURCE_SET, NULL, NULL);
-         set != NULL; set = pcmk__xe_next_same(set)) {
+         set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
         any_sets = true;
         set = pcmk__xe_resolve_idref(set, scheduler->input);

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -588,7 +588,8 @@ unpack_order_set(const xmlNode *set, enum pe_order_kind parent_kind,
     for (const xmlNode *xml_rsc = pcmk__xe_first_child(set,
                                                        PCMK_XE_RESOURCE_REF,
                                                        NULL, NULL);
-         xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+         xml_rsc != NULL;
+         xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
         EXPAND_CONSTRAINT_IDREF(id, resource, pcmk__xe_id(xml_rsc));
         resources = g_list_append(resources, resource);
@@ -727,7 +728,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
 
         for (xml_rsc = pcmk__xe_first_child(set1, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_1, pcmk__xe_id(xml_rsc));
 
@@ -743,7 +745,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
         }
         for (xml_rsc_2 = pcmk__xe_first_child(set2, PCMK_XE_RESOURCE_REF, NULL,
                                               NULL);
-             xml_rsc_2 != NULL; xml_rsc_2 = pcmk__xe_next_same(xml_rsc_2)) {
+             xml_rsc_2 != NULL;
+             xml_rsc_2 = pcmk__xe_next(xml_rsc_2, PCMK_XE_RESOURCE_REF)) {
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_2, pcmk__xe_id(xml_rsc_2));
 
@@ -775,7 +778,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
 
             for (xml_rsc = pcmk__xe_first_child(set1, PCMK_XE_RESOURCE_REF,
                                                 NULL, NULL);
-                 xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+                 xml_rsc != NULL;
+                 xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
                 rid = pcmk__xe_id(xml_rsc);
             }
@@ -790,7 +794,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
 
             for (xml_rsc = pcmk__xe_first_child(set2, PCMK_XE_RESOURCE_REF,
                                                 NULL, NULL);
-                 xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+                 xml_rsc != NULL;
+                 xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
                 rid = pcmk__xe_id(xml_rsc);
             }
@@ -812,7 +817,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
     } else if (rsc_1 != NULL) {
         for (xml_rsc = pcmk__xe_first_child(set2, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_2, pcmk__xe_id(xml_rsc));
             pcmk__order_resource_actions(rsc_1, action_1, rsc_2, action_2,
@@ -822,7 +828,8 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
     } else if (rsc_2 != NULL) {
         for (xml_rsc = pcmk__xe_first_child(set1, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_1, pcmk__xe_id(xml_rsc));
             pcmk__order_resource_actions(rsc_1, action_1, rsc_2, action_2,
@@ -832,14 +839,16 @@ order_rsc_sets(const char *id, const xmlNode *set1, const xmlNode *set2,
     } else {
         for (xml_rsc = pcmk__xe_first_child(set1, PCMK_XE_RESOURCE_REF, NULL,
                                             NULL);
-             xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+             xml_rsc != NULL;
+             xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
             EXPAND_CONSTRAINT_IDREF(id, rsc_1, pcmk__xe_id(xml_rsc));
 
             for (xmlNode *xml_rsc_2 = pcmk__xe_first_child(set2,
                                                            PCMK_XE_RESOURCE_REF,
                                                            NULL, NULL);
-                 xml_rsc_2 != NULL; xml_rsc_2 = pcmk__xe_next_same(xml_rsc_2)) {
+                 xml_rsc_2 != NULL;
+                 xml_rsc_2 = pcmk__xe_next(xml_rsc_2, PCMK_XE_RESOURCE_REF)) {
 
                 EXPAND_CONSTRAINT_IDREF(id, rsc_2, pcmk__xe_id(xml_rsc_2));
                 pcmk__order_resource_actions(rsc_1, action_1, rsc_2,
@@ -1005,7 +1014,7 @@ pcmk__unpack_ordering(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
 
     // If the constraint has resource sets, unpack them
     for (set = pcmk__xe_first_child(xml_obj, PCMK_XE_RESOURCE_SET, NULL, NULL);
-         set != NULL; set = pcmk__xe_next_same(set)) {
+         set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
         set = pcmk__xe_resolve_idref(set, scheduler->input);
         if ((set == NULL) // Configuration error, message already logged

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -65,7 +65,7 @@ is_op_dup(const pcmk_resource_t *rsc, const char *name, guint interval_ms)
 
     for (xmlNode *op = pcmk__xe_first_child(rsc->priv->ops_xml, PCMK_XE_OP,
                                             NULL, NULL);
-         op != NULL; op = pcmk__xe_next_same(op)) {
+         op != NULL; op = pcmk__xe_next(op, PCMK_XE_OP)) {
 
         // Check whether action name and interval match
         if (!pcmk__str_eq(crm_element_value(op, PCMK_XA_NAME), name,
@@ -620,7 +620,7 @@ pcmk__create_recurring_actions(pcmk_resource_t *rsc)
 
     for (xmlNode *op = pcmk__xe_first_child(rsc->priv->ops_xml, PCMK_XE_OP,
                                             NULL, NULL);
-         op != NULL; op = pcmk__xe_next_same(op)) {
+         op != NULL; op = pcmk__xe_next(op, PCMK_XE_OP)) {
 
         struct op_history op_history = { NULL, };
 

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -259,7 +259,8 @@ unpack_rsc_ticket_set(xmlNode *set, pcmk__ticket_t *ticket,
 
     for (xmlNode *xml_rsc = pcmk__xe_first_child(set, PCMK_XE_RESOURCE_REF,
                                                  NULL, NULL);
-         xml_rsc != NULL; xml_rsc = pcmk__xe_next_same(xml_rsc)) {
+         xml_rsc != NULL;
+         xml_rsc = pcmk__xe_next(xml_rsc, PCMK_XE_RESOURCE_REF)) {
 
         pcmk_resource_t *resource = NULL;
 
@@ -465,7 +466,7 @@ pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
     }
 
     for (set = pcmk__xe_first_child(xml_obj, PCMK_XE_RESOURCE_SET, NULL, NULL);
-         set != NULL; set = pcmk__xe_next_same(set)) {
+         set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
         const char *loss_policy = NULL;
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1035,7 +1035,8 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
         for (xml_child = pcmk__xe_first_child(xml_obj, PCMK_XE_PORT_MAPPING,
                                               NULL, NULL);
-             xml_child != NULL; xml_child = pcmk__xe_next_same(xml_child)) {
+             xml_child != NULL;
+             xml_child = pcmk__xe_next(xml_child, PCMK_XE_PORT_MAPPING)) {
 
             pe__bundle_port_t *port =
                 pcmk__assert_alloc(1, sizeof(pe__bundle_port_t));
@@ -1067,7 +1068,8 @@ pe__unpack_bundle(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
                                    NULL);
     for (xml_child = pcmk__xe_first_child(xml_obj, PCMK_XE_STORAGE_MAPPING,
                                           NULL, NULL);
-         xml_child != NULL; xml_child = pcmk__xe_next_same(xml_child)) {
+         xml_child != NULL;
+         xml_child = pcmk__xe_next(xml_child, PCMK_XE_STORAGE_MAPPING)) {
 
         const char *source = crm_element_value(xml_child, PCMK_XA_SOURCE_DIR);
         const char *target = crm_element_value(xml_child, PCMK_XA_TARGET_DIR);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -384,7 +384,7 @@ clone_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
     // Clones may contain a single group or primitive
     for (a_child = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
-         a_child != NULL; a_child = pcmk__xe_next(a_child)) {
+         a_child != NULL; a_child = pcmk__xe_next(a_child, NULL)) {
 
         if (pcmk__str_any_of((const char *) a_child->name,
                              PCMK_XE_PRIMITIVE, PCMK_XE_GROUP, NULL)) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -336,7 +336,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
                                         NULL);
 
     for (child_xml = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
-         child_xml != NULL; child_xml = pcmk__xe_next(child_xml)) {
+         child_xml != NULL; child_xml = pcmk__xe_next(child_xml, NULL)) {
 
         xmlNode *new_child = pcmk__xml_copy(new_xml, child_xml);
 
@@ -350,7 +350,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
         GHashTable *rsc_ops_hash = pcmk__strkey_table(free, NULL);
 
         for (op = pcmk__xe_first_child(rsc_ops, NULL, NULL, NULL); op != NULL;
-             op = pcmk__xe_next(op)) {
+             op = pcmk__xe_next(op, NULL)) {
 
             char *key = template_op_key(op);
 
@@ -358,7 +358,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
         }
 
         for (op = pcmk__xe_first_child(template_ops, NULL, NULL, NULL);
-             op != NULL; op = pcmk__xe_next(op)) {
+             op != NULL; op = pcmk__xe_next(op, NULL)) {
 
             char *key = template_op_key(op);
 

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -204,7 +204,7 @@ group_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
     for (xml_native_rsc = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
          xml_native_rsc != NULL;
-         xml_native_rsc = pcmk__xe_next(xml_native_rsc)) {
+         xml_native_rsc = pcmk__xe_next(xml_native_rsc, NULL)) {
 
         if (pcmk__xe_is(xml_native_rsc, PCMK_XE_PRIMITIVE)) {
             pcmk_resource_t *new_rsc = NULL;

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -202,23 +202,22 @@ group_unpack(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 
     clone_id = crm_element_value(rsc->priv->xml, PCMK__META_CLONE);
 
-    for (xml_native_rsc = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
+    for (xml_native_rsc = pcmk__xe_first_child(xml_obj, PCMK_XE_PRIMITIVE,
+                                               NULL, NULL);
          xml_native_rsc != NULL;
-         xml_native_rsc = pcmk__xe_next(xml_native_rsc, NULL)) {
+         xml_native_rsc = pcmk__xe_next(xml_native_rsc, PCMK_XE_PRIMITIVE)) {
 
-        if (pcmk__xe_is(xml_native_rsc, PCMK_XE_PRIMITIVE)) {
-            pcmk_resource_t *new_rsc = NULL;
+        pcmk_resource_t *new_rsc = NULL;
 
-            crm_xml_add(xml_native_rsc, PCMK__META_CLONE, clone_id);
-            if (pe__unpack_resource(xml_native_rsc, &new_rsc, rsc,
-                                    scheduler) != pcmk_rc_ok) {
-                continue;
-            }
-
-            rsc->priv->children = g_list_append(rsc->priv->children, new_rsc);
-            group_data->last_child = new_rsc;
-            pcmk__rsc_trace(rsc, "Added %s member %s", rsc->id, new_rsc->id);
+        crm_xml_add(xml_native_rsc, PCMK__META_CLONE, clone_id);
+        if (pe__unpack_resource(xml_native_rsc, &new_rsc, rsc,
+                                scheduler) != pcmk_rc_ok) {
+            continue;
         }
+
+        rsc->priv->children = g_list_append(rsc->priv->children, new_rsc);
+        group_data->last_child = new_rsc;
+        pcmk__rsc_trace(rsc, "Added %s member %s", rsc->id, new_rsc->id);
     }
 
     if (rsc->priv->children == NULL) {

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -94,7 +94,7 @@ find_exact_action_config(const pcmk_resource_t *rsc, const char *action_name,
 {
     for (xmlNode *operation = pcmk__xe_first_child(rsc->priv->ops_xml,
                                                    PCMK_XE_OP, NULL, NULL);
-         operation != NULL; operation = pcmk__xe_next_same(operation)) {
+         operation != NULL; operation = pcmk__xe_next(operation, PCMK_XE_OP)) {
 
         bool enabled = false;
         const char *config_name = NULL;
@@ -460,7 +460,8 @@ validate_on_fail(const pcmk_resource_t *rsc, const char *action_name,
          */
         for (xmlNode *operation = pcmk__xe_first_child(rsc->priv->ops_xml,
                                                        PCMK_XE_OP, NULL, NULL);
-             operation != NULL; operation = pcmk__xe_next_same(operation)) {
+             operation != NULL;
+             operation = pcmk__xe_next(operation, PCMK_XE_OP)) {
 
             bool enabled = false;
             const char *promote_on_fail = NULL;
@@ -629,7 +630,7 @@ most_frequent_monitor(const pcmk_resource_t *rsc)
 
     for (xmlNode *operation = pcmk__xe_first_child(rsc->priv->ops_xml,
                                                    PCMK_XE_OP, NULL, NULL);
-         operation != NULL; operation = pcmk__xe_next_same(operation)) {
+         operation != NULL; operation = pcmk__xe_next(operation, PCMK_XE_OP)) {
 
         bool enabled = false;
         guint interval_ms = 0U;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -145,8 +145,9 @@ get_operation_list(xmlNode *rsc_entry) {
     GList *op_list = NULL;
     xmlNode *rsc_op = NULL;
 
-    for (rsc_op = pcmk__xe_first_child(rsc_entry, NULL, NULL, NULL);
-         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, NULL)) {
+    for (rsc_op = pcmk__xe_first_child(rsc_entry, PCMK__XE_LRM_RSC_OP, NULL,
+                                       NULL);
+         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, PCMK__XE_LRM_RSC_OP)) {
 
         const char *task = crm_element_value(rsc_op, PCMK_XA_OPERATION);
         const char *interval_ms_s = crm_element_value(rsc_op,
@@ -169,9 +170,7 @@ get_operation_list(xmlNode *rsc_entry) {
             continue;
         }
 
-        if (pcmk__xe_is(rsc_op, PCMK__XE_LRM_RSC_OP)) {
-            op_list = g_list_append(op_list, rsc_op);
-        }
+        op_list = g_list_append(op_list, rsc_op);
     }
 
     op_list = g_list_sort(op_list, sort_op_by_callid);

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -146,7 +146,7 @@ get_operation_list(xmlNode *rsc_entry) {
     xmlNode *rsc_op = NULL;
 
     for (rsc_op = pcmk__xe_first_child(rsc_entry, NULL, NULL, NULL);
-         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op)) {
+         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, NULL)) {
 
         const char *task = crm_element_value(rsc_op, PCMK_XA_OPERATION);
         const char *interval_ms_s = crm_element_value(rsc_op,
@@ -1679,7 +1679,7 @@ failed_action_list(pcmk__output_t *out, va_list args) {
 
     for (xml_op = pcmk__xe_first_child(scheduler->priv->failed, NULL, NULL,
                                        NULL);
-         xml_op != NULL; xml_op = pcmk__xe_next(xml_op)) {
+         xml_op != NULL; xml_op = pcmk__xe_next(xml_op, NULL)) {
 
         char *rsc = NULL;
 
@@ -2458,7 +2458,8 @@ node_history_list(pcmk__output_t *out, va_list args) {
     /* Print history of each of the node's resources */
     for (rsc_entry = pcmk__xe_first_child(lrm_rsc, PCMK__XE_LRM_RESOURCE, NULL,
                                           NULL);
-         rsc_entry != NULL; rsc_entry = pcmk__xe_next_same(rsc_entry)) {
+         rsc_entry != NULL;
+         rsc_entry = pcmk__xe_next(rsc_entry, PCMK__XE_LRM_RESOURCE)) {
 
         const char *rsc_id = crm_element_value(rsc_entry, PCMK_XA_ID);
         pcmk_resource_t *rsc = NULL;
@@ -2721,7 +2722,8 @@ node_summary(pcmk__output_t *out, va_list args) {
 
     for (node_state = pcmk__xe_first_child(cib_status, PCMK__XE_NODE_STATE,
                                            NULL, NULL);
-         node_state != NULL; node_state = pcmk__xe_next_same(node_state)) {
+         node_state != NULL;
+         node_state = pcmk__xe_next(node_state, PCMK__XE_NODE_STATE)) {
 
         pcmk_node_t *node = pe_find_node_id(scheduler->nodes,
                                             pcmk__xe_id(node_state));

--- a/lib/pengine/rules.c
+++ b/lib/pengine/rules.c
@@ -71,7 +71,7 @@ populate_hash(xmlNode *nvpair_list, GHashTable *hash, bool overwrite)
 
     for (xmlNode *nvpair = pcmk__xe_first_child(nvpair_list, PCMK_XE_NVPAIR,
                                                 NULL, NULL);
-         nvpair != NULL; nvpair = pcmk__xe_next_same(nvpair)) {
+         nvpair != NULL; nvpair = pcmk__xe_next(nvpair, PCMK_XE_NVPAIR)) {
 
         xmlNode *ref_nvpair = pcmk__xe_resolve_idref(nvpair, NULL);
         const char *name = NULL;
@@ -154,7 +154,7 @@ make_pairs(const xmlNode *xml_obj, const char *set_name)
         return NULL;
     }
     for (xmlNode *attr_set = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
-         attr_set != NULL; attr_set = pcmk__xe_next(attr_set)) {
+         attr_set != NULL; attr_set = pcmk__xe_next(attr_set, NULL)) {
 
         if ((set_name == NULL) || pcmk__xe_is(attr_set, set_name)) {
             xmlNode *expanded_attr_set = pcmk__xe_resolve_idref(attr_set, NULL);

--- a/lib/pengine/rules_alerts.c
+++ b/lib/pengine/rules_alerts.c
@@ -104,7 +104,7 @@ get_envvars_from_cib(xmlNode *basenode, pcmk__alert_t *entry)
     }
 
     for (child = pcmk__xe_first_child(child, PCMK_XE_NVPAIR, NULL, NULL);
-         child != NULL; child = pcmk__xe_next_same(child)) {
+         child != NULL; child = pcmk__xe_next(child, PCMK_XE_NVPAIR)) {
 
         const char *name = crm_element_value(child, PCMK_XA_NAME);
         const char *value = crm_element_value(child, PCMK_XA_VALUE);
@@ -127,7 +127,7 @@ unpack_alert_filter(xmlNode *basenode, pcmk__alert_t *entry)
     uint32_t flags = pcmk__alert_none;
 
     for (event_type = pcmk__xe_first_child(select, NULL, NULL, NULL);
-         event_type != NULL; event_type = pcmk__xe_next(event_type)) {
+         event_type != NULL; event_type = pcmk__xe_next(event_type, NULL)) {
 
         if (pcmk__xe_is(event_type, PCMK_XE_SELECT_FENCING)) {
             flags |= pcmk__alert_fencing;
@@ -146,7 +146,7 @@ unpack_alert_filter(xmlNode *basenode, pcmk__alert_t *entry)
             flags |= pcmk__alert_attribute;
             for (attr = pcmk__xe_first_child(event_type, PCMK_XE_ATTRIBUTE,
                                              NULL, NULL);
-                 attr != NULL; attr = pcmk__xe_next_same(attr)) {
+                 attr != NULL; attr = pcmk__xe_next(attr, PCMK_XE_ATTRIBUTE)) {
 
                 attr_name = crm_element_value(attr, PCMK_XA_NAME);
                 if (attr_name) {
@@ -223,7 +223,7 @@ pe_unpack_alerts(const xmlNode *alerts)
     }
 
     for (alert = pcmk__xe_first_child(alerts, PCMK_XE_ALERT, NULL, NULL);
-         alert != NULL; alert = pcmk__xe_next_same(alert)) {
+         alert != NULL; alert = pcmk__xe_next(alert, PCMK_XE_ALERT)) {
 
         xmlNode *recipient;
         int recipients = 0;
@@ -260,7 +260,8 @@ pe_unpack_alerts(const xmlNode *alerts)
 
         for (recipient = pcmk__xe_first_child(alert, PCMK_XE_RECIPIENT, NULL,
                                               NULL);
-             recipient != NULL; recipient = pcmk__xe_next_same(recipient)) {
+             recipient != NULL;
+             recipient = pcmk__xe_next(recipient, PCMK_XE_RECIPIENT)) {
 
             pcmk__alert_t *recipient_entry = pcmk__dup_alert(entry);
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -526,14 +526,14 @@ expand_remote_rsc_meta(xmlNode *xml_obj, xmlNode *parent, pcmk_scheduler_t *data
     const char *is_managed = NULL;
 
     for (attr_set = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
-         attr_set != NULL; attr_set = pcmk__xe_next(attr_set)) {
+         attr_set != NULL; attr_set = pcmk__xe_next(attr_set, NULL)) {
 
         if (!pcmk__xe_is(attr_set, PCMK_XE_META_ATTRIBUTES)) {
             continue;
         }
 
         for (attr = pcmk__xe_first_child(attr_set, NULL, NULL, NULL);
-             attr != NULL; attr = pcmk__xe_next(attr)) {
+             attr != NULL; attr = pcmk__xe_next(attr, NULL)) {
 
             const char *value = crm_element_value(attr, PCMK_XA_VALUE);
             const char *name = crm_element_value(attr, PCMK_XA_NAME);
@@ -609,7 +609,7 @@ unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *scheduler)
     const char *type = NULL;
 
     for (xml_obj = pcmk__xe_first_child(xml_nodes, NULL, NULL, NULL);
-         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {
+         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj, NULL)) {
 
         if (pcmk__xe_is(xml_obj, PCMK_XE_NODE)) {
             int score = 0;
@@ -692,7 +692,7 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
      * before unpacking resources.
      */
     for (xml_obj = pcmk__xe_first_child(xml_resources, NULL, NULL, NULL);
-         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {
+         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj, NULL)) {
 
         const char *new_node_id = NULL;
 
@@ -740,7 +740,7 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
         if (pcmk__xe_is(xml_obj, PCMK_XE_GROUP)) {
             xmlNode *xml_obj2 = NULL;
             for (xml_obj2 = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
-                 xml_obj2 != NULL; xml_obj2 = pcmk__xe_next(xml_obj2)) {
+                 xml_obj2 != NULL; xml_obj2 = pcmk__xe_next(xml_obj2, NULL)) {
 
                 new_node_id = expand_remote_rsc_meta(xml_obj2, xml_resources,
                                                      scheduler);
@@ -824,7 +824,7 @@ unpack_resources(const xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
     scheduler->priv->templates = pcmk__strkey_table(free, pcmk__free_idref);
 
     for (xml_obj = pcmk__xe_first_child(xml_resources, NULL, NULL, NULL);
-         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {
+         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj, NULL)) {
 
         pcmk_resource_t *new_rsc = NULL;
         const char *id = pcmk__xe_id(xml_obj);
@@ -901,7 +901,7 @@ pcmk__validate_fencing_topology(const xmlNode *xml)
 
     for (const xmlNode *level = pcmk__xe_first_child(xml, PCMK_XE_FENCING_LEVEL,
                                                      NULL, NULL);
-         level != NULL; level = pcmk__xe_next_same(level)) {
+         level != NULL; level = pcmk__xe_next(level, PCMK_XE_FENCING_LEVEL)) {
 
         const char *id = pcmk__xe_id(level);
         int index = 0;
@@ -933,7 +933,7 @@ unpack_tags(xmlNode *xml_tags, pcmk_scheduler_t *scheduler)
     scheduler->priv->tags = pcmk__strkey_table(free, pcmk__free_idref);
 
     for (xml_tag = pcmk__xe_first_child(xml_tags, NULL, NULL, NULL);
-         xml_tag != NULL; xml_tag = pcmk__xe_next(xml_tag)) {
+         xml_tag != NULL; xml_tag = pcmk__xe_next(xml_tag, NULL)) {
 
         xmlNode *xml_obj_ref = NULL;
         const char *tag_id = pcmk__xe_id(xml_tag);
@@ -949,7 +949,8 @@ unpack_tags(xmlNode *xml_tags, pcmk_scheduler_t *scheduler)
         }
 
         for (xml_obj_ref = pcmk__xe_first_child(xml_tag, NULL, NULL, NULL);
-             xml_obj_ref != NULL; xml_obj_ref = pcmk__xe_next(xml_obj_ref)) {
+             xml_obj_ref != NULL;
+             xml_obj_ref = pcmk__xe_next(xml_obj_ref, NULL)) {
 
             const char *obj_ref = pcmk__xe_id(xml_obj_ref);
 
@@ -1053,7 +1054,7 @@ unpack_tickets_state(xmlNode *xml_tickets, pcmk_scheduler_t *scheduler)
     xmlNode *xml_obj = NULL;
 
     for (xml_obj = pcmk__xe_first_child(xml_tickets, NULL, NULL, NULL);
-         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj)) {
+         xml_obj != NULL; xml_obj = pcmk__xe_next(xml_obj, NULL)) {
 
         if (!pcmk__xe_is(xml_obj, PCMK__XE_TICKET_STATE)) {
             continue;
@@ -1307,7 +1308,7 @@ unpack_node_history(const xmlNode *status, bool fence,
     for (const xmlNode *state = pcmk__xe_first_child(status,
                                                      PCMK__XE_NODE_STATE, NULL,
                                                      NULL);
-         state != NULL; state = pcmk__xe_next_same(state)) {
+         state != NULL; state = pcmk__xe_next(state, PCMK__XE_NODE_STATE)) {
 
         const char *id = pcmk__xe_id(state);
         const char *uname = crm_element_value(state, PCMK_XA_UNAME);
@@ -1415,7 +1416,7 @@ unpack_status(xmlNode *status, pcmk_scheduler_t *scheduler)
     }
 
     for (state = pcmk__xe_first_child(status, NULL, NULL, NULL); state != NULL;
-         state = pcmk__xe_next(state)) {
+         state = pcmk__xe_next(state, NULL)) {
 
         if (pcmk__xe_is(state, PCMK_XE_TICKETS)) {
             unpack_tickets_state((xmlNode *) state, scheduler);
@@ -2761,7 +2762,7 @@ unpack_lrm_resource(pcmk_node_t *node, const xmlNode *lrm_resource,
      */
     for (rsc_op = pcmk__xe_first_child(lrm_resource, PCMK__XE_LRM_RSC_OP, NULL,
                                        NULL);
-         rsc_op != NULL; rsc_op = pcmk__xe_next_same(rsc_op)) {
+         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, PCMK__XE_LRM_RSC_OP)) {
 
         op_list = g_list_prepend(op_list, rsc_op);
     }
@@ -2839,7 +2840,7 @@ handle_removed_launched_resources(const xmlNode *lrm_rsc_list,
 {
     for (const xmlNode *rsc_entry = pcmk__xe_first_child(lrm_rsc_list, NULL,
                                                          NULL, NULL);
-         rsc_entry != NULL; rsc_entry = pcmk__xe_next(rsc_entry)) {
+         rsc_entry != NULL; rsc_entry = pcmk__xe_next(rsc_entry, NULL)) {
 
         pcmk_resource_t *rsc;
         pcmk_resource_t *launcher = NULL;
@@ -2903,7 +2904,8 @@ unpack_node_lrm(pcmk_node_t *node, const xmlNode *xml,
     for (const xmlNode *rsc_entry = pcmk__xe_first_child(xml,
                                                          PCMK__XE_LRM_RESOURCE,
                                                          NULL, NULL);
-         rsc_entry != NULL; rsc_entry = pcmk__xe_next_same(rsc_entry)) {
+         rsc_entry != NULL;
+         rsc_entry = pcmk__xe_next(rsc_entry, PCMK__XE_LRM_RESOURCE)) {
 
         pcmk_resource_t *rsc = unpack_lrm_resource(node, rsc_entry, scheduler);
 
@@ -3099,7 +3101,7 @@ non_monitor_after(const char *rsc_id, const char *node_name,
 
     for (xmlNode *op = pcmk__xe_first_child(lrm_resource, PCMK__XE_LRM_RSC_OP,
                                             NULL, NULL);
-         op != NULL; op = pcmk__xe_next_same(op)) {
+         op != NULL; op = pcmk__xe_next(op, PCMK__XE_LRM_RSC_OP)) {
 
         const char * task = NULL;
 
@@ -5008,7 +5010,7 @@ extract_operations(const char *node, const char *rsc, xmlNode * rsc_entry, gbool
     sorted_op_list = NULL;
 
     for (rsc_op = pcmk__xe_first_child(rsc_entry, NULL, NULL, NULL);
-         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op)) {
+         rsc_op != NULL; rsc_op = pcmk__xe_next(rsc_op, NULL)) {
 
         if (pcmk__xe_is(rsc_op, PCMK__XE_LRM_RSC_OP)) {
             crm_xml_add(rsc_op, PCMK_XA_RESOURCE, rsc);
@@ -5071,7 +5073,7 @@ find_operations(const char *rsc, const char *node, gboolean active_filter,
     CRM_CHECK(status != NULL, return NULL);
 
     for (node_state = pcmk__xe_first_child(status, NULL, NULL, NULL);
-         node_state != NULL; node_state = pcmk__xe_next(node_state)) {
+         node_state != NULL; node_state = pcmk__xe_next(node_state, NULL)) {
 
         if (pcmk__xe_is(node_state, PCMK__XE_NODE_STATE)) {
             const char *uname = crm_element_value(node_state, PCMK_XA_UNAME);
@@ -5106,7 +5108,7 @@ find_operations(const char *rsc, const char *node, gboolean active_filter,
                                            NULL);
 
                 for (lrm_rsc = pcmk__xe_first_child(tmp, NULL, NULL, NULL);
-                     lrm_rsc != NULL; lrm_rsc = pcmk__xe_next(lrm_rsc)) {
+                     lrm_rsc != NULL; lrm_rsc = pcmk__xe_next(lrm_rsc, NULL)) {
 
                     if (pcmk__xe_is(lrm_rsc, PCMK__XE_LRM_RESOURCE)) {
                         const char *rsc_id = crm_element_value(lrm_rsc,

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -889,7 +889,7 @@ pe__failed_probe_for_rsc(const pcmk_resource_t *rsc, const char *name)
 
     for (xmlNode *xml_op = pcmk__xe_first_child(scheduler->priv->failed,
                                                 NULL, NULL, NULL);
-         xml_op != NULL; xml_op = pcmk__xe_next(xml_op)) {
+         xml_op != NULL; xml_op = pcmk__xe_next(xml_op, NULL)) {
 
         const char *value = NULL;
         char *op_id = NULL;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -805,7 +805,7 @@ clear_rsc_failures(pcmk__output_t *out, pcmk_ipc_api_t *controld_api,
 
     for (xmlNode *xml_op = pcmk__xe_first_child(scheduler->priv->failed, NULL,
                                                 NULL, NULL);
-         xml_op != NULL; xml_op = pcmk__xe_next(xml_op)) {
+         xml_op != NULL; xml_op = pcmk__xe_next(xml_op, NULL)) {
 
         failed_id = crm_element_value(xml_op, PCMK__XA_RSC_ID);
         if (failed_id == NULL) {


### PR DESCRIPTION
Currently, we have `pcmk__xe_next()` which looks for the next XML sibling element of any type, and `pcmk__xe_next_same()` which looks for the next XML sibling element of the same type. Now, `pcmk__xe_next()` takes an optional element type to get the next XML sibling element of that type. This allows `for` loops to have a more consistent structure and makes planned changes easier.