### PR TITLE
Add logging to schema transformations

### DIFF
--- a/cts/scheduler/xml/bug-1820-1.xml
+++ b/cts/scheduler/xml/bug-1820-1.xml
@@ -51,18 +51,22 @@
     <constraints>
       <rsc_colocation id="foo" rsc="gr1" with-rsc="p1" score="INFINITY"/>
       <rsc_location id="loc1" rsc="gr1">
-        <rule id="loc1-rule1" score="INFINITY">
+        <rule id="loc1-rule" score="INFINITY">
           <expression id="expression.id22088" attribute="#uname" operation="eq" value="star"/>
         </rule>
-        <rule id="loc1-rule2" score="1000">
+      </rsc_location>
+      <rsc_location id="loc2" rsc="gr1">
+        <rule id="loc2-rule" score="1000">
           <expression id="expression.id22106" attribute="#uname" operation="eq" value="world"/>
         </rule>
       </rsc_location>
-      <rsc_location id="loc2" rsc="p1">
-        <rule id="loc2-rule1" score="INFINITY">
+      <rsc_location id="loc3" rsc="p1">
+        <rule id="loc3-rule" score="INFINITY">
           <expression id="expression.id22131" attribute="#uname" operation="eq" value="star"/>
         </rule>
-        <rule id="loc2-rule2" score="1000">
+      </rsc_location>
+      <rsc_location id="loc4" rsc="p1">
+        <rule id="loc4-rule" score="1000">
           <expression id="expression.id22149" attribute="#uname" operation="eq" value="world"/>
         </rule>
       </rsc_location>

--- a/cts/scheduler/xml/bug-1820.xml
+++ b/cts/scheduler/xml/bug-1820.xml
@@ -49,10 +49,12 @@
     </resources>
     <constraints>
       <rsc_location id="loc1" rsc="gr1">
-        <rule id="loc1-rule1" score="INFINITY">
+        <rule id="loc1-rule" score="INFINITY">
           <expression id="expression.id22067" attribute="#uname" operation="eq" value="star"/>
         </rule>
-        <rule id="loc1-rule2" score="1000">
+      </rsc_location>
+      <rsc_location id="loc2" rsc="gr1">
+        <rule id="loc2-rule" score="1000">
           <expression id="expression.id22085" attribute="#uname" operation="eq" value="world"/>
         </rule>
       </rsc_location>

--- a/cts/scheduler/xml/bug-1822.xml
+++ b/cts/scheduler/xml/bug-1822.xml
@@ -79,10 +79,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="loc-ms-sf" rsc="ms-sf">
+      <rsc_location id="loc-ms-sf-0" rsc="ms-sf">
         <rule id="rule-ms-sf-0" role="Promoted" score="100">
           <expression attribute="#uname" operation="eq" value="process1a" id="expression.id22321"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="loc-ms-sf-1" rsc="ms-sf">
         <rule id="rule-ms-sf-1" role="Promoted" score="50">
           <expression attribute="#uname" operation="eq" value="process2b" id="expression.id22340"/>
         </rule>

--- a/cts/scheduler/xml/bug-5186-partial-migrate.xml
+++ b/cts/scheduler/xml/bug-5186-partial-migrate.xml
@@ -181,36 +181,50 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="l1" rsc="prmDummy">
-        <rule score="200" id="l1-rule">
+      <rsc_location id="l1-a" rsc="prmDummy">
+        <rule score="200" id="l1-a-rule">
           <expression attribute="#uname" operation="eq" value="bl460g1n6" id="l1-expression"/>
         </rule>
-        <rule score="300" id="l1-rule-0">
+      </rsc_location>
+      <rsc_location id="l1-b" rsc="prmDummy">
+        <rule score="300" id="l1-b-rule">
           <expression attribute="#uname" operation="eq" value="bl460g1n7" id="l1-expression-0"/>
         </rule>
-        <rule score="200" id="l1-rule-1">
+      </rsc_location>
+      <rsc_location id="l1-c" rsc="prmDummy">
+        <rule score="200" id="l1-c-rule">
           <expression attribute="#uname" operation="eq" value="bl460g1n8" id="l1-expression-1"/>
         </rule>
       </rsc_location>
-      <rsc_location id="l2" rsc="prmVM2">
-        <rule score="200" id="l2-rule">
+      <rsc_location id="l2-a" rsc="prmVM2">
+        <rule score="200" id="l2-a-rule">
           <expression attribute="#uname" operation="eq" value="bl460g1n6" id="l2-expression"/>
         </rule>
-        <rule score="300" id="l2-rule-0">
+      </rsc_location>
+      <rsc_location id="l2-b" rsc="prmVM2">
+        <rule score="300" id="l2-b-rule">
           <expression attribute="#uname" operation="eq" value="bl460g1n7" id="l2-expression-0"/>
         </rule>
-        <rule score="200" id="l2-rule-1">
+      </rsc_location>
+      <rsc_location id="l2-c" rsc="prmVM2">
+        <rule score="200" id="l2-c-rule">
           <expression attribute="#uname" operation="eq" value="bl460g1n8" id="l2-expression-1"/>
         </rule>
-        <rule score="-INFINITY" boolean-op="or" id="l2-rule-2">
+      </rsc_location>
+      <rsc_location id="l2-d" rsc="prmVM2">
+        <rule score="-INFINITY" boolean-op="or" id="l2-d-rule">
           <expression operation="not_defined" attribute="default_ping_set" id="l2-expression-2"/>
           <expression attribute="default_ping_set" operation="lt" value="100" id="l2-expression-3"/>
         </rule>
-        <rule score="-INFINITY" boolean-op="or" id="l2-rule-3">
+      </rsc_location>
+      <rsc_location id="l2-e" rsc="prmVM2">
+        <rule score="-INFINITY" boolean-op="or" id="l2-e-rule">
           <expression operation="not_defined" attribute="diskcheck_status" id="l2-expression-4"/>
           <expression attribute="diskcheck_status" operation="eq" value="ERROR" id="l2-expression-5"/>
         </rule>
-        <rule score="-INFINITY" boolean-op="or" id="l2-rule-4">
+      </rsc_location>
+      <rsc_location id="l2-f" rsc="prmVM2">
+        <rule score="-INFINITY" boolean-op="or" id="l2-f-rule">
           <expression operation="not_defined" attribute="diskcheck_status_internal" id="l2-expression-6"/>
           <expression attribute="diskcheck_status_internal" operation="eq" value="ERROR" id="l2-expression-7"/>
         </rule>

--- a/cts/scheduler/xml/bug-cl-5212.xml
+++ b/cts/scheduler/xml/bug-cl-5212.xml
@@ -115,11 +115,15 @@
         <rule role="Promoted" score="300" id="rsc_location-msPostgresql-1-rule">
           <expression attribute="#uname" operation="eq" value="srv01" id="rsc_location-msPostgresql-1-expression"/>
         </rule>
-        <rule role="Promoted" score="200" id="rsc_location-msPostgresql-1-rule-0">
-          <expression attribute="#uname" operation="eq" value="srv02" id="rsc_location-msPostgresql-1-expression-0"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-msPostgresql-2" rsc="msPostgresql">
+        <rule role="Promoted" score="200" id="rsc_location-msPostgresql-2-rule">
+          <expression attribute="#uname" operation="eq" value="srv02" id="rsc_location-msPostgresql-2-expression"/>
         </rule>
-        <rule role="Promoted" score="100" id="rsc_location-msPostgresql-1-rule-1">
-          <expression attribute="#uname" operation="eq" value="srv03" id="rsc_location-msPostgresql-1-expression-1"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-msPostgresql-3" rsc="msPostgresql">
+        <rule role="Promoted" score="100" id="rsc_location-msPostgresql-3-rule">
+          <expression attribute="#uname" operation="eq" value="srv03" id="rsc_location-msPostgresql-3-expression"/>
         </rule>
       </rsc_location>
       <rsc_colocation id="rsc_colocation-msPostgresql-clnPingd-1" score="INFINITY" rsc="msPostgresql" rsc-role="Promoted" with-rsc="clnPingd">

