### PR TITLE
Refactor: python: Convert to using f-strings in the python module.

### DIFF
--- a/python/pacemaker/_cts/CTS.py
+++ b/python/pacemaker/_cts/CTS.py
@@ -1,7 +1,7 @@
 """Main classes for Pacemaker's Cluster Test Suite (CTS)."""
 
 __all__ = ["CtsLab", "NodeStatus", "Process"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import sys
@@ -85,7 +85,7 @@ class CtsLab:
         self._logger.log("Cluster nodes: ")
         # pylint: disable=unsubscriptable-object
         for node in self._env["nodes"]:
-            self._logger.log("    * %s" % (node))
+            self._logger.log(f"    * {node}")
 
         if not scenario.setup():
             return ExitStatus.ERROR
@@ -96,7 +96,7 @@ class CtsLab:
         try:
             scenario.run(iterations)
         except:  # noqa: E722
-            self._logger.log("Exception by %s" % sys.exc_info()[0])
+            self._logger.log(f"Exception by {sys.exc_info()[0]}")
             self._logger.traceback(traceback)
 
             scenario.summarize()
@@ -135,7 +135,7 @@ class NodeStatus:
     def _node_booted(self, node):
         """Return True if the given node is booted (responds to pings)."""
         # pylint: disable=not-callable
-        (rc, _) = RemoteFactory().getInstance()("localhost", "ping -nq -c1 -w1 %s" % node, verbose=0)
+        (rc, _) = RemoteFactory().getInstance()("localhost", f"ping -nq -c1 -w1 {node}", verbose=0)
         return rc == 0
 
     def _sshd_up(self, node):
@@ -162,20 +162,20 @@ class NodeStatus:
                 if anytimeouts:
                     # Fudge to wait for the system to finish coming up
                     time.sleep(30)
-                    LogFactory().debug("Node %s now up" % node)
+                    LogFactory().debug(f"Node {node} now up")
 
                 return True
 
             time.sleep(30)
             if not anytimeouts:
-                LogFactory().debug("Waiting for node %s to come up" % node)
+                LogFactory().debug(f"Waiting for node {node} to come up")
 
             anytimeouts = True
             timeout -= 1
 
-        LogFactory().log("%s did not come up within %d tries" % (node, initial_timeout))
+        LogFactory().log(f"{node} did not come up within {initial_timeout} tries")
         if not should_continue(self._env["continue"]):
-            raise ValueError("%s did not come up within %d tries" % (node, initial_timeout))
+            raise ValueError(f"{node} did not come up within {initial_timeout} tries")
 
         return False
 
@@ -224,7 +224,7 @@ class Process:
 
     def kill(self, node):
         """Kill the instance of this process running on the given node."""
-        (rc, _) = self._cm.rsh(node, "killall -9 %s" % self.name)
+        (rc, _) = self._cm.rsh(node, f"killall -9 {self.name}")
 
         if rc != 0:
-            self._cm.log("ERROR: Kill %s failed on node %s" % (self.name, node))
+            self._cm.log(f"ERROR: Kill {self.name} failed on node {node}")

--- a/python/pacemaker/_cts/cmcorosync.py
+++ b/python/pacemaker/_cts/cmcorosync.py
@@ -1,7 +1,7 @@
 """Corosync-specific class for Pacemaker's Cluster Test Suite (CTS)."""
 
 __all__ = ["Corosync2"]
-__copyright__ = "Copyright 2007-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2007-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.CTS import Process
@@ -41,7 +41,7 @@ class Corosync2(ClusterManager):
                 "pacemaker-fenced"
             ]
             for c in daemons:
-                badnews = self.templates.get_component("%s-ignore" % c) + common_ignore
+                badnews = self.templates.get_component(f"{c}-ignore") + common_ignore
                 proc = Process(self, c, pats=self.templates.get_component(c),
                                badnews_ignore=badnews)
                 self._fullcomplist[c] = proc
@@ -64,7 +64,7 @@ class Corosync2(ClusterManager):
         vgrind = self.env["valgrind-procs"].split()
         for (key, val) in self._fullcomplist.items():
             if self.env["valgrind-tests"] and key in vgrind:
-                self.log("Filtering %s from the component list as it is being profiled by valgrind" % key)
+                self.log(f"Filtering {key} from the component list as it is being profiled by valgrind")
                 continue
 
             if key == "pacemaker-fenced" and not self.env["DoFencing"]:

--- a/python/pacemaker/_cts/environment.py
+++ b/python/pacemaker/_cts/environment.py
@@ -101,8 +101,7 @@ class Environment:
 
         keys.sort()
         for key in keys:
-            s = "Environment[%s]" % key
-            self._logger.debug("{key:35}: {val}".format(key=s, val=str(self[key])))
+            self._logger.debug(f"{f'Environment[{key}]':35}: {str(self[key])}")
 
     def keys(self):
         """Return a list of all environment keys stored in this instance."""
@@ -150,7 +149,7 @@ class Environment:
                     socket.gethostbyname_ex(n)
                     self._nodes.append(n)
                 except socket.herror:
-                    self._logger.log("%s not found in DNS... aborting" % node)
+                    self._logger.log(f"{node} not found in DNS... aborting")
                     raise
 
             self._filter_nodes()
@@ -175,7 +174,7 @@ class Environment:
             self.data["Stack"] = "corosync 2+"
 
         else:
-            raise ValueError("Unknown stack: %s" % name)
+            raise ValueError(f"Unknown stack: {name}")
 
     def _get_stack_short(self):
         """Return the short name for the currently set cluster stack."""
@@ -185,8 +184,8 @@ class Environment:
         if self.data["Stack"] == "corosync 2+":
             return "crm-corosync"
 
-        LogFactory().log("Unknown stack: %s" % self["stack"])
-        raise ValueError("Unknown stack: %s" % self["stack"])
+        LogFactory().log(f"Unknown stack: {self['stack']}")
+        raise ValueError(f"Unknown stack: {self['stack']}")
 
     def _detect_systemd(self):
         """Detect whether systemd is in use on the target node."""
@@ -213,22 +212,22 @@ class Environment:
         """Disable the given service on the given node."""
         if self["have_systemd"]:
             # Systemd
-            (rc, _) = self._rsh(node, "systemctl disable %s" % service)
+            (rc, _) = self._rsh(node, f"systemctl disable {service}")
             return rc
 
         # SYS-V
-        (rc, _) = self._rsh(node, "chkconfig %s off" % service)
+        (rc, _) = self._rsh(node, f"chkconfig {service} off")
         return rc
 
     def enable_service(self, node, service):
         """Enable the given service on the given node."""
         if self["have_systemd"]:
             # Systemd
