### PR TITLE
 Low: libcrmcommon: Fix memory leak in text_end_list()/curses_end_list()

### DIFF
--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the Pacemaker project contributors
+ * Copyright 2019-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -34,6 +34,7 @@ free_list_data(gpointer data) {
 
     free(list_data->singular_noun);
     free(list_data->plural_noun);
+    free(list_data);
 }
 
 static void

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the Pacemaker project contributors
+ * Copyright 2019-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -40,6 +40,7 @@ free_list_data(gpointer data) {
 
     free(list_data->singular_noun);
     free(list_data->plural_noun);
+    free(list_data);
 }
 
 static void


### PR DESCRIPTION
We were freeing the string members of text_list_data_t, but not the text_list_data_t object itself. Similarly for curses_list_data_t.

Ref T704