--- a/cts/scheduler/xml/bug-cl-5213.xml
+++ b/cts/scheduler/xml/bug-cl-5213.xml
@@ -49,8 +49,10 @@
         <rule role="Promoted" score="200" id="rsc_location-msStateful-1-rule">
           <expression attribute="#uname" operation="eq" value="srv01" id="rsc_location-msStateful-1-expression"/>
         </rule>
-        <rule role="Promoted" score="-INFINITY" id="rsc_location-msStateful-1-rule-0">
-          <expression attribute="#uname" operation="eq" value="srv02" id="rsc_location-msStateful-1-expression-0"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-msStateful-2" rsc="msPostgresql">
+        <rule role="Promoted" score="-INFINITY" id="rsc_location-msStateful-2-rule">
+          <expression attribute="#uname" operation="eq" value="srv02" id="rsc_location-msStateful-2-expression"/>
         </rule>
       </rsc_location>
       <rsc_colocation id="rsc_colocation-promoted-1" score="INFINITY" rsc="msPostgresql" rsc-role="Promoted" with-rsc="A-master">

--- a/cts/scheduler/xml/bug-cl-5247.xml
+++ b/cts/scheduler/xml/bug-cl-5247.xml
@@ -144,8 +144,10 @@
         <rule score="-INFINITY" id="rsc_location-msPostgresql-1-rule">
           <expression attribute="#uname" operation="eq" value="bl460g8n3" id="rsc_location-msPostgresql-1-rule-expression"/>
         </rule>
-        <rule score="-INFINITY" id="rsc_location-msPostgresql-1-rule-0">
-          <expression attribute="#uname" operation="eq" value="bl460g8n4" id="rsc_location-msPostgresql-1-rule-0-expression"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-msPostgresql-2" rsc="msPostgresql">
+        <rule score="-INFINITY" id="rsc_location-msPostgresql-2-rule">
+          <expression attribute="#uname" operation="eq" value="bl460g8n4" id="rsc_location-msPostgresql-2-rule-expression"/>
         </rule>
       </rsc_location>
       <rsc_location id="rsc_location-prmDB1-2" rsc="prmDB1">

--- a/cts/scheduler/xml/bug-lf-2508.xml
+++ b/cts/scheduler/xml/bug-lf-2508.xml
@@ -216,12 +216,18 @@
         <rule id="rule-grp01-1" score="200">
           <expression id="exp-grp01-1" attribute="#uname" operation="eq" value="srv01"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp01-2" rsc="Group01">
         <rule id="rule-grp01-2" score="-INFINITY">
           <expression id="exp-grp01-2" attribute="#uname" operation="eq" value="srv02"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp01-3" rsc="Group01">
         <rule id="rule-grp01-3" score="-INFINITY">
           <expression id="exp-grp01-3" attribute="#uname" operation="eq" value="srv03"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp01-4" rsc="Group01">
         <rule id="rule-grp01-4" score="100">
           <expression id="exp-grp01-4" attribute="#uname" operation="eq" value="srv04"/>
         </rule>
@@ -230,12 +236,18 @@
         <rule id="rule-grp02-1" score="-INFINITY">
           <expression id="exp-grp02-1" attribute="#uname" operation="eq" value="srv01"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp02-2" rsc="Group02">
         <rule id="rule-grp02-2" score="200">
           <expression id="exp-grp02-2" attribute="#uname" operation="eq" value="srv02"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp02-3" rsc="Group02">
         <rule id="rule-grp02-3" score="-INFINITY">
           <expression id="exp-grp02-3" attribute="#uname" operation="eq" value="srv03"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp02-4" rsc="Group02">
         <rule id="rule-grp02-4" score="100">
           <expression id="exp-grp02-4" attribute="#uname" operation="eq" value="srv04"/>
         </rule>
@@ -244,12 +256,18 @@
         <rule id="rule-grp03-1" score="-INFINITY">
           <expression id="exp-grp03-1" attribute="#uname" operation="eq" value="srv01"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp03-2" rsc="Group03">
         <rule id="rule-grp03-2" score="-INFINITY">
           <expression id="exp-grp03-2" attribute="#uname" operation="eq" value="srv02"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp03-3" rsc="Group03">
         <rule id="rule-grp03-3" score="200">
           <expression id="exp-grp03-3" attribute="#uname" operation="eq" value="srv03"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-grp03-4" rsc="Group03">
         <rule id="rule-grp03-4" score="100">
           <expression id="exp-grp03-4" attribute="#uname" operation="eq" value="srv04"/>
         </rule>

--- a/cts/scheduler/xml/bug-lf-2574.xml
+++ b/cts/scheduler/xml/bug-lf-2574.xml
@@ -56,28 +56,36 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc_location-main_rsc" rsc="main_rsc">
-        <rule id="rsc_location-main_rsc-rule" score="200">
-          <expression attribute="#uname" id="rsc_location-main_rsc-expression" operation="eq" value="srv01"/>
-        </rule>
-        <rule id="rsc_location-main_rsc-rule-0" score="100">
-          <expression attribute="#uname" id="rsc_location-main_rsc-expression-0" operation="eq" value="srv03"/>
-        </rule>
-        <rule boolean-op="or" id="pingd-main_rsc-rule" score="-INFINITY">
-          <expression attribute="pingd" id="rsc_location-main_rsc-expression-1" operation="not_defined"/>
-          <expression attribute="pingd" id="rsc_location-main_rsc-expression-2" operation="lt" value="1"/>
+      <rsc_location id="rsc_location-main_rsc-1" rsc="main_rsc">
+        <rule id="rsc_location-main_rsc-1-rule" score="200">
+          <expression attribute="#uname" id="rsc_location-main_rsc-1-expression" operation="eq" value="srv01"/>
         </rule>
       </rsc_location>
-      <rsc_location id="rsc_location-main_rsc2" rsc="main_rsc2">
-        <rule id="rsc_location-main_rsc2-rule" score="200">
-          <expression attribute="#uname" id="rsc_location-main_rsc2-expression" operation="eq" value="srv02"/>
+      <rsc_location id="rsc_location-main_rsc-2" rsc="main_rsc">
+        <rule id="rsc_location-main_rsc-2-rule" score="100">
+          <expression attribute="#uname" id="rsc_location-main_rsc-2-expression" operation="eq" value="srv03"/>
         </rule>
-        <rule id="rsc_location-main_rsc2-rule-0" score="100">
-          <expression attribute="#uname" id="rsc_location-main_rsc2-expression-0" operation="eq" value="srv03"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-main_rsc-3" rsc="main_rsc">
+        <rule boolean-op="or" id="rsc_location-main_rsc-3-rule" score="-INFINITY">
+          <expression attribute="pingd" id="rsc_location-main_rsc-3-expression-1" operation="not_defined"/>
+          <expression attribute="pingd" id="rsc_location-main_rsc-3-expression-2" operation="lt" value="1"/>
         </rule>
-        <rule boolean-op="or" id="pingd-main_rsc2-rule" score="-INFINITY">
-          <expression attribute="pingd" id="rsc_location-main_rsc2-expression-1" operation="not_defined"/>
-          <expression attribute="pingd" id="rsc_location-main_rsc2-expression-2" operation="lt" value="1"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-main_rsc2-1" rsc="main_rsc2">
+        <rule id="rsc_location-main_rsc2-1-rule" score="200">
+          <expression attribute="#uname" id="rsc_location-main_rsc2-1-expression" operation="eq" value="srv02"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-main_rsc2-2" rsc="main_rsc2">
+        <rule id="rsc_location-main_rsc2-2-rule" score="100">
+          <expression attribute="#uname" id="rsc_location-main_rsc2-2-expression" operation="eq" value="srv03"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-main_rsc2-3" rsc="main_rsc2">
+        <rule boolean-op="or" id="rsc_location-main_rsc2-3-rule" score="-INFINITY">
+          <expression attribute="pingd" id="rsc_location-main_rsc2-3-expression-1" operation="not_defined"/>
+          <expression attribute="pingd" id="rsc_location-main_rsc2-3-expression-2" operation="lt" value="1"/>
         </rule>
       </rsc_location>
       <rsc_colocation id="rsc_colocation-clnPingd-clnDummy1-1" rsc="clnPingd" score="INFINITY" with-rsc="clnDummy1"/>

