### PR TITLE
Fix: libpe_status: consider parents of an unmanaged resource active on the node

### DIFF
--- a/cts/scheduler/summary/stop-failure-no-fencing.summary
+++ b/cts/scheduler/summary/stop-failure-no-fencing.summary
@@ -9,6 +9,9 @@ Current cluster status:
   * Full List of Resources:
     * Clone Set: dlm-clone [dlm]:
       * Stopped: [ pcmk-1 pcmk-2 pcmk-3 pcmk-4 ]
+    * Clone Set: clvm-clone [clvm]:
+      * clvm	(lsb:clvmd):	 FAILED pcmk-3 (UNCLEAN, blocked)
+      * Stopped: [ pcmk-1 pcmk-2 pcmk-4 ]
     * ClusterIP	(ocf:heartbeat:IPaddr2):	 Stopped
 
 Transition Summary:
@@ -24,4 +27,7 @@ Revised Cluster Status:
   * Full List of Resources:
     * Clone Set: dlm-clone [dlm]:
       * Stopped: [ pcmk-1 pcmk-2 pcmk-3 pcmk-4 ]
+    * Clone Set: clvm-clone [clvm]:
+      * clvm	(lsb:clvmd):	 FAILED pcmk-3 (UNCLEAN, blocked)
+      * Stopped: [ pcmk-1 pcmk-2 pcmk-4 ]
     * ClusterIP	(ocf:heartbeat:IPaddr2):	 Stopped

--- a/cts/scheduler/summary/stop-failure-no-quorum.summary
+++ b/cts/scheduler/summary/stop-failure-no-quorum.summary
@@ -13,7 +13,7 @@ Current cluster status:
     * Clone Set: clvm-clone [clvm]:
       * clvm	(lsb:clvmd):	 FAILED pcmk-2
       * clvm	(lsb:clvmd):	 FAILED pcmk-3 (UNCLEAN, blocked)
-      * Stopped: [ pcmk-1 pcmk-3 pcmk-4 ]
+      * Stopped: [ pcmk-1 pcmk-4 ]
     * ClusterIP	(ocf:heartbeat:IPaddr2):	 Stopped
     * Fencing	(stonith:fence_xvm):	 Stopped
 
@@ -41,5 +41,8 @@ Revised Cluster Status:
   * Full List of Resources:
     * Clone Set: dlm-clone [dlm]:
       * Stopped: [ pcmk-1 pcmk-2 pcmk-3 pcmk-4 ]
+    * Clone Set: clvm-clone [clvm]:
+      * clvm	(lsb:clvmd):	 FAILED pcmk-3 (UNCLEAN, blocked)
+      * Stopped: [ pcmk-1 pcmk-2 pcmk-4 ]
     * ClusterIP	(ocf:heartbeat:IPaddr2):	 Stopped
     * Fencing	(stonith:fence_xvm):	 Stopped

--- a/cts/scheduler/summary/unmanaged-promoted.summary
+++ b/cts/scheduler/summary/unmanaged-promoted.summary
@@ -9,7 +9,6 @@ Current cluster status:
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-4 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-2 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-1 (unmanaged)
-      * Stopped: [ pcmk-3 pcmk-4 ]
     * Resource Group: group-1 (unmanaged):
       * r192.168.122.126	(ocf:heartbeat:IPaddr):	 Started pcmk-2 (unmanaged)
       * r192.168.122.127	(ocf:heartbeat:IPaddr):	 Started pcmk-2 (unmanaged)
@@ -25,13 +24,11 @@ Current cluster status:
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-4 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-2 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
-      * Stopped: [ pcmk-3 pcmk-4 ]
     * Clone Set: master-1 [stateful-1] (promotable, unmanaged):
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-3 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-1 (unmanaged)
-      * Stopped: [ pcmk-3 pcmk-4 ]
 
 Transition Summary:
 
@@ -50,7 +47,6 @@ Revised Cluster Status:
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-4 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-2 (unmanaged)
       * FencingChild	(stonith:fence_xvm):	 Started pcmk-1 (unmanaged)
-      * Stopped: [ pcmk-3 pcmk-4 ]
     * Resource Group: group-1 (unmanaged):
       * r192.168.122.126	(ocf:heartbeat:IPaddr):	 Started pcmk-2 (unmanaged)
       * r192.168.122.127	(ocf:heartbeat:IPaddr):	 Started pcmk-2 (unmanaged)
@@ -66,10 +62,8 @@ Revised Cluster Status:
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-4 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-2 (unmanaged)
       * ping-1	(ocf:pacemaker:ping):	 Started pcmk-1 (unmanaged)
-      * Stopped: [ pcmk-3 pcmk-4 ]
     * Clone Set: master-1 [stateful-1] (promotable, unmanaged):
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-3 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-4 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Promoted pcmk-2 (unmanaged)
       * stateful-1	(ocf:pacemaker:Stateful):	 Unpromoted pcmk-1 (unmanaged)
-      * Stopped: [ pcmk-3 pcmk-4 ]

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -120,7 +120,7 @@ native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
         resource_location(rsc, node, PCMK_SCORE_INFINITY,
                           "not_managed_default", scheduler);
 
-        while(p && node->details->online) {
+        while(p) {
             /* add without the additional location constraint */
             p->priv->active_nodes = g_list_append(p->priv->active_nodes, node);
             p = p->priv->parent;


### PR DESCRIPTION
... even if the node is offline.

Previously, parents of an unmanaged resource were not added to the node
if the node was offline. So that for instance a resource group in
`maintenance` mode as a whole would not be displayed by
crm_mon/crm_simulate at all.