### PR TITLE
Fix the FileAudit test in CTS for systemd systems

### DIFF
--- a/python/pacemaker/_cts/audits.py
+++ b/python/pacemaker/_cts/audits.py
@@ -263,30 +263,37 @@ class FileAudit(ClusterAudit):
         self.known = []
         self.name = "FileAudit"
 
+    def _find_core_on_fs(self, node, path, tool):
+        """Check for core dumps on the given node, under the given path."""
+        found = False
+        (_, lsout) = self._cm.rsh(node, f"ls -al {path} | grep core.[0-9]", verbose=1)
+
+        for line in lsout:
+            line = line.strip()
+
+            if line in self.known:
+                continue
+
+            found = True
+            self.known.append(line)
+            self._cm.log(f"Warning: {tool} core file on {node}: {line}")
+
+        return found
+
     def __call__(self):
         """Perform the audit action."""
         result = True
 
         self._cm.ns.wait_for_all_nodes(self._cm.env["nodes"])
+
         for node in self._cm.env["nodes"]:
+            found = self._find_core_on_fs(node, "/var/lib/pacemaker/cores/*", "Pacemaker")
+            if found:
+                result = False
 
-            (_, lsout) = self._cm.rsh(node, "ls -al /var/lib/pacemaker/cores/* | grep core.[0-9]", verbose=1)
-            for line in lsout:
-                line = line.strip()
-
-                if line not in self.known:
-                    result = False
-                    self.known.append(line)
-                    self._cm.log(f"Warning: Pacemaker core file on {node}: {line}")
-
-            (_, lsout) = self._cm.rsh(node, "ls -al /var/lib/corosync | grep core.[0-9]", verbose=1)
-            for line in lsout:
-                line = line.strip()
-
-                if line not in self.known:
-                    result = False
-                    self.known.append(line)
-                    self._cm.log(f"Warning: Corosync core file on {node}: {line}")
+            found = self._find_core_on_fs(node, "/var/lib/corosync", "Corosync")
+            if found:
+                result = False
 
             if self._cm.expected_status.get(node) == "down":
                 clean = False


### PR DESCRIPTION
After:

```
Jan 23 16:25:27 Cluster nodes:
Jan 23 16:25:27 * rhel9-ctslab-1
Jan 23 16:25:27 * rhel9-ctslab-2
Jan 23 16:25:27 * rhel9-ctslab-3
Jan 23 16:25:31 Warning: Core file on rhel9-ctslab-1: Thu 2025-01-23 16:25:03 EST 834 0 0 SIGSEGV none /root/crash -
Jan 23 16:25:33 Audit FileAudit FAILED.
```