--- a/cts/scheduler/xml/bug-pm-11.xml
+++ b/cts/scheduler/xml/bug-pm-11.xml
@@ -38,10 +38,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc_location" rsc="ms-sf">
+      <rsc_location id="rsc_location-0" rsc="ms-sf">
         <rule id="location-0" role="Promoted" score="100">
           <expression id="expression.id22011" attribute="#uname" operation="eq" value="node-a"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-1" rsc="ms-sf">
         <rule id="location-1" role="Promoted" score="50">
           <expression id="expression.id22030" attribute="#uname" operation="eq" value="node-b"/>
         </rule>

--- a/cts/scheduler/xml/bug-pm-12.xml
+++ b/cts/scheduler/xml/bug-pm-12.xml
@@ -43,10 +43,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc_location" rsc="ms-sf">
+      <rsc_location id="rsc_location-0" rsc="ms-sf">
         <rule id="location-0" role="Promoted" score="100">
           <expression id="expression.id22037" attribute="#uname" operation="eq" value="node-a"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-1" rsc="ms-sf">
         <rule id="location-1" role="Promoted" score="50">
           <expression id="expression.id22056" attribute="#uname" operation="eq" value="node-b"/>
         </rule>

--- a/cts/scheduler/xml/coloc-unpromoted-anti.xml
+++ b/cts/scheduler/xml/coloc-unpromoted-anti.xml
@@ -159,10 +159,12 @@
       </primitive>
     </resources>
     <constraints>
-      <rsc_location id="rsc-location-drbd-msr" rsc="drbd-msr">
-        <rule id="preferred-location-drbd-msr" role="Promoted" score="50">
+      <rsc_location id="rsc-location-drbd-msr-1" rsc="drbd-msr">
+        <rule id="preferred-location-drbd-msr-1" role="Promoted" score="50">
           <expression id="expression.id22801" attribute="#uname" operation="eq" value="pollux"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc-location-drbd-msr-2" rsc="drbd-msr">
         <rule id="pingd-score-group-1" role="Promoted" score-attribute="pingd-1-node-attribute">
           <expression id="expression.id22822" attribute="pingd-1-node-attribute" operation="defined"/>
         </rule>
@@ -170,19 +172,23 @@
       <rsc_colocation id="group-1-prefer-on-drbd-msr-promoted" rsc="group-1" with-rsc="drbd-msr" with-rsc-role="Promoted" score="INFINITY"/>
       <rsc_colocation id="group-1-never-on-drbd-msr-unpromoted" rsc="group-1" with-rsc="drbd-msr" with-rsc-role="Unpromoted" score="-INFINITY"/>
       <rsc_order id="group-1-after-drbd-msr" first="drbd-msr" then="group-1" then-action="start" first-action="promote"/>
-      <rsc_location id="pollux-fencing-placement" rsc="pollux-fencing">
-        <rule id="pollux-fencing-placement-1" score="INFINITY">
+      <rsc_location id="pollux-fencing-placement-1" rsc="pollux-fencing">
+        <rule id="pollux-fencing-placement-1-rule" score="INFINITY">
           <expression id="expression.id22883" attribute="#uname" operation="ne" value="pollux"/>
         </rule>
-        <rule id="pollux-fencing-placement-2" score="-INFINITY">
+      </rsc_location>
+      <rsc_location id="pollux-fencing-placement-2" rsc="pollux-fencing">
+        <rule id="pollux-fencing-placement-2-rule" score="-INFINITY">
           <expression id="expression.id22901" attribute="#uname" operation="eq" value="pollux"/>
         </rule>
       </rsc_location>
-      <rsc_location id="sirius-fencing-placement" rsc="sirius-fencing">
-        <rule id="sirius-fencing-placement-1" score="INFINITY">
+      <rsc_location id="sirius-fencing-placement-1" rsc="sirius-fencing">
+        <rule id="sirius-fencing-placement-1-rule" score="INFINITY">
           <expression id="expression.id22928" attribute="#uname" operation="ne" value="sirius"/>
         </rule>
-        <rule id="sirius-fencing-placement-2" score="-INFINITY">
+      </rsc_location>
+      <rsc_location id="sirius-fencing-placement-2" rsc="sirius-fencing">
+        <rule id="sirius-fencing-placement-2-rule" score="-INFINITY">
           <expression id="expression.id22946" attribute="#uname" operation="eq" value="sirius"/>
         </rule>
       </rsc_location>

--- a/cts/scheduler/xml/failcount.xml
+++ b/cts/scheduler/xml/failcount.xml
@@ -461,11 +461,13 @@
         </rule>
       </rsc_location>
       <rsc_order first="cl-ldirectord" id="or-wesbprod" then="cl-wesbprod"/>
-      <rsc_location id="lo-drdns-ping" rsc="re-drdns-ip">
+      <rsc_location id="lo-drdns-ping-1" rsc="re-drdns-ip">
         <rule boolean-op="or" id="re-drdns-ping-rule" score="-INFINITY">
           <expression attribute="at-ping-sjim" id="lo-drdns-ping-expression" operation="not_defined"/>
           <expression attribute="at-ping-sjim" id="lo-drdns-ping-expression-0" operation="lte" value="0"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="lo-drdns-ping-2" rsc="re-drdns-ip">
         <rule id="lo-drdns-ping-rule" score="INFINITY">
           <expression attribute="#uname" id="lo-drdns-ping-expression-1" operation="eq" value="dresproddns01"/>
         </rule>

--- a/cts/scheduler/xml/nvpair-date-rules-1.xml
+++ b/cts/scheduler/xml/nvpair-date-rules-1.xml
@@ -146,13 +146,15 @@
       </primitive>
     </resources>
     <constraints>
-      <rsc_location id="location-rsc1-rhel7-1-INFINITY" rsc="rsc1">
+      <rsc_location id="location-rsc1-rhel7-1-INFINITY-1" rsc="rsc1">
         <rule id="rule-2-1" score="INFINITY" boolean-op="and">
           <expression id="expression-2-1" attribute="#uname" operation="eq" value="rhel7-5"/>
           <rule id="rule-2-2" score="INFINITY">
             <date_expression id="expression-2-2" operation="in_range" start="2019-09-23 11:00:00 -05:00" end="2019-09-23 13:00:00 -05:00"/>
           </rule>
         </rule>
+      </rsc_location>
+      <rsc_location id="location-rsc1-rhel7-1-INFINITY-2" rsc="rsc1">
         <rule id="rule-3-1" score="INFINITY" boolean-op="and">
           <expression id="expression-3-1" attribute="#uname" operation="eq" value="rhel7-4"/>
           <rule id="rule-3-2" score="INFINITY">

--- a/cts/scheduler/xml/order-first-probes.xml
+++ b/cts/scheduler/xml/order-first-probes.xml
@@ -40,13 +40,15 @@
       </group>
     </resources>
     <constraints>
+      <!--### Resource Location ###-->
       <rsc_location id="rsc_location-msDrbd-1" rsc="grpDummy">
-        <!--### Resource Location ###-->
         <rule score="200" id="rsc_location-msDrbd-1-rule">
           <expression attribute="#uname" operation="eq" value="rh72-01" id="rsc_location-msDrbd-1-rule-expression"/>
         </rule>
-        <rule score="100" id="rsc_location-msDrbd-1-rule-0">
-          <expression attribute="#uname" operation="eq" value="rh72-02" id="rsc_location-msDrbd-1-rule-0-expression"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-msDrbd-2" rsc="grpDummy">
+        <rule score="100" id="rsc_location-msDrbd-2-rule">
+          <expression attribute="#uname" operation="eq" value="rh72-02" id="rsc_location-msDrbd-2-rule-expression"/>
         </rule>
       </rsc_location>
     </constraints>

