### PR TITLE
Prepare for the systemd+dbus PR

### DIFF
--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -820,6 +820,9 @@ action_complete(svc_action_t * action)
 #ifdef PCMK__TIME_USE_CGT
     const char *rclass = NULL;
     bool goagain = false;
+    int time_sum = 0;
+    int timeout_left = 0;
+    int delay = 0;
 #endif
 
     if (!cmd) {
@@ -922,59 +925,62 @@ action_complete(svc_action_t * action)
 #endif
 
 #ifdef PCMK__TIME_USE_CGT
-    if (goagain) {
-        int time_sum = time_diff_ms(NULL, &(cmd->t_first_run));
-        int timeout_left = cmd->timeout_orig - time_sum;
-        int delay = cmd->timeout_orig / 10;
+    if (!goagain) {
+        goto finalize;
+    }
 
-        if(delay >= timeout_left && timeout_left > 20) {
-            delay = timeout_left/2;
-        }
+    time_sum = time_diff_ms(NULL, &(cmd->t_first_run));
+    timeout_left = cmd->timeout_orig - time_sum;
+    delay = cmd->timeout_orig / 10;
 
-        delay = QB_MIN(2000, delay);
-        if (delay < timeout_left) {
-            cmd->start_delay = delay;
-            cmd->timeout = timeout_left;
+    if (delay >= timeout_left && timeout_left > 20) {
+        delay = timeout_left/2;
+    }
 
-            if (pcmk__result_ok(&(cmd->result))) {
-                crm_debug("%s %s may still be in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
-                          cmd->rsc_id, cmd->real_action, time_sum, timeout_left, delay);
+    delay = QB_MIN(2000, delay);
+    if (delay < timeout_left) {
+        cmd->start_delay = delay;
+        cmd->timeout = timeout_left;
 
-            } else if (cmd->result.execution_status == PCMK_EXEC_PENDING) {
-                crm_info("%s %s is still in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
-                         cmd->rsc_id, cmd->action, time_sum, timeout_left, delay);
+        if (pcmk__result_ok(&(cmd->result))) {
+            crm_debug("%s %s may still be in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
+                      cmd->rsc_id, cmd->real_action, time_sum, timeout_left, delay);
 
-            } else {
-                crm_notice("%s %s failed '%s' (%d): re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
-                           cmd->rsc_id, cmd->action,
-                           services_ocf_exitcode_str(cmd->result.exit_status),
-                           cmd->result.exit_status, time_sum, timeout_left,
-                           delay);
-            }
-
-            cmd_reset(cmd);
-            if(rsc) {
-                rsc->active = NULL;
-            }
-            schedule_lrmd_cmd(rsc, cmd);
-
-            /* Don't finalize cmd, we're not done with it yet */
-            return;
+        } else if (cmd->result.execution_status == PCMK_EXEC_PENDING) {
+            crm_info("%s %s is still in progress: re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
+                     cmd->rsc_id, cmd->action, time_sum, timeout_left, delay);
 
         } else {
-            crm_notice("Giving up on %s %s (rc=%d): timeout (elapsed=%dms, remaining=%dms)",
-                       cmd->rsc_id,
-                       (cmd->real_action? cmd->real_action : cmd->action),
-                       cmd->result.exit_status, time_sum, timeout_left);
-            pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
-                             PCMK_EXEC_TIMEOUT,
-                             "Investigate reason for timeout, and adjust "
-                             "configured operation timeout if necessary");
-            cmd_original_times(cmd);
+            crm_notice("%s %s failed '%s' (%d): re-scheduling (elapsed=%dms, remaining=%dms, start_delay=%dms)",
+                       cmd->rsc_id, cmd->action,
+                       services_ocf_exitcode_str(cmd->result.exit_status),
+                       cmd->result.exit_status, time_sum, timeout_left,
+                       delay);
         }
+
+        cmd_reset(cmd);
+        if (rsc) {
+            rsc->active = NULL;
+        }
+        schedule_lrmd_cmd(rsc, cmd);
+
+        /* Don't finalize cmd, we're not done with it yet */
+        return;
+
+    } else {
+        crm_notice("Giving up on %s %s (rc=%d): timeout (elapsed=%dms, remaining=%dms)",
+                   cmd->rsc_id,
+                   (cmd->real_action? cmd->real_action : cmd->action),
+                   cmd->result.exit_status, time_sum, timeout_left);
+        pcmk__set_result(&(cmd->result), PCMK_OCF_UNKNOWN_ERROR,
+                         PCMK_EXEC_TIMEOUT,
+                         "Investigate reason for timeout, and adjust "
+                         "configured operation timeout if necessary");
+        cmd_original_times(cmd);
     }
 #endif
 
+finalize:
     pcmk__set_result_output(&(cmd->result), services__grab_stdout(action),
                             services__grab_stderr(action));
     cmd_finalize(cmd, rsc);

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -294,12 +294,12 @@ pcmk_dbus_connect(void)
 void
 pcmk_dbus_disconnect(DBusConnection *connection)
 {
-    /* Per the DBus documentation, connections created with
-     * dbus_connection_open() are owned by libdbus and should never be closed.
-     *
-     * @TODO Should we call dbus_connection_unref() here?
+    /* We acquire our dbus connection with dbus_bus_get(), which makes it a
+     * shared connection.  Therefore, we can't close or free it here.  The
+     * best we can do is decrement the reference count so dbus knows when
+     * there are no more clients connected to it.
      */
-    return;
+    dbus_connection_unref(connection);
 }
 
 // Custom DBus error names to use

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -14,6 +14,7 @@
 #include <crm/services_internal.h>
 #include <crm/common/mainloop.h>
 
+#include <stdbool.h>
 #include <stdio.h>                  // fopen(), NULL, etc.
 #include <sys/stat.h>
 #include <gio/gio.h>
@@ -134,7 +135,7 @@ systemd_call_simple_method(const char *method)
     return reply;
 }
 
-static gboolean
+static bool
 systemd_init(void)
 {
     static int need_init = 1;
@@ -153,9 +154,9 @@ systemd_init(void)
         systemd_proxy = pcmk_dbus_connect();
     }
     if (systemd_proxy == NULL) {
-        return FALSE;
+        return false;
     }
-    return TRUE;
+    return true;
 }
 
 static inline char *
