### PR TITLE
Overhaul crm_resource

### DIFF
--- a/cts/cli/regression.crm_resource.exp
+++ b/cts/cli/regression.crm_resource.exp
@@ -2,7 +2,6 @@
 crm_resource: non-option ARGV-elements:
 [1 of 2] foo
 [2 of 2] bar
-
 =#=#=#= End test: crm_resource run with extra arguments - Incorrect usage (64) =#=#=#=
 * Passed: crm_resource          - crm_resource run with extra arguments
 =#=#=#= Begin test: List all available resource options (invalid type) =#=#=#=

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -1804,7 +1804,7 @@ class CrmResourceRegressionTest(RegressionTest):
                             "crm_resource --locate -r promotable-rsc:1 {fmt}",
                             [Test, ValidatingTest]),
             Test("Try to move an instance of a cloned resource",
-                 "crm_resource -r promotable-rsc:0 --move --node node1",
+                 "crm_resource -r promotable-rsc:0 --move --node cluster01",
                  expected_rc=ExitStatus.INVALID_PARAM),
         ]
 

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -250,6 +250,7 @@ copy_action_arguments(svc_action_t *op, uint32_t ra_caps, const char *name,
     return pcmk_rc_ok;
 }
 
+// Takes ownership of params
 svc_action_t *
 services__create_resource_action(const char *name, const char *standard,
                         const char *provider, const char *agent,

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1478,6 +1478,30 @@ handle_digests(pcmk_resource_t *rsc, const pcmk_node_t *node)
     return pcmk__resource_digests(out, rsc, node, options.override_params);
 }
 
+static int
+handle_execute_agent(pcmk_resource_t *rsc)
+{
+    if (options.cmdline_config) {
+        exit_code = cli_resource_execute_from_params(out, NULL, options.v_class,
+                                                     options.v_provider,
+                                                     options.v_agent,
+                                                     options.operation,
+                                                     options.cmdline_params,
+                                                     options.override_params,
+                                                     options.timeout_ms,
+                                                     args->verbosity,
+                                                     options.force,
+                                                     options.check_level);
+    } else {
+        exit_code = cli_resource_execute(rsc, options.rsc_id, options.operation,
+                                         options.override_params,
+                                         options.timeout_ms, cib_conn,
+                                         scheduler, args->verbosity,
+                                         options.force, options.check_level);
+    }
+    return pcmk_rc_ok;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1893,19 +1917,8 @@ main(int argc, char **argv)
             break;
 
         case cmd_execute_agent:
-            if (options.cmdline_config) {
-                exit_code = cli_resource_execute_from_params(out, NULL,
-                    options.v_class, options.v_provider, options.v_agent,
-                    options.operation, options.cmdline_params,
-                    options.override_params, options.timeout_ms,
-                    args->verbosity, options.force, options.check_level);
-            } else {
-                exit_code = cli_resource_execute(rsc, options.rsc_id,
-                    options.operation, options.override_params,
-                    options.timeout_ms, cib_conn, scheduler,
-                    args->verbosity, options.force, options.check_level);
-            }
-            goto done;
+            rc = handle_execute_agent(rsc);
+            break;
 
         case cmd_digests:
             rc = handle_digests(rsc, node);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1628,6 +1628,12 @@ handle_list_resources(void)
     return rc;
 }
 
+static int
+handle_list_standards(void)
+{
+    return pcmk__list_standards(out);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1997,7 +2003,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_standards:
-            rc = pcmk__list_standards(out);
+            rc = handle_list_standards();
             break;
 
         case cmd_list_providers:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1502,6 +1502,18 @@ handle_execute_agent(pcmk_resource_t *rsc)
     return pcmk_rc_ok;
 }
 
+static int
+handle_fail(const pcmk_node_t *node)
+{
+    int rc = cli_resource_fail(controld_api, node, options.rsc_id,
+                               scheduler);
+
+    if (rc == pcmk_rc_ok) {
+        start_mainloop(controld_api);
+    }
+    return rc;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1933,11 +1945,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_fail:
-            rc = cli_resource_fail(controld_api, node, options.rsc_id,
-                                   scheduler);
-            if (rc == pcmk_rc_ok) {
-                start_mainloop(controld_api);
-            }
+            rc = handle_fail(node);
             break;
 
         case cmd_list_active_ops:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1597,6 +1597,17 @@ handle_list_alternatives(void)
     return pcmk__list_alternatives(out, options.agent_spec);
 }
 
+static int
+handle_list_instances(void)
+{
+    // coverity[var_deref_op] False positive
+    if (out->message(out, "resource-names-list",
+                     scheduler->priv->resources) != pcmk_rc_ok) {
+        return ENXIO;
+    }
+    return pcmk_rc_ok;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1961,14 +1972,7 @@ main(int argc, char **argv)
         }
 
         case cmd_list_instances:
-            // coverity[var_deref_op] False positive
-            rc = out->message(out, "resource-names-list",
-                              scheduler->priv->resources);
-
-            if (rc != pcmk_rc_ok) {
-                rc = ENXIO;
-            }
-
+            rc = handle_list_instances();
             break;
 
         case cmd_list_options:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1705,6 +1705,24 @@ handle_restart(pcmk_resource_t *rsc, const pcmk_node_t *node)
                                 options.promoted_role_only, options.force);
 }
 