--- a/cts/scheduler/xml/per-op-failcount.xml
+++ b/cts/scheduler/xml/per-op-failcount.xml
@@ -46,13 +46,15 @@
       </primitive>
     </resources>
     <constraints>
+      <!--### Resource Location ###-->
       <rsc_location id="rsc_location-1" rsc="prmDummy">
-        <!--### Resource Location ###-->
         <rule score="300" id="rsc_location-1-rule">
           <expression attribute="#uname" operation="eq" value="rh73-01-snmp" id="rsc_location-1-rule-expression"/>
         </rule>
-        <rule score="200" id="rsc_location-1-rule-0">
-          <expression attribute="#uname" operation="eq" value="rh73-02-snmp" id="rsc_location-1-rule-0-expression"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-2" rsc="prmDummy">
+        <rule score="200" id="rsc_location-2-rule">
+          <expression attribute="#uname" operation="eq" value="rh73-02-snmp" id="rsc_location-2-rule-expression"/>
         </rule>
       </rsc_location>
     </constraints>

--- a/cts/scheduler/xml/promoted-3.xml
+++ b/cts/scheduler/xml/promoted-3.xml
@@ -27,10 +27,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc1_promoted" rsc="rsc1">
+      <rsc_location id="rsc1_promoted-1" rsc="rsc1">
         <rule id="pref_rsc1_master-1" score="100" role="Promoted">
           <expression id="expression.id21950" attribute="#uname" operation="eq" value="node2"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc1_promoted-2" rsc="rsc1">
         <rule id="pref_rsc1_master-2" score="-INFINITY" role="Promoted">
           <expression id="expression.id21969" attribute="#uname" operation="eq" value="node1"/>
         </rule>

--- a/cts/scheduler/xml/promoted-demote.xml
+++ b/cts/scheduler/xml/promoted-demote.xml
@@ -142,18 +142,22 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="cyrus_address_location" rsc="cyrus_address">
+      <rsc_location id="cyrus_address_location-1" rsc="cyrus_address">
         <rule id="cyrus_address_ping_rule" score-attribute="pingd">
           <expression id="expression.id22688" attribute="pingd" operation="defined"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="cyrus_address_location-2" rsc="cyrus_address">
         <rule id="cyrus_address_node_rule" score="10">
           <expression id="expression.id22704" attribute="#uname" operation="eq" value="cxa1"/>
         </rule>
       </rsc_location>
-      <rsc_location id="named_address_location" rsc="named_address">
+      <rsc_location id="named_address_location-1" rsc="named_address">
         <rule id="named_address_ping_rule" score-attribute="pingd">
           <expression id="expression.id22730" attribute="pingd" operation="defined"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="named_address_location-2" rsc="named_address">
         <rule id="named_address_node_rule" score="10">
           <expression id="expression.id22747" attribute="#uname" operation="eq" value="cxb1"/>
         </rule>

--- a/cts/scheduler/xml/promoted-failed-demote-2.xml
+++ b/cts/scheduler/xml/promoted-failed-demote-2.xml
@@ -72,10 +72,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc_location" rsc="ms-sf">
+      <rsc_location id="rsc_location-0" rsc="ms-sf">
         <rule id="location-0" role="Promoted" score="100">
           <expression id="expression.id22304" attribute="#uname" operation="eq" value="dl380g5a"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-1" rsc="ms-sf">
         <rule id="location-1" role="Promoted" score="500">
           <expression id="expression.id22324" attribute="#uname" operation="eq" value="dl380g5b"/>
         </rule>

--- a/cts/scheduler/xml/promoted-failed-demote.xml
+++ b/cts/scheduler/xml/promoted-failed-demote.xml
@@ -72,10 +72,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc_location" rsc="ms-sf">
+      <rsc_location id="rsc_location-0" rsc="ms-sf">
         <rule id="location-0" role="Promoted" score="100">
           <expression id="expression.id22304" attribute="#uname" operation="eq" value="dl380g5a"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-1" rsc="ms-sf">
         <rule id="location-1" role="Promoted" score="500">
           <expression id="expression.id22324" attribute="#uname" operation="eq" value="dl380g5b"/>
         </rule>

--- a/cts/scheduler/xml/promoted-group.xml
+++ b/cts/scheduler/xml/promoted-group.xml
@@ -78,10 +78,12 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rlcPostgreSQLDB" rsc="test">
+      <rsc_location id="rlcPostgreSQLDB-1" rsc="test">
         <rule id="rulPostgreSQLDB_node01" score="200">
           <expression id="expression.id22323" attribute="#uname" operation="eq" value="rh44-1"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rlcPostgreSQLDB-2" rsc="test">
         <rule id="rulPostgreSQLDB_node02" score="100">
           <expression id="expression.id22341" attribute="#uname" operation="eq" value="rh44-2"/>
         </rule>
@@ -90,6 +92,8 @@
         <rule id="preferred_location_group_0" role="Promoted" score="100">
           <expression id="expression.id22369" attribute="#uname" operation="eq" value="rh44-1"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location_group_1" rsc="ms-sf">
         <rule id="preferred_location_group_1" role="Promoted" score="50">
           <expression id="expression.id22390" attribute="#uname" operation="eq" value="rh44-2"/>
         </rule>

--- a/cts/scheduler/xml/promoted-move.xml
+++ b/cts/scheduler/xml/promoted-move.xml
@@ -66,8 +66,10 @@
         <rule id="rsc_location-1-rule" role="Promoted" score="200">
           <expression attribute="#uname" id="rsc_location-1-expression" operation="eq" value="bl460g1n13"/>
         </rule>
-        <rule id="rsc_location-1-rule-0" role="Promoted" score="100">
-          <expression attribute="#uname" id="rsc_location-1-expression-0" operation="eq" value="bl460g1n14"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-2" rsc="msDRBD">
+        <rule id="rsc_location-2-rule" role="Promoted" score="100">
+          <expression attribute="#uname" id="rsc_location-2-expression" operation="eq" value="bl460g1n14"/>
         </rule>
       </rsc_location>
       <rsc_colocation id="rsc_colocation-1" rsc="grpDRBD" score="INFINITY" with-rsc="msDRBD" with-rsc-role="Promoted"/>

--- a/cts/scheduler/xml/rsc-sets-promoted.xml
+++ b/cts/scheduler/xml/rsc-sets-promoted.xml
@@ -36,10 +36,12 @@
           <resource_ref id="ms-rsc"/>
         </resource_set>
       </rsc_colocation>
-      <rsc_location id="pref-ms-rsc-1" rsc="ms-rsc">
+      <rsc_location id="pref-ms-rsc-0" rsc="ms-rsc">
         <rule id="prefer-master-1-rule-0" role="Promoted" score="500">
           <expression attribute="#uname" id="pref-ms-rsc-1-expression-0" operation="eq" value="node1"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="pref-ms-rsc-1" rsc="ms-rsc">
         <rule id="prefer-master-1-rule-1" role="Promoted" score="300">
           <expression attribute="#uname" id="pref-ms-rsc-1-expression-1" operation="eq" value="node2"/>
         </rule>

--- a/cts/scheduler/xml/simple11.xml
+++ b/cts/scheduler/xml/simple11.xml
@@ -25,10 +25,12 @@
       </primitive>
     </resources>
     <constraints>
-      <rsc_location id="run_rsc1" rsc="rsc1">
+      <rsc_location id="run_rsc1-1" rsc="rsc1">
         <rule id="can1" score="1">
           <expression id="expression.id21940" attribute="#uname" operation="ne" value="darthvader"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="run_rsc1-2" rsc="rsc1">
         <rule id="score1" score="10">
           <expression id="expression.id21958" attribute="#uname" operation="eq" value="node1"/>
         </rule>

