### PR TITLE
Test: cts-scheduler: Remove sed needed for backwards compat.

### DIFF
--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1503,21 +1503,9 @@ class CtsScheduler(object):
             print(" ".join(test_cmd_full))
 
         with io.open(summary_output_filename, "wt") as f:
-            simulation = subprocess.Popen(test_cmd_full, stdout=subprocess.PIPE,
-                                          stderr=subprocess.STDOUT,
-                                          env=os.environ)
-            # This makes diff happy regardless of --enable-compat-2.0.
-            # Use sed -E to make Linux and BSD special characters more compatible.
-            sed = subprocess.Popen(["sed", "-E",
-                                    "-e", "s/ocf::/ocf:/g",
-                                    "-e", r"s/Masters:/Promoted:/",
-                                    "-e", r"s/Slaves:/Unpromoted:/",
-                                    "-e", r"s/ Master( |\[|$)/ Promoted\1/",
-                                    "-e", r"s/ Slave / Unpromoted /",
-                                   ], stdin=simulation.stdout, stdout=f,
-                                   stderr=subprocess.STDOUT)
-            simulation.stdout.close()
-            sed.communicate()
+            subprocess.run(test_cmd_full, stdout=f, stderr=subprocess.STDOUT,
+                           env=os.environ, check=False)
+
         if self.args.run:
             cat(summary_output_filename)
 


### PR DESCRIPTION
Master/Slave terminology and "ocf::" have been completely removed in the main branch, so there's no need to continue doing these substitutions.