### PR TITLE
Fix: libcrmcommon: provide a description for pcmk_rc_no_dc return code

### DIFF
--- a/cts/cli/regression.error_codes.exp
+++ b/cts/cli/regression.error_codes.exp
@@ -145,6 +145,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: Get negative Pacemaker return code (with name) (XML) - OK (0) =#=#=#=
 * Passed: crm_error             - Get negative Pacemaker return code (with name) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) =#=#=#=
+-1040: DC is not yet elected
 -1039: Compression/decompression error
 -1038: Nameserver resolution error
 -1037: No active transaction found
@@ -189,6 +190,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error             - List Pacemaker return codes (non-positive)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -l -r --output-as=xml">
+  <result-code code="-1040" description="DC is not yet elected"/>
   <result-code code="-1039" description="Compression/decompression error"/>
   <result-code code="-1038" description="Nameserver resolution error"/>
   <result-code code="-1037" description="No active transaction found"/>
@@ -233,6 +235,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: List Pacemaker return codes (non-positive) (XML) - OK (0) =#=#=#=
 * Passed: crm_error             - List Pacemaker return codes (non-positive) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) =#=#=#=
+-1040: pcmk_rc_no_dc               DC is not yet elected
 -1039: pcmk_rc_compression         Compression/decompression error
 -1038: pcmk_rc_ns_resolution       Nameserver resolution error
 -1037: pcmk_rc_no_transaction      No active transaction found
@@ -277,6 +280,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error             - List Pacemaker return codes (non-positive) (with names)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -n -l -r --output-as=xml">
+  <result-code code="-1040" name="pcmk_rc_no_dc" description="DC is not yet elected"/>
   <result-code code="-1039" name="pcmk_rc_compression" description="Compression/decompression error"/>
   <result-code code="-1038" name="pcmk_rc_ns_resolution" description="Nameserver resolution error"/>
   <result-code code="-1037" name="pcmk_rc_no_transaction" description="No active transaction found"/>

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -426,6 +426,10 @@ static const struct pcmk__rc_info {
       "Compression/decompression error",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_no_dc",
+      "DC is not yet elected",
+      -pcmk_err_generic,
+    },
 };
 
 /*!


### PR DESCRIPTION
This adds an info entry for `pcmk_rc_no_dc` return code so that pcmk_rc_str() provides an informative description for it rather than just an "Error".

This should have been done with a1d94f7ab5.

In particular for the output of `crmadmin --dc_lookup/-D`, dc() function outputs somewhat redundant information when DC is not yet elected. But I'm not sure whether/how we should change the output format there.