### PR TITLE
Remove compression in the IPC code

### DIFF
--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -115,12 +115,12 @@ cib_notify_send(const xmlNode *xml)
         update.iov = iov;
         update.iov_size = bytes;
         pcmk__foreach_ipc_client(cib_notify_send_one, &update);
+        pcmk_free_ipc_event(iov);
 
     } else {
         crm_notice("Could not notify clients: %s " QB_XS " rc=%d",
                    pcmk_rc_str(rc), rc);
     }
-    pcmk_free_ipc_event(iov);
 }
 
 void

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -108,7 +108,7 @@ cib_notify_send(const xmlNode *xml)
     struct cib_notification_s update;
 
     ssize_t bytes = 0;
-    int rc = pcmk__ipc_prepare_iov(0, xml, 0, &iov, &bytes);
+    int rc = pcmk__ipc_prepare_iov(0, xml, &iov, &bytes);
 
     if (rc == pcmk_rc_ok) {
         update.msg = xml;

--- a/doc/sphinx/Pacemaker_Explained/local-options.rst
+++ b/doc/sphinx/Pacemaker_Explained/local-options.rst
@@ -680,19 +680,6 @@ whose location varies by OS (most commonly ``/etc/sysconfig/pacemaker`` or
        * ``posix``
        * ``sysv``
 
-   * - .. _pcmk_ipc_buffer:
-
-       .. index::
-          pair: node option; PCMK_ipc_buffer
-
-       PCMK_ipc_buffer
-     - :ref:`nonnegative integer <nonnegative_integer>`
-     - 131072
-     - *Advanced Use Only:* Specify an IPC buffer size in bytes. This can be
-       useful when connecting to large clusters that result in messages
-       exceeding the default size (which will also result in log messages
-       referencing this variable).
-
    * - .. _pcmk_cluster_type:
 
        .. index::

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -348,14 +348,6 @@
 #
 # Default: PCMK_ipc_type="shared-mem"
 
-# PCMK_ipc_buffer (Advanced Use Only)
-#
-# Specify an IPC buffer size in bytes. This can be useful when connecting to
-# large clusters that result in messages exceeding the default size (which will
-# also result in log messages referencing this variable).
-#
-# Default: PCMK_ipc_buffer="131072"
-
 
 ## Cluster type
 

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -134,7 +134,7 @@ int pcmk_ipc_purge_node(pcmk_ipc_api_t *api, const char *node_name,
 enum crm_ipc_flags
 {
     crm_ipc_flags_none              = UINT32_C(0),
-    //! Message has been compressed
+    //! \deprecated Since 3.0.1
     crm_ipc_compressed              = (UINT32_C(1) << 0),
     //! _ALL_ replies to proxied connections need to be sent as events
     crm_ipc_proxied                 = (UINT32_C(1) << 8),

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -240,7 +240,6 @@ int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
     pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (tag), (ver), (st))
 
 int pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
-                          uint32_t max_send_size,
                           struct iovec **result, ssize_t *bytes);
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);

--- a/include/crm/common/mainloop.h
+++ b/include/crm/common/mainloop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2024 the Pacemaker project contributors
+ * Copyright 2009-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -132,6 +132,7 @@ qb_ipcs_service_t *mainloop_add_ipc_server_with_prio(const char *name,
 
 void mainloop_del_ipc_server(qb_ipcs_service_t * server);
 
+// @COMPAT max_size parameter is deprecated and unused since 3.0.1
 mainloop_io_t *mainloop_add_ipc_client(const char *name, int priority, size_t max_size,
                                        void *userdata, struct ipc_client_callbacks *callbacks);
 

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -135,7 +135,6 @@ bool pcmk__valid_stonith_watchdog_timeout(const char *value);
 #define PCMK__ENV_DEBUG                     "debug"
 #define PCMK__ENV_DH_MAX_BITS               "dh_max_bits"
 #define PCMK__ENV_FAIL_FAST                 "fail_fast"
-#define PCMK__ENV_IPC_BUFFER                "ipc_buffer"
 #define PCMK__ENV_IPC_TYPE                  "ipc_type"
 #define PCMK__ENV_KEY_FILE                  "key_file"
 #define PCMK__ENV_LOGFACILITY               "logfacility"

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004 International Business Machines
- * Later changes copyright 2004-2024 the Pacemaker project contributors
+ * Later changes copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -297,8 +297,8 @@ cib_native_signon(cib_t *cib, const char *name, enum cib_conn_type type)
 
     crm_trace("Connecting %s channel", channel);
 
-    native->source = mainloop_add_ipc_client(channel, G_PRIORITY_HIGH,
-                                             512 * 1024, cib, &cib_callbacks);
+    native->source = mainloop_add_ipc_client(channel, G_PRIORITY_HIGH, 0, cib,
+                                             &cib_callbacks);
     native->ipc = mainloop_get_ipc_client(native->source);
 
     if (rc != pcmk_ok || native->ipc == NULL || !crm_ipc_connected(native->ipc)) {

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -311,8 +311,7 @@ struct pcmk_ipc_api_s {
 
 typedef struct pcmk__ipc_header_s {
     struct qb_ipc_response_header qb;
-    uint32_t size_uncompressed;
-    uint32_t size_compressed;
+    uint32_t size;
     uint32_t flags;
     uint8_t version;
 } pcmk__ipc_header_t;

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -300,7 +300,6 @@ typedef struct pcmk__ipc_methods_s {
 struct pcmk_ipc_api_s {
     enum pcmk_ipc_server server;          // Daemon this IPC API instance is for
     enum pcmk_ipc_dispatch dispatch_type; // How replies should be dispatched
-    size_t ipc_size_max;                  // maximum IPC buffer size
     crm_ipc_t *ipc;                       // IPC connection
     mainloop_io_t *mainloop_io;     // If using mainloop, I/O source for IPC
     bool free_on_disconnect;        // Whether disconnect should free object

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -327,9 +327,6 @@ void pcmk__call_ipc_callback(pcmk_ipc_api_t *api,
                              crm_exit_t status, void *event_data);
 
 G_GNUC_INTERNAL
-unsigned int pcmk__ipc_buffer_size(unsigned int max);
-
-G_GNUC_INTERNAL
 bool pcmk__valid_ipc_header(const pcmk__ipc_header_t *header);
 
 G_GNUC_INTERNAL

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -845,6 +845,8 @@ struct crm_ipc_s {
  *       crm_ipc_destroy().
  * \note This should be considered deprecated for use with daemons supported by
  *       pcmk_new_ipc_api().
+ * \note @COMPAT Since 3.0.1, \p max_size is ignored and the default given by
+ *       \c crm_ipc_default_buffer_size() will be used instead.
  */
 crm_ipc_t *
 crm_ipc_new(const char *name, size_t max_size)
@@ -864,7 +866,7 @@ crm_ipc_new(const char *name, size_t max_size)
         free(client);
         return NULL;
     }
-    client->buf_size = pcmk__ipc_buffer_size(max_size);
+    client->buf_size = crm_ipc_default_buffer_size();
     client->buffer = malloc(client->buf_size);
     if (client->buffer == NULL) {
         crm_err("Could not create %s IPC connection: %s",

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1297,7 +1297,6 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
     ssize_t bytes = 0;
     struct iovec *iov;
     static uint32_t id = 0;
-    static int factor = 8;
     pcmk__ipc_header_t *header;
 
     if (client == NULL) {
@@ -1345,16 +1344,6 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
     if (pcmk_is_set(flags, crm_ipc_proxied)) {
         /* Don't look for a synchronous response */
         pcmk__clear_ipc_flags(flags, "client", crm_ipc_client_response);
-    }
-
-    if(header->size_compressed) {
-        if(factor < 10 && (client->max_buf_size / 10) < (bytes / factor)) {
-            crm_notice("Compressed message exceeds %d0%% of configured IPC "
-                       "limit (%u bytes); consider setting PCMK_ipc_buffer to "
-                       "%u or higher",
-                       factor, client->max_buf_size, 2 * client->max_buf_size);
-            factor++;
-        }
     }
 
     crm_trace("Sending %s IPC request %d of %u bytes using %dms timeout",

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1112,7 +1112,7 @@ crm_ipc_read(crm_ipc_t * client)
 
     if (header) {
         /* Data excluding the header */
-        return header->size_uncompressed;
+        return header->size;
     }
     return -ENOMSG;
 }

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -61,16 +61,13 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
         return EOPNOTSUPP;
     }
 
-    (*api)->ipc_size_max = 0;
-
-    // Set server methods and max_size (if not default)
+    // Set server methods
     switch (server) {
         case pcmk_ipc_attrd:
             (*api)->cmds = pcmk__attrd_api_methods();
             break;
 
         case pcmk_ipc_based:
-            (*api)->ipc_size_max = 512 * 1024; // 512KB
             break;
 
         case pcmk_ipc_controld:
@@ -89,8 +86,6 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
 
         case pcmk_ipc_schedulerd:
             (*api)->cmds = pcmk__schedulerd_api_methods();
-            // @TODO max_size could vary by client, maybe take as argument?
-            (*api)->ipc_size_max = 5 * 1024 * 1024; // 5MB
             break;
 
         default: // pcmk_ipc_unknown

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1332,7 +1332,7 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
 
     id++;
     CRM_LOG_ASSERT(id != 0); /* Crude wrap-around detection */
-    rc = pcmk__ipc_prepare_iov(id, message, client->max_buf_size, &iov, &bytes);
+    rc = pcmk__ipc_prepare_iov(id, message, &iov, &bytes);
     if (rc != pcmk_rc_ok) {
         crm_warn("Couldn't prepare %s IPC request: %s " QB_XS " rc=%d",
                  client->server_name, pcmk_rc_str(rc), rc);

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -819,7 +819,6 @@ pcmk_ipc_purge_node(pcmk_ipc_api_t *api, const char *node_name, uint32_t nodeid)
 
 struct crm_ipc_s {
     struct pollfd pfd;
-    unsigned int max_buf_size; // maximum bytes we can send or receive over IPC
     unsigned int buf_size;     // size of allocated buffer
     int msg_size;
     int need_reply;
@@ -870,9 +869,6 @@ crm_ipc_new(const char *name, size_t max_size)
         free(client);
         return NULL;
     }
-
-    /* Clients initiating connection pick the max buf size */
-    client->max_buf_size = client->buf_size;
 
     client->pfd.fd = -1;
     client->pfd.events = POLLIN;
@@ -935,18 +931,6 @@ pcmk__connect_generic_ipc(crm_ipc_t *ipc)
         }
         crm_ipc_close(ipc);
         return rc;
-    }
-
-    ipc->max_buf_size = qb_ipcc_get_buffer_size(ipc->ipc);
-    if (ipc->max_buf_size > ipc->buf_size) {
-        free(ipc->buffer);
-        ipc->buffer = calloc(ipc->max_buf_size, sizeof(char));
-        if (ipc->buffer == NULL) {
-            rc = errno;
-            crm_ipc_close(ipc);
-            return rc;
-        }
-        ipc->buf_size = ipc->max_buf_size;
     }
 
     return pcmk_rc_ok;

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -104,8 +104,7 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
         return ENOMEM;
     }
 
-    (*api)->ipc = crm_ipc_new(pcmk_ipc_name(*api, false),
-                              (*api)->ipc_size_max);
+    (*api)->ipc = crm_ipc_new(pcmk_ipc_name(*api, false), 0);
     if ((*api)->ipc == NULL) {
         pcmk_free_ipc_api(*api);
         *api = NULL;
@@ -498,7 +497,7 @@ pcmk__connect_ipc(pcmk_ipc_api_t *api, enum pcmk_ipc_dispatch dispatch_type,
     }
 
     if (api->ipc == NULL) {
-        api->ipc = crm_ipc_new(pcmk_ipc_name(api, false), api->ipc_size_max);
+        api->ipc = crm_ipc_new(pcmk_ipc_name(api, false), 0);
         if (api->ipc == NULL) {
             return ENOMEM;
         }

--- a/lib/common/ipc_common.c
+++ b/lib/common/ipc_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -16,83 +16,21 @@
 #include <crm/common/xml.h>
 #include "crmcommon_private.h"
 
-#define MIN_MSG_SIZE    12336    // sizeof(struct qb_ipc_connection_response)
-#define MAX_MSG_SIZE    128*1024 // 128k default
-
-/*!
- * \internal
- * \brief Choose an IPC buffer size in bytes
- *
- * \param[in] max  Use this value if environment/default is lower
- *
- * \return Maximum of max and value of PCMK_ipc_buffer (default 128KB)
+/* The IPC buffer is always 128k.  If we are asked to send a message larger
+ * than that size, it will be split into multiple messages that must be
+ * reassembled on the other end.
  */
-unsigned int
-pcmk__ipc_buffer_size(unsigned int max)
-{
-    static long long env_value = 0LL; // Will be bounded to unsigned int
-
-    if (env_value == 0LL) {
-        const char *env_value_s = pcmk__env_option(PCMK__ENV_IPC_BUFFER);
-        int rc = pcmk__scan_ll(env_value_s, &env_value, MAX_MSG_SIZE);
-
-        if (rc != pcmk_rc_ok) {
-            env_value = MAX_MSG_SIZE;
-            max = QB_MAX(max, env_value);
-            crm_warn("Using %u as IPC buffer size because '%s' is not "
-                     "a valid value for PCMK_" PCMK__ENV_IPC_BUFFER ": %s",
-                     max, env_value_s, pcmk_rc_str(rc));
-
-        } else if (env_value <= 0LL) {
-            env_value = MAX_MSG_SIZE;
-            max = QB_MAX(max, env_value);
-            crm_warn("Using %u as IPC buffer size because PCMK_"
-                     PCMK__ENV_IPC_BUFFER " (%s) is not a positive integer",
-                     max, env_value_s);
-
-        } else if (env_value < MIN_MSG_SIZE) {
-            env_value = MIN_MSG_SIZE;
-            max = QB_MAX(max, env_value);
-            crm_debug("Using %u as IPC buffer size because PCMK_"
-                      PCMK__ENV_IPC_BUFFER " (%s) is too small",
-                      max, env_value_s);
-
-        } else if (env_value > UINT_MAX) {
-            env_value = UINT_MAX;
-            max = UINT_MAX;
-            crm_debug("Using %u as IPC buffer size because PCMK_"
-                      PCMK__ENV_IPC_BUFFER " (%s) is too big",
-                      max, env_value_s);
-        }
-    }
-
-    if (env_value > max) {
-        const char *source = "PCMK_" PCMK__ENV_IPC_BUFFER;
-
-        if (env_value == MAX_MSG_SIZE) {
-            source = "default";
-        }
-        crm_debug("Using IPC buffer size %lld from %s (not %u)",
-                  env_value, source, max);
-        max = env_value;
-    }
-    return max;
-}
+#define BUFFER_SIZE     (128*1024) // 128k
 
 /*!
- * \brief Return pacemaker's default IPC buffer size
+ * \brief Return pacemaker's IPC buffer size
  *
  * \return IPC buffer size in bytes
  */
 unsigned int
 crm_ipc_default_buffer_size(void)
 {
-    static unsigned int default_size = 0;
-
-    if (default_size == 0) {
-        default_size = pcmk__ipc_buffer_size(0);
-    }
-    return default_size;
+    return BUFFER_SIZE;
 }
 
 /*!

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -581,7 +581,6 @@ crm_ipcs_flush_events(pcmk__client_t *c)
  *
  * \param[in]  request        Identifier for libqb response header
  * \param[in]  message        XML message to send
- * \param[in]  max_send_size  If 0, default IPC buffer size is used
  * \param[out] result         Where to store prepared I/O vector
  * \param[out] bytes          Size of prepared data in bytes
  *
@@ -589,11 +588,11 @@ crm_ipcs_flush_events(pcmk__client_t *c)
  */
 int
 pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
-                      uint32_t max_send_size, struct iovec **result,
-                      ssize_t *bytes)
+                      struct iovec **result, ssize_t *bytes)
 {
     struct iovec *iov;
     unsigned int total = 0;
+    unsigned int max_send_size = crm_ipc_default_buffer_size();
     GString *buffer = NULL;
     pcmk__ipc_header_t *header = NULL;
     int rc = pcmk_rc_ok;
@@ -611,11 +610,6 @@ pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
 
     buffer = g_string_sized_new(1024);
     pcmk__xml_string(message, 0, buffer, 0);
-
-    if (max_send_size == 0) {
-        max_send_size = crm_ipc_default_buffer_size();
-    }
-    CRM_LOG_ASSERT(max_send_size != 0);
 
     *result = NULL;
     iov = pcmk__new_ipc_event();
@@ -770,8 +764,7 @@ pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request, const xmlNode *message,
     if (c == NULL) {
         return EINVAL;
     }
-    rc = pcmk__ipc_prepare_iov(request, message, crm_ipc_default_buffer_size(),
-                               &iov, NULL);
+    rc = pcmk__ipc_prepare_iov(request, message, &iov, NULL);
     if (rc == pcmk_rc_ok) {
         pcmk__set_ipc_flags(flags, "send data", crm_ipc_server_free);
         rc = pcmk__ipc_send_iov(c, iov, flags);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -620,44 +620,17 @@ pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
     header->size_uncompressed = 1 + buffer->len;
     total = iov[0].iov_len + header->size_uncompressed;
 
-    if (total < max_send_size) {
-        iov[1].iov_base = pcmk__str_copy(buffer->str);
-        iov[1].iov_len = header->size_uncompressed;
-
-    } else {
-        static unsigned int biggest = 0;
-
-        char *compressed = NULL;
-        unsigned int new_size = 0;
-
-        if (pcmk__compress(buffer->str,
-                           (unsigned int) header->size_uncompressed,
-                           (unsigned int) max_send_size, &compressed,
-                           &new_size) == pcmk_rc_ok) {
-
-            pcmk__set_ipc_flags(header->flags, "send data", crm_ipc_compressed);
-            header->size_compressed = new_size;
-
-            iov[1].iov_len = header->size_compressed;
-            iov[1].iov_base = compressed;
-
-            biggest = QB_MAX(header->size_compressed, biggest);
-
-        } else {
-            crm_log_xml_trace(message, "EMSGSIZE");
-            biggest = QB_MAX(header->size_uncompressed, biggest);
-
-            crm_err("Could not compress %u-byte message into less than IPC "
-                    "limit of %u bytes; set PCMK_ipc_buffer to higher value "
-                    "(%u bytes suggested)",
-                    header->size_uncompressed, max_send_size, 4 * biggest);
-
-            free(compressed);
-            pcmk_free_ipc_event(iov);
-            rc = EMSGSIZE;
-            goto done;
-        }
+    if (total >= max_send_size) {
+        crm_log_xml_trace(message, "EMSGSIZE");
+        crm_err("Could not transmit message; message size %" PRIu32" bytes is "
+                "larger than the maximum of %" PRIu32, header->size_uncompressed,
+                max_send_size);
+        rc = EMSGSIZE;
+        goto done;
     }
+
+    iov[1].iov_base = pcmk__str_copy(buffer->str);
+    iov[1].iov_len = header->size_uncompressed;
 
     header->qb.size = iov[0].iov_len + iov[1].iov_len;
     header->qb.id = (int32_t)request;    /* Replying to a specific request */

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -397,7 +397,6 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
                       uint32_t *flags)
 {
     xmlNode *xml = NULL;
-    char *uncompressed = NULL;
     char *text = ((char *)data) + sizeof(pcmk__ipc_header_t);
     pcmk__ipc_header_t *header = data;
 
@@ -420,33 +419,10 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
         pcmk__set_client_flags(c, pcmk__client_proxied);
     }
 
-    if (header->size_compressed) {
-        int rc = 0;
-        unsigned int size_u = 1 + header->size_uncompressed;
-        uncompressed = pcmk__assert_alloc(1, size_u);
-
-        crm_trace("Decompressing message data %u bytes into %u bytes",
-                  header->size_compressed, size_u);
-
-        rc = BZ2_bzBuffToBuffDecompress(uncompressed, &size_u, text, header->size_compressed, 1, 0);
-        text = uncompressed;
-
-        rc = pcmk__bzlib2rc(rc);
-
-        if (rc != pcmk_rc_ok) {
-            crm_err("Decompression failed: %s " QB_XS " rc=%d",
-                    pcmk_rc_str(rc), rc);
-            free(uncompressed);
-            return NULL;
-        }
-    }
-
     pcmk__assert(text[header->size_uncompressed - 1] == 0);
 
     xml = pcmk__xml_parse(text);
     crm_log_xml_trace(xml, "[IPC received]");
-
-    free(uncompressed);
     return xml;
 }
 
@@ -527,14 +503,9 @@ crm_ipcs_flush_events(pcmk__client_t *c)
 
         sent++;
         header = event[0].iov_base;
-        if (header->size_compressed) {
-            crm_trace("Event %" PRId32 " to %p[%u] (%zd compressed bytes) sent",
-                      header->qb.id, c->ipcs, c->pid, qb_rc);
-        } else {
-            crm_trace("Event %" PRId32 " to %p[%u] (%zd bytes) sent: %.120s",
-                      header->qb.id, c->ipcs, c->pid, qb_rc,
-                      (char *) (event[1].iov_base));
-        }
+        crm_trace("Event %" PRId32 " to %p[%u] (%zd bytes) sent: %.120s",
+                  header->qb.id, c->ipcs, c->pid, qb_rc,
+                  (char *) (event[1].iov_base));
         pcmk_free_ipc_event(event);
     }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -419,7 +419,7 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
         pcmk__set_client_flags(c, pcmk__client_proxied);
     }
 
-    pcmk__assert(text[header->size_uncompressed - 1] == 0);
+    pcmk__assert(text[header->size - 1] == 0);
 
     xml = pcmk__xml_parse(text);
     crm_log_xml_trace(xml, "[IPC received]");
@@ -588,20 +588,20 @@ pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
     iov[0].iov_base = header;
 
     header->version = PCMK__IPC_VERSION;
-    header->size_uncompressed = 1 + buffer->len;
-    total = iov[0].iov_len + header->size_uncompressed;
+    header->size = buffer->len + 1;
+    total = iov[0].iov_len + header->size;
 
     if (total >= max_send_size) {
         crm_log_xml_trace(message, "EMSGSIZE");
         crm_err("Could not transmit message; message size %" PRIu32" bytes is "
-                "larger than the maximum of %" PRIu32, header->size_uncompressed,
+                "larger than the maximum of %" PRIu32, header->size,
                 max_send_size);
         rc = EMSGSIZE;
         goto done;
     }
 
     iov[1].iov_base = pcmk__str_copy(buffer->str);
-    iov[1].iov_len = header->size_uncompressed;
+    iov[1].iov_len = header->size;
 
     header->qb.size = iov[0].iov_len + iov[1].iov_len;
     header->qb.id = (int32_t)request;    /* Replying to a specific request */

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -552,7 +552,8 @@ crm_ipcs_flush_events(pcmk__client_t *c)
  *
  * \param[in]  request        Identifier for libqb response header
  * \param[in]  message        XML message to send
- * \param[out] result         Where to store prepared I/O vector
+ * \param[out] result         Where to store prepared I/O vector - NULL
+ *                            on error
  * \param[out] bytes          Size of prepared data in bytes
  *
  * \return Standard Pacemaker return code
@@ -597,6 +598,7 @@ pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
                 "larger than the maximum of %" PRIu32, header->size,
                 max_send_size);
         rc = EMSGSIZE;
+        pcmk_free_ipc_event(iov);
         goto done;
     }
 
@@ -713,7 +715,6 @@ pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request, const xmlNode *message,
         pcmk__set_ipc_flags(flags, "send data", crm_ipc_server_free);
         rc = pcmk__ipc_send_iov(c, iov, flags);
     } else {
-        pcmk_free_ipc_event(iov);
         crm_notice("IPC message to pid %d failed: %s " QB_XS " rc=%d",
                    c->pid, pcmk_rc_str(rc), rc);
     }

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -916,7 +916,7 @@ mainloop_io_t *
 mainloop_add_ipc_client(const char *name, int priority, size_t max_size,
                         void *userdata, struct ipc_client_callbacks *callbacks)
 {
-    crm_ipc_t *ipc = crm_ipc_new(name, max_size);
+    crm_ipc_t *ipc = crm_ipc_new(name, 0);
     mainloop_io_t *source = NULL;
     int rc = pcmk__add_mainloop_ipc(ipc, priority, userdata, callbacks,
                                     &source);

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -664,7 +664,7 @@ mainloop_add_ipc_server_with_prio(const char *name, enum qb_ipc_type type,
         qb_ipcs_request_rate_limit(server, conv_libqb_prio2ratelimit(prio));
     }
 
-    // All clients should use at least PCMK_ipc_buffer as their buffer size
+    // Enforce a minimum IPC buffer size on all clients
     qb_ipcs_enforce_buffer_size(server, crm_ipc_default_buffer_size());
     qb_ipcs_poll_handlers_set(server, &gio_poll_funcs);
 


### PR DESCRIPTION
This is also in preparation for the IPC split message split up code.  These commits are surprisingly standalone, which will make testing the actual split up easier.  Note that merging this PR will get rid of IPC compression entirely, which will break anyone with a large cluster.

My proposal is that we get this into an approved state and leave it unmerged so I can finish debugging the split up code.  I don't want to merge this quite yet just in case something happens on the split up patches and we are unable to get it done before release time.  Once that's also ready to go, we merge both PRs.

I expect to have the split up PR done fairly soon.  It mostly works, but I have some double free related segfaults to sort out still.