@@ -546,7 +547,7 @@ systemd_unit_listall(void)
     DBusMessageIter elem;
     DBusMessage *reply = NULL;
 
-    if (systemd_init() == FALSE) {
+    if (!systemd_init()) {
         return NULL;
     }
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -105,12 +105,14 @@ systemd_send_recv(DBusMessage *msg, DBusError *error, int timeout)
 static DBusMessage *
 systemd_call_simple_method(const char *method)
 {
-    DBusMessage *msg = systemd_new_method(method);
+    DBusMessage *msg = NULL;
     DBusMessage *reply = NULL;
     DBusError error;
 
     /* Don't call systemd_init() here, because that calls this */
     CRM_CHECK(systemd_proxy, return NULL);
+
+    msg = systemd_new_method(method);
 
     if (msg == NULL) {
         crm_err("Could not create message to send %s to systemd", method);


### PR DESCRIPTION
This builds on #3840 and I haven't tested it yet, so I'm marking it as a draft.  But I wanted to get it pushed so I could write down these notes.  This is the same as #3816 except for the following:

* [Refactor: daemons: Fix whitespace problems in execd_commands.c](https://github.com/ClusterLabs/pacemaker/pull/3816/commits/9138d96d027b42e95aa93b837479f3040158b95f) - doesn't apply, I think because the tabs were added by #3746
* [Refactor: daemons: Get rid of an unnecessary #endif/#ifdef.](https://github.com/ClusterLabs/pacemaker/pull/3816/commits/9151b51c50b16608df0b11102f047f2766841911) - doesn't apply, because the code between the #endif and #ifdef still exists due to nagios support.
* [Refactor: daemons: Unindent a block of code in action_complete.](https://github.com/ClusterLabs/pacemaker/pull/3816/commits/96e9f97e4926b126ebe731270c456a5dc6935290) - might or might not apply, but given that nagios support is still all over this function, this patch seems like it'll do more harm than good.
* [Refactor: daemons: Improve whitespace in action_complete.](https://github.com/ClusterLabs/pacemaker/pull/3816/commits/96e9bff3ff7b140c5fb208389b50f852039f3a16) - doesn't apply, also added by #3746