--- a/cts/scheduler/xml/simple12.xml
+++ b/cts/scheduler/xml/simple12.xml
@@ -17,10 +17,12 @@
       <primitive id="rsc2" class="ocf" provider="heartbeat" type="apache"/>
     </resources>
     <constraints>
-      <rsc_location id="run_rsc1" rsc="rsc1">
+      <rsc_location id="run_rsc1-1" rsc="rsc1">
         <rule id="can1" score="1">
           <expression id="expression.id21907" attribute="#uname" operation="ne" value="darthvader"/>
         </rule>
+      </rsc_location>
+      <rsc_location id="run_rsc1-2" rsc="rsc1">
         <rule id="score1" score="10">
           <expression id="expression.id21925" attribute="#uname" operation="eq" value="node2"/>
         </rule>

--- a/cts/scheduler/xml/systemhealth1.xml
+++ b/cts/scheduler/xml/systemhealth1.xml
@@ -18,9 +18,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealth2.xml
+++ b/cts/scheduler/xml/systemhealth2.xml
@@ -21,9 +21,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealth3.xml
+++ b/cts/scheduler/xml/systemhealth3.xml
@@ -21,9 +21,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthm1.xml
+++ b/cts/scheduler/xml/systemhealthm1.xml
@@ -19,9 +19,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthm2.xml
+++ b/cts/scheduler/xml/systemhealthm2.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthm3.xml
+++ b/cts/scheduler/xml/systemhealthm3.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthn1.xml
+++ b/cts/scheduler/xml/systemhealthn1.xml
@@ -19,9 +19,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthn2.xml
+++ b/cts/scheduler/xml/systemhealthn2.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthn3.xml
+++ b/cts/scheduler/xml/systemhealthn3.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealtho1.xml
+++ b/cts/scheduler/xml/systemhealtho1.xml
@@ -19,9 +19,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealtho2.xml
+++ b/cts/scheduler/xml/systemhealtho2.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealtho3.xml
+++ b/cts/scheduler/xml/systemhealtho3.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthp1.xml
+++ b/cts/scheduler/xml/systemhealthp1.xml
@@ -19,9 +19,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthp2.xml
+++ b/cts/scheduler/xml/systemhealthp2.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/systemhealthp3.xml
+++ b/cts/scheduler/xml/systemhealthp3.xml
@@ -22,9 +22,6 @@
         <operations id="apache_1-operations">
           <op id="apache_1-op-monitor-10" interval="10" name="monitor" start-delay="1m" timeout="20"/>
         </operations>
-        <instance_attributes id="apache_1-instance_attributes">
-          <nvpair id="nvpair-a915b958-b215-4fa1-b465-23ab60aa06ca" name="configfile"/>
-        </instance_attributes>
       </primitive>
       <primitive class="ocf" id="nfs_1" provider="heartbeat" type="Filesystem">
         <meta_attributes id="nfs_1-meta_attributes">

--- a/cts/scheduler/xml/utilization-shuffle.xml
+++ b/cts/scheduler/xml/utilization-shuffle.xml
@@ -179,55 +179,73 @@
       </clone>
     </resources>
     <constraints>
-      <rsc_location id="rsc_location-grpPostgreSQLDB1" rsc="grpPostgreSQLDB1">
-        <rule id="rsc_location-grpPostgreSQLDB1-rule" score="200">
-          <expression attribute="#uname" id="rsc_location-grpPostgreSQLDB1-expression" operation="eq" value="act1"/>
-        </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB1-rule-0" score="-INFINITY">
-          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB1-expression-0" operation="not_defined"/>
-          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB1-expression-1" operation="lt" value="100"/>
-        </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB1-rule-1" score="-INFINITY">
-          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB1-expression-2" operation="not_defined"/>
-          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB1-expression-3" operation="eq" value="ERROR"/>
-        </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB1-rule-2" score="-INFINITY">
-          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB1-expression-4" operation="not_defined"/>
-          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB1-expression-5" operation="eq" value="ERROR"/>
+      <rsc_location id="rsc_location-grpPostgreSQLDB1-1" rsc="grpPostgreSQLDB1">
+        <rule id="rsc_location-grpPostgreSQLDB1-1-rule" score="200">
+          <expression attribute="#uname" id="rsc_location-grpPostgreSQLDB1-1-expression" operation="eq" value="act1"/>
         </rule>
       </rsc_location>
-      <rsc_location id="rsc_location-grpPostgreSQLDB2" rsc="grpPostgreSQLDB2">
-        <rule id="rsc_location-grpPostgreSQLDB2-rule" score="200">
-          <expression attribute="#uname" id="rsc_location-grpPostgreSQLDB2-expression" operation="eq" value="act2"/>
-        </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB2-rule-0" score="-INFINITY">
-          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB2-expression-0" operation="not_defined"/>
-          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB2-expression-1" operation="lt" value="100"/>
-        </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB2-rule-1" score="-INFINITY">
-          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB2-expression-2" operation="not_defined"/>
-          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB2-expression-3" operation="eq" value="ERROR"/>
-        </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB2-rule-2" score="-INFINITY">
-          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB2-expression-4" operation="not_defined"/>
-          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB2-expression-5" operation="eq" value="ERROR"/>
+      <rsc_location id="rsc_location-grpPostgreSQLDB1-2" rsc="grpPostgreSQLDB1">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB1-2-rule" score="-INFINITY">
+          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB1-2-expression-1" operation="not_defined"/>
+          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB1-2-expression-2" operation="lt" value="100"/>
         </rule>
       </rsc_location>
-      <rsc_location id="rsc_location-grpPostgreSQLDB3" rsc="grpPostgreSQLDB3">
-        <rule id="rsc_location-grpPostgreSQLDB3-rule" score="200">
-          <expression attribute="#uname" id="rsc_location-grpPostgreSQLDB3-expression" operation="eq" value="act3"/>
+      <rsc_location id="rsc_location-grpPostgreSQLDB1-3" rsc="grpPostgreSQLDB1">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB1-3-rule" score="-INFINITY">
+          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB1-3-expression-1" operation="not_defined"/>
+          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB1-3-expression-2" operation="eq" value="ERROR"/>
         </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB3-rule-0" score="-INFINITY">
-          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB3-expression-0" operation="not_defined"/>
-          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB3-expression-1" operation="lt" value="100"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB1-4" rsc="grpPostgreSQLDB1">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB1-4-rule" score="-INFINITY">
+          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB1-4-expression-1" operation="not_defined"/>
+          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB1-4-expression-2" operation="eq" value="ERROR"/>
         </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB3-rule-1" score="-INFINITY">
-          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB3-expression-2" operation="not_defined"/>
-          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB3-expression-3" operation="eq" value="ERROR"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB2-1" rsc="grpPostgreSQLDB2">
+        <rule id="rsc_location-grpPostgreSQLDB2-1-rule" score="200">
+          <expression attribute="#uname" id="rsc_location-grpPostgreSQLDB2-1-expression" operation="eq" value="act2"/>
         </rule>