+static int
+handle_set_param(pcmk_resource_t *rsc, xmlNode *cib_xml_orig)
+{
+    if (pcmk__str_empty(options.prop_value)) {
+        exit_code = CRM_EX_USAGE;
+        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                    _("You need to supply a value with the -v option"));
+        return pcmk_rc_ok;
+    }
+
+    // coverity[var_deref_model] False positive
+    return cli_resource_update_attribute(rsc, options.rsc_id, options.prop_set,
+                                         options.attr_set_type, options.prop_id,
+                                         options.prop_name, options.prop_value,
+                                         options.recursive, cib_conn,
+                                         cib_xml_orig, options.force);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2156,22 +2174,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_set_param:
-            if (pcmk__str_empty(options.prop_value)) {
-                exit_code = CRM_EX_USAGE;
-                g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                            _("You need to supply a value with the -v option"));
-                goto done;
-            }
-
-            /* coverity[var_deref_model] False positive */
-            rc = cli_resource_update_attribute(rsc, options.rsc_id,
-                                               options.prop_set,
-                                               options.attr_set_type,
-                                               options.prop_id,
-                                               options.prop_name,
-                                               options.prop_value,
-                                               options.recursive, cib_conn,
-                                               cib_xml_orig, options.force);
+            rc = handle_set_param(rsc, cib_xml_orig);
             break;
 
         case cmd_delete_param:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1591,6 +1591,12 @@ handle_list_all_ops(const pcmk_node_t *node)
                                          scheduler);
 }
 
+static int
+handle_list_alternatives(void)
+{
+    return pcmk__list_alternatives(out, options.agent_spec);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1970,7 +1976,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_alternatives:
-            rc = pcmk__list_alternatives(out, options.agent_spec);
+            rc = handle_list_alternatives();
             break;
 
         case cmd_list_agents:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1634,6 +1634,16 @@ handle_list_standards(void)
     return pcmk__list_standards(out);
 }
 
+static int
+handle_locate(pcmk_resource_t *rsc)
+{
+    GList *nodes = cli_resource_search(rsc, options.rsc_id, scheduler);
+    int rc = out->message(out, "resource-search-list", nodes, options.rsc_id);
+
+    g_list_free_full(nodes, free);
+    return rc;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2058,12 +2068,9 @@ main(int argc, char **argv)
             rc = handle_list_all_ops(node);
             break;
 
-        case cmd_locate: {
-            GList *nodes = cli_resource_search(rsc, options.rsc_id, scheduler);
-            rc = out->message(out, "resource-search-list", nodes, options.rsc_id);
-            g_list_free_full(nodes, free);
+        case cmd_locate:
+            rc = handle_locate(rsc);
             break;
-        }
 
         case cmd_query_xml:
             rc = cli_resource_print(rsc, scheduler, true);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1604,6 +1604,12 @@ handle_list_options(void)
     }
 }
 
