### PR TITLE
Build improvements around copr

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -13,13 +13,11 @@
 # These should be provided by COPR, so these are just fallbacks
 MAKE	?= make
 outdir	?= .
-spec	?= ..
 
 LAST_RELEASE	=
 
 srpm:
-	dnf -y install git
-	cd "$(spec)"/rpm			\
+	cd rpm			\
 		&& echo "$$(git rev-list --count $$(git describe --tags --abbrev=0)..HEAD)"	\
 			> build.counter		\
 		&& $(MAKE) -f Makefile.am srpm	\

--- a/mk/release.mk
+++ b/mk/release.mk
@@ -43,7 +43,7 @@ VERSION		?= $(shell if [ -z "$(CHECKOUT)" ]; then			\
 			echo 0.0.0;						\
 		     else							\
 			"$(GIT)" tag -l						\
-				| sed -n -e 's/^\(Pacemaker-[0-9.]*\)$$/\1/p'	\
+				| sed -n -e 's/^Pacemaker-\([0-9.]*\)$$/\1/p'	\
 				| sort -Vr | head -n 1;				\
 		     fi)
 

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -13,6 +13,7 @@
 top_srcdir              ?= ..
 abs_srcdir              ?= $(shell pwd)
 abs_builddir 	?= $(abs_srcdir)
+GIT                     ?= git
 MAKE                    ?= make
 PACKAGE                 ?= pacemaker
 AM_V_at                 ?= @


### PR DESCRIPTION
This gets it working again locally, at least.  See:  https://copr.fedorainfracloud.org/coprs/clumens/pacemaker.  I haven't tried setting up the webhook but it doesn't look difficult.  If that's something we want to do, I'm happy to do it (as well as run the pacemaker copr repo under my own account).