### PR TITLE
Add TLS support for Pacemaker Remote connections

### DIFF
--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -90,7 +90,7 @@ init_remote_listener(int port, gboolean encrypted)
     }
 
     if (encrypted) {
-        bool use_cert = pcmk__x509_enabled(true);
+        bool use_cert = pcmk__x509_enabled();
 
         crm_notice("Starting TLS listener on port %d", port);
 

--- a/doc/sphinx/Pacemaker_Explained/local-options.rst
+++ b/doc/sphinx/Pacemaker_Explained/local-options.rst
@@ -482,21 +482,6 @@ whose location varies by OS (most commonly ``/etc/sysconfig/pacemaker`` or
        sync values are more likely to preserve log messages, but with the risk
        that the host may be left active if the synchronization hangs.
 
-   * - .. _pcmk_authkey_location:
-
-       .. index::
-          pair: node option; PCMK_authkey_location
-
-       PCMK_authkey_location
-     - :ref:`text <text>`
-     - |PCMK_AUTHKEY_FILE|
-     - Use the contents of this file as the authorization key to use with
-       :ref:`Pacemaker Remote <pacemaker_remote>` connections. This file must
-       be readable by Pacemaker daemons (that is, it must allow read
-       permissions to either the |CRM_DAEMON_USER| user or the
-       |CRM_DAEMON_GROUP| group), and its contents must be identical on all
-       nodes.
-
    * - .. _pcmk_remote_address:
 
        .. index::
@@ -525,6 +510,91 @@ whose location varies by OS (most commonly ``/etc/sysconfig/pacemaker`` or
      - 3121
      - Use this TCP port number for :ref:`Pacemaker Remote <pacemaker_remote>`
        node connections. This value must be the same on all nodes.
+
+   * - .. _pcmk_ca_file:
+
+       .. index::
+          pair: node option; PCMK_ca_file
+
+       PCMK_ca_file
+     - :ref:`text <text>`
+     -
+     - The location of a file containing trusted Certificate Authorities, used to
+       verify client or server certificates. This file must be in PEM format and
+       must be readable by Pacemaker daemons (that is, it must allow read permissions
+       to either the |CRM_DAEMON_USER| user or the |CRM_DAEMON_GROUP| group).
+       If set, along with :ref:`PCMK_key_file <PCMK_key_file>` and
+       :ref:`PCMK_cert_file <PCMK_cert_file>`, X509 authentication will be enabled
+       for :ref:`Pacemaker Remote <pacemaker_remote>` and remote CIB connections.
+
+       Example: ``PCMK_ca_file="/etc/pacemaker/ca.cert.pem"``
+
+   * - .. _pcmk_cert_file:
+
+       .. index::
+          pair: node option; PCMK_cert_file
+
+       PCMK_cert_file
+     - :ref:`text <text>`
+     -
+     - The location of a file containing the signed certificate for the server
+       side of the connection. This file must be in PEM format and must be
+       readable by Pacemaker daemons (that is, it must allow read permissions
+       to either the |CRM_DAEMON_USER| user or the |CRM_DAEMON_GROUP| group).
+       If set, along with :ref:`PCMK_ca_file <PCMK_ca_file>` and
+       :ref:`PCMK_key_file <PCMK_key_file>`, X509 authentication will be enabled
+       for :ref:`Pacemaker Remote <pacemaker_remote>` and remote CIB connections.
+
+       Example: ``PCMK_cert_file="/etc/pacemaker/server.cert.pem"``
+
+   * - .. _pcmk_crl_file:
+
+       .. index::
+          pair: node option; PCMK_crl_file
+
+       PCMK_crl_file
+     - :ref:`text <text>`
+     -
+     - The location of a Certificate Revocation List file, in PEM format. This
+       setting is optional for X509 authentication.
+
+       Example: ``PCMK_cr1_file="/etc/pacemaker/crl.pem"``
+
+   * - .. _pcmk_key_file:
+
+       .. index::
+          pair: node option; PCMK_key_file
+
+       PCMK_key_file
+     - :ref:`text <text>`
+     -
+     - The location of a file containing the private key for the matching
+       :ref:`PCMK_cert_file <PCMK_cert_file>`, in PEM format. This file must
+       be readble by Pacemaker daemons (that is, it must allow read permissions
+       to either the |CRM_DAEMON_USER| user or the |CRM_DAEMON_GROUP| group).
+       If set, along with :ref:`PCMK_ca_file <PCMK_ca_file>` and
+       :ref:`PCMK_cert_file <PCMK_cert_file>`, X509 authentication will be
+       enabled for :ref:`Pacemaker Remote <pacemaker_remote>` and remote CIB
+       connections.
+
+       Example: ``PCMK_key_file="/etc/pacemaker/server.key.pem"``
+
+   * - .. _pcmk_authkey_location:
+
+       .. index::
+          pair: node option; PCMK_authkey_location
+
+       PCMK_authkey_location
+     - :ref:`text <text>`
+     - |PCMK_AUTHKEY_FILE|
+     - As an alternative to using X509 authentication for :ref:`Pacemaker Remote
+       <pacemaker_remote>` connections, use the contents of this file as the
+       authorization key. This file must be readable by Pacemaker daemons (that
+       is, it must allow read permissions to either the |CRM_DAEMON_USER| user
+       or the |CRM_DAEMON_GROUP| group), and its contents must be identical on
+       all nodes.
+
+       This is an alternative to using X509 certificates.
 
    * - .. _pcmk_remote_pid1:
 

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -231,7 +231,9 @@
 # PCMK_ca_file
 #
 # The location of a file containing trusted Certificate Authorities, used to
-# verify client or server certificates.  This file should be in PEM format.
+# verify client or server certificates. This file must be in PEM format and
+# must be readable by Pacemaker daemons (that is, it must allow read permissions
+# to either the @CRM_DAEMON_USER@ user or the @CRM_DAEMON_GROUP@ group).
 # If set, along with PCMK_key_file and PCMK_cert_file, X509 authentication
 # will be enabled for remote CIB connections.
 #
@@ -240,15 +242,17 @@
 # PCMK_cert_file
 #
 # The location of a file containing the signed certificate for the server
-# (CIB manager) side of the connection, in PEM format.  If set, along with
-# PCMK_ca_file and PCMK_key_file, X509 authentication will be enabled for
-# remote CIB connections.
+# (CIB manager) side of the connection. This file must be in PEM format and
+# must be readable by Pacemaker daemons (that is, it must allow read
+# permissions to either the @CRM_DAEMON_USER@ user or the @CRM_DAEMON_GROUP@
+# group). If set, along with PCMK_ca_file and PCMK_key_file, X509
+# authentication will be enabled for remote CIB connections.
 #
 # Default: PCMK_cert_file=""
 
 # PCMK_crl_file
 #
-# The location of a Certificate Revocation List file, in PEM format.  This
+# The location of a Certificate Revocation List file, in PEM format. This
 # setting is optional for X509 authentication.
 #
 # Default: PCMK_crl_file=""
@@ -256,8 +260,10 @@
 # PCMK_key_file
 #
 # The location of a file containing the private key for the matching PCMK_cert_file,
-# in PEM format.  If set, along with PCMK_ca_file and PCMK_cert_file, X509
-# authentication will be enabled for remote CIB connections.
+# in PEM format. This file must be readble by Pacemaker daemons (that is, it
+# must allow read permissions to either the @CRM_DAEMON_USER@ user or the
+# @CRM_DAEMON_GROUP@ group). If set, along with PCMK_ca_file and PCMK_cert_file,
+# X509 authentication will be enabled for remote CIB connections.
 #
 # Default: PCMK_key_file=""
 

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -200,15 +200,6 @@
 
 ## Pacemaker Remote and remote CIB administration
 
-# PCMK_authkey_location
-#
-# Use the contents of this file as the authorization key to use with Pacemaker
-# Remote connections. This file must be readable by Pacemaker daemons (that is,
-# it must allow read permissions to either the @CRM_DAEMON_USER@ user or the
-# @CRM_DAEMON_GROUP@ group), and its contents must be identical on all nodes.
-#
-# Default: PCMK_authkey_location="@PACEMAKER_CONFIG_DIR@/authkey"
-
 # PCMK_remote_address
 #
 # By default, if the Pacemaker Remote service is run on the local node, it will
@@ -235,18 +226,18 @@
 # must be readable by Pacemaker daemons (that is, it must allow read permissions
 # to either the @CRM_DAEMON_USER@ user or the @CRM_DAEMON_GROUP@ group).
 # If set, along with PCMK_key_file and PCMK_cert_file, X509 authentication
-# will be enabled for remote CIB connections.
+# will be enabled for Pacemaker Remote and remote CIB connections.
 #
 # Default: PCMK_ca_file=""
 
 # PCMK_cert_file
 #
 # The location of a file containing the signed certificate for the server
-# (CIB manager) side of the connection. This file must be in PEM format and
-# must be readable by Pacemaker daemons (that is, it must allow read
-# permissions to either the @CRM_DAEMON_USER@ user or the @CRM_DAEMON_GROUP@
-# group). If set, along with PCMK_ca_file and PCMK_key_file, X509
-# authentication will be enabled for remote CIB connections.
+# side of the connection. This file must be in PEM format and must be
+# readable by Pacemaker daemons (that is, it must allow read permissions
+# to either the @CRM_DAEMON_USER@ user or the @CRM_DAEMON_GROUP@ group).
+# If set, along with PCMK_ca_file and PCMK_key_file, X509 authentication
+# will be enabled for Pacemaker Remote and remote CIB connections.
 #
 # Default: PCMK_cert_file=""
 
@@ -263,9 +254,22 @@
 # in PEM format. This file must be readble by Pacemaker daemons (that is, it
 # must allow read permissions to either the @CRM_DAEMON_USER@ user or the
 # @CRM_DAEMON_GROUP@ group). If set, along with PCMK_ca_file and PCMK_cert_file,
-# X509 authentication will be enabled for remote CIB connections.
+# X509 authentication will be enabled for Pacemaker Remote and remote CIB
+# connections.
 #
 # Default: PCMK_key_file=""
+
+# PCMK_authkey_location
+#
+# As an alternative to using X509 authentication for Pacemaker Remote
+# connections, use the contents of this file as the authorization key. This
+# file must be readable by Pacemaker daemons (that is, it must allow read
+# permissions to either the @CRM_DAEMON_USER@ user or the @CRM_DAEMON_GROUP@
+# group), and its contents must be identical on all nodes.
+#
+# This is an alternative to using X509 certificates.
+#
+# Default: PCMK_authkey_location="@PACEMAKER_CONFIG_DIR@/authkey"
 
 # PCMK_remote_pid1 (Advanced Use Only)
 #

--- a/include/crm/common/tls_internal.h
+++ b/include/crm/common/tls_internal.h
@@ -170,12 +170,10 @@ int pcmk__tls_client_try_handshake(pcmk__remote_t *remote, int *gnutls_rc);
  * \internal
  * \brief Is X509 authentication supported by the environment?
  *
- * \param[in] server Is this a server?
- *
  * \return true if the appropriate environment variables are set (see
  *         etc/sysconfig/pacemaker.in), otherwise false
  */
-bool pcmk__x509_enabled(bool server);
+bool pcmk__x509_enabled(void);
 
 #ifdef __cplusplus
 }

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -375,7 +375,7 @@ cib_tls_signon(cib_t *cib, pcmk__remote_t *connection, gboolean event_channel)
     }
 
     if (private->encrypted) {
-        bool use_cert = pcmk__x509_enabled(false);
+        bool use_cert = pcmk__x509_enabled();
         int tls_rc = GNUTLS_E_SUCCESS;
 
         rc = pcmk__init_tls(&tls, false, use_cert ? GNUTLS_CRD_CERTIFICATE : GNUTLS_CRD_ANON);

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -25,8 +25,13 @@ get_gnutls_priorities(gnutls_credentials_type_t cred_type)
         prio_base = PCMK__GNUTLS_PRIORITIES;
     }
 
-    return crm_strdup_printf("%s:%s", prio_base,
-                             (cred_type == GNUTLS_CRD_ANON)? "+ANON-DH" : "+DHE-PSK:+PSK");
+    if (cred_type == GNUTLS_CRD_ANON) {
+        return crm_strdup_printf("%s:+ANON-DH", prio_base);
+    } else if (cred_type == GNUTLS_CRD_PSK) {
+        return crm_strdup_printf("%s:+DHE-PSK:+PSK", prio_base);
+    } else {
+        return strdup(prio_base);
+    }
 }
 
 static const char *

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -200,6 +200,7 @@ pcmk__init_tls(pcmk__tls_t **tls, bool server, gnutls_credentials_type_t cred_ty
         rc = pcmk__init_tls_dh(&(*tls)->dh_params);
         if (rc != pcmk_rc_ok) {
             pcmk__free_tls(*tls);
+            *tls = NULL;
             return rc;
         }
     }
@@ -250,6 +251,7 @@ pcmk__init_tls(pcmk__tls_t **tls, bool server, gnutls_credentials_type_t cred_ty
         rc = tls_load_x509_data(*tls);
         if (rc != pcmk_rc_ok) {
             pcmk__free_tls(*tls);
+            *tls = NULL;
             return rc;
         }
     } else if (cred_type == GNUTLS_CRD_PSK) {


### PR DESCRIPTION
Tested:

- Still works without certs
- If certs are enabled on the server but not the client, falling back to PSK keys is not allowed
- Moving a Pacemaker Remote resource from a node with a cert to one without does not work (the cluster does not like this happening, but removing the constraint will cause the resource to move back to the node with the cert)
- Moving a Pacemaker Remote resource from a nod with a cert to one with its own cert does work

I did not explicitly test expirations or CRLs, but it's the exact same code as on the remote CIB connections and both worked there so I have no reason to think they wouldn't work here.