### PR TITLE
Replace the egrep command with the EGREP definition in ping RA

### DIFF
--- a/agents/ocf/ping.in
+++ b/agents/ocf/ping.in
@@ -368,7 +368,7 @@ hosts_family() {
     return $family
 }
 
-integer=$(echo ${OCF_RESKEY_timeout} | egrep -o '[0-9]*')
+integer=$(echo ${OCF_RESKEY_timeout} | $EGREP -o '[0-9]*')
 case "${OCF_RESKEY_timeout}" in
     *[0-9]ms|*[0-9]msec) OCF_RESKEY_timeout=$(expr $integer / 1000);;
     *[0-9]m|*[0-9]min) OCF_RESKEY_timeout=$(expr $integer \* 60);;


### PR DESCRIPTION
Hi all!

I found the following warning appeared  when trying to create a ping resource on RHEL 10.0 beta.
```
[root@rh10-b01 tmp]# pcs -f ping.xml resource create ping ocf:pacemaker:ping \
    name="ping-status" host_list="192.168.122.1" attempts="2" timeout="2" debug="true" \
    op start timeout=60s on-fail=restart \
    monitor timeout=60s interval=10s on-fail=restart \
    stop timeout=60s on-fail=fence
Warning: Validating resource options using the resource agent itself is enabled by default and produces warnings. In a future version, this might be changed to errors. Specify --agent-validation to switch to the future behavior.
Warning: Validation result from agent:
  egrep: warning: egrep is obsolescent; using grep -E
```
The environment where this issue occurred is as follows: 
```
[root@rh10-b01 tmp]# cat /etc/redhat-release
Red Hat Enterprise Linux release 10.0 Beta (Coughlan)
[root@rh10-b01 tmp]# pacemakerd --version
Pacemaker 2.1.8-3.el10
Written by Andrew Beekhof and the Pacemaker project contributors
[root@rh10-b01 tmp]# pcs --version
0.12.0a1
[root@rh10-b01 tmp]# egrep --version
grep (GNU grep) 3.11
Copyright (C) 2023 Free Software Foundation, Inc.
: (snip)
```
I also tested with the 3.0 branch, but the same warning appeared.

It seems that egrep has begun issuing warnings in GNU grep 3.8 and later.
```
[root@rh10-b01 tmp]# cat /usr/bin/egrep
#!/usr/bin/sh
cmd=${0##*/}
echo "$cmd: warning: $cmd is obsolescent; using grep -E" >&2
exec grep -E "$@"
```
Normally, this is not an issue because an alias is created by default. 
However, it seems that problems can occur in cases such as when /usr/bin/egrep is executed directly or 
when the egrep command is used in a shell script.
```
[root@rh10-b01 tmp]# which egrep
alias egrep='grep -E --color=auto'
        /usr/bin/grep
```

I believe this issue is not limited to the ping resource
but is also related to many other resource agents and testing tools and similar components.
Furthermore, this issue is likely to affect not only egrep but also fgrep.
This PR is merely a submission of one possible solution.
Possibly, there might be a more comprehensive and appropriate one.
Perhaps this is uncalled for, but I thought it might still be worth sharing.
I would be glad if this can be of any help.

Regards, 
SatomiOSAWA