### PR TITLE
[WIP] High: fenced: Registration of a STONITH device without placement constraints fails.

### DIFF
--- a/daemons/fenced/fenced_scheduler.c
+++ b/daemons/fenced/fenced_scheduler.c
@@ -115,6 +115,11 @@ local_node_allowed_for(const pcmk_resource_t *rsc)
     if ((rsc != NULL) && (scheduler->priv->local_node_name != NULL)) {
         GHashTableIter iter;
         pcmk_node_t *node = NULL;
+        /* If there is no placement node (e.g., no placement constraint), 
+         * registration on the local node is permitted. */
+        if (g_hash_table_size(rsc->priv->allowed_nodes) == 0) {
+            return pcmk_find_node(scheduler, scheduler->priv->local_node_name);	
+        }
 
         g_hash_table_iter_init(&iter, rsc->priv->allowed_nodes);
         while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {


### PR DESCRIPTION
Hi All,

Starting with Pacemaker 3.0.0, registration of STONITH devices without placement constraints is not performed, so unfencing of STONITH devices fails.

```
[root@rh94-dev01 pacemaker]# pcs status --full
Cluster name: dev_cluster
Cluster Summary:
  * Stack: corosync (Pacemaker is running)
  * Current DC: rh94-dev02 (2) (version 3.0.0-6d6734a86b) - partition with quorum
  * Last updated: Wed Mar 19 14:55:08 2025 on rh94-dev01
  * Last change:  Wed Mar 19 14:54:16 2025 by hacluster via hacluster on rh94-dev02
  * 2 nodes configured
  * 11 resource instances configured

Node List:
  * Node rh94-dev01 (1): online, feature set 3.20.0
  * Node rh94-dev02 (2): online, feature set 3.20.0

Full List of Resources:
  * Resource Group: pgsql-group:
    * filesystem1       (ocf:heartbeat:Dummy):   Stopped
    * filesystem2       (ocf:heartbeat:Dummy):   Stopped
    * filesystem3       (ocf:heartbeat:Dummy):   Stopped
    * ipaddr    (ocf:heartbeat:Dummy):   Stopped
    * pgsql     (ocf:heartbeat:Dummy):   Stopped
  * Clone Set: ping-clone [ping]:
    * ping      (ocf:pacemaker:ping):    Stopped
    * ping      (ocf:pacemaker:ping):    Stopped
  * Clone Set: storage-mon-clone [storage-mon]:
    * storage-mon       (ocf:heartbeat:storage-mon):     Stopped
    * storage-mon       (ocf:heartbeat:storage-mon):     Stopped
  * fence1-scsi (stonith:fence_scsi):    Stopped
  * fence2-scsi (stonith:fence_scsi):    Stopped

Migration Summary:

Failed Fencing Actions:
  * unfencing of rh94-dev02 failed: client=pacemaker-fenced.611291, origin=rh94-dev01, completed='2025-03-19 14:54:16.138143 +09:00'
  * unfencing of rh94-dev01 failed: client=pacemaker-controld.89352, origin=rh94-dev02, completed='2025-03-19 14:54:16.136143 +09:00'

Tickets:

PCSD Status:
  rh94-dev01: Online
  rh94-dev02: Online

Daemon Status:
  corosync: active/disabled
  pacemaker: active/disabled
  pcsd: active/enabled
[root@rh94-dev01 pacemaker]# 

---- cib.xml
(snip)
      <primitive id="fence1-scsi" class="stonith" type="fence_scsi">
        <instance_attributes id="fence1-scsi-instance_attributes">
          <nvpair id="fence1-scsi-instance_attributes-devices" name="devices" value="/dev/sdb"/>
          <nvpair id="fence1-scsi-instance_attributes-pcmk_host_list" name="pcmk_host_list" value="rh94-dev01"/> 
(snip)
      <primitive id="fence2-scsi" class="stonith" type="fence_scsi">
        <instance_attributes id="fence2-scsi-instance_attributes">
          <nvpair id="fence2-scsi-instance_attributes-devices" name="devices" value="/dev/sdb"/>
          <nvpair id="fence2-scsi-instance_attributes-pcmk_host_list" name="pcmk_host_list" value="rh94-dev02"/>
(snip)
    <fencing-topology>
      <fencing-level index="1" devices="fence1-scsi" target="rh94-dev01" id="fl-rh10-b01-1"/>
      <fencing-level index="1" devices="fence2-scsi" target="rh94-dev02" id="fl-rh10-b02-1"/>
    </fencing-topology>
(snip)
```

Pacemaker 2.1.9 and earlier did not have this problem, so it seems that some fix in the 3.0.0 series of Pacemaker is affecting it.

I have not tracked down the fix, so I will send a tentative fix. (It is probably a degradation of some process.)

I will leave it to the community to come up with a fix that takes the regression into account.

Best Regards,
Hideo Yamauchi.
