### PR TITLE
Fix: libraries: Update version numbers in so names

### DIFF
--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -53,7 +53,7 @@ void cib_dump_pending_callbacks(void);
 int num_cib_op_callbacks(void);
 void remove_cib_op_callback(int call_id, gboolean all_callbacks);
 
-#  define CIB_LIBRARY "libcib.so.27"
+#define CIB_LIBRARY "libcib.so.54"
 
 #ifdef __cplusplus
 }

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -643,7 +643,7 @@ time_t stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress);
 
  */
 
-#  define STONITH_LIBRARY "libstonithd.so.26"
+#define STONITH_LIBRARY "libstonithd.so.56"
 
 typedef int (*st_api_kick_fn) (int nodeid, const char *uname, int timeout, bool off);
 typedef time_t (*st_api_time_fn) (int nodeid, const char *uname, bool in_progress);


### PR DESCRIPTION
This fixes a longstanding regression, introduced in dad2411 for libstonithd and in e014c52 for libcib.

The libstonithd version mismatch currently causes issues with dlm_controld, impacting gfs2 filesystems.

It's not clear whether anything uses the CIB_LIBRARY constant. It looks as if it could be deprecated. Nothing internal uses it. However, dlm includes stonith-ng.h, which uses STONITH_LIBRARY in inline functions.