### PR TITLE
Update cppcheck config to pass cleanly

### DIFF
--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -467,11 +467,19 @@ start_child(pcmk_child_t * child)
         /* parent */
         mainloop_child_add(child->pid, 0, name, child, pcmk_child_exit);
 
-        crm_info("Forked process %lld using user %lu (%s) and group %lu "
-                 "for subdaemon %s%s",
-                 (long long) child->pid, (unsigned long) uid,
-                 pcmk__s(child->uid, "root"), (unsigned long) gid, name,
-                 use_valgrind ? " (valgrind enabled: " PCMK__VALGRIND_EXEC ")" : "");
+	if (use_valgrind) {
+	    crm_info("Forked process %lld using user %lu (%s) and group %lu "
+		     "for subdaemon %s (valgrind enabled: %s)",
+		     (long long) child->pid, (unsigned long) uid,
+		     pcmk__s(child->uid, "root"), (unsigned long) gid, name,
+		     PCMK__VALGRIND_EXEC);
+	} else {
+	    crm_info("Forked process %lld using user %lu (%s) and group %lu "
+		     "for subdaemon %s",
+		     (long long) child->pid, (unsigned long) uid,
+		     pcmk__s(child->uid, "root"), (unsigned long) gid, name);
+	}
+
         return pcmk_rc_ok;
 
     } else {

--- a/devel/Makefile.am
+++ b/devel/Makefile.am
@@ -180,6 +180,8 @@ CPPCHECK_OUT = $(abs_top_builddir)/cppcheck.out
 .PHONY: cppcheck
 cppcheck:
 	cppcheck $(CPPCHECK_ARGS) -I $(top_srcdir)/include	\
+		-I $(top_srcdir)/lib/common 			\
+		--include=/usr/include/qb/qblog.h 		\
 		--output-file=$(CPPCHECK_OUT)			\
 		--max-configs=30 --inline-suppr -q		\
 		--library=posix --library=gnu --library=gtk	\

--- a/include/crm/common/io_internal.h
+++ b/include/crm/common/io_internal.h
@@ -53,8 +53,6 @@ void pcmk__close_fds_in_child(bool);
 static inline void
 pcmk__open_devnull(int flags)
 {
-    // Static analysis clutter
-    // cppcheck-suppress leakReturnValNotUsed
     (void) open("/dev/null", flags);
 }
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -996,8 +996,6 @@ send_cpg_text(const char *data, const pcmk__node_status_t *node,
             msg->compressed_size = new_size;
 
         } else {
-            // cppcheck seems not to understand the abort logic in pcmk__realloc
-            // cppcheck-suppress memleak
             msg = pcmk__realloc(msg, msg->header.size);
             memcpy(msg->data, data, msg->size);
         }

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -107,7 +107,6 @@ pcmk__build_arg_context(pcmk__common_args_t *common_args, const char *fmts,
     }
 
     // main_group is now owned by context, we don't free it here
-    // cppcheck-suppress memleak
     return context;
 }
 
@@ -139,7 +138,6 @@ pcmk__add_arg_group(GOptionContext *context, const char *name,
     g_option_group_add_entries(group, entries);
     g_option_context_add_group(context, group);
     // group is now owned by context, we don't free it here
-    // cppcheck-suppress memleak
 }
 
 static gchar *

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -44,8 +44,6 @@ pcmk__build_path(const char *path_c, mode_t mode)
     int rc = pcmk_rc_ok;
     char *path = strdup(path_c);
 
-    // cppcheck seems not to understand the abort logic in CRM_CHECK
-    // cppcheck-suppress memleak
     CRM_CHECK(path != NULL, return -ENOMEM);
     for (len = strlen(path); offset < len; offset++) {
         if (path[offset] == '/') {

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -132,6 +132,8 @@ pcmk__register_format(GOptionGroup *group, const char *name,
 
     pcmk__assert((create != NULL) && !pcmk__str_empty(name));
 
+    // cppcheck doesn't understand the above pcmk__assert line
+    // cppcheck-suppress ctunullpointer
     name_copy = strdup(name);
     if (name_copy == NULL) {
         return ENOMEM;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -750,8 +750,6 @@ connect_socket_retry(int sock, const struct sockaddr *addr, socklen_t addrlen,
         *timer_id = timer;
     }
 
-    // timer callback should be taking care of cb_data
-    // cppcheck-suppress memleak
     return pcmk_rc_ok;
 }
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -910,6 +910,8 @@ pcmk__parse_ll_range(const char *srcstring, long long *start, long long *end)
     pcmk__assert((start != NULL) && (end != NULL));
 
     *start = PCMK__PARSE_INT_DEFAULT;
+    // cppcheck doesn't understand the above pcmk__assert line
+    // cppcheck-suppress ctunullpointer
     *end = PCMK__PARSE_INT_DEFAULT;
 
     crm_trace("Attempting to decode: [%s]", srcstring);

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -57,8 +57,6 @@ decompress_file(const char *filename)
         goto done;
     }
 
-    // cppcheck seems not to understand the abort-logic in pcmk__realloc
-    // cppcheck-suppress memleak
     do {
         int read_len = 0;
 

--- a/lib/pacemaker/pcmk_ticket.c
+++ b/lib/pacemaker/pcmk_ticket.c
@@ -82,6 +82,8 @@ pcmk__get_ticket_state(cib_t *cib, const char *ticket_id, xmlNode **state)
     char *xpath = NULL;
 
     pcmk__assert((cib != NULL) && (state != NULL));
+    // cppcheck doesn't understand the above pcmk__assert line
+    // cppcheck-suppress ctunullpointer
     *state = NULL;
 
     if (ticket_id != NULL) {


### PR DESCRIPTION
@waltdisgrace Here's another simple one.  My only concern here is that different versions of cppcheck may still require the older suppression messages.  However, I don't think we mention anywhere what version of static analysis tools the pacemaker code is expected to pass with.  Maybe we should specify that somewhere.