+static int
+handle_list_providers(void)
+{
+    return pcmk__list_providers(out, options.agent_spec);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1988,7 +1994,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_providers:
-            rc = pcmk__list_providers(out, options.agent_spec);
+            rc = handle_list_providers();
             break;
 
         case cmd_metadata:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1818,8 +1818,8 @@ main(int argc, char **argv)
             break;
 
         case cmd_fail:
-            rc = cli_resource_fail(controld_api, options.host_uname,
-                                   options.rsc_id, scheduler);
+            rc = cli_resource_fail(controld_api, node, options.rsc_id,
+                                   scheduler);
             if (rc == pcmk_rc_ok) {
                 start_mainloop(controld_api);
             }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -2084,127 +2084,97 @@ main(int argc, char **argv)
      * setting exit_code based on rc after the switch.
      */
     switch (options.rsc_cmd) {
-        case cmd_list_resources:
-            rc = handle_list_resources();
-            break;
-
-        case cmd_list_instances:
-            rc = handle_list_instances();
-            break;
-
-        case cmd_list_options:
-            rc = handle_list_options();
-            break;
-
-        case cmd_list_alternatives:
-            rc = handle_list_alternatives();
-            break;
-
-        case cmd_list_agents:
-            rc = handle_list_agents();
-            break;
-
-        case cmd_list_standards:
-            rc = handle_list_standards();
-            break;
-
-        case cmd_list_providers:
-            rc = handle_list_providers();
-            break;
-
-        case cmd_metadata:
-            rc = handle_metadata();
-            break;
-
-        case cmd_restart:
-            rc = handle_restart(rsc, node);
-            break;
-
-        case cmd_wait:
-            rc = handle_wait();
-            break;
-
-        case cmd_execute_agent:
-            rc = handle_execute_agent(rsc);
-            break;
-
-        case cmd_digests:
-            rc = handle_digests(rsc, node);
-            break;
-
-        case cmd_colocations:
-            rc = handle_colocations(rsc);
-            break;
-
-        case cmd_cts:
-            rc = handle_cts();
-            break;
-
-        case cmd_fail:
-            rc = handle_fail(node);
-            break;
-
-        case cmd_list_active_ops:
-            rc = handle_list_active_ops(node);
-            break;
-
-        case cmd_list_all_ops:
-            rc = handle_list_all_ops(node);
-            break;
-
-        case cmd_locate:
-            rc = handle_locate(rsc);
-            break;
-
-        case cmd_query_xml:
-            rc = handle_query_xml(rsc);
-            break;
-
-        case cmd_query_xml_raw:
-            rc = handle_query_xml_raw(rsc);
-            break;
-
-        case cmd_why:
-            rc = handle_why(rsc, node);
-            break;
-
-        case cmd_clear:
-            rc = handle_clear(node);
-            break;
-
-        case cmd_move:
-            rc = handle_move(rsc, node);
-            break;
-
         case cmd_ban:
             rc = handle_ban(rsc, node);
             break;
-
+        case cmd_cleanup:
+            rc = handle_cleanup(rsc, node);
+            break;
+        case cmd_clear:
+            rc = handle_clear(node);
+            break;
+        case cmd_colocations:
+            rc = handle_colocations(rsc);
+            break;
+        case cmd_cts:
+            rc = handle_cts();
+            break;
+        case cmd_delete:
+            rc = handle_delete();
+            break;
+        case cmd_delete_param:
+            rc = handle_delete_param(rsc, cib_xml_orig);
+            break;
+        case cmd_digests:
+            rc = handle_digests(rsc, node);
+            break;
+        case cmd_execute_agent:
+            rc = handle_execute_agent(rsc);
+            break;
+        case cmd_fail:
+            rc = handle_fail(node);
+            break;
         case cmd_get_param:
             // coverity[var_deref_model] False positive
             rc = handle_get_param(rsc);
             break;
-
-        case cmd_set_param:
-            rc = handle_set_param(rsc, cib_xml_orig);
+        case cmd_list_active_ops:
+            rc = handle_list_active_ops(node);
             break;
-
-        case cmd_delete_param:
-            rc = handle_delete_param(rsc, cib_xml_orig);
+        case cmd_list_agents:
+            rc = handle_list_agents();
             break;
-
-        case cmd_cleanup:
-            rc = handle_cleanup(rsc, node);
+        case cmd_list_all_ops:
+            rc = handle_list_all_ops(node);
             break;
-
+        case cmd_list_alternatives:
+            rc = handle_list_alternatives();
+            break;
+        case cmd_list_instances:
+            rc = handle_list_instances();
+            break;
+        case cmd_list_providers:
+            rc = handle_list_providers();
+            break;
+        case cmd_list_options:
+            rc = handle_list_options();
+            break;
+        case cmd_list_resources:
+            rc = handle_list_resources();
+            break;
+        case cmd_list_standards:
+            rc = handle_list_standards();
+            break;
+        case cmd_locate:
+            rc = handle_locate(rsc);
+            break;
+        case cmd_metadata:
+            rc = handle_metadata();
+            break;
+        case cmd_move:
+            rc = handle_move(rsc, node);
+            break;
+        case cmd_query_xml:
+            rc = handle_query_xml(rsc);
+            break;
+        case cmd_query_xml_raw:
+            rc = handle_query_xml_raw(rsc);
+            break;
         case cmd_refresh:
             rc = handle_refresh(rsc, node);
             break;
-
-        case cmd_delete:
-            rc = handle_delete();
+        case cmd_restart:
+            rc = handle_restart(rsc, node);
             break;
-
+        case cmd_set_param:
+            rc = handle_set_param(rsc, cib_xml_orig);
+            break;
+        case cmd_wait:
+            rc = handle_wait();
+            break;
+        case cmd_why:
+            rc = handle_why(rsc, node);
+            break;
         default:
             exit_code = CRM_EX_USAGE;
             g_set_error(&error, PCMK__EXITC_ERROR, exit_code,

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1839,21 +1839,21 @@ main(int argc, char **argv)
             goto done;
         }
 
-        for (gchar **s = options.remainder; *s; s++) {
-            char *name = pcmk__assert_alloc(1, strlen(*s));
-            char *value = pcmk__assert_alloc(1, strlen(*s));
-            int rc = sscanf(*s, "%[^=]=%s", name, value);
+        for (gchar **arg = options.remainder; *arg != NULL; arg++) {
+            gchar *name = NULL;
+            gchar *value = NULL;
+            int rc = pcmk__scan_nvpair(*arg, &name, &value);
 
-            if (rc != 2) {
+            if (rc != pcmk_rc_ok) {
                 exit_code = CRM_EX_USAGE;
                 g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                            _("Error parsing '%s' as a name=value pair"),
-                            argv[optind]);
-                free(value);
-                free(name);
+                            _("Error parsing '%s' as a name=value pair"), *arg);
                 goto done;
             }
-            g_hash_table_replace(options.override_params, name, value);
+
+            pcmk__insert_dup(options.override_params, name, value);
+            g_free(name);
+            g_free(value);
         }
     }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1990,9 +1990,8 @@ main(int argc, char **argv)
 
         case cmd_cleanup:
             if (rsc == NULL) {
-                rc = cli_cleanup_all(controld_api, options.host_uname,
-                                     options.operation, options.interval_spec,
-                                     scheduler);
+                rc = cli_cleanup_all(controld_api, node, options.operation,
+                                     options.interval_spec, scheduler);
                 if (rc == pcmk_rc_ok) {
                     start_mainloop(controld_api);
                 }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1729,6 +1729,13 @@ handle_wait(void)
     return wait_till_stable(out, options.timeout_ms, cib_conn);
 }
 
+static int
+handle_why(pcmk_resource_t *rsc, pcmk_node_t *node)
+{
+    return out->message(out, "resource-reasons-list",
+                        scheduler->priv->resources, rsc, node);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2158,8 +2165,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_why:
-            rc = out->message(out, "resource-reasons-list",
-                              scheduler->priv->resources, rsc, node);
+            rc = handle_why(rsc, node);
             break;
 
         case cmd_clear:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1582,6 +1582,15 @@ handle_list_active_ops(const pcmk_node_t *node)
                                          scheduler);
 }
 
