### PR TITLE
OCF: controld.in: Remove gfs_controld command as it's already obsoleted

### DIFF
--- a/agents/ocf/controld.in
+++ b/agents/ocf/controld.in
@@ -27,10 +27,6 @@
 : ${OCF_RESOURCE_INSTANCE:=""}
 
 case "$OCF_RESOURCE_INSTANCE" in
-    *[gG][fF][sS]*)
-        : ${OCF_RESKEY_args=-g 0}
-        : ${OCF_RESKEY_daemon:=gfs_controld}
-        ;;
     *[dD][lL][mM]*)
         : ${OCF_RESKEY_args=-s 0}
         : ${OCF_RESKEY_daemon:=dlm_controld}
@@ -74,7 +70,7 @@ Any additional options to start the dlm_controld service with
 
 <parameter name="daemon" unique-group="daemon">
 <longdesc lang="en">
-The daemon to start - supports gfs_controld and dlm_controld
+The daemon to start - supports dlm_controld
 </longdesc>
 <shortdesc lang="en">The daemon to start</shortdesc>
 <content type="string" default="dlm_controld" />


### PR DESCRIPTION
I found that when my DLM RA's id starts with `gfs` and `GFS`, the log shows:
```
pacemaker-controld[2039]:  notice: GFs2-dlm_start_0@alp-2 output [ /usr/lib/ocf/resource.d/pacemaker/controld: line 184: gfs_controld: command not found
```

Consider this log
```
commit 75934649b85259d1559eabca40be820095643239
Author: Andrew Price <anprice@redhat.com>
Date:   Tue Feb 12 09:58:11 2019 +0000

    gfs2.5: General updates and layout improvements
    
    - Update the manpage to mention lvmlockd and don't mention gfs2_quota
      or gfs_controld (both obsolete).
```

Should we drop gfs_controld from RA?