### PR TITLE
Low: controller: address format-overflow warnings

### DIFF
--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -327,7 +327,6 @@ get_cancel_action(const char *id, const char *node)
 
             task = crm_element_value(action->xml, PCMK__XA_OPERATION_KEY);
             if (!pcmk__str_eq(task, id, pcmk__str_casei)) {
-                crm_trace("Wrong key %s for %s on %s", task, id, node);
                 continue;
             }
 


### PR DESCRIPTION
When using -O3 to build pacemaker, gcc (14) will throw format-overflow warnings for some possibly null '%s' directive arguments. This the current instances of such warnings by introducing checks for null pointers.

alerts.c:153:19: error: '%s' directive argument is null [-Werror=format-overflow=]
153 |         crm_trace("Inserting alert key %s = '%s'", *key, value);
    |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
alerts.c:153:46: note: format string is defined here
153 |         crm_trace("Inserting alert key %s = '%s'", *key, value);
    |