-        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB3-rule-2" score="-INFINITY">
-          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB3-expression-4" operation="not_defined"/>
-          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB3-expression-5" operation="eq" value="ERROR"/>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB2-2" rsc="grpPostgreSQLDB2">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB2-2-rule" score="-INFINITY">
+          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB2-2-expression-1" operation="not_defined"/>
+          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB2-2-expression-2" operation="lt" value="100"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB2-3" rsc="grpPostgreSQLDB2">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB2-3-rule" score="-INFINITY">
+          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB2-3-expression-1" operation="not_defined"/>
+          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB2-3-expression-2" operation="eq" value="ERROR"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB2-4" rsc="grpPostgreSQLDB2">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB2-4-rule" score="-INFINITY">
+          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB2-4-expression-1" operation="not_defined"/>
+          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB2-4-expression-2" operation="eq" value="ERROR"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB3-1" rsc="grpPostgreSQLDB3">
+        <rule id="rsc_location-grpPostgreSQLDB3-1-rule" score="200">
+          <expression attribute="#uname" id="rsc_location-grpPostgreSQLDB3-1-expression" operation="eq" value="act3"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB3-2" rsc="grpPostgreSQLDB3">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB3-2-rule" score="-INFINITY">
+          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB3-2-expression-1" operation="not_defined"/>
+          <expression attribute="default_ping_set" id="rsc_location-grpPostgreSQLDB3-2-expression-2" operation="lt" value="100"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB3-3" rsc="grpPostgreSQLDB3">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB3-3-rule" score="-INFINITY">
+          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB3-3-expression-1" operation="not_defined"/>
+          <expression attribute="diskcheck_status" id="rsc_location-grpPostgreSQLDB3-3-expression-2" operation="eq" value="ERROR"/>
+        </rule>
+      </rsc_location>
+      <rsc_location id="rsc_location-grpPostgreSQLDB3-4" rsc="grpPostgreSQLDB3">
+        <rule boolean-op="or" id="rsc_location-grpPostgreSQLDB3-4-rule" score="-INFINITY">
+          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB3-4-expression-1" operation="not_defined"/>
+          <expression attribute="diskcheck_status_internal" id="rsc_location-grpPostgreSQLDB3-4-expression-2" operation="eq" value="ERROR"/>
         </rule>
       </rsc_location>
       <rsc_colocation id="grp1_colocation-1" rsc="grpPostgreSQLDB1" score="INFINITY" with-rsc="clnPingd">

--- a/cts/schemas/test-3/ref.err/bundle-promoted-max-legacy.ref.err-4
+++ b/cts/schemas/test-3/ref.err/bundle-promoted-max-legacy.ref.err-4
@@ -1,0 +1,1 @@
+WARNING: Dropping bundle resource bundle3 because rkt containers are no longer supported

--- a/cts/schemas/test-3/ref.err/can-fail.ref.err-4
+++ b/cts/schemas/test-3/ref.err/can-fail.ref.err-4
@@ -1,0 +1,7 @@
+WARNING: Dropping can_fail meta-attribute from template1_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping can_fail meta-attribute from rsc1_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping can_fail meta-attribute from rsc2_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping can_fail meta-attribute from rsc3_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping can_fail meta-attribute from rsc4_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping can_fail meta-attribute from rsc5_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping can_fail meta-attribute from op_defaults-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead

--- a/cts/schemas/test-3/ref.err/lifetime-1.ref.err-3
+++ b/cts/schemas/test-3/ref.err/lifetime-1.ref.err-3
@@ -1,0 +1,4 @@
+WARNING: Dropping lifetime element from constraint rsc2-with-rsc1 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint
+WARNING: Dropping lifetime element from constraint rsc4-with-rsc3 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint
+WARNING: Dropping lifetime element from constraint rsc1-then-rsc2 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint
+WARNING: Dropping lifetime element from constraint rsc3-then-rsc4 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint

--- a/cts/schemas/test-3/ref.err/lifetime-2.ref.err-3
+++ b/cts/schemas/test-3/ref.err/lifetime-2.ref.err-3
@@ -1,0 +1,4 @@
+WARNING: Dropping lifetime element from constraint rsc2-with-rsc1 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint
+WARNING: Dropping lifetime element from constraint rsc4-with-rsc3 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint
+WARNING: Dropping lifetime element from constraint rsc1-then-rsc2 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint
+WARNING: Dropping lifetime element from constraint rsc3-then-rsc4 because lifetime elements are no longer supported. Any rules contained there will no longer apply to the constraint

--- a/cts/schemas/test-3/ref.err/moon.ref.err-1
+++ b/cts/schemas/test-3/ref.err/moon.ref.err-1
@@ -1,0 +1,2 @@
+WARNING: Dropping moon attribute from date spec cluster-properties1-rule-expr-date_spec because moon phase is no longer supported
+WARNING: Dropping moon attribute from date spec cluster-properties2-rule-expr-date_spec because moon phase is no longer supported

--- a/cts/schemas/test-3/ref.err/nagios.ref.err-4
+++ b/cts/schemas/test-3/ref.err/nagios.ref.err-4
@@ -1,8 +1,11 @@
 WARNING: Dropping template template_drop because nagios resources are no longer supported
 WARNING: Dropping resource primitive1_drop because nagios resources are no longer supported
 WARNING: Dropping resource primitive3_drop because nagios resources are no longer supported
+INFO: Dropping group grp1_drop because it would become empty
 WARNING: Dropping resource grp2_rsc1_drop because nagios resources are no longer supported
 WARNING: Dropping resource grp2_rsc3_drop because nagios resources are no longer supported
+INFO: Dropping clone clone1_drop because it would become empty
+INFO: Dropping clone clone3_drop because it would become empty
 WARNING: Dropping resource clone4_grp_rsc1_drop because nagios resources are no longer supported
 WARNING: Dropping resource clone4_grp_rsc3_drop because nagios resources are no longer supported
 WARNING: Dropping resource bundle_rsc_drop because nagios resources are no longer supported

--- a/cts/schemas/test-3/ref.err/nagios.ref.err-4
+++ b/cts/schemas/test-3/ref.err/nagios.ref.err-4
@@ -1,0 +1,8 @@
+WARNING: Dropping template template_drop because nagios resources are no longer supported
+WARNING: Dropping resource primitive1_drop because nagios resources are no longer supported
+WARNING: Dropping resource primitive3_drop because nagios resources are no longer supported
+WARNING: Dropping resource grp2_rsc1_drop because nagios resources are no longer supported
+WARNING: Dropping resource grp2_rsc3_drop because nagios resources are no longer supported
+WARNING: Dropping resource clone4_grp_rsc1_drop because nagios resources are no longer supported
+WARNING: Dropping resource clone4_grp_rsc3_drop because nagios resources are no longer supported
+WARNING: Dropping resource bundle_rsc_drop because nagios resources are no longer supported

--- a/cts/schemas/test-3/ref.err/remove-after-stop.ref.err-1
+++ b/cts/schemas/test-3/ref.err/remove-after-stop.ref.err-1
@@ -1,0 +1,1 @@
+WARNING: Dropping nvpair cib-bootstrap-options-remove-after-stop because the remove-after-stop property is unsupported

--- a/cts/schemas/test-3/ref.err/restart-type.ref.err-4
+++ b/cts/schemas/test-3/ref.err/restart-type.ref.err-4
@@ -1,0 +1,12 @@
+WARNING: Dropping restart-type meta-attribute from template1-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from rsc1-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from rsc2-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from grp1-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from rsc3-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from clone1-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from rsc4-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from grp2-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from clone2-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from rsc5-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from bundle1-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints
+WARNING: Dropping restart-type meta-attribute from rsc_defaults-meta_attributes because it is no longer supported. Consider setting the "kind" attribute for relevant constraints

--- a/cts/schemas/test-3/ref.err/rkt.ref.err-4
+++ b/cts/schemas/test-3/ref.err/rkt.ref.err-4
@@ -1,0 +1,2 @@
+WARNING: Dropping bundle resource bundle1_drop because rkt containers are no longer supported
+WARNING: Dropping bundle resource bundle4_drop because rkt containers are no longer supported

--- a/cts/schemas/test-3/ref.err/role-after-failure.ref.err-4
+++ b/cts/schemas/test-3/ref.err/role-after-failure.ref.err-4
@@ -1,0 +1,7 @@
+WARNING: Dropping role_after_failure meta-attribute from template1_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping role_after_failure meta-attribute from rsc1_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping role_after_failure meta-attribute from rsc2_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping role_after_failure meta-attribute from rsc3_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping role_after_failure meta-attribute from rsc4_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping role_after_failure meta-attribute from rsc5_monitor_20000-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead
+WARNING: Dropping role_after_failure meta-attribute from op_defaults-meta_attributes because it is no longer supported. Consider setting the "on-fail" operation attribute instead