+static int
+handle_list_all_ops(const pcmk_node_t *node)
+{
+    const char *node_name = (node != NULL)? node->priv->name : NULL;
+
+    return cli_resource_print_operations(options.rsc_id, node_name, false,
+                                         scheduler);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2021,12 +2030,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_all_ops:
-            {
-                const char *node_name = (node != NULL)? node->priv->name : NULL;
-
-                rc = cli_resource_print_operations(options.rsc_id, node_name,
-                                                   false, scheduler);
-            }
+            rc = handle_list_all_ops(node);
             break;
 
         case cmd_locate: {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1683,6 +1683,16 @@ handle_query_xml_raw(pcmk_resource_t *rsc)
     return cli_resource_print(rsc, scheduler, false);
 }
 
+static int
+handle_refresh(pcmk_resource_t *rsc, pcmk_node_t *node)
+{
+    if (rsc == NULL) {
+        return refresh(out, node);
+    }
+    refresh_resource(out, rsc, node);
+    return pcmk_rc_ok;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2169,11 +2179,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_refresh:
-            if (rsc == NULL) {
-                rc = refresh(out, node);
-            } else {
-                refresh_resource(out, rsc, node);
-            }
+            rc = handle_refresh(rsc, node);
             break;
 
         case cmd_delete:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1436,6 +1436,32 @@ handle_cts(void)
     return pcmk_rc_ok;
 }
 
+static int
+handle_delete(void)
+{
+    /* rsc_id was already checked for NULL much earlier when validating command
+     * line arguments
+     */
+    int rc = pcmk_rc_ok;
+
+    if (options.rsc_type == NULL) {
+        exit_code = CRM_EX_USAGE;
+        g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
+                    _("You need to specify a resource type with -t"));
+
+    } else {
+        rc = pcmk__resource_delete(cib_conn, cib_sync_call, options.rsc_id,
+                                   options.rsc_type);
+
+        if (rc != pcmk_rc_ok) {
+            g_set_error(&error, PCMK__RC_ERROR, rc,
+                        _("Could not delete resource %s: %s"),
+                        options.rsc_id, pcmk_rc_str(rc));
+        }
+    }
+    return rc;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2049,24 +2075,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_delete:
-            /* rsc_id was already checked for NULL much earlier when validating
-             * command line arguments.
-             */
-            if (options.rsc_type == NULL) {
-                exit_code = CRM_EX_USAGE;
-                g_set_error(&error, PCMK__EXITC_ERROR, CRM_EX_USAGE,
-                            _("You need to specify a resource type with -t"));
-            } else {
-                rc = pcmk__resource_delete(cib_conn, cib_sync_call,
-                                           options.rsc_id, options.rsc_type);
-
-                if (rc != pcmk_rc_ok) {
-                    g_set_error(&error, PCMK__RC_ERROR, rc,
-                                _("Could not delete resource %s: %s"),
-                                options.rsc_id, pcmk_rc_str(rc));
-                }
-            }
-
+            rc = handle_delete();
             break;
 
         default:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1796,12 +1796,8 @@ main(int argc, char **argv)
             goto done;
 
         case cmd_digests:
-            if (node == NULL) {
-                rc = pcmk_rc_node_unknown;
-            } else {
-                rc = pcmk__resource_digests(out, rsc, node,
-                                            options.override_params);
-            }
+            rc = pcmk__resource_digests(out, rsc, node,
+                                        options.override_params);
             break;
 
         case cmd_colocations:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1419,6 +1419,13 @@ handle_clear(const pcmk_node_t *node)
     return rc;
 }
 
+static int
+handle_colocations(pcmk_resource_t *rsc)
+{
+    return out->message(out, "locations-and-colocations", rsc,
+                        options.recursive, options.force);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1854,8 +1861,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_colocations:
-            rc = out->message(out, "locations-and-colocations", rsc,
-                              options.recursive, (bool) options.force);
+            rc = handle_colocations(rsc);
             break;
 
         case cmd_cts:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1866,10 +1866,10 @@ main(int argc, char **argv)
             break;
 
         case cmd_move:
-            if (options.host_uname == NULL) {
+            if (node == NULL) {
                 rc = ban_or_move(out, rsc, options.move_lifetime);
             } else {
-                rc = cli_resource_move(rsc, options.rsc_id, options.host_uname,
+                rc = cli_resource_move(rsc, options.rsc_id, node,
                                        options.move_lifetime, cib_conn,
                                        scheduler, options.promoted_role_only,
                                        options.force);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1693,6 +1693,18 @@ handle_refresh(pcmk_resource_t *rsc, pcmk_node_t *node)
     return pcmk_rc_ok;
 }
 
+static int
+handle_restart(pcmk_resource_t *rsc, const pcmk_node_t *node)
+{
+    /* We don't pass scheduler because rsc needs to stay valid for the entire
+     * lifetime of cli_resource_restart(), but it will reset and update the
+     * scheduler data multiple times, so it needs to use its own copy.
+     */
+    return cli_resource_restart(out, rsc, node, options.move_lifetime,
+                                options.timeout_ms, cib_conn,
+                                options.promoted_role_only, options.force);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2074,15 +2086,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_restart:
-            /* We don't pass scheduler because rsc needs to stay valid for the
-             * entire lifetime of cli_resource_restart(), but it will reset and
-             * update the scheduler data multiple times, so it needs to use its
-             * own copy.
-             */
-            rc = cli_resource_restart(out, rsc, node, options.move_lifetime,
-                                      options.timeout_ms, cib_conn,
-                                      options.promoted_role_only,
-                                      options.force);
+            rc = handle_restart(rsc, node);
             break;
 
         case cmd_wait:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1651,6 +1651,26 @@ handle_metadata(void)
     return rc;
 }
 
+static int
+handle_move(pcmk_resource_t *rsc, const pcmk_node_t *node)
+{
+    int rc = pcmk_rc_ok;
+
+    if (node == NULL) {
+        rc = ban_or_move(out, rsc, options.move_lifetime);
+    } else {
+        rc = cli_resource_move(rsc, options.rsc_id, node, options.move_lifetime,
+                               cib_conn, scheduler, options.promoted_role_only,
+                               options.force);
+    }
+
+    if (rc == EINVAL) {
+        exit_code = CRM_EX_USAGE;
+        return pcmk_rc_ok;
+    }
+    return rc;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2097,20 +2117,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_move:
-            if (node == NULL) {
-                rc = ban_or_move(out, rsc, options.move_lifetime);
-            } else {
-                rc = cli_resource_move(rsc, options.rsc_id, node,
-                                       options.move_lifetime, cib_conn,
-                                       scheduler, options.promoted_role_only,
-                                       options.force);
-            }
-
-            if (rc == EINVAL) {
-                exit_code = CRM_EX_USAGE;
-                goto done;
-            }
-
+            rc = handle_move(rsc, node);
             break;
 
         case cmd_ban:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1512,6 +1512,12 @@ handle_list_active_ops(const pcmk_node_t *node)
 }
 
 static int
+handle_list_agents(void)
+{
+    return pcmk__list_agents(out, options.agent_spec);
+}
+
+static int
 handle_list_all_ops(const pcmk_node_t *node)
 {
     const char *node_name = (node != NULL)? node->priv->name : NULL;
@@ -2010,7 +2016,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_agents:
-            rc = pcmk__list_agents(out, options.agent_spec);
+            rc = handle_list_agents();
             break;
 
         case cmd_list_standards:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1426,6 +1426,16 @@ handle_colocations(pcmk_resource_t *rsc)
                         options.recursive, options.force);
 }
 
+static int
+handle_cts(void)
+{
+    // coverity[var_deref_op] False positive
+    g_list_foreach(scheduler->priv->resources, (GFunc) cli_resource_print_cts,
+                   out);
+    cli_resource_print_cts_constraints(scheduler);
+    return pcmk_rc_ok;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1865,11 +1875,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_cts:
-            rc = pcmk_rc_ok;
-            // coverity[var_deref_op] False positive
-            g_list_foreach(scheduler->priv->resources,
-                           (GFunc) cli_resource_print_cts, out);
-            cli_resource_print_cts_constraints(scheduler);
+            rc = handle_cts();
             break;
 
         case cmd_fail:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -772,6 +772,12 @@ option_cb(const gchar *option_name, const gchar *optarg, gpointer data,
     if (pcmk__scan_nvpair(optarg, &name, &value) != pcmk_rc_ok) {
         return FALSE;
     }
+
+    /* services__create_resource_action() ultimately takes ownership of
+     * options.cmdline_params. It's not worth trying to ensure that the entire
+     * call path uses (gchar *) strings and g_free(). So create the table for
+     * (char *) strings, and duplicate the (gchar *) strings when inserting.
+     */
     if (options.cmdline_params == NULL) {
         options.cmdline_params = pcmk__strkey_table(free, free);
     }
@@ -1902,7 +1908,6 @@ main(int argc, char **argv)
         g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                     _("--option must be used with --validate and without -r"));
         g_hash_table_destroy(options.cmdline_params);
-        options.cmdline_params = NULL;
         goto done;
     }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1472,6 +1472,12 @@ handle_delete_param(pcmk_resource_t *rsc, xmlNode *cib_xml_orig)
                                          cib_xml_orig, options.force);
 }
 
