### PR TITLE
Build: rpm: Ignore the lib-package-without-%mklibname rpmlint error

### DIFF
--- a/rpm/rpmlintrc
+++ b/rpm/rpmlintrc
@@ -9,3 +9,7 @@ addFilter("W: invalid-url Source0:")
 
 # pacemaker_remote scriptlets use a state file
 addFilter("W: dangerous-command-in-%(pre|postun|posttrans) rm")
+
+# This is a Mandriva-specific specific check that is sometimes enabled
+# on other distributions
+addFilter("E: lib-package-without-%mklibname")


### PR DESCRIPTION
For some reason, this Mandriva-specific check is enabled on centos 10. There's no information about it being used elsewhere, and no clear reason why we are starting to see it now and only on pacemaker.  Disable it in our config file.