### PR TITLE
Fix: libcib: Don't send CRM_OP_REGISTER from cib_remote client

### DIFF
--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -469,7 +469,6 @@ cib_remote_signon(cib_t *cib, const char *name, enum cib_conn_type type)
 {
     int rc = pcmk_ok;
     cib_remote_opaque_t *private = cib->variant_opaque;
-    xmlNode *hello = NULL;
 
     if (name == NULL) {
         name = pcmk__s(crm_system_name, "client");
@@ -497,19 +496,6 @@ cib_remote_signon(cib_t *cib, const char *name, enum cib_conn_type type)
     }
 
     rc = cib_tls_signon(cib, &(private->callback), TRUE);
-    if (rc != pcmk_ok) {
-        goto done;
-    }
-
-    rc = cib__create_op(cib, CRM_OP_REGISTER, NULL, NULL, NULL, cib_none, NULL,
-                        name, &hello);
-    if (rc != pcmk_ok) {
-        goto done;
-    }
-
-    rc = pcmk__remote_send_xml(&private->command, hello);
-    rc = pcmk_rc2legacy(rc);
-    pcmk__xml_free(hello);
 
 done:
     if (rc == pcmk_ok) {


### PR DESCRIPTION
The remote pacemaker-based server doesn't process it. This somehow clogs up the message send/receive machinery. As a result, if the client makes a synchronous call immediately after signon, the call will often time out in pcmk__remote_ready() (while polling for readable data).

This issue was encountered when running cibadmin. In my testing, it rarely occurred when running cibadmin under strace. So there was some yet-undiagnosed timing issue caused by this gratuitous CRM_OP_REGISTER.

This fixes a regression introduced by https://github.com/ClusterLabs/pacemaker/commit/d41c79a84e50d9b293827086f1eccfb6889c9b9c, in which cibadmin often times out when run by a remote CIB client. This regression has not made it into any release.

---

Ideally, we'd also want to fix whatever is wrong on the remote server end. Processing of the `cib_query` after the `register` message would stall as shown below:
```
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_listen@based_remote.c:313) 	info: Clear-text connection from 192.168.22.1 pending authentication for client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:423) 	trace: Remote TCP message received for client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:459) 	trace: Expanding buffer to 80 bytes
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:494) 	trace: Received 80 more bytes (80 total)
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:517) 	trace: Read partial remote message (80 of 126 bytes)
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:423) 	trace: Remote TCP message received for client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:459) 	trace: Expanding buffer to 252 bytes
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:494) 	trace: Received 46 more bytes (126 total)
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:521) 	trace: Read full remote message of 126 bytes
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__remote_message_xml@remote.c:359) 	trace: [remote msg]   <cib_command op="authenticate" user="hacluster" password="*****" hidden="password"/>
Jan 06 00:39:35.264 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_auth@based_remote.c:230) 	debug: auth   <cib_command op="authenticate" user="hacluster" password="*****" hidden="password"/>
Jan 06 00:39:35.320 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:496) 	notice: Remote connection accepted for authenticated user hacluster | client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.320 fastvm-fedora40uefi-22 pacemaker-based     [2729] (send_plaintext@remote.c:181) 	debug: Sending plaintext message of 40 bytes to socket 14
Jan 06 00:39:35.320 fastvm-fedora40uefi-22 pacemaker-based     [2729] (send_plaintext@remote.c:207) 	trace: Sent all 40 bytes remaining: ��ں
Jan 06 00:39:35.320 fastvm-fedora40uefi-22 pacemaker-based     [2729] (send_plaintext@remote.c:181) 	debug: Sending plaintext message of 84 bytes to socket 14
Jan 06 00:39:35.320 fastvm-fedora40uefi-22 pacemaker-based     [2729] (send_plaintext@remote.c:207) 	trace: Sent all 84 bytes remaining: <cib_result cib_op="register" cib_clientid="fe9058da-9136-4e03-8003-fc8c7666e7e0"/>
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:423) 	trace: Remote TCP message received for client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:494) 	trace: Received 40 more bytes (40 total)
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:517) 	trace: Read partial remote message (40 of 138 bytes)
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:423) 	trace: Remote TCP message received for client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:494) 	trace: Received 212 more bytes (252 total)
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:521) 	trace: Read full remote message of 252 bytes
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__remote_message_xml@remote.c:359) 	trace: [remote msg]   <cib_command t="cib" cib_op="register" cib_clientname="cibadmin" cib_callid="2" cib_callopt="0"/>
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:511) 	trace: Remote message received from client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.377 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_handle_remote_msg@based_remote.c:411) 	trace: Remote command:    <cib_command t="cib" cib_op="register" cib_clientname="fe9058da-9136-4e03-8003-fc8c7666e7e0" cib_callid="2" cib_callopt="0" cib_clientid="fe9058da-9136-4e03-8003-fc8c7666e7e0" cib_user="hacluster"/>
Jan 06 00:39:35.378 fastvm-fedora40uefi-22 pacemaker-based     [2729] (cib_remote_msg@based_remote.c:423) 	trace: Remote TCP message received for client fe9058da-9136-4e03-8003-fc8c7666e7e0
Jan 06 00:39:35.378 fastvm-fedora40uefi-22 pacemaker-based     [2729] (pcmk__read_available_remote_data@remote.c:494) 	trace: Received 23 more bytes (23 total)
```

To me, this suggests that when the remote server receives two requests in rapid succession, it reads past the end of the first message, causing the second message to appear incomplete when it processes that one. If so, `pcmk__read_available_remote_data()` should likely pay better attention to the payload size stored in the header, and stop reading the first message there.

I've had some preliminary success with replacing `remote->buffer` with `read_len` in the size arguments of `gnutls_record_recv()` and `read()` in `pcmk__read_available_remote_data()`. This would lead to some weird behavior if the header is missing or malformed, but we should probably handle "missing header" more actively anyway and either exit, close the socket, or read and discard all the remaining data... haven't thought that far.