+static int
+handle_digests(pcmk_resource_t *rsc, const pcmk_node_t *node)
+{
+    return pcmk__resource_digests(out, rsc, node, options.override_params);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1902,8 +1908,7 @@ main(int argc, char **argv)
             goto done;
 
         case cmd_digests:
-            rc = pcmk__resource_digests(out, rsc, node,
-                                        options.override_params);
+            rc = handle_digests(rsc, node);
             break;
 
         case cmd_colocations:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -939,26 +939,6 @@ initialize_scheduler_data(xmlNode **cib_xml_orig)
     return pcmk_rc_ok;
 }
 
-static void
-list_options(void)
-{
-    switch (options.opt_list) {
-        case pcmk__opt_fencing:
-            exit_code = pcmk_rc2exitc(pcmk__list_fencing_params(out,
-                                                                options.all));
-            break;
-        case pcmk__opt_primitive:
-            exit_code = pcmk_rc2exitc(pcmk__list_primitive_meta(out,
-                                                                options.all));
-            break;
-        default:
-            exit_code = CRM_EX_SOFTWARE;
-            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                        "BUG: Invalid option list type");
-            break;
-    }
-}
-
 static int
 refresh(pcmk__output_t *out, const pcmk_node_t *node)
 {
@@ -1608,6 +1588,22 @@ handle_list_instances(void)
     return pcmk_rc_ok;
 }
 
+static int
+handle_list_options(void)
+{
+    switch (options.opt_list) {
+        case pcmk__opt_fencing:
+            return pcmk__list_fencing_params(out, options.all);
+        case pcmk__opt_primitive:
+            return pcmk__list_primitive_meta(out, options.all);
+        default:
+            exit_code = CRM_EX_SOFTWARE;
+            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                        "BUG: Invalid option list type");
+            return pcmk_rc_ok;
+    }
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1976,7 +1972,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_options:
-            list_options();
+            rc = handle_list_options();
             break;
 
         case cmd_list_alternatives:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1671,6 +1671,18 @@ handle_move(pcmk_resource_t *rsc, const pcmk_node_t *node)
     return rc;
 }
 
+static int
+handle_query_xml(pcmk_resource_t *rsc)
+{
+    return cli_resource_print(rsc, scheduler, true);
+}
+
+static int
+handle_query_xml_raw(pcmk_resource_t *rsc)
+{
+    return cli_resource_print(rsc, scheduler, false);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2100,11 +2112,11 @@ main(int argc, char **argv)
             break;
 
         case cmd_query_xml:
-            rc = cli_resource_print(rsc, scheduler, true);
+            rc = handle_query_xml(rsc);
             break;
 
         case cmd_query_xml_raw:
-            rc = cli_resource_print(rsc, scheduler, false);
+            rc = handle_query_xml_raw(rsc);
             break;
 
         case cmd_why:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1610,6 +1610,24 @@ handle_list_providers(void)
     return pcmk__list_providers(out, options.agent_spec);
 }
 
