### PR TITLE
scandir() fixes for schema transformations

### DIFF
--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -284,9 +284,9 @@ wrap_libxslt(bool finalize)
 static int
 transform_filter(const struct dirent *entry)
 {
-    return pcmk__str_eq(entry->d_name,
-                        "upgrade-[[:digit:]]+.[[:digit:]]+-[[:digit:]]+.xsl",
-                        pcmk__str_regex)? 1 : 0;
+    const char *re = "upgrade-[[:digit:]]+\\.[[:digit:]]+-[[:digit:]]+\\.xsl";
+
+    return pcmk__str_eq(entry->d_name, re, pcmk__str_regex)? 1 : 0;
 }
 
 /*!


### PR DESCRIPTION
Currently this fails the `pcmk__schema_files_later_than_test.c:valid_name()` unit test on FreeBSD. Since we don't get access to CI builders anymore, I'm not sure where to begin other than setting up a FreeBSD VM and learning how to compile C code on it. I guess I'll thoroughly inspect the POSIX and FreeBSD docs for each regexes and `sscanf()` and try to figure out what differs.