### PR TITLE
[3.0] Fix: libpacemaker: set fail-count to INFINITY for fatal failures

### DIFF
--- a/include/crm/common/xml_names_internal.h
+++ b/include/crm/common/xml_names_internal.h
@@ -153,6 +153,8 @@ extern "C" {
 #define PCMK__XA_ELECTION_AGE_NANO_SEC  "election-age-nano-sec"
 #define PCMK__XA_ELECTION_ID            "election-id"
 #define PCMK__XA_ELECTION_OWNER         "election-owner"
+#define PCMK__XA_FAILED_START_OFFSET    "failed-start-offset"
+#define PCMK__XA_FAILED_STOP_OFFSET     "failed-stop-offset"
 #define PCMK__XA_GRANTED                "granted"
 #define PCMK__XA_HIDDEN                 "hidden"
 #define PCMK__XA_HTTP_EQUIV             "http-equiv"

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -983,7 +983,8 @@ xmlNode *pcmk__inject_resource_history(pcmk__output_t *out, xmlNode *cib_node,
 G_GNUC_INTERNAL
 void pcmk__inject_failcount(pcmk__output_t *out, cib_t *cib_conn,
                             xmlNode *cib_node, const char *resource,
-                            const char *task, guint interval_ms, int rc);
+                            const char *task, guint interval_ms, int rc,
+                            bool infinity);
 
 G_GNUC_INTERNAL
 xmlNode *pcmk__inject_action_result(xmlNode *cib_resource,

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -769,9 +769,9 @@ pcmk__unpack_graph(const xmlNode *xml_graph, const char *reference)
         pcmk__scan_min_int(buf, &(new_graph->migration_limit), -1);
 
         new_graph->failed_stop_offset =
-            crm_element_value_copy(xml_graph, "failed-stop-offset");
+            crm_element_value_copy(xml_graph, PCMK__XA_FAILED_STOP_OFFSET);
         new_graph->failed_start_offset =
-            crm_element_value_copy(xml_graph, "failed-start-offset");
+            crm_element_value_copy(xml_graph, PCMK__XA_FAILED_START_OFFSET);
 
         if (crm_element_value_epoch(xml_graph, "recheck-by",
                                     &(new_graph->recheck_by)) != pcmk_ok) {

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -1021,12 +1021,14 @@ pcmk__create_graph(pcmk_scheduler_t *scheduler)
     value = pcmk__cluster_option(config_hash, PCMK_OPT_STONITH_TIMEOUT);
     crm_xml_add(scheduler->priv->graph, PCMK_OPT_STONITH_TIMEOUT, value);
 
-    crm_xml_add(scheduler->priv->graph, "failed-stop-offset", "INFINITY");
+    crm_xml_add(scheduler->priv->graph, PCMK__XA_FAILED_STOP_OFFSET,
+                PCMK_VALUE_INFINITY);
 
     if (pcmk_is_set(scheduler->flags, pcmk__sched_start_failure_fatal)) {
-        crm_xml_add(scheduler->priv->graph, "failed-start-offset", "INFINITY");
+        crm_xml_add(scheduler->priv->graph, PCMK__XA_FAILED_START_OFFSET,
+                    PCMK_VALUE_INFINITY);
     } else {
-        crm_xml_add(scheduler->priv->graph, "failed-start-offset", "1");
+        crm_xml_add(scheduler->priv->graph, PCMK__XA_FAILED_START_OFFSET, "1");
     }
 
     value = pcmk__cluster_option(config_hash, PCMK_OPT_BATCH_LIMIT);

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -89,11 +89,13 @@ inject_transient_attr(pcmk__output_t *out, xmlNode *cib_node,
  * \param[in]     exit_status  Action result for fail count to inject (if
  *                             \c PCMK_OCF_OK, or \c PCMK_OCF_NOT_RUNNING when
  *                             \p interval_ms is 0, inject nothing)
+ * \param[in]     infinity     If true, set fail count to "INFINITY", otherwise
+ *                             increase it by 1
  */
 void
 pcmk__inject_failcount(pcmk__output_t *out, cib_t *cib_conn, xmlNode *cib_node,
                        const char *resource, const char *task,
-                       guint interval_ms, int exit_status)
+                       guint interval_ms, int exit_status, bool infinity)
 {
     char *name = NULL;
     char *value = NULL;
@@ -120,7 +122,14 @@ pcmk__inject_failcount(pcmk__output_t *out, cib_t *cib_conn, xmlNode *cib_node,
             failcount = 0;
         }
     }
-    value = pcmk__itoa(failcount + 1);
+
+    if (infinity) {
+        value = pcmk__str_copy(PCMK_VALUE_INFINITY);
+
+    } else {
+        value = pcmk__itoa(failcount + 1);
+    }
+
     inject_transient_attr(out, cib_node, name, value);
 
     free(name);
@@ -565,6 +574,7 @@ inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
     xmlNode *cib_resource = NULL;
     const pcmk_resource_t *rsc = NULL;
     lrmd_event_data_t *op = NULL;
+    bool infinity = false;
 
     out->message(out, "inject-spec", spec);
 
@@ -592,8 +602,17 @@ inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
     cib_node = pcmk__inject_node(cib, node, NULL);
     pcmk__assert(cib_node != NULL);
 
+    if (pcmk__str_eq(task, PCMK_ACTION_STOP, pcmk__str_none)) {
+        infinity = true;
+
+    } else if (pcmk__str_eq(task, PCMK_ACTION_START, pcmk__str_none)
+               && pcmk_is_set(scheduler->flags,
+                              pcmk__sched_start_failure_fatal)) {
+        infinity = true;
+    }
+
     pcmk__inject_failcount(out, cib, cib_node, resource, task, interval_ms,
-                           outcome);
+                           outcome, infinity);
 
     cib_resource = pcmk__inject_resource_history(out, cib_node,
                                                  resource, resource,

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -600,6 +600,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
         const char *spec = (const char *) iter->data;
         char *key = NULL;
         const char *match_name = NULL;
+        const char *offset = NULL;
 
         // Allow user to specify anonymous clone with or without instance number
         key = crm_strdup_printf(PCMK__OP_FMT "@%s=", resource, op->op_type,
@@ -637,8 +638,18 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
                   action->id, op->rc);
         pcmk__set_graph_action_flags(action, pcmk__graph_action_failed);
         graph->abort_priority = PCMK_SCORE_INFINITY;
+
+        if (pcmk__str_eq(op->op_type, PCMK_ACTION_START, pcmk__str_none)) {
+            offset = pcmk__s(graph->failed_start_offset, PCMK_VALUE_INFINITY);
+
+        } else if (pcmk__str_eq(op->op_type, PCMK_ACTION_STOP,
+                                pcmk__str_none)) {
+            offset = pcmk__s(graph->failed_stop_offset, PCMK_VALUE_INFINITY);
+        }
+
         pcmk__inject_failcount(out, fake_cib, cib_node, match_name, op->op_type,
-                               op->interval_ms, op->rc);
+                               op->interval_ms, op->rc,
+                               pcmk_str_is_infinity(offset));
         break;
     }
 


### PR DESCRIPTION
... to be consistent with what controller does with update_failcount()

Backport https://github.com/ClusterLabs/pacemaker/pull/3769 to 3.0