### PR TITLE
Fix: pacemaker-attrd: prevent segfault if a peer leaves when its name is unknown yet

### DIFF
--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -114,7 +114,7 @@ attrd_cpg_dispatch(cpg_handle_t handle,
     xml = pcmk__xml_parse(data);
 
     if (xml == NULL) {
-        crm_err("Bad message received from %s[%u]: '%.120s'",
+        crm_err("Bad message received from %s[%" PRIu32 "]: '%.120s'",
                 from, nodeid, data);
     } else {
         attrd_peer_message(pcmk__get_node(nodeid, from, NULL,

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -192,10 +192,16 @@ attrd_peer_change_cb(enum pcmk__node_update kind, pcmk__node_status_t *peer,
                 /* If we're the writer, send new peers a list of all attributes
                  * (unless it's a remote node, which doesn't run its own attrd)
                  */
-                if (attrd_election_won()
-                    && !pcmk_is_set(peer->flags, pcmk__node_status_remote)) {
-                    attrd_peer_sync(peer);
+                if (!is_remote) {
+                   if (attrd_election_won()) {
+                       attrd_peer_sync(peer);
+
+                   } else {
+                       // Anyway send a message so that the peer learns our name
+                       attrd_send_protocol(peer);
+                   }
                 }
+
             } else {
                 // Remove all attribute values associated with lost nodes
                 if (peer->name != NULL) {

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -195,14 +195,16 @@ attrd_peer_change_cb(enum pcmk__node_update kind, pcmk__node_status_t *peer,
                 }
             } else {
                 // Remove all attribute values associated with lost nodes
-                attrd_peer_remove(peer->name, false, "loss");
+                if (peer->name != NULL) {
+                    attrd_peer_remove(peer->name, false, "loss");
+                }
                 gone = true;
             }
             break;
     }
 
     // Remove votes from cluster nodes that leave, in case election in progress
-    if (gone && !is_remote) {
+    if (gone && !is_remote && peer->name != NULL) {
         attrd_remove_voter(peer);
         attrd_remove_peer_protocol_ver(peer->name);
         attrd_do_not_expect_from_peer(peer->name);

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -325,8 +325,13 @@ update_attr_on_host(attribute_t *a, const pcmk__node_status_t *peer,
     // Remember node's XML ID if we're just learning it
     if ((node_xml_id != NULL)
         && !pcmk__str_eq(node_xml_id, prev_xml_id, pcmk__str_none)) {
+        // Remember node's name in case unknown in the membership cache
+        pcmk__node_status_t *known_peer =
+            pcmk__get_node(0, host, node_xml_id,
+                           pcmk__node_search_cluster_member);
+
         crm_trace("Learned %s[%s] node XML ID is %s (was %s)",
-                  a->id, v->nodename, node_xml_id,
+                  a->id, known_peer->name, node_xml_id,
                   pcmk__s(prev_xml_id, "unknown"));
         attrd_set_node_xml_id(v->nodename, node_xml_id);
         if (attrd_election_won()) {

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -168,23 +168,26 @@ attrd_peer_change_cb(enum pcmk__node_update kind, pcmk__node_status_t *peer,
 
     switch (kind) {
         case pcmk__node_update_name:
-            crm_debug("%s node %s is now %s",
+            crm_debug("%s node %s[%" PRIu32 "] is now %s",
                       (is_remote? "Remote" : "Cluster"),
-                      peer->name, state_text(peer->state));
+                      pcmk__s(peer->name, "unknown"), peer->cluster_layer_id,
+                      state_text(peer->state));
             break;
 
         case pcmk__node_update_processes:
             if (!pcmk_is_set(peer->processes, crm_get_cluster_proc())) {
                 gone = true;
             }
-            crm_debug("Node %s is %s a peer",
-                      peer->name, (gone? "no longer" : "now"));
+            crm_debug("Node %s[%" PRIu32 "] is %s a peer",
+                      pcmk__s(peer->name, "unknown"), peer->cluster_layer_id,
+                      (gone? "no longer" : "now"));
             break;
 
         case pcmk__node_update_state:
-            crm_debug("%s node %s is now %s (was %s)",
+            crm_debug("%s node %s[%" PRIu32 "] is now %s (was %s)",
                       (is_remote? "Remote" : "Cluster"),
-                      peer->name, state_text(peer->state), state_text(data));
+                      pcmk__s(peer->name, "unknown"), peer->cluster_layer_id,
+                      state_text(peer->state), state_text(data));
             if (pcmk__str_eq(peer->state, PCMK_VALUE_MEMBER, pcmk__str_none)) {
                 /* If we're the writer, send new peers a list of all attributes
                  * (unless it's a remote node, which doesn't run its own attrd)

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -328,7 +328,7 @@ attrd_broadcast_protocol(void)
 }
 
 gboolean
-attrd_send_message(pcmk__node_status_t *node, xmlNode *data, bool confirm)
+attrd_send_message(const pcmk__node_status_t *node, xmlNode *data, bool confirm)
 {
     const char *op = crm_element_value(data, PCMK_XA_TASK);
 

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -302,10 +302,10 @@ attrd_handle_request(pcmk__request_t *request)
 
 /*!
     \internal
-    \brief Broadcast private attribute for local node with protocol version
+    \brief Send or broadcast private attribute for local node with protocol version
 */
 void
-attrd_broadcast_protocol(void)
+attrd_send_protocol(const pcmk__node_status_t *peer)
 {
     xmlNode *attrd_op = pcmk__xe_create(NULL, __func__);
 
@@ -319,10 +319,24 @@ attrd_broadcast_protocol(void)
     crm_xml_add(attrd_op, PCMK__XA_ATTR_HOST_ID,
                 attrd_cluster->priv->node_xml_id);
 
-    crm_debug("Broadcasting attrd protocol version %s for node %s",
-              ATTRD_PROTOCOL_VERSION, attrd_cluster->priv->node_name);
+    if (peer == NULL) {
+        crm_debug("Broadcasting attrd protocol version %s for node %s[%" PRIu32
+                  "]",
+                  ATTRD_PROTOCOL_VERSION,
+                  pcmk__s(attrd_cluster->priv->node_name, "unknown"),
+                  attrd_cluster->priv->node_id);
 
-    attrd_send_message(NULL, attrd_op, false); /* ends up at attrd_peer_message() */
+    } else {
+        crm_debug("Sending attrd protocol version %s for node %s[%" PRIu32
+                  "] to node %s[%" PRIu32 "]",
+                  ATTRD_PROTOCOL_VERSION,
+                  pcmk__s(attrd_cluster->priv->node_name, "unknown"),
+                  attrd_cluster->priv->node_id,
+                  pcmk__s(peer->name, "unknown"),
+                  peer->cluster_layer_id);
+    }
+
+    attrd_send_message(peer, attrd_op, false); /* ends up at attrd_peer_message() */
 
     pcmk__xml_free(attrd_op);
 }

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -184,7 +184,7 @@ main(int argc, char **argv)
      * across all nodes. It also ensures that the writer learns our node name,
      * so it can send our attributes to the CIB.
      */
-    attrd_broadcast_protocol();
+    attrd_send_protocol(NULL);
 
     attrd_init_ipc();
     crm_notice("Pacemaker node attribute manager successfully started and accepting connections");

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -200,7 +200,7 @@ xmlNode *attrd_client_clear_failure(pcmk__request_t *request);
 xmlNode *attrd_client_update(pcmk__request_t *request);
 xmlNode *attrd_client_refresh(pcmk__request_t *request);
 xmlNode *attrd_client_query(pcmk__request_t *request);
-gboolean attrd_send_message(pcmk__node_status_t *node, xmlNode *data,
+gboolean attrd_send_message(const pcmk__node_status_t *node, xmlNode *data,
                             bool confirm);
 
 xmlNode *attrd_add_value_xml(xmlNode *parent, const attribute_t *a,

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -194,7 +194,7 @@ void attrd_peer_clear_failure(pcmk__request_t *request);
 void attrd_peer_sync_response(const pcmk__node_status_t *peer, bool peer_won,
                               xmlNode *xml);
 
-void attrd_broadcast_protocol(void);
+void attrd_send_protocol(const pcmk__node_status_t *peer);
 xmlNode *attrd_client_peer_remove(pcmk__request_t *request);
 xmlNode *attrd_client_clear_failure(pcmk__request_t *request);
 xmlNode *attrd_client_update(pcmk__request_t *request);

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -271,7 +271,7 @@ pcmk__cluster_node_name(uint32_t nodeid)
     }
 
     crm_notice("Could not obtain a node name for node with "
-               PCMK_XA_ID "=" PRIu32,
+               PCMK_XA_ID "=%" PRIu32,
                nodeid);
     return NULL;
 }


### PR DESCRIPTION
If nodes are not configured with names in corosync, when a node joins
the cluster, it takes a while for it to learn the names of all the other
online peers. Previously, if any of the peers happened to leave when its
`name` was unknown to us yet, pacemaker-attrd would trigger assertion in
`attrd_peer_remove()` and segfault in
`attrd_remove_peer_protocol_ver()`.