### PR TITLE
Mid: systemd: Improved Pending status in monitor/probe for systemd resources. 

### DIFF
--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -869,8 +869,16 @@ action_complete(svc_action_t * action)
             cmd->real_action = cmd->action;
             cmd->action = pcmk__str_copy(PCMK_ACTION_MONITOR);
 
-        } else if (cmd->real_action != NULL) {
-            // This is follow-up monitor to check whether start/stop completed
+        } else if (cmd->result.execution_status == PCMK_EXEC_PENDING &&
+                   pcmk__str_any_of(cmd->action, PCMK_ACTION_MONITOR, PCMK_ACTION_STATUS, NULL) &&
+                   cmd->interval_ms == 0 &&
+                   cmd->real_action == NULL) {
+            /* If the state is Pending at the time of probe, execute follow-up monitor. */
+            goagain = true;
+            cmd->real_action = cmd->action;
+            cmd->action = pcmk__str_copy(PCMK_ACTION_MONITOR);
+	} else if (cmd->real_action != NULL) {
+            // This is follow-up monitor to check whether start/stop/probe(monitor) completed
             if (cmd->result.execution_status == PCMK_EXEC_PENDING) {
                 goagain = true;
 


### PR DESCRIPTION
Hi @kgaillot 
Hi All,

This fix PR is an improvement on the next PR.
 * https://github.com/ClusterLabs/pacemaker/pull/3720
-----
1. It speeds up error detection when the systemd resource monitor continues to return pending.
1. In addition, if the systemd resource probe returns pending, a follow up monitor will be performed until the timeout occurs, waiting for RUNNING/NOT RUNNING to be detected.

Best Regards,
Hideo Yamauchi.