-            (rc, _) = self._rsh(node, "systemctl enable %s" % service)
+            (rc, _) = self._rsh(node, f"systemctl enable {service}")
             return rc
 
         # SYS-V
-        (rc, _) = self._rsh(node, "chkconfig %s on" % service)
+        (rc, _) = self._rsh(node, f"chkconfig {service} on")
         return rc
 
     def service_is_enabled(self, node, service):
@@ -240,11 +239,11 @@ class Environment:
             # explicitly "enabled" instead of the return code. For example it returns
             # 0 if the service is "static" or "indirect", but they don't really count
             # as "enabled".
-            (rc, _) = self._rsh(node, "systemctl is-enabled %s | grep enabled" % service)
+            (rc, _) = self._rsh(node, f"systemctl is-enabled {service} | grep enabled")
             return rc == 0
 
         # SYS-V
-        (rc, _) = self._rsh(node, "chkconfig --list | grep -e %s.*on" % service)
+        (rc, _) = self._rsh(node, f"chkconfig --list | grep -e {service}.*on")
         return rc == 0
 
     def _detect_at_boot(self):
@@ -269,17 +268,18 @@ class Environment:
             if not self["IPBase"]:
                 self["IPBase"] = " fe80::1234:56:7890:1000"
                 self._logger.log("Could not determine an offset for IPaddr resources.  Perhaps nmap is not installed on the nodes.")
-                self._logger.log("Defaulting to '%s', use --test-ip-base to override" % self["IPBase"])
+                self._logger.log(f"""Defaulting to '{self["IPBase"]}', use --test-ip-base to override""")
                 return
 
             # pylint thinks self["IPBase"] is a list, not a string, which causes it
             # to error out because a list doesn't have split().
             # pylint: disable=no-member
-            if int(self["IPBase"].split('.')[3]) >= 240:
-                self._logger.log("Could not determine an offset for IPaddr resources. Upper bound is too high: %s %s"
-                                 % (self["IPBase"], self["IPBase"].split('.')[3]))
+            last_part = self["IPBase"].split('.')[3]
+
+            if int(last_part) >= 240:
+                self._logger.log(f"Could not determine an offset for IPaddr resources. Upper bound is too high: {self['IPBase']} {last_part}")
                 self["IPBase"] = " fe80::1234:56:7890:1000"
-                self._logger.log("Defaulting to '%s', use --test-ip-base to override" % self["IPBase"])
+                self._logger.log(f"""Defaulting to '{self["IPBase"]}', use --test-ip-base to override""")
 
     def _filter_nodes(self):
         """
@@ -290,11 +290,8 @@ class Environment:
         """
         if self["node-limit"] > 0:
             if len(self["nodes"]) > self["node-limit"]:
-                # pylint thinks self["node-limit"] is a list even though we initialize
-                # it as an int in __init__ and treat it as an int everywhere.
-                # pylint: disable=bad-string-format-type
-                self._logger.log("Limiting the number of nodes configured=%d (max=%d)"
-                                 % (len(self["nodes"]), self["node-limit"]))
+                self._logger.log(f"Limiting the number of nodes configured={len(self['nodes'])} "
+                                 f"(max={self['node-limit']})")
 
                 while len(self["nodes"]) > self["node-limit"]:
                     self["nodes"].pop(len(self["nodes"]) - 1)
@@ -333,7 +330,7 @@ class Environment:
         if not argv:
             argv = sys.argv[1:]
 