--- a/cts/schemas/test-3/ref.err/upstart.ref.err-4
+++ b/cts/schemas/test-3/ref.err/upstart.ref.err-4
@@ -1,8 +1,11 @@
 WARNING: Dropping template template_drop because upstart resources are no longer supported
 WARNING: Dropping resource primitive1_drop because upstart resources are no longer supported
 WARNING: Dropping resource primitive3_drop because upstart resources are no longer supported
+INFO: Dropping group grp1_drop because it would become empty
 WARNING: Dropping resource grp2_rsc1_drop because upstart resources are no longer supported
 WARNING: Dropping resource grp2_rsc3_drop because upstart resources are no longer supported
+INFO: Dropping clone clone1_drop because it would become empty
+INFO: Dropping clone clone3_drop because it would become empty
 WARNING: Dropping resource clone4_grp_rsc1_drop because upstart resources are no longer supported
 WARNING: Dropping resource clone4_grp_rsc3_drop because upstart resources are no longer supported
 WARNING: Dropping resource bundle_rsc_drop because upstart resources are no longer supported

--- a/cts/schemas/test-3/ref.err/upstart.ref.err-4
+++ b/cts/schemas/test-3/ref.err/upstart.ref.err-4
@@ -1,0 +1,8 @@
+WARNING: Dropping template template_drop because upstart resources are no longer supported
+WARNING: Dropping resource primitive1_drop because upstart resources are no longer supported
+WARNING: Dropping resource primitive3_drop because upstart resources are no longer supported
+WARNING: Dropping resource grp2_rsc1_drop because upstart resources are no longer supported
+WARNING: Dropping resource grp2_rsc3_drop because upstart resources are no longer supported
+WARNING: Dropping resource clone4_grp_rsc1_drop because upstart resources are no longer supported
+WARNING: Dropping resource clone4_grp_rsc3_drop because upstart resources are no longer supported
+WARNING: Dropping resource bundle_rsc_drop because upstart resources are no longer supported

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -797,7 +797,7 @@ cib_upgrade_err(void *ctx, const char *fmt, ...)
     va_list ap, aq;
     char *arg_cur;
 
-    bool found = FALSE;
+    bool found = false;
     const char *fmt_iter = fmt;
     uint8_t msg_log_level = LOG_WARNING;  /* default for runaway messages */
     const unsigned * log_level = (const unsigned *) ctx;
@@ -821,44 +821,31 @@ cib_upgrade_err(void *ctx, const char *fmt, ...)
             break;
         case 's':
             if (scan_state == escan_seenpercent) {
+                size_t prefix_len = 0;
+
                 scan_state = escan_seennothing;
                 arg_cur = va_arg(aq, char *);
-                if (arg_cur != NULL) {
-                    switch (arg_cur[0]) {
-                    case 'W':
-                        if (!strncmp(arg_cur, "WARNING: ",
-                                     sizeof("WARNING: ") - 1)) {
-                            msg_log_level = LOG_WARNING;
-                        }
-                        if (ctx == NULL) {
-                            memmove(arg_cur, arg_cur + sizeof("WARNING: ") - 1,
-                                    strlen(arg_cur + sizeof("WARNING: ") - 1) + 1);
-                        }
-                        found = TRUE;
-                        break;
-                    case 'I':
-                        if (!strncmp(arg_cur, "INFO: ",
-                                     sizeof("INFO: ") - 1)) {
-                            msg_log_level = LOG_INFO;
-                        }
-                        if (ctx == NULL) {
-                            memmove(arg_cur, arg_cur + sizeof("INFO: ") - 1,
-                                    strlen(arg_cur + sizeof("INFO: ") - 1) + 1);
-                        }
-                        found = TRUE;
-                        break;
-                    case 'D':
-                        if (!strncmp(arg_cur, "DEBUG: ",
-                                     sizeof("DEBUG: ") - 1)) {
-                            msg_log_level = LOG_DEBUG;
-                        }
-                        if (ctx == NULL) {
-                            memmove(arg_cur, arg_cur + sizeof("DEBUG: ") - 1,
-                                    strlen(arg_cur + sizeof("DEBUG: ") - 1) + 1);
-                        }
-                        found = TRUE;
-                        break;
-                    }
+
+                if (pcmk__starts_with(arg_cur, "WARNING: ")) {
+                    prefix_len = sizeof("WARNING: ") - 1;
+                    msg_log_level = LOG_WARNING;
+
+                } else if (pcmk__starts_with(arg_cur, "INFO: ")) {
+                    prefix_len = sizeof("INFO: ") - 1;
+                    msg_log_level = LOG_INFO;
+
+                } else if (pcmk__starts_with(arg_cur, "DEBUG: ")) {
+                    prefix_len = sizeof("DEBUG: ") - 1;
+                    msg_log_level = LOG_DEBUG;
+
+                } else {
+                    break;
+                }
+
+                found = true;
+                if (ctx == NULL) {
+                    memmove(arg_cur, arg_cur + prefix_len,
+                            strlen(arg_cur + prefix_len) + 1);
                 }
             }
             break;

--- a/xml/upgrade-3.10-1.xsl
+++ b/xml/upgrade-3.10-1.xsl
@@ -132,7 +132,15 @@
 <!-- Rules -->
 
 <!-- Drop the moon attribute from date_spec elements -->
-<xsl:template match="date_spec/@moon"/>
+<xsl:template match="date_spec/@moon">
+    <xsl:call-template name="warning">
+        <xsl:with-param name="msg"
+                        select="concat('Dropping moon attribute from',
+                                       ' date spec ', ../@id,
+                                       ' because moon phase is no longer',
+                                       ' supported')"/>
+    </xsl:call-template>
+</xsl:template>
 
 
 <!-- Cluster properties -->

--- a/xml/upgrade-3.10-1.xsl
+++ b/xml/upgrade-3.10-1.xsl
@@ -164,7 +164,14 @@
 </xsl:template>
 
 <!-- Drop remove-after-stop property -->
-<xsl:template match="cluster_property_set/nvpair[@name = 'remove-after-stop']"/>
+<xsl:template match="cluster_property_set/nvpair[@name = 'remove-after-stop']">
+    <xsl:call-template name="warning">
+        <xsl:with-param name="msg"
+                        select="concat('Dropping nvpair ', @id,
+                                       ' because the remove-after-stop',
+                                       ' property is unsupported')"/>
+    </xsl:call-template>
+</xsl:template>
 
 <!-- Replace stonith-action="poweroff" with stonith-action="off" -->
 <xsl:template match="cluster_property_set/nvpair[@name = 'stonith-action']

--- a/xml/upgrade-3.10-3.xsl
+++ b/xml/upgrade-3.10-3.xsl
@@ -19,10 +19,11 @@
        top-level constraint rule, containing the existing top-level constraint
        rule and the lifetime-based rule.
    * If a lifetime element existed in a colocation or order constraint prior to
-     this transformation, its rules are in a new location constraint that does
-     not apply to any resources. This is in case some other rule references
-     them. A rule in a lifetime element may contain a node attribute expression,
-     which is now allowed only within a location constraint rule.
+     this transformation, we drop it. If any rules contained in it are
+     referenced elsewhere, those rules are in a new location constraint that
+     does not apply to any resources. (A rule in a lifetime element may contain
+     a node attribute expression, which is now allowed only within a location
+     constraint rule.)
  -->
 
 <xsl:stylesheet version="1.0"

--- a/xml/upgrade-3.10-3.xsl
+++ b/xml/upgrade-3.10-3.xsl
@@ -224,7 +224,17 @@
 </xsl:template>
 
 <!-- Drop lifetime elements within colocation and order constraints -->
-<xsl:template match="rsc_colocation/lifetime"/>
-<xsl:template match="rsc_order/lifetime"/>
+<xsl:template match="rsc_colocation/lifetime
+                     |rsc_order/lifetime">
+    <xsl:call-template name="warning">
+        <xsl:with-param name="msg"
+                        select="concat('Dropping lifetime element from',
+                                       ' constraint ', ../@id,
+                                       ' because lifetime elements are no',
+                                       ' longer supported. Any rules contained',
+                                       ' there will no longer apply to the',
+                                       ' constraint')"/>
+    </xsl:call-template>
+</xsl:template>
 
 </xsl:stylesheet>

