### PR TITLE
High: fenced: Fixed an issue where registering a STONITH device to fenced failed when the node name was unknown (for compatibility with 2.1 series).

### DIFF
--- a/daemons/fenced/fenced_scheduler.c
+++ b/daemons/fenced/fenced_scheduler.c
@@ -248,7 +248,7 @@ fenced_scheduler_run(xmlNode *cib)
 
     scheduler->input = cib;
     pcmk__set_scheduler_flags(scheduler,
-                              pcmk__sched_location_only|pcmk__sched_no_counts);
+                              pcmk__sched_location_only|pcmk__sched_no_counts|pcmk__sched_for_fenced);
     pcmk__schedule_actions(scheduler);
     g_list_foreach(scheduler->priv->resources, register_if_fencing_device,
                    NULL);

--- a/include/crm/common/scheduler_internal.h
+++ b/include/crm/common/scheduler_internal.h
@@ -154,6 +154,13 @@ enum pcmk__scheduler_flags {
      * applying node-specific location criteria, assignment, etc.)
      */
     pcmk__sched_validate_only           = (1ULL << 27),
+    /* To maintain compatibility with fenced behavior in 2.1.9, 
+     * when the node name is unknown, the local node name will be set 
+     * for location calculations in fenced.
+     * This will cause stonith device registration to be performed 
+     * when fenced receives the cib.
+     */
+    pcmk__sched_for_fenced           = (1ULL << 28),
 };
 
 // Implementation of pcmk__scheduler_private_t

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -374,6 +374,8 @@ bool pe__native_is_filtered(const pcmk_resource_t *rsc, const GList *only_rsc,
 
 xmlNode *pe__failed_probe_for_rsc(const pcmk_resource_t *rsc, const char *name);
 
+void pe__create_fake_local_node(pcmk_scheduler_t * scheduler);
+
 const char *pe__clone_child_id(const pcmk_resource_t *rsc);
 
 int pe__sum_node_health_scores(const pcmk_node_t *node, int base_health);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -160,14 +160,7 @@ cluster_status(pcmk_scheduler_t * scheduler)
                   scheduler->priv->blocked_resources);
     }
 
-    if ((scheduler->priv->local_node_name != NULL)
-        && (pcmk_find_node(scheduler,
-                           scheduler->priv->local_node_name) == NULL)) {
-        crm_info("Creating a fake local node for %s",
-                 scheduler->priv->local_node_name);
-        pe_create_node(scheduler->priv->local_node_name,
-                       scheduler->priv->local_node_name, NULL, 0, scheduler);
-    }
+    pe__create_fake_local_node(scheduler);
 
     pcmk__set_scheduler_flags(scheduler, pcmk__sched_have_status);
     return TRUE;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -643,6 +643,13 @@ unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *scheduler)
         crm_trace("Done with node %s",
                   crm_element_value(xml_obj, PCMK_XA_UNAME));
     }
+    
+    /* If the request is from fenced and the node name is not set, 
+     * the local node will be set.
+     */
+    if (pcmk_is_set(scheduler->flags, pcmk__sched_for_fenced)) {
+        pe__create_fake_local_node(scheduler);
+    }
 
     return TRUE;
 }

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -888,3 +888,15 @@ pe__failed_probe_for_rsc(const pcmk_resource_t *rsc, const char *name)
 
     return NULL;
 }
+
+void
+pe__create_fake_local_node(pcmk_scheduler_t * scheduler){
+    if ((scheduler->priv->local_node_name != NULL)
+        && (pcmk_find_node(scheduler,
+                           scheduler->priv->local_node_name) == NULL)) {
+        crm_info("Creating a fake local node for %s",
+                  scheduler->priv->local_node_name);
+        pe_create_node(scheduler->priv->local_node_name,
+        scheduler->priv->local_node_name, NULL, 0, scheduler);
+    }
+}


### PR DESCRIPTION
Hi All,

This PR is a modified version of the next PR.
 - https://github.com/ClusterLabs/pacemaker/pull/3849

In Pacemaker 3.0, the node name is not set when calculating the state transition for fenced, so STONITH device registration is not performed.

As a result, unfencing will fail even if you submit a cib.xml that worked with Pacemaker 2.1 that used fence_scsi.

For compatibility with Pacemaker 2.1, the process will be modified so that the node name is set on the local node when calculating the state transition for fenced.

We strongly request that this fix be included in the RHEL 10.0 release version of Pacemaker.




Best Regards,
Hideo Yamauchi.
