### PR TITLE
Refactor: daemons: Get rid of an implicit fallthrough.

### DIFF
--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -2143,25 +2143,14 @@ log_executor_event(const lrmd_event_data_t *op, const char *op_key,
 
         case PCMK_EXEC_CANCELLED:
             log_level = LOG_INFO;
-	    /* order of __attribute__ and Fall through comment is IMPORTANT!
-	     * do not change it without proper testing with both clang and gcc
-	     * in multiple versions.
-	     * the clang check allows to build with all versions of clang.
-	     * the has_c_attribute check is to workaround a bug in clang version
-	     * in rhel7. has_attribute would happily return "YES SIR WE GOT IT"
-	     * and fail the build the next line.
-	     */
-#ifdef __clang__
-#ifdef __has_c_attribute
-#if __has_attribute(fallthrough)
-	    __attribute__((fallthrough));
-#endif
-#endif
-#endif
-            // Fall through
+            pcmk__g_strcat(str, ": ", pcmk_exec_status_str(op->op_status),
+                           NULL);
+            break;
+
         default:
             pcmk__g_strcat(str, ": ", pcmk_exec_status_str(op->op_status),
                            NULL);
+            break;
     }
 
     if ((op->exit_reason != NULL)


### PR DESCRIPTION
Support for `__attribute__((fallthrough))` varies between compilers and releases, so we've got macros to detect and deal with it.  However, there's only one spot we are making use of the implicit fallthrough and it only saves duplication of one line.  Plus, that's really kind of a misfeature of C (hence the compiler warning).

So, just get rid of it and remember to not use implicit fallthroughs in the future.

Fixes T558