### PR TITLE
Build: devel: Replace indent with clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,184 @@
+# These options seem to change all the time.  I've removed things that are C++,
+# Objective-C, or JSON specific.  For reference:
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+---
+Language:        Cpp
+BasedOnStyle: GNU
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+   AfterCaseLabel:  false
+   AfterControlStatement: Never
+   AfterEnum:       false
+   AfterExternBlock: true
+   AfterFunction:   true
+   AfterStruct:     false
+   AfterUnion:      false
+   BeforeElse:      false
+   BeforeWhile:     false
+   IndentBraces:    false
+   SplitEmptyFunction: true
+   SplitEmptyRecord: true
+   SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: false
+BreakAfterAttributes: Leave
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: false
+ColumnLimit:     80
+CommentPragmas:  '^\\.+'
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:
+IfMacros:
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseBlocks: true
+IndentCaseLabels: true
+IndentGotoLabels: false
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    true
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: MultipleParentheses
+RemoveSemicolon: true
+SeparateDefinitionBlocks: Always
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: false
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Custom
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        c++03
+StatementAttributeLikeMacros:
+StatementMacros:
+TabWidth:        4
+UseTab:          Never
+WhitespaceSensitiveMacros:
+...

--- a/devel/Makefile.am
+++ b/devel/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2023 the Pacemaker project contributors
+# Copyright 2020-2025 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -247,58 +247,20 @@ coverage-partial-clean:
 coverage-clean: coverage-partial-clean
 	-find $(top_builddir) -name "*.gcno" -exec rm -f \{\} \;
 
-#
-# indent cannot cope with all our exceptions and needs heavy manual editing
-#
-# @TODO investigate using clang-format instead
-#
+# Automatic code formatting - this makes use of clang-format and the .clang-format
+# config file.  It's based on GNU coding, but heavily modified for our needs
+# and to reflect the C coding guidelines documentation.
 
-# indent target: Limit indent to these directories
+# Limit clang-format to these directories
 INDENT_DIRS	?= .
 
-# indent target: Extra options to pass to indent
+# Extra options to pass to clang-format
 INDENT_OPTS	?=
-
-INDENT_IGNORE_PATHS	= daemons/controld/controld_fsa.h
-INDENT_PACEMAKER_STYLE	= --blank-lines-after-declarations		\
-			  --blank-lines-after-procedures		\
-			  --braces-after-func-def-line			\
-			  --braces-on-if-line				\
-			  --braces-on-struct-decl-line			\
-			  --break-before-boolean-operator		\
-			  --case-brace-indentation4			\
-			  --case-indentation4				\
-			  --comment-indentation0			\
-			  --continuation-indentation4			\
-			  --continue-at-parentheses			\
-			  --cuddle-do-while				\
-			  --cuddle-else					\
-			  --declaration-comment-column0			\
-			  --declaration-indentation1			\
-			  --else-endif-column0				\
-			  --honour-newlines				\
-			  --indent-label0				\
-			  --indent-level4				\
-			  --line-comments-indentation0			\
-			  --line-length80				\
-			  --no-blank-lines-after-commas			\
-			  --no-comment-delimiters-on-blank-lines	\
-			  --no-space-after-function-call-names		\
-			  --no-space-after-parentheses			\
-			  --no-tabs					\
-			  --preprocessor-indentation2			\
-			  --procnames-start-lines			\
-			  --space-after-cast				\
-			  --start-left-side-of-comments			\
-			  --swallow-optional-blank-lines		\
-			  --tab-size8
 
 .PHONY: indent
 indent:
-	VERSION_CONTROL=none					\
-		find $(INDENT_DIRS) -type f -name "*.[ch]"	\
-		$(INDENT_IGNORE_PATHS:%= ! -path '%')		\
-		-exec indent $(INDENT_PACEMAKER_STYLE) $(INDENT_OPTS) \{\} \;
+	find $(INDENT_DIRS) -type f -name "*.[ch]" \
+		-exec clang-format $(INDENT_OPTS) \{\} \;
 
 #
 # Check whether copyrights have been updated appropriately


### PR DESCRIPTION
The indent tool has fallen out of favor with a lot of developers, while clang-format seems to be growing in popularity.  We're not enforcing the usage of any style tool because they never get everything 100% right, and I'm not really sure anyone ever actually uses this target - I know I never have.

However, this at least updates it to be something more modern should anyone want to use it.  To generate this config, I dumped the default GNU coding style (clang-format -style=gnu -dump-config), removed anything that wasn't related to regular old C, and then went through every config option and checked to make sure it was close to our existing style.  I'm sure something incorrect has snuck through.