+static int
+handle_list_resources(void)
+{
+    GList *all = g_list_prepend(NULL, (gpointer) "*");
+    int rc = out->message(out, "resource-list", scheduler,
+                          pcmk_show_inactive_rscs
+                          |pcmk_show_rsc_only
+                          |pcmk_show_pending,
+                          true, all, all, false);
+
+    g_list_free(all);
+
+    if (rc == pcmk_rc_no_output) {
+        rc = ENXIO;
+    }
+    return rc;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -1958,20 +1976,9 @@ main(int argc, char **argv)
      * setting exit_code based on rc after the switch.
      */
     switch (options.rsc_cmd) {
-        case cmd_list_resources: {
-            GList *all = NULL;
-            uint32_t show_opts = pcmk_show_inactive_rscs | pcmk_show_rsc_only | pcmk_show_pending;
-
-            all = g_list_prepend(all, (gpointer) "*");
-            rc = out->message(out, "resource-list", scheduler,
-                              show_opts, true, all, all, false);
-            g_list_free(all);
-
-            if (rc == pcmk_rc_no_output) {
-                rc = ENXIO;
-            }
+        case cmd_list_resources:
+            rc = handle_list_resources();
             break;
-        }
 
         case cmd_list_instances:
             rc = handle_list_instances();

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -901,9 +901,9 @@ cleanup(pcmk__output_t *out, pcmk_resource_t *rsc, pcmk_node_t *node)
 
     crm_debug("Erasing failures of %s (%s requested) on %s",
               rsc->id, options.rsc_id, (options.host_uname? options.host_uname: "all nodes"));
-    rc = cli_resource_delete(controld_api, options.host_uname, rsc,
-                             options.operation, options.interval_spec, TRUE,
-                             scheduler, options.force);
+    rc = cli_resource_delete(controld_api, node, rsc, options.operation,
+                             options.interval_spec, true, scheduler,
+                             options.force);
 
     if ((rc == pcmk_rc_ok) && !out->is_quiet(out)) {
         // Show any reasons why resource might stay stopped
@@ -1076,8 +1076,8 @@ refresh_resource(pcmk__output_t *out, pcmk_resource_t *rsc, pcmk_node_t *node)
 
     crm_debug("Re-checking the state of %s (%s requested) on %s",
               rsc->id, options.rsc_id, (options.host_uname? options.host_uname: "all nodes"));
-    rc = cli_resource_delete(controld_api, options.host_uname, rsc, NULL, 0,
-                             FALSE, scheduler, options.force);
+    rc = cli_resource_delete(controld_api, node, rsc, NULL, 0, false, scheduler,
+                             options.force);
 
     if ((rc == pcmk_rc_ok) && !out->is_quiet(out)) {
         // Show any reasons why resource might stay stopped

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1723,6 +1723,12 @@ handle_set_param(pcmk_resource_t *rsc, xmlNode *cib_xml_orig)
                                          cib_xml_orig, options.force);
 }
 
+static int
+handle_wait(void)
+{
+    return wait_till_stable(out, options.timeout_ms, cib_conn);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2108,7 +2114,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_wait:
-            rc = wait_till_stable(out, options.timeout_ms, cib_conn);
+            rc = handle_wait();
             break;
 
         case cmd_execute_agent:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1462,6 +1462,16 @@ handle_delete(void)
     return rc;
 }
 
+static int
+handle_delete_param(pcmk_resource_t *rsc, xmlNode *cib_xml_orig)
+{
+    /* coverity[var_deref_model] False positive */
+    return cli_resource_delete_attribute(rsc, options.rsc_id, options.prop_set,
+                                         options.attr_set_type, options.prop_id,
+                                         options.prop_name, cib_conn,
+                                         cib_xml_orig, options.force);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2053,13 +2063,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_delete_param:
-            /* coverity[var_deref_model] False positive */
-            rc = cli_resource_delete_attribute(rsc, options.rsc_id,
-                                               options.prop_set,
-                                               options.attr_set_type,
-                                               options.prop_id,
-                                               options.prop_name, cib_conn,
-                                               cib_xml_orig, options.force);
+            rc = handle_delete_param(rsc, cib_xml_orig);
             break;
 
         case cmd_cleanup:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1649,6 +1649,20 @@ main(int argc, char **argv)
             exit_code = pcmk_rc2exitc(rc);
             goto done;
         }
+
+        /* If user supplied a node name, check whether it exists.
+         * Commands that don't require scheduler data ignore the node argument.
+         */
+        if (options.host_uname != NULL) {
+            node = pcmk_find_node(scheduler, options.host_uname);
+
+            if (node == NULL) {
+                exit_code = CRM_EX_NOSUCH;
+                g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                            _("Node '%s' not found"), options.host_uname);
+                goto done;
+            }
+        }
     }
 
     find_flags = get_find_flags();
@@ -1674,18 +1688,6 @@ main(int argc, char **argv)
             exit_code = CRM_EX_INVALID_PARAM;
             g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                         _("Cannot operate on clone resource instance '%s'"), options.rsc_id);
-            goto done;
-        }
-    }
-
-    // If user supplied a node name, check whether it exists
-    if ((options.host_uname != NULL) && (scheduler != NULL)) {
-        node = pcmk_find_node(scheduler, options.host_uname);
-
-        if (node == NULL) {
-            exit_code = CRM_EX_NOSUCH;
-            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
-                        _("Node '%s' not found"), options.host_uname);
             goto done;
         }
     }

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1400,6 +1400,24 @@ handle_ban(pcmk_resource_t *rsc, const pcmk_node_t *node)
     return rc;
 }
 
+static int
+handle_cleanup(pcmk_resource_t *rsc, pcmk_node_t *node)
+{
+    if (rsc == NULL) {
+        int rc = cli_cleanup_all(controld_api, node, options.operation,
+                                 options.interval_spec, scheduler);
+
+        if (rc == pcmk_rc_ok) {
+            start_mainloop(controld_api);
+        }
+
+    } else {
+        cleanup(out, rsc, node);
+    }
+
+    return pcmk_rc_ok;
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2006,15 +2024,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_cleanup:
-            if (rsc == NULL) {
-                rc = cli_cleanup_all(controld_api, node, options.operation,
-                                     options.interval_spec, scheduler);
-                if (rc == pcmk_rc_ok) {
-                    start_mainloop(controld_api);
-                }
-            } else {
-                cleanup(out, rsc, node);
-            }
+            rc = handle_cleanup(rsc, node);
             break;
 
         case cmd_refresh:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1573,6 +1573,15 @@ handle_get_param(pcmk_resource_t *rsc)
     return rc;
 }
 
