### PR TITLE
Mid: schedullerd: Resetting error and warning flags.

### DIFF
--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -164,6 +164,8 @@ handle_pecalc_request(pcmk__request_t *request)
     pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
 
 done:
+    pcmk__config_has_error = false;
+    pcmk__config_has_warning = false;
     pcmk__xml_free(converted);
     pcmk_free_scheduler(scheduler);
 


### PR DESCRIPTION
Hi All,

If an error or warning occurs even once when calculating a state transition, that error or warning will remain in any subsequent calculations of correct state transitions.

This will prompt you to run crm_verify, and the pe-error file will be output.

```
[root@rh94-dev01 ~]# egrep "pe-error|verify" /var/log/messages
(snip)
Jan  8 09:07:03 rh94-dev01 pacemaker-schedulerd[1945059]: error: Calculated transition 1 (with errors), saving inputs in /var/lib/pacemaker/pengine/pe-error-0.bz2
Jan  8 09:07:03 rh94-dev01 pacemaker-schedulerd[1945059]: notice: Configuration errors found during scheduler processing,  please run "crm_verify -L" to identify issues
Jan  8 09:07:09 rh94-dev01 pacemaker-schedulerd[1945059]: error: Calculated transition 2 (with errors), saving inputs in /var/lib/pacemaker/pengine/pe-error-1.bz2
Jan  8 09:07:09 rh94-dev01 pacemaker-schedulerd[1945059]: notice: Configuration errors found during scheduler processing,  please run "crm_verify -L" to identify issues
Jan  8 09:07:10 rh94-dev01 pacemaker-schedulerd[1945059]: error: Calculated transition 3 (with errors), saving inputs in /var/lib/pacemaker/pengine/pe-error-2.bz2
Jan  8 09:07:10 rh94-dev01 pacemaker-schedulerd[1945059]: notice: Configuration errors found during scheduler processing,  please run "crm_verify -L" to identify issues
(snip)
Jan  8 09:07:31 rh94-dev01 pacemaker-schedulerd[1945059]: error: Calculated transition 11 (with errors), saving inputs in /var/lib/pacemaker/pengine/pe-error-10.bz2
Jan  8 09:07:31 rh94-dev01 pacemaker-schedulerd[1945059]: notice: Configuration errors found during scheduler processing,  please run "crm_verify -L" to identify issues
```

This fix will clear the error and warning flags every time.

Best Regards,
Hideo Yamauchi.