### PR TITLE
Low: python: Fix setting schema directory in source checkout.

### DIFF
--- a/python/pacemaker/_cts/validate.py
+++ b/python/pacemaker/_cts/validate.py
@@ -36,7 +36,7 @@ def rng_directory():
 
     for path in sys.path:
         if os.path.exists(f"{path}/cts-fencing.in"):
-            return f"{path}/xml"
+            return f"{path}/../xml"
 
     return BuildOptions.SCHEMA_DIR
 


### PR DESCRIPTION
If running from a source checkout and you don't have PCMK_schema_directory set, then rng_directory would fail because it returns an incorrect path.  This hasn't failed for me in the past because even though I run cts tests from a source checkout, I always have PCMK_schema_directory set locally in /etc/sysconfig/pacemaker.

Fixes T982