+static int
+handle_list_active_ops(const pcmk_node_t *node)
+{
+    const char *node_name = (node != NULL)? node->priv->name : NULL;
+
+    return cli_resource_print_operations(options.rsc_id, node_name, true,
+                                         scheduler);
+}
+
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
@@ -2008,12 +2017,7 @@ main(int argc, char **argv)
             break;
 
         case cmd_list_active_ops:
-            {
-                const char *node_name = (node != NULL)? node->priv->name : NULL;
-
-                rc = cli_resource_print_operations(options.rsc_id, node_name,
-                                                   true, scheduler);
-            }
+            rc = handle_list_active_ops(node);
             break;
 
         case cmd_list_all_ops:

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -312,7 +312,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
         options.rsc_cmd = cmd_digests;
 
         if (options.override_params == NULL) {
-            options.override_params = pcmk__strkey_table(free, free);
+            options.override_params = pcmk__strkey_table(g_free, g_free);
         }
 
     } else if (pcmk__str_any_of(option_name,
@@ -325,7 +325,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
         options.operation = g_strdup(option_name + 2);  // skip "--"
 
         if (options.override_params == NULL) {
-            options.override_params = pcmk__strkey_table(free, free);
+            options.override_params = pcmk__strkey_table(g_free, g_free);
         }
 
         if (optarg != NULL) {
@@ -1851,9 +1851,7 @@ main(int argc, char **argv)
                 goto done;
             }
 
-            pcmk__insert_dup(options.override_params, name, value);
-            g_free(name);
-            g_free(value);
+            g_hash_table_insert(options.override_params, name, value);
         }
     }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1796,7 +1796,6 @@ main(int argc, char **argv)
             goto done;
 
         case cmd_digests:
-            node = pcmk_find_node(scheduler, options.host_uname);
             if (node == NULL) {
                 rc = pcmk_rc_node_unknown;
             } else {

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -101,7 +101,7 @@ int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                          guint timeout_ms, cib_t *cib,
                          gboolean promoted_role_only, gboolean force);
 int cli_resource_move(const pcmk_resource_t *rsc, const char *rsc_id,
-                      const char *host_name, const char *move_lifetime,
+                      const pcmk_node_t *node, const char *move_lifetime,
                       cib_t *cib, pcmk_scheduler_t *scheduler,
                       bool promoted_role_only, bool force);
 crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -92,7 +92,7 @@ GList *cli_resource_search(pcmk_resource_t *rsc, const char *requested_name,
 int cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
                         const pcmk_resource_t *rsc, const char *operation,
                         const char *interval_spec, bool just_failures,
-                        pcmk_scheduler_t *scheduler, gboolean force);
+                        pcmk_scheduler_t *scheduler, bool force);
 int cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
                     const char *operation, const char *interval_spec,
                     pcmk_scheduler_t *scheduler);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -89,7 +89,7 @@ int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
                       const char *rsc_id, pcmk_scheduler_t *scheduler);
 GList *cli_resource_search(pcmk_resource_t *rsc, const char *requested_name,
                              pcmk_scheduler_t *scheduler);
-int cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
+int cli_resource_delete(pcmk_ipc_api_t *controld_api, const pcmk_node_t *node,
                         const pcmk_resource_t *rsc, const char *operation,
                         const char *interval_spec, bool just_failures,
                         pcmk_scheduler_t *scheduler, bool force);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -93,7 +93,7 @@ int cli_resource_delete(pcmk_ipc_api_t *controld_api, const pcmk_node_t *node,
                         const pcmk_resource_t *rsc, const char *operation,
                         const char *interval_spec, bool just_failures,
                         pcmk_scheduler_t *scheduler, bool force);
