### PR TITLE
[2.1] Low: various: address format-overflow warnings

### DIFF
--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -327,7 +327,6 @@ get_cancel_action(const char *id, const char *node)
 
             task = crm_element_value(action->xml, PCMK__XA_OPERATION_KEY);
             if (!pcmk__str_eq(task, id, pcmk__str_casei)) {
-                crm_trace("Wrong key %s for %s on %s", task, id, node);
                 continue;
             }
 

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -150,10 +150,11 @@ pcmk__add_alert_key(GHashTable *table, enum pcmk__alert_keys_e name,
                     const char *value)
 {
     for (const char **key = pcmk__alert_keys[name]; *key; key++) {
-        crm_trace("Inserting alert key %s = '%s'", *key, value);
         if (value) {
+            crm_trace("Inserting alert key %s = '%s'", *key, value);
             pcmk__insert_dup(table, *key, value);
         } else {
+            crm_trace("Removing alert key %s (no value given)", *key);
             g_hash_table_remove(table, *key);
         }
     }


### PR DESCRIPTION
Backporting https://github.com/ClusterLabs/pacemaker/pull/3794

When using -O3 to build pacemaker, gcc (14) will throw format-overflow warnings for some possibly null '%s' directive arguments. This the current instances of such warnings by introducing checks for null pointers.

alerts.c:153:19: error: '%s' directive argument is null [-Werror=format-overflow=]
153 |         crm_trace("Inserting alert key %s = '%s'", *key, value);
    |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
alerts.c:153:46: note: format string is defined here
153 |         crm_trace("Inserting alert key %s = '%s'", *key, value);
    |