--- a/xml/upgrade-3.10-4.xsl
+++ b/xml/upgrade-3.10-4.xsl
@@ -116,16 +116,38 @@
 
 <!-- Drop groups that would become empty -->
 <xsl:template match="group">
-    <xsl:if test="count(.|$dropped_groups) != count($dropped_groups)">
-        <xsl:call-template name="identity"/>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="count(.|$dropped_groups) = count($dropped_groups)">
+            <xsl:call-template name="info">
+                <xsl:with-param name="msg"
+                                select="concat('Dropping group ', @id,
+                                               ' because it would become',
+                                               ' empty')"/>
+            </xsl:call-template>
+        </xsl:when>
+
+        <xsl:otherwise>
+            <xsl:call-template name="identity"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Drop clones that would become empty -->
 <xsl:template match="clone">
-    <xsl:if test="count(.|$dropped_clones) != count($dropped_clones)">
-        <xsl:call-template name="identity"/>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="count(.|$dropped_clones) = count($dropped_clones)">
+            <xsl:call-template name="info">
+                <xsl:with-param name="msg"
+                                select="concat('Dropping clone ', @id,
+                                               ' because it would become',
+                                               ' empty')"/>
+            </xsl:call-template>
+        </xsl:when>
+
+        <xsl:otherwise>
+            <xsl:call-template name="identity"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Drop rkt bundles -->

--- a/xml/upgrade-3.10-4.xsl
+++ b/xml/upgrade-3.10-4.xsl
@@ -129,7 +129,14 @@
 </xsl:template>
 
 <!-- Drop rkt bundles -->
-<xsl:template match="bundle[rkt]"/>
+<xsl:template match="bundle[rkt]">
+    <xsl:call-template name="warning">
+        <xsl:with-param name="msg"
+                        select="concat('Dropping bundle resource ', @id,
+                                       ' because rkt containers are no longer',
+                                       ' supported')"/>
+    </xsl:call-template>
+</xsl:template>
 
 <!-- Drop restart-type resource meta-attribute -->
 <xsl:template match="template/meta_attributes/nvpair[@name = 'restart-type']

--- a/xml/upgrade-3.10-4.xsl
+++ b/xml/upgrade-3.10-4.xsl
@@ -74,16 +74,44 @@
 
 <!-- Drop nagios- and upstart-class resource templates -->
 <xsl:template match="template">
-    <xsl:if test="count(.|$dropped_templates) != count($dropped_templates)">
-        <xsl:call-template name="identity"/>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="count(.|$dropped_templates)
+                        = count($dropped_templates)">
+            <xsl:call-template name="warning">
+                <xsl:with-param name="msg"
+                                select="concat('Dropping template ', @id,
+                                               ' because ', @class,
+                                               ' resources are no longer',
+                                               ' supported')"/>
+            </xsl:call-template>
+        </xsl:when>
+
+        <xsl:otherwise>
+            <xsl:call-template name="identity"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Drop nagios- and upstart-class primitives -->
 <xsl:template match="primitive">
-    <xsl:if test="count(.|$dropped_primitives) != count($dropped_primitives)">
-        <xsl:call-template name="identity"/>
-    </xsl:if>
+    <xsl:choose>
+        <xsl:when test="count(.|$dropped_primitives)
+                        = count($dropped_primitives)">
+            <xsl:variable name="class"
+                          select="@class|key('template_id', @template)/@class"/>
+            <xsl:call-template name="warning">
+                <xsl:with-param name="msg"
+                                select="concat('Dropping resource ', @id,
+                                               ' because ', $class,
+                                               ' resources are no longer',
+                                               ' supported')"/>
+            </xsl:call-template>
+        </xsl:when>
+
+        <xsl:otherwise>
+            <xsl:call-template name="identity"/>
+        </xsl:otherwise>
+    </xsl:choose>
 </xsl:template>
 
 <!-- Drop groups that would become empty -->

--- a/xml/upgrade-3.10-4.xsl
+++ b/xml/upgrade-3.10-4.xsl
@@ -156,14 +156,22 @@
     </xsl:call-template>
 </xsl:template>
 
-<!-- Drop can_fail operation meta-attribute -->
+<!-- Drop can_fail and role_after_failure operation meta-attributes -->
 <xsl:template match="op/meta_attributes/nvpair[@name = 'can_fail']
-                     |op_defaults/meta_attributes/nvpair[@name = 'can_fail']"/>
-
-<!-- Drop role_after_failure operation meta-attribute -->
-<xsl:template match="op/meta_attributes/nvpair[@name = 'role_after_failure']
+                     |op/meta_attributes/nvpair[@name = 'role_after_failure']
+                     |op_defaults/meta_attributes/nvpair[@name = 'can_fail']
                      |op_defaults/meta_attributes/nvpair
-                         [@name = 'role_after_failure']"/>
+                         [@name = 'role_after_failure']">
+    <xsl:call-template name="warning">
+        <xsl:with-param name="msg"
+                        select="concat('Dropping ', @name,
+                                       ' meta-attribute from ', ../@id,
+                                       ' because it is no longer supported.',
+                                       ' Consider setting the',
+                                       ' &quot;on-fail&quot; operation',
+                                       ' attribute instead')"/>
+    </xsl:call-template>
+</xsl:template>
 
 
 <!-- Constraints -->

--- a/xml/upgrade-3.10-4.xsl
+++ b/xml/upgrade-3.10-4.xsl
@@ -145,7 +145,16 @@
                      |clone/meta_attributes/nvpair[@name = 'restart-type']
                      |bundle/meta_attributes/nvpair[@name = 'restart-type']
                      |rsc_defaults/meta_attributes/nvpair
-                         [@name = 'restart-type']"/>
+                         [@name = 'restart-type']">
+    <xsl:call-template name="warning">
+        <xsl:with-param name="msg"
+                        select="concat('Dropping ', @name,
+                                       ' meta-attribute from ', ../@id,
+                                       ' because it is no longer supported.',
+                                       ' Consider setting the &quot;kind&quot;',
+                                       ' attribute for relevant constraints')"/>
+    </xsl:call-template>
+</xsl:template>
 
 <!-- Drop can_fail operation meta-attribute -->
 <xsl:template match="op/meta_attributes/nvpair[@name = 'can_fail']

--- a/xml/upgrade-3.10-common.xsl
+++ b/xml/upgrade-3.10-common.xsl
@@ -121,4 +121,21 @@
     </xsl:message>
 </xsl:template>
 
+<!--
+ Outputs an info message
+
+ Output a message with the prefix "INFO: ". This directs Pacemaker's XSLT error
+ handler to strip the prefix and log the message at info level.
+
+ Params:
+ * msg: Message to output
+ -->
+<xsl:template name="info">
+    <xsl:param name="msg"/>
+
+    <xsl:message>
+        <xsl:value-of select="concat('INFO: ', $msg)"/>
+    </xsl:message>
+</xsl:template>
+
 </xsl:stylesheet>

--- a/xml/upgrade-3.10-common.xsl
+++ b/xml/upgrade-3.10-common.xsl
@@ -104,4 +104,21 @@
     </xsl:copy>
 </xsl:template>
 
+<!--
+ Outputs a warning message
+
+ Output a message with the prefix "WARNING: ". This directs Pacemaker's XSLT
+ error handler to strip the prefix and log the message at warning level.
+
+ Params:
+ * msg: Message to output
+ -->
+<xsl:template name="warning">
+    <xsl:param name="msg"/>
+
+    <xsl:message>
+        <xsl:value-of select="concat('WARNING: ', $msg)"/>
+    </xsl:message>
+</xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Pacemaker already has a handler in place.

We can do fewer of these, change some of the log levels, and/or add debug-level logs for more minor transformations.

Closes T896