-int cli_cleanup_all(pcmk_ipc_api_t *controld_api, const char *node_name,
+int cli_cleanup_all(pcmk_ipc_api_t *controld_api, const pcmk_node_t *node,
                     const char *operation, const char *interval_spec,
                     pcmk_scheduler_t *scheduler);
 int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -85,7 +85,7 @@ int cli_resource_print_operations(const char *rsc_id, const char *host_uname,
 /* runtime */
 int cli_resource_check(pcmk__output_t *out, pcmk_resource_t *rsc,
                        pcmk_node_t *node);
-int cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
+int cli_resource_fail(pcmk_ipc_api_t *controld_api, const pcmk_node_t *node,
                       const char *rsc_id, pcmk_scheduler_t *scheduler);
 GList *cli_resource_search(pcmk_resource_t *rsc, const char *requested_name,
                              pcmk_scheduler_t *scheduler);

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -103,7 +103,7 @@ int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
 int cli_resource_move(const pcmk_resource_t *rsc, const char *rsc_id,
                       const char *host_name, const char *move_lifetime,
                       cib_t *cib, pcmk_scheduler_t *scheduler,
-                      gboolean promoted_role_only, gboolean force);
+                      bool promoted_role_only, bool force);
 crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                             const char *rsc_class, const char *rsc_prov,
                                             const char *rsc_type, const char *rsc_action,

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -362,6 +362,7 @@ override_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
+// Does not modify overrides or its contents
 PCMK__OUTPUT_ARGS("resource-agent-action", "int", "const char *", "const char *",
                   "const char *", "const char *", "const char *", "GHashTable *",
                   "crm_exit_t", "int", "const char *", "const char *", "const char *")
@@ -422,6 +423,7 @@ resource_agent_action_default(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
+// Does not modify overrides or its contents
 PCMK__OUTPUT_ARGS("resource-agent-action", "int", "const char *", "const char *",
                   "const char *", "const char *", "const char *", "GHashTable *",
                   "crm_exit_t", "int", "const char *", "const char *", "const char *")

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -2395,25 +2395,20 @@ cli_resource_execute(pcmk_resource_t *rsc, const char *requested_name,
 // \return Standard Pacemaker return code
 int
 cli_resource_move(const pcmk_resource_t *rsc, const char *rsc_id,
-                  const char *host_name, const char *move_lifetime, cib_t *cib,
-                  pcmk_scheduler_t *scheduler, bool promoted_role_only,
-                  bool force)
+                  const pcmk_node_t *dest, const char *move_lifetime,
+                  cib_t *cib, pcmk_scheduler_t *scheduler,
+                  bool promoted_role_only, bool force)
 {
     pcmk__output_t *out = NULL;
     int rc = pcmk_rc_ok;
     unsigned int count = 0;
     pcmk_node_t *current = NULL;
-    pcmk_node_t *dest = NULL;
     bool cur_is_dest = false;
     const char *active_s = promoted_role_only? "promoted" : "active";
 
-    pcmk__assert(scheduler != NULL);
+    pcmk__assert((dest != NULL) && (scheduler != NULL));
 
     out = scheduler->priv->out;
-    dest = pcmk_find_node(scheduler, host_name);
-    if (dest == NULL) {
-        return pcmk_rc_node_unknown;
-    }
 
     if (promoted_role_only
         && !pcmk_is_set(rsc->flags, pcmk__rsc_promotable)) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -2238,7 +2238,9 @@ apply_overrides(GHashTable *params, GHashTable *overrides)
     }
 }
 
-// Does not modify override_hash or its contents
+/* Takes ownership of params.
+ * Does not modify override_hash or its contents.
+ */
 crm_exit_t
 cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                  const char *rsc_class, const char *rsc_prov,
@@ -2260,6 +2262,7 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
     set_agent_environment(params, timeout_ms, check_level, resource_verbose);
     apply_overrides(params, override_hash);
 
+    // services__create_resource_action() takes ownership of params on success
     op = services__create_resource_action(rsc_name? rsc_name : "test",
                                           rsc_class, rsc_prov, rsc_type, action,
                                           0, QB_MIN(timeout_ms, INT_MAX),

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -978,8 +978,7 @@ cli_resource_delete(pcmk_ipc_api_t *controld_api, const char *host_uname,
 
         if (nodes == NULL) {
             if (force) {
-                // @FIXME This leaks memory
-                nodes = pcmk__copy_node_list(scheduler->nodes, false);
+                nodes = g_list_copy(scheduler->nodes);
 
             } else if (pcmk_is_set(rsc->flags, pcmk__rsc_exclusive_probes)) {
                 GHashTableIter iter;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1241,11 +1241,14 @@ cli_resource_check(pcmk__output_t *out, pcmk_resource_t *rsc, pcmk_node_t *node)
 
 // \return Standard Pacemaker return code
 int
-cli_resource_fail(pcmk_ipc_api_t *controld_api, const char *host_uname,
+cli_resource_fail(pcmk_ipc_api_t *controld_api, const pcmk_node_t *node,
                   const char *rsc_id, pcmk_scheduler_t *scheduler)
 {
-    crm_notice("Failing %s on %s", rsc_id, host_uname);
-    return send_lrm_rsc_op(controld_api, true, host_uname, rsc_id, scheduler);
+    pcmk__assert(node != NULL);
+
+    crm_notice("Failing %s on %s", rsc_id, pcmk__node_name(node));
+    return send_lrm_rsc_op(controld_api, true, node->priv->name, rsc_id,
+                           scheduler);
 }
 
 static GHashTable *

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -2238,6 +2238,7 @@ apply_overrides(GHashTable *params, GHashTable *overrides)
     }
 }
 
+// Does not modify override_hash or its contents
 crm_exit_t
 cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                  const char *rsc_class, const char *rsc_prov,
@@ -2330,6 +2331,7 @@ get_action_timeout(pcmk_resource_t *rsc, const char *action)
     return (guint) QB_MIN(timeout_ms, UINT_MAX);
 }
 
+// Does not modify override_hash or its contents
 crm_exit_t
 cli_resource_execute(pcmk_resource_t *rsc, const char *requested_name,
                      const char *rsc_action, GHashTable *override_hash,


### PR DESCRIPTION
Coverity is throwing some new false positives in https://github.com/ClusterLabs/pacemaker/pull/3832. Two of them are in code that I actually modified, but a lot more are in totally unrelated code in `crm_resource`. It's flagging NULL dereferences along code paths that are verifiably impossible to reach.

We could add Coverity suppressions. But false positives are often a sign that the code is too hard to follow in the first place. And I think that's the case here.

The changes that I've started on also happen to be first steps toward moving more functionality into libpacemaker.

The first few commits focus on avoiding passing around `options.host_uname` as much as possible. Coverity was complaining; it gets confusing to verify that it's non-NULL when it's supposed to be; and we're duplicating work with node lookups. Later commits mostly focus on breaking out the switch statement in `main()` into handler functions.

There's a lot more work to be done. For example, the new handler function bodies were basically copy-pasted from `main()`. They take as arguments only the things that were not already global. (For example, they don't take `out` as an argument, because it's a global variable.)

I haven't decided on what the end state will be. It might be a function table like we use for processing CIB operations. And there might be a set of enum flags that determine what objects (CIB connection, scheduler data, resource and node arguments, etc.) each operation needs or supports. That way we can run the necessary setup steps right before the operation, instead of calling `is_scheduler_required()` (etc.) near the top of `main()`.