### PR TITLE
 Fix: libcrmcluster: prevent external callers from triggering assertion when connecting to cluster

### DIFF
--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -805,7 +805,10 @@ pcmk__cpg_connect(pcmk_cluster_t *cluster)
 
     cpg_evicted = false;
 
-    cpg_group_name = pcmk__server_message_type(cluster->priv->server);
+    if (cluster->priv->server != pcmk_ipc_unknown) {
+        cpg_group_name = pcmk__server_message_type(cluster->priv->server);
+    }
+
     if (cpg_group_name == NULL) {
         /* The name will already be non-NULL for Pacemaker servers. If a
          * command-line tool or external caller connects to the cluster,


### PR DESCRIPTION
When sbd is connecting to cluster by calling crm_cluster_connect() -> pcmk_cluster_connect() -> pcmk__corosync_connect() -> pcmk__cpg_connect() -> pcmk__server_message_type()

, it triggers assertion:

error: log_assertion_as: pcmk__server_message_type: Triggered fatal assertion at servers.c:165 : (server > 0) && (server < PCMK__NELEM(server_info))

This fixes it by avoiding calling pcmk__server_message_type() in pcmk__cpg_connect().