-        parser = argparse.ArgumentParser(epilog="%s -g virt1 -r --stonith ssh --schema pacemaker-2.0 500" % sys.argv[0])
+        parser = argparse.ArgumentParser(epilog=f"{sys.argv[0]} -g virt1 -r --stonith ssh --schema pacemaker-2.0 500")
 
         grp1 = parser.add_argument_group("Common options")
         grp1.add_argument("-g", "--dsh-group", "--group",
@@ -431,7 +428,7 @@ class Environment:
                           help="Use QARSH to access nodes instead of SSH")
         grp4.add_argument("--schema",
                           metavar="SCHEMA",
-                          default="pacemaker-%s" % BuildOptions.CIB_SCHEMA_VERSION,
+                          default=f"pacemaker-{BuildOptions.CIB_SCHEMA_VERSION}",
                           help="Create a CIB conforming to the given schema")
         grp4.add_argument("--seed",
                           metavar="SEED",
@@ -508,10 +505,10 @@ class Environment:
             self["nodes"] = []
 
         if args.group:
-            self["OutputFile"] = "%s/cluster-%s.log" % (os.environ['HOME'], args.dsh_group)
+            self["OutputFile"] = f"{os.environ['HOME']}/cluster-{args.dsh_group}.log"
             LogFactory().add_file(self["OutputFile"], "CTS")
 
-            dsh_file = "%s/.dsh/group/%s" % (os.environ['HOME'], args.dsh_group)
+            dsh_file = f"{os.environ['HOME']}/.dsh/group/{args.dsh_group}"
 
             if os.path.isfile(dsh_file):
                 self["nodes"] = []
@@ -523,7 +520,7 @@ class Environment:
                         if not stripped.startswith('#'):
                             self["nodes"].append(stripped)
             else:
-                print("Unknown DSH group: %s" % args.dsh_group)
+                print(f"Unknown DSH group: {args.dsh_group}")
 
         # Everything else either can't have a default set in an add_argument
         # call (likely because we don't want to always have a value set for it)
@@ -564,24 +561,24 @@ class Environment:
                     self["stonith-type"] = "fence_openstack"
 
                     print("Obtaining OpenStack credentials from the current environment")
-                    self["stonith-params"] = "region=%s,tenant=%s,auth=%s,user=%s,password=%s" % (
-                        os.environ['OS_REGION_NAME'],
-                        os.environ['OS_TENANT_NAME'],
-                        os.environ['OS_AUTH_URL'],
-                        os.environ['OS_USERNAME'],
-                        os.environ['OS_PASSWORD']
-                    )
+                    region = os.environ['OS_REGION_NAME']
+                    tenant = os.environ['OS_TENANT_NAME']
+                    auth = os.environ['OS_AUTH_URL']
+                    user = os.environ['OS_USERNAME']
+                    password = os.environ['OS_PASSWORD']
+
+                    self["stonith-params"] = f"region={region},tenant={tenant},auth={auth},user={user},password={password}"
 
                 elif args.fencing == "rhevm":
                     self["stonith-type"] = "fence_rhevm"
 
                     print("Obtaining RHEV-M credentials from the current environment")
-                    self["stonith-params"] = "login=%s,passwd=%s,ipaddr=%s,ipport=%s,ssl=1,shell_timeout=10" % (
-                        os.environ['RHEVM_USERNAME'],
-                        os.environ['RHEVM_PASSWORD'],
-                        os.environ['RHEVM_SERVER'],
-                        os.environ['RHEVM_PORT'],
-                    )
+                    user = os.environ['RHEVM_USERNAME']
+                    password = os.environ['RHEVM_PASSWORD']
+                    server = os.environ['RHEVM_SERVER']
+                    port = os.environ['RHEVM_PORT']
+
+                    self["stonith-params"] = f"login={user},passwd={password},ipaddr={server},ipport={port},ssl=1,shell_timeout=10"
 
         if args.ip:
             self["CIBResource"] = True
@@ -624,7 +621,7 @@ class Environment:
         for kv in args.set:
             (name, value) = kv.split("=")
             self[name] = value
-            print("Setting %s = %s" % (name, value))
+            print(f"Setting {name} = {value}")
 
 
 class EnvFactory:

--- a/python/pacemaker/_cts/logging.py
+++ b/python/pacemaker/_cts/logging.py
@@ -1,7 +1,7 @@
 """Logging classes for Pacemaker's Cluster Test Suite (CTS)."""
 
 __all__ = ["LogFactory"]
-__copyright__ = "Copyright 2014-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2014-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import os
@@ -21,7 +21,7 @@ class Logger:
         self._logfile = filename
 
         if tag:
-            self._source = "%s: " % tag
+            self._source = f"{tag}: "
         else:
             self._source = ""
 
@@ -59,7 +59,7 @@ class StdErrLog(Logger):
             lines = [lines]
 
         for line in lines:
-            print("%s%s" % (timestamp, line), file=sys.__stderr__)
+            print(f"{timestamp}{line}", file=sys.__stderr__)
 
         sys.__stderr__.flush()
 
@@ -81,8 +81,7 @@ class FileLog(Logger):
                 lines = [lines]
 
             for line in lines:
-                print("%s%s %s%s" % (timestamp, self._hostname, self._source, line),
-                      file=logf)
+                print(f"{timestamp}{self._hostname} {self._source}{line}", file=logf)
 
 
 class LogFactory:
@@ -111,7 +110,7 @@ class LogFactory:
         """Log a debug message (to all configured log destinations)."""
         for logfn in LogFactory.log_methods:
             if logfn.is_debug_target:
-                logfn("debug: %s" % args.strip())
+                logfn(f"debug: {args.strip()}")
 
     def traceback(self, traceback):
         """Log a stack trace (to all configured log destinations)."""

--- a/python/pacemaker/_cts/network.py
+++ b/python/pacemaker/_cts/network.py
@@ -1,7 +1,7 @@
 """Network related utilities for CTS."""
 
 __all__ = ["next_ip"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 # pylint: disable=global-statement
@@ -55,5 +55,5 @@ def next_ip(ip_base=None, reset=False):
         if new_ip > 255:
             raise ValueError("No more available IP addresses")
 
-    CURRENT_IP = "%s%s%s" % (fields[0], fields[1], new_ip)
+    CURRENT_IP = f"{fields[0]}{fields[1]}{new_ip}"
     return CURRENT_IP

--- a/python/pacemaker/_cts/patterns.py
+++ b/python/pacemaker/_cts/patterns.py
@@ -1,7 +1,7 @@
 """Pattern-holding classes for Pacemaker's Cluster Test Suite (CTS)."""
 
 __all__ = ["PatternSelector"]
-__copyright__ = "Copyright 2008-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2008-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+)"
 
 import argparse
@@ -95,7 +95,7 @@ class BasePatterns:
         if key in self._components:
             return self._components[key]
 
-        print("Unknown component '%s' for %s" % (key, self._name))
+        print(f"Unknown component '{key}' for {self._name}")
         return []
 
     def get_patterns(self, key):
@@ -116,7 +116,7 @@ class BasePatterns:
         if key == "Components":
             return self._components
 
-        print("Unknown pattern '%s' for %s" % (key, self._name))
+        print(f"Unknown pattern '{key}' for {self._name}")
         return None
 
     def __getitem__(self, key):
@@ -127,7 +127,7 @@ class BasePatterns:
         if key in self._search:
             return self._search[key]
 
-        print("Unknown template '%s' for %s" % (key, self._name))
+        print(f"Unknown template '{key}' for {self._name}")
         return None
 
 

--- a/python/pacemaker/_cts/process.py
+++ b/python/pacemaker/_cts/process.py
@@ -1,7 +1,7 @@
 """A module for managing and communicating with external processes."""
 
 __all__ = ["killall", "exit_if_proc_running", "pipe_communicate", "stdout_from_command"]
-__copyright__ = "Copyright 2009-2023 the Pacemaker project contributors"
+__copyright__ = "Copyright 2009-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+)"
 
 import subprocess
@@ -46,8 +46,8 @@ def is_proc_running(process_name):
 def exit_if_proc_running(process_name):
     """Exit with error if a given process is running."""
     if is_proc_running(process_name):
-        print("Error: %s is already running!" % process_name)
-        print("Run %s only when the cluster is stopped." % sys.argv[0])
+        print(f"Error: {process_name} is already running!")
+        print(f"Run {sys.argv[0]} only when the cluster is stopped.")
         sys.exit(ExitStatus.ERROR)
 
 

--- a/python/pacemaker/_cts/remote.py
+++ b/python/pacemaker/_cts/remote.py
@@ -1,7 +1,7 @@
 """Remote command runner for Pacemaker's Cluster Test Suite (CTS)."""
 
 __all__ = ["RemoteExec", "RemoteFactory"]
-__copyright__ = "Copyright 2014-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2014-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re
@@ -69,20 +69,20 @@ class AsyncCmd(Thread):
             # pylint: disable=consider-using-with
             self._proc = Popen(self._command, stdout=PIPE, stderr=PIPE, close_fds=True, shell=True)
 
-        self._logger.debug("cmd: async: target=%s, pid=%d: %s" % (self._node, self._proc.pid, self._command))
+        self._logger.debug(f"cmd: async: target={self._node}, pid={self._proc.pid}: {self._command}")
         self._proc.wait()
 
         if self._delegate:
-            self._logger.debug("cmd: pid %d returned %d to %r" % (self._proc.pid, self._proc.returncode, self._delegate))
+            self._logger.debug(f"cmd: pid {self._proc.pid} returned {self._proc.returncode} to {self._delegate!r}")
         else:
-            self._logger.debug("cmd: pid %d returned %d" % (self._proc.pid, self._proc.returncode))
+            self._logger.debug(f"cmd: pid {self._proc.pid} returned {self._proc.returncode}")
 
         if self._proc.stderr:
             err = self._proc.stderr.readlines()
             self._proc.stderr.close()
 
             for line in err:
-                self._logger.debug("cmd: stderr[%d]: %s" % (self._proc.pid, line))
+                self._logger.debug(f"cmd: stderr[{self._proc.pid}]: {line}")
 
             err = convert2string(err)
 
@@ -129,7 +129,7 @@ class RemoteExec:
         if sysname is None or sysname.lower() in [self._our_node, "localhost"]:
             ret = command
         else:
-            ret = "%s %s '%s'" % (self._command, sysname, self._fixcmd(command))
+            ret = f"{self._command} {sysname} '{self._fixcmd(command)}'"
 
         return ret
 
@@ -196,7 +196,7 @@ class RemoteExec:
         rc = proc.wait()
 
         if verbose > 0:
-            self._debug("cmd: target=%s, rc=%d: %s" % (node, rc, command))
+            self._debug(f"cmd: target={node}, rc={rc}: {command}")
 
         result = convert2string(result)
 
@@ -205,11 +205,11 @@ class RemoteExec:
             proc.stderr.close()
 
             for err in errors:
-                self._debug("cmd: stderr: %s" % err)
+                self._debug(f"cmd: stderr: {err}")
 
         if verbose == 2:
             for line in result:
-                self._debug("cmd: stdout: %s" % line)
+                self._debug(f"cmd: stdout: {line}")
 
         return (rc, result)
 
@@ -224,18 +224,18 @@ class RemoteExec:
         """
         # @TODO Use subprocess module with argument array instead
         # (self._cp_command should be an array too)
-        cmd = "%s '%s' '%s'" % (self._cp_command, source, target)
+        cmd = f"{self._cp_command} '{source}' '{target}'"
         rc = os.system(cmd)
 
         if not silent:
-            self._debug("cmd: rc=%d: %s" % (rc, cmd))
+            self._debug(f"cmd: rc={rc}: {cmd}")
 
         return rc
 
     def exists_on_all(self, filename, hosts):
         """Return True if specified file exists on all specified hosts."""
         for host in hosts:
-            rc = self(host, "test -r %s" % filename)
+            rc = self(host, f"test -r {filename}")
             if rc != 0:
                 return False
 

--- a/python/pacemaker/_cts/scenarios.py
+++ b/python/pacemaker/_cts/scenarios.py
@@ -8,7 +8,7 @@ __all__ = [
     "RandomTests",
     "Sequence",
 ]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re
@@ -208,8 +208,7 @@ class Scenario:
         did_run = False
 
         self._cm.clear_instance_errors_to_ignore()
-        choice = "(%s)" % nodechoice
-        self._cm.log("Running test {:<22} {:<15} [{:>3}]".format(test.name, choice, testcount))
+        self._cm.log(f"Running test {test.name:<22} {f'({nodechoice})':<15} [{testcount:>3}]")
 
         starttime = test.set_timer()
 
@@ -224,7 +223,7 @@ class Scenario:
             self._cm.log("Teardown failed")
 
             if not should_continue(self._cm.env):
-                raise ValueError("Teardown of %s on %s failed" % (test.name, nodechoice))
+                raise ValueError(f"Teardown of {test.name} on {nodechoice} failed")
 
             ret = False
 
@@ -276,13 +275,11 @@ class Scenario:
             for key in stat_filter:
                 stat_filter[key] = test.stats[key]
 
-            name = "Test %s:" % test.name
-            self._cm.log("{:<25} {!r}".format(name, stat_filter))
+            self._cm.log(f"{f'Test {test.name}':<25} {stat_filter!r}")
 
         self._cm.debug("Detailed Results")
         for test in self.tests:
-            name = "Test %s:" % test.name
-            self._cm.debug("{:<25} {!r}".format(name, stat_filter))
+            self._cm.debug(f"{f'Test {test.name}':<25} {stat_filter!r}")
 
         self._cm.log("<<<<<<<<<<<<<<<< TESTS COMPLETED")
 
@@ -307,10 +304,10 @@ class Scenario:
         failed = 0
         for audit in self._audits:
             if not audit():
-                self._cm.log("Audit %s FAILED." % audit.name)
+                self._cm.log(f"Audit {audit.name} FAILED.")
                 failed += 1
             else:
-                self._cm.debug("Audit %s passed." % audit.name)
+                self._cm.debug(f"Audit {audit.name} passed.")
 
         while errcount < 1000:
             match = None
@@ -325,7 +322,7 @@ class Scenario:
                         add_err = False
 
                 if add_err:
-                    self._cm.log("BadNews: %s" % match)
+                    self._cm.log(f"BadNews: {match}")
                     self.incr("BadNews")
                     errcount += 1
             else:

--- a/python/pacemaker/_cts/scenarios.py
+++ b/python/pacemaker/_cts/scenarios.py
@@ -279,7 +279,7 @@ class Scenario:
 
         self._cm.debug("Detailed Results")
         for test in self.tests:
-            self._cm.debug(f"{f'Test {test.name}':<25} {stat_filter!r}")
+            self._cm.debug(f"{f'Test {test.name}: ':<25} {test.stats!r}")
 
         self._cm.log("<<<<<<<<<<<<<<<< TESTS COMPLETED")
 

--- a/python/pacemaker/_cts/tests/componentfail.py
+++ b/python/pacemaker/_cts/tests/componentfail.py
@@ -1,7 +1,7 @@
 """Kill a pacemaker daemon and test how the cluster recovers."""
 
 __all__ = ["ComponentFail"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re
@@ -66,7 +66,7 @@ class ComponentFail(CTSTest):
         while chosen.dc_only and not node_is_dc:
             chosen = self._env.random_gen.choice(self._complist)
 
-        self.debug("...component %s (dc=%s)" % (chosen.name, node_is_dc))
+        self.debug(f"...component {chosen.name} (dc={node_is_dc})")
         self.incr(chosen.name)
 
         if chosen.name != "corosync":
@@ -127,11 +127,11 @@ class ComponentFail(CTSTest):
         self.debug("Waiting for the cluster to re-stabilize with all nodes")
         self._cm.cluster_stable(self._env["StartTime"])
 
-        self.debug("Checking if %s was shot" % node)
+        self.debug(f"Checking if {node} was shot")
         shot = stonith.look(60)
 
         if shot:
-            self.debug("Found: %r" % shot)
+            self.debug(f"Found: {shot!r}")
             self._okerrpatterns.append(self.templates["Pat:Fencing_start"] % node)
 
             if not self._env["at-boot"]:
@@ -144,16 +144,16 @@ class ComponentFail(CTSTest):
         # check for logs indicating a graceful recovery
         matched = watch.look_for_all(allow_multiple_matches=True)
         if watch.unmatched:
-            self._logger.log("Patterns not found: %r" % watch.unmatched)
+            self._logger.log(f"Patterns not found: {watch.unmatched!r}")
 
         self.debug("Waiting for the cluster to re-stabilize with all nodes")
         is_stable = self._cm.cluster_stable(self._env["StartTime"])
 
         if not matched:
-            return self.failure("Didn't find all expected %s patterns" % chosen.name)
+            return self.failure(f"Didn't find all expected {chosen.name} patterns")
 
         if not is_stable:
-            return self.failure("Cluster did not become stable after killing %s" % chosen.name)
+            return self.failure(f"Cluster did not become stable after killing {chosen.name}")
 
         return self.success()
 

--- a/python/pacemaker/_cts/tests/ctstest.py
+++ b/python/pacemaker/_cts/tests/ctstest.py
@@ -1,7 +1,7 @@
 """Base classes for CTS tests."""
 
 __all__ = ["CTSTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re
@@ -92,7 +92,7 @@ class CTSTest:
             return
 
         elapsed = self._timers[key].elapsed
-        self.debug("%s:%s runtime: %.2f" % (self.name, key, elapsed))
+        self.debug(f"{self.name}:{key} runtime: {elapsed:.2f}")
         del self._timers[key]
 
     def incr(self, name):
@@ -110,7 +110,7 @@ class CTSTest:
         """Increment the failure count, with an optional failure reason."""
         self.passed = False
         self.incr("failure")
-        self._logger.log(("Test %s" % self.name).ljust(35) + " FAILED: %s" % reason)
+        self._logger.log(f"{f'Test {self.name}':<35} FAILED: {reason}")
 
         return False
 
@@ -134,7 +134,7 @@ class CTSTest:
 
         for audit in self.audits:
             if not audit():
-                self._logger.log("Internal %s Audit %s FAILED." % (self.name, audit.name))
+                self._logger.log(f"Internal {self.name} Audit {audit.name} FAILED.")
                 self.incr("auditfail")
                 passed = False
 
@@ -207,7 +207,7 @@ class CTSTest:
                         add_err = False
 
                 if add_err:
-                    self._logger.log("%s %s" % (prefix, match))
+                    self._logger.log(f"{prefix} {match}")
                     errcount += 1
             else:
                 break

--- a/python/pacemaker/_cts/tests/fliptest.py
+++ b/python/pacemaker/_cts/tests/fliptest.py
@@ -1,7 +1,7 @@
 """Stop running nodes, and start stopped nodes."""
 
 __all__ = ["FlipTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import time
@@ -56,4 +56,4 @@ class FlipTest(CTSTest):
         if ret:
             return self.success()
 
-        return self.failure("%s failure" % kind)
+        return self.failure(f"{kind} failure")

--- a/python/pacemaker/_cts/tests/nearquorumpointtest.py
+++ b/python/pacemaker/_cts/tests/nearquorumpointtest.py
@@ -1,7 +1,7 @@
 """Randomly start and stop nodes to bring the cluster close to the quorum point."""
 
 __all__ = ["NearQuorumPointTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -47,8 +47,8 @@ class NearQuorumPointTest(CTSTest):
             elif action == "stop":
                 stopset.append(node)
 
-        self.debug("start nodes:%r" % startset)
-        self.debug("stop nodes:%r" % stopset)
+        self.debug(f"start nodes:{startset!r}")
+        self.debug(f"stop nodes:{stopset!r}")
 
         # add search patterns
         watchpats = []
@@ -89,7 +89,7 @@ class NearQuorumPointTest(CTSTest):
             self._cm.fencing_cleanup("NearQuorumPoint", stonith)
             return self.success()
 
-        self._logger.log("Warn: Patterns not found: %r" % watch.unmatched)
+        self._logger.log(f"Warn: Patterns not found: {watch.unmatched!r}")
 
         # get the "bad" nodes
         upnodes = []
@@ -113,9 +113,9 @@ class NearQuorumPointTest(CTSTest):
             return self.success()
 
         if upnodes:
-            self._logger.log("Warn: Unstoppable nodes: %r" % upnodes)
+            self._logger.log(f"Warn: Unstoppable nodes: {upnodes!r}")
 
         if downnodes:
-            self._logger.log("Warn: Unstartable nodes: %r" % downnodes)
+            self._logger.log(f"Warn: Unstartable nodes: {downnodes!r}")
 
         return self.failure()

--- a/python/pacemaker/_cts/tests/partialstart.py
+++ b/python/pacemaker/_cts/tests/partialstart.py
@@ -1,7 +1,7 @@
 """Start a node and then tell it to stop before it is fully running."""
 
 __all__ = ["PartialStart"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -53,12 +53,12 @@ class PartialStart(CTSTest):
         self._cm.start_cm_async(node)
         ret = watch.look_for_all()
         if not ret:
-            self._logger.log("Patterns not found: %r" % watch.unmatched)
-            return self.failure("Setup of %s failed" % node)
+            self._logger.log(f"Patterns not found: {watch.unmatched!r}")
+            return self.failure(f"Setup of {node} failed")
 
         ret = self._stop(node)
         if not ret:
-            return self.failure("%s did not stop in time" % node)
+            return self.failure(f"{node} did not stop in time")
 
         return self.success()
 

--- a/python/pacemaker/_cts/tests/reattach.py
+++ b/python/pacemaker/_cts/tests/reattach.py
@@ -1,7 +1,7 @@
 """Restart the cluster and verify resources remain running."""
 
 __all__ = ["Reattach"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import re
@@ -80,7 +80,7 @@ class Reattach(CTSTest):
         """Re-enable resources that were incompatible with this test."""
         self.debug("Re-enable incompatible resources")
         xml = """<meta_attributes id="cts-lab-Reattach-meta"/>"""
-        return self._rsh(node, """cibadmin --delete --xml-text '%s'""" % xml)
+        return self._rsh(node, f"""cibadmin --delete --xml-text '{xml}'""")
 
     def _reprobe(self, node):
         """
@@ -143,7 +143,7 @@ class Reattach(CTSTest):
         self._set_unmanaged(node)
 
         if not managed.look_for_all():
-            self._logger.log("Patterns not found: %r" % managed.unmatched)
+            self._logger.log(f"Patterns not found: {managed.unmatched!r}")
             return self.failure("Resource management not disabled")
 
         pats = [
@@ -191,7 +191,7 @@ class Reattach(CTSTest):
                 r = AuditResource(self._cm, line)
 
                 if r.rclass == "stonith":
-                    self.debug("Ignoring start actions for %s" % r.id)
+                    self.debug(f"Ignoring start actions for {r.id}")
                     ignore.append(self.templates["Pat:RscOpOK"] % ("start", r.id))
 
         if self.local_badnews("ResourceActivity:", watch, ignore):

--- a/python/pacemaker/_cts/tests/restartonebyone.py
+++ b/python/pacemaker/_cts/tests/restartonebyone.py
@@ -1,7 +1,7 @@
 """Restart all nodes in order."""
 
 __all__ = ["RestartOnebyOne"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -51,6 +51,6 @@ class RestartOnebyOne(CTSTest):
                 did_fail.append(node)
 
         if did_fail:
-            return self.failure("Could not restart %d nodes: %r" % (len(did_fail), did_fail))
+            return self.failure(f"Could not restart {len(did_fail)} nodes: {did_fail!r}")
 
         return self.success()

--- a/python/pacemaker/_cts/tests/restarttest.py
+++ b/python/pacemaker/_cts/tests/restarttest.py
@@ -1,7 +1,7 @@
 """Stop and restart a node."""
 
 __all__ = ["RestartTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -29,19 +29,19 @@ class RestartTest(CTSTest):
     def __call__(self, node):
         """Perform this test."""
         self.incr("calls")
-        self.incr("node:%s" % node)
+        self.incr(f"node:{node}")
 
         if self._cm.stat_cm(node):
             self.incr("WasStopped")
             if not self._start(node):
-                return self.failure("start (setup) failure: %s" % node)
+                return self.failure(f"start (setup) failure: {node}")
 
         self.set_timer()
 
         if not self._stop(node):
-            return self.failure("stop failure: %s" % node)
+            return self.failure(f"stop failure: {node}")
 
         if not self._start(node):
-            return self.failure("start failure: %s" % node)
+            return self.failure(f"start failure: {node}")
 
         return self.success()

--- a/python/pacemaker/_cts/tests/resynccib.py
+++ b/python/pacemaker/_cts/tests/resynccib.py
@@ -1,7 +1,7 @@
 """Start the cluster without a CIB and verify it gets copied from another node."""
 
 __all__ = ["ResyncCIB"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker import BuildOptions
@@ -46,11 +46,11 @@ class ResyncCIB(CTSTest):
             return self.failure("Could not stop all nodes")
 
         # Test config recovery when the other nodes come up
-        self._rsh(node, "rm -f %s/cib*" % BuildOptions.CIB_DIR)
+        self._rsh(node, f"rm -f {BuildOptions.CIB_DIR}/cib*")
 
         # Start the selected node
         if not self._restart1(node):
-            return self.failure("Could not start %s" % node)
+            return self.failure(f"Could not start {node}")
 
         # Start all remaining nodes
         if not self._startall(None):

--- a/python/pacemaker/_cts/tests/simulstartlite.py
+++ b/python/pacemaker/_cts/tests/simulstartlite.py
@@ -1,7 +1,7 @@
 """Simultaneously start stopped nodes."""
 
 __all__ = ["SimulStartLite"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -36,7 +36,7 @@ class SimulStartLite(CTSTest):
     def __call__(self, dummy):
         """Return whether starting all stopped nodes more or less simultaneously succeeds."""
         self.incr("calls")
-        self.debug("Setup: %s" % self.name)
+        self.debug(f"Setup: {self.name}")
 
         # We ignore the "node" parameter...
         node_list = []
@@ -78,26 +78,26 @@ class SimulStartLite(CTSTest):
 
             # Remove node_list messages from watch.unmatched
             for node in node_list:
-                self._logger.debug("Dealing with stonith operations for %s" % node_list)
+                self._logger.debug(f"Dealing with stonith operations for {node_list}")
                 if watch.unmatched:
                     try:
                         watch.unmatched.remove(uppat % node)
                     except ValueError:
-                        self.debug("Already matched: %s" % (uppat % node))
+                        self.debug(f"Already matched: {uppat % node}")
 
                     try:
                         watch.unmatched.remove(self.templates["Pat:InfraUp"] % node)
                     except ValueError:
-                        self.debug("Already matched: %s" % (self.templates["Pat:InfraUp"] % node))
+                        self.debug(f"Already matched: {self.templates['Pat:InfraUp'] % node}")
 
                     try:
                         watch.unmatched.remove(self.templates["Pat:PacemakerUp"] % node)
                     except ValueError:
-                        self.debug("Already matched: %s" % (self.templates["Pat:PacemakerUp"] % node))
+                        self.debug(f"Already matched: {self.templates['Pat:PacemakerUp'] % node}")
 
             if watch.unmatched:
                 for regex in watch.unmatched:
-                    self._logger.log("Warn: Startup pattern not found: %s" % regex)
+                    self._logger.log(f"Warn: Startup pattern not found: {regex}")
 
             if not self._cm.cluster_stable():
                 return self.failure("Cluster did not stabilize")
@@ -110,7 +110,7 @@ class SimulStartLite(CTSTest):
                 unstable.append(node)
 
         if did_fail:
-            return self.failure("Unstarted nodes exist: %s" % unstable)
+            return self.failure(f"Unstarted nodes exist: {unstable}")
 
         unstable = []
         for node in self._env["nodes"]:
@@ -119,7 +119,7 @@ class SimulStartLite(CTSTest):
                 unstable.append(node)
 
         if did_fail:
-            return self.failure("Unstable cluster nodes exist: %s" % unstable)
+            return self.failure(f"Unstable cluster nodes exist: {unstable}")
 
         return self.success()
 

--- a/python/pacemaker/_cts/tests/simulstoplite.py
+++ b/python/pacemaker/_cts/tests/simulstoplite.py
@@ -1,7 +1,7 @@
 """Simultaneously stop running nodes."""
 
 __all__ = ["SimulStopLite"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -39,7 +39,7 @@ class SimulStopLite(CTSTest):
     def __call__(self, dummy):
         """Return whether stopping all running nodes more or less simultaneously succeeds."""
         self.incr("calls")
-        self.debug("Setup: %s" % self.name)
+        self.debug(f"Setup: {self.name}")
 
         # We ignore the "node" parameter...
         watchpats = []
@@ -76,10 +76,10 @@ class SimulStopLite(CTSTest):
                 up_nodes.append(node)
 
         if did_fail:
-            return self.failure("Active nodes exist: %s" % up_nodes)
+            return self.failure(f"Active nodes exist: {up_nodes}")
 
-        self._logger.log("Warn: All nodes stopped but CTS didn't detect: %s" % watch.unmatched)
-        return self.failure("Missing log message: %s " % watch.unmatched)
+        self._logger.log(f"Warn: All nodes stopped but CTS didn't detect: {watch.unmatched}")
+        return self.failure(f"Missing log message: {watch.unmatched}")
 
     def is_applicable(self):
         """Return True if this test is applicable in the current test configuration."""

--- a/python/pacemaker/_cts/tests/splitbraintest.py
+++ b/python/pacemaker/_cts/tests/splitbraintest.py
@@ -1,7 +1,7 @@
 """Create a split brain cluster and verify a resource is multiply managed."""
 
 __all__ = ["SplitBrainTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import time
@@ -53,17 +53,17 @@ class SplitBrainTest(CTSTest):
             try:
                 other_nodes.remove(node)
             except ValueError:
-                self._logger.log("Node %s not in %r from %r" % (node, self._env["nodes"], partition))
+                self._logger.log(f"Node {node} not in {self._env['nodes']!r} from {partition!r}")
 
         if not other_nodes:
             return
 
-        self.debug("Creating partition: %r" % partition)
-        self.debug("Everyone else: %r" % other_nodes)
+        self.debug(f"Creating partition: {partition!r}")
+        self.debug(f"Everyone else: {other_nodes!r}")
 
         for node in partition:
             if not self._cm.isolate_node(node, other_nodes):
-                self._logger.log("Could not isolate %s" % node)
+                self._logger.log(f"Could not isolate {node}")
                 return
 
     def _heal_partition(self, partition):
@@ -74,13 +74,13 @@ class SplitBrainTest(CTSTest):
             try:
                 other_nodes.remove(node)
             except ValueError:
-                self._logger.log("Node %s not in %r" % (node, self._env["nodes"]))
+                self._logger.log(f"Node {node} not in {self._env['nodes']!r}")
 
         if len(other_nodes) == 0:
             return
 
-        self.debug("Healing partition: %r" % partition)
-        self.debug("Everyone else: %r" % other_nodes)
+        self.debug(f"Healing partition: {partition!r}")
+        self.debug(f"Everyone else: {other_nodes!r}")
 
         for node in partition:
             self._cm.unisolate_node(node, other_nodes)
@@ -112,9 +112,9 @@ class SplitBrainTest(CTSTest):
                 break
             # else, try again
 
-        self.debug("Created %d partitions" % p_max)
+        self.debug(f"Created {p_max} partitions")
         for (key, val) in partitions.items():
-            self.debug("Partition[%s]:\t%r" % (key, val))
+            self.debug(f"Partition[{key}]:\t{val!r}")
 
         # Disabling STONITH to reduce test complexity for now
         self._rsh(node, "crm_attribute -V -n stonith-enabled -v false")

--- a/python/pacemaker/_cts/tests/standbytest.py
+++ b/python/pacemaker/_cts/tests/standbytest.py
@@ -1,7 +1,7 @@
 """Put a node into standby mode and check that resources migrate."""
 
 __all__ = ["StandbyTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -48,15 +48,15 @@ class StandbyTest(CTSTest):
         if not ret:
             return self.failure("Start all nodes failed")
 
-        self.debug("Make sure node %s is active" % node)
+        self.debug(f"Make sure node {node} is active")
         if self._cm.in_standby_mode(node):
             if not self._cm.set_standby_mode(node, False):
-                return self.failure("can't set node %s to active mode" % node)
+                return self.failure(f"can't set node {node} to active mode")
 
         self._cm.cluster_stable()
 
         if self._cm.in_standby_mode(node):
-            return self.failure("standby status of %s is [on] but we expect [off]" % node)
+            return self.failure(f"standby status of {node} is [on] but we expect [off]")
 
         watchpats = [
             r"State transition .* -> S_POLICY_ENGINE",
@@ -64,42 +64,42 @@ class StandbyTest(CTSTest):
         watch = self.create_watch(watchpats, self._env["DeadTime"] + 10)
         watch.set_watch()
 
-        self.debug("Setting node %s to standby mode" % node)
+        self.debug(f"Setting node {node} to standby mode")
         if not self._cm.set_standby_mode(node, True):
-            return self.failure("can't set node %s to standby mode" % node)
+            return self.failure(f"can't set node {node} to standby mode")
 
         self.set_timer("on")
 
         ret = watch.look_for_all()
         if not ret:
-            self._logger.log("Patterns not found: %r" % watch.unmatched)
+            self._logger.log(f"Patterns not found: {watch.unmatched!r}")
             self._cm.set_standby_mode(node, False)
-            return self.failure("cluster didn't react to standby change on %s" % node)
+            return self.failure(f"cluster didn't react to standby change on {node}")
 
         self._cm.cluster_stable()
 
         if not self._cm.in_standby_mode(node):
-            return self.failure("standby status of %s is [off] but we expect [on]" % node)
+            return self.failure(f"standby status of {node} is [off] but we expect [on]")
 
         self.log_timer("on")
 
         self.debug("Checking resources")
         rscs_on_node = self._cm.active_resources(node)
         if rscs_on_node:
-            rc = self.failure("%s set to standby, %r is still running on it" % (node, rscs_on_node))
-            self.debug("Setting node %s to active mode" % node)
+            rc = self.failure(f"{node} set to standby, {rscs_on_node!r} is still running on it")
+            self.debug(f"Setting node {node} to active mode")
             self._cm.set_standby_mode(node, False)
             return rc
 
-        self.debug("Setting node %s to active mode" % node)
+        self.debug(f"Setting node {node} to active mode")
         if not self._cm.set_standby_mode(node, False):
-            return self.failure("can't set node %s to active mode" % node)
+            return self.failure(f"can't set node {node} to active mode")
 
         self.set_timer("off")
         self._cm.cluster_stable()
 
         if self._cm.in_standby_mode(node):
-            return self.failure("standby status of %s is [on] but we expect [off]" % node)
+            return self.failure(f"standby status of {node} is [on] but we expect [off]")
 
         self.log_timer("off")
 

--- a/python/pacemaker/_cts/tests/startonebyone.py
+++ b/python/pacemaker/_cts/tests/startonebyone.py
@@ -1,7 +1,7 @@
 """Start all stopped nodes serially."""
 
 __all__ = ["StartOnebyOne"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -48,6 +48,6 @@ class StartOnebyOne(CTSTest):
                 failed.append(node)
 
         if failed:
-            return self.failure("Some node failed to start: %r" % failed)
+            return self.failure(f"Some node failed to start: {failed!r}")
 
         return self.success()

--- a/python/pacemaker/_cts/tests/starttest.py
+++ b/python/pacemaker/_cts/tests/starttest.py
@@ -1,7 +1,7 @@
 """Start the cluster manager on a given node."""
 
 __all__ = ["StartTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -48,5 +48,4 @@ class StartTest(CTSTest):
         if self._cm.start_cm(node):
             return self.success()
 
-        return self.failure("Startup %s on node %s failed"
-                            % (self._env["Name"], node))
+        return self.failure(f"Startup {self._env['Name']} on node {node} failed")

--- a/python/pacemaker/_cts/tests/stoponebyone.py
+++ b/python/pacemaker/_cts/tests/stoponebyone.py
@@ -1,7 +1,7 @@
 """Stop all running nodes serially."""
 
 __all__ = ["StopOnebyOne"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -49,6 +49,6 @@ class StopOnebyOne(CTSTest):
                 failed.append(node)
 
         if failed:
-            return self.failure("Some node failed to stop: %r" % failed)
+            return self.failure(f"Some node failed to stop: {failed!r}")
 
         return self.success()

--- a/python/pacemaker/_cts/tests/stoptest.py
+++ b/python/pacemaker/_cts/tests/stoptest.py
@@ -1,7 +1,7 @@
 """Stop the cluster manager on a given node."""
 
 __all__ = ["StopTest"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 from pacemaker._cts.tests.ctstest import CTSTest
@@ -79,8 +79,8 @@ class StopTest(CTSTest):
                 self.debug(line)
 
             for regex in watch.unmatched:
-                self._logger.log("ERROR: Shutdown pattern not found: %s" % regex)
-                unmatched_str += "%s||" % regex
+                self._logger.log(f"ERROR: Shutdown pattern not found: {regex}")
+                unmatched_str += f"{regex}||"
                 failreason = "Missing shutdown pattern"
 
         self._cm.cluster_stable(self._env["DeadTime"])
@@ -89,7 +89,7 @@ class StopTest(CTSTest):
             return self.success()
 
         if len(watch.unmatched) >= self._cm.upcount():
-            return self.failure("no match against (%s)" % unmatched_str)
+            return self.failure(f"no match against ({unmatched_str})")
 
         if failreason is None:
             return self.success()

--- a/python/pacemaker/_cts/timer.py
+++ b/python/pacemaker/_cts/timer.py
@@ -1,7 +1,7 @@
 """Timer-related utilities for CTS."""
 
 __all__ = ["Timer"]
-__copyright__ = "Copyright 2000-2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2000-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+) WITHOUT ANY WARRANTY"
 
 import time
@@ -42,7 +42,7 @@ class Timer:
 
     def __exit__(self, *args):
         """When used as a context manager, log the elapsed time."""
-        self._logger.debug("%s:%s runtime: %.2f" % (self._test_name, self._timer_name, self.elapsed))
+        self._logger.debug(f"{self._test_name}:{self._timer_name} runtime: {self.elapsed:.2f}")
 
     def reset(self):
         """Restart the timer."""

--- a/python/pacemaker/_cts/validate.py
+++ b/python/pacemaker/_cts/validate.py
@@ -1,6 +1,6 @@
 """A module providing XML validation utilities."""
 
-__copyright__ = "Copyright 2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2024-2025 the Pacemaker project contributors"
 __license__ = "GNU General Public License version 2 or later (GPLv2+)"
 
 __all__ = ["validate"]
@@ -26,7 +26,7 @@ def find_validator(rng_file):
 
         return [BuildOptions.XMLLINT_PATH, "--relaxng", rng_file, "-"]
 
-    raise FileNotFoundError("Could not find validator for %s" % rng_file)
+    raise FileNotFoundError(f"Could not find validator for {rng_file}")
 
 
 def rng_directory():
@@ -35,8 +35,8 @@ def rng_directory():
         return os.environ["PCMK_schema_directory"]
 
     for path in sys.path:
-        if os.path.exists("%s/cts-fencing.in" % path):
-            return "%s/xml" % path
+        if os.path.exists(f"{path}/cts-fencing.in"):
+            return f"{path}/xml"
 
     return BuildOptions.SCHEMA_DIR
 
@@ -44,14 +44,15 @@ def rng_directory():
 def validate(xml, check_rng=True, verbose=False):
     """Validate the given XML input string against a schema."""
     if check_rng:
-        rng_file = "%s/api/api-result.rng" % rng_directory()
+        rng_file = f"{rng_directory()}/api/api-result.rng"
     else:
         rng_file = None
 
     cmd = find_validator(rng_file)
 
     if verbose:
-        print("\nRunning: %s" % " ".join(cmd))
+        s = " ".join(cmd)
+        print(f"\nRunning: {s}")
 
     with subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as validator:
         output = pipe_communicate(validator, check_stderr=True, stdin=xml)

--- a/python/pacemaker/_library.py
+++ b/python/pacemaker/_library.py
@@ -1,7 +1,7 @@
 """A module providing private library management code."""
 
 __all__ = ["_libcrmcommon"]
-__copyright__ = "Copyright 2024 the Pacemaker project contributors"
+__copyright__ = "Copyright 2024-2025 the Pacemaker project contributors"
 __license__ = "GNU Lesser General Public License version 2.1 or later (LGPLv2.1+)"
 
 import ctypes
@@ -20,8 +20,8 @@ def load_library(basename):
     # for it in the build directory
     if path is None:
         # pylint: disable=protected-access
-        for d in glob("%s/lib/*/.libs" % BuildOptions._BUILD_DIR):
-            path = "%s/lib%s.so" % (d, basename)
+        for d in glob(f"{BuildOptions._BUILD_DIR}/lib/*/.libs"):
+            path = f"{d}/lib{basename}.so"
 
             if os.path.exists(path):
                 break


### PR DESCRIPTION
With the new minimum requirement of python-3.6, we can now use f-strings instead of the older substitutions.  I'm not sure whether this looks better or not, but it does shut up pylint.