### PR TITLE
Split up IPC messages

### DIFF
--- a/cts/cli/regression.error_codes.exp
+++ b/cts/cli/regression.error_codes.exp
@@ -145,6 +145,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: Get negative Pacemaker return code (with name) (XML) - OK (0) =#=#=#=
 * Passed: crm_error             - Get negative Pacemaker return code (with name) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) =#=#=#=
+-1041: More IPC message fragments to send
 -1040: DC is not yet elected
 -1039: Compression/decompression error
 -1038: Nameserver resolution error
@@ -190,6 +191,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error             - List Pacemaker return codes (non-positive)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -l -r --output-as=xml">
+  <result-code code="-1041" description="More IPC message fragments to send"/>
   <result-code code="-1040" description="DC is not yet elected"/>
   <result-code code="-1039" description="Compression/decompression error"/>
   <result-code code="-1038" description="Nameserver resolution error"/>
@@ -235,6 +237,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: List Pacemaker return codes (non-positive) (XML) - OK (0) =#=#=#=
 * Passed: crm_error             - List Pacemaker return codes (non-positive) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) =#=#=#=
+-1041: pcmk_rc_ipc_more            More IPC message fragments to send
 -1040: pcmk_rc_no_dc               DC is not yet elected
 -1039: pcmk_rc_compression         Compression/decompression error
 -1038: pcmk_rc_ns_resolution       Nameserver resolution error
@@ -280,6 +283,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error             - List Pacemaker return codes (non-positive) (with names)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -n -l -r --output-as=xml">
+  <result-code code="-1041" name="pcmk_rc_ipc_more" description="More IPC message fragments to send"/>
   <result-code code="-1040" name="pcmk_rc_no_dc" description="DC is not yet elected"/>
   <result-code code="-1039" name="pcmk_rc_compression" description="Compression/decompression error"/>
   <result-code code="-1038" name="pcmk_rc_ns_resolution" description="Nameserver resolution error"/>

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -106,9 +106,13 @@ cib_notify_send(const xmlNode *xml)
 {
     struct iovec *iov;
     struct cib_notification_s update;
-
+    GString *iov_buffer = NULL;
     ssize_t bytes = 0;
-    int rc = pcmk__ipc_prepare_iov(0, xml, &iov, &bytes);
+    int rc = pcmk_rc_ok;
+
+    iov_buffer = g_string_sized_new(1024);
+    pcmk__xml_string(xml, 0, iov_buffer, 0);
+    rc = pcmk__ipc_prepare_iov(0, iov_buffer, &iov, &bytes);
 
     if (rc == pcmk_rc_ok) {
         update.msg = xml;
@@ -121,6 +125,8 @@ cib_notify_send(const xmlNode *xml)
         crm_notice("Could not notify clients: %s " QB_XS " rc=%d",
                    pcmk_rc_str(rc), rc);
     }
+
+    g_string_free(iov_buffer, TRUE);
 }
 
 void

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -112,7 +112,7 @@ cib_notify_send(const xmlNode *xml)
 
     iov_buffer = g_string_sized_new(1024);
     pcmk__xml_string(xml, 0, iov_buffer, 0);
-    rc = pcmk__ipc_prepare_iov(0, iov_buffer, &iov, &bytes);
+    rc = pcmk__ipc_prepare_iov(0, iov_buffer, 0, &iov, &bytes);
 
     if (rc == pcmk_rc_ok) {
         update.msg = xml;

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -123,15 +123,44 @@ lrmd_ipc_created(qb_ipcs_connection_t * c)
 static int32_t
 lrmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     pcmk__client_t *client = pcmk__find_client(c);
-    xmlNode *request = pcmk__client_data2xml(client, data, &id, &flags);
+    xmlNode *request = NULL;
 
     CRM_CHECK(client != NULL, crm_err("Invalid client");
               return FALSE);
     CRM_CHECK(client->id != NULL, crm_err("Invalid client: %p", client);
               return FALSE);
+
+    rc = pcmk__ipc_msg_append(&client->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        request = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        g_byte_array_free(client->buffer, TRUE);
+        client->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (client->buffer != NULL) {
+            g_byte_array_free(client->buffer, TRUE);
+            client->buffer = NULL;
+        }
+
+        return 0;
+    }
 
     CRM_CHECK(flags & crm_ipc_client_response, crm_err("Invalid client request: %p", client);
               return FALSE);

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the Pacemaker project contributors
+ * Copyright 2012-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -227,6 +227,7 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
 static int32_t
 ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     pcmk__client_t *client = pcmk__find_client(c);
@@ -253,7 +254,33 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
      * This function is receiving a request from connection
      * 1 and forwarding it to connection 2.
      */
-    request = pcmk__client_data2xml(client, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&client->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        request = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        g_byte_array_free(client->buffer, TRUE);
+        client->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (client->buffer != NULL) {
+            g_byte_array_free(client->buffer, TRUE);
+            client->buffer = NULL;
+        }
+
+        return 0;
+    }
 
     if (!request) {
         return 0;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -100,12 +100,38 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         return 0;
     }
 
-    request = pcmk__client_data2xml(c, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&c->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        request = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (c->buffer != NULL) {
+            g_byte_array_free(c->buffer, TRUE);
+            c->buffer = NULL;
+        }
+
+        return 0;
+    }
+
     if (request == NULL) {
         pcmk__ipc_send_ack(c, id, flags, PCMK__XE_NACK, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
-
 
     op = crm_element_value(request, PCMK__XA_CRM_TASK);
     if(pcmk__str_eq(op, CRM_OP_RM_NODE_CACHE, pcmk__str_casei)) {

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 the Pacemaker project contributors
+ * Copyright 2010-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -207,6 +207,7 @@ pcmk_ipc_destroy(qb_ipcs_connection_t * c)
 static int32_t
 pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     xmlNode *msg = NULL;
@@ -218,7 +219,34 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         pcmkd_register_handlers();
     }
 
-    msg = pcmk__client_data2xml(c, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&c->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        msg = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (c->buffer != NULL) {
+            g_byte_array_free(c->buffer, TRUE);
+            c->buffer = NULL;
+        }
+
+        return 0;
+    }
+
     if (msg == NULL) {
         pcmk__ipc_send_ack(c, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
         return 0;

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -223,6 +223,7 @@ pe_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
 static int32_t
 pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     xmlNode *msg = NULL;
@@ -235,7 +236,34 @@ pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         schedulerd_register_handlers();
     }
 
-    msg = pcmk__client_data2xml(c, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&c->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        msg = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (c->buffer != NULL) {
+            g_byte_array_free(c->buffer, TRUE);
+            c->buffer = NULL;
+        }
+
+        return 0;
+    }
+
     if (msg == NULL) {
         pcmk__ipc_send_ack(c, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
         return 0;

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -150,6 +150,10 @@ enum crm_ipc_flags
     //! All replies to proxied connections are sent as events.  This flag
     //! preserves whether the events should be treated as an Event or a Response
     crm_ipc_proxied_relay_response  = (UINT32_C(1) << 18),
+    //! This is a multi-part IPC message
+    crm_ipc_multipart               = (UINT32_C(1) << 19),
+    //! This is the end of a multi-part IPC message
+    crm_ipc_multipart_end           = (UINT32_C(1) << 20),
 };
 
 typedef struct crm_ipc_s crm_ipc_t;

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -244,6 +244,9 @@ int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);
+bool pcmk__ipc_msg_is_multipart(void *data);
+bool pcmk__ipc_msg_is_multipart_end(void *data);
+uint16_t pcmk__ipc_multipart_id(void *data);
 xmlNode *pcmk__client_data2xml(pcmk__client_t *c, void *data,
                                uint32_t *id, uint32_t *flags);
 

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -244,6 +244,7 @@ int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);
+int pcmk__ipc_msg_append(GByteArray **buffer, void *data);
 bool pcmk__ipc_msg_is_multipart(void *data);
 bool pcmk__ipc_msg_is_multipart_end(void *data);
 uint16_t pcmk__ipc_multipart_id(void *data);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -240,7 +240,7 @@ int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
     pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (tag), (ver), (st))
 
 int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
-                          struct iovec **result, ssize_t *bytes);
+                          uint16_t index, struct iovec **result, ssize_t *bytes);
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -239,7 +239,7 @@ int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
 #define pcmk__ipc_send_ack(c, req, flags, tag, ver, st) \
     pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (tag), (ver), (st))
 
-int pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
+int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
                           struct iovec **result, ssize_t *bytes);
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -172,6 +172,16 @@ struct pcmk__client_s {
     int event_timer;
     GQueue *event_queue;
 
+    /* Buffer used to store a multipart IPC message when we are building it
+     * up over multiple reads.
+     *
+     * NOTE: The use of a GByteArray here restricts the maximum size of an
+     * IPC message.  A GByteArray can hold G_MAXUINT bytes, which is the same
+     * as UINT_MAX.  So, an IPC message can be about 4 GB in size, minus the
+     * header.
+     */
+    GByteArray *buffer;
+
     /* Depending on the client type, only some of the following will be
      * populated/valid. @TODO Maybe convert to a union.
      */

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -110,6 +110,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_ipc_more            = -1041,
     pcmk_rc_no_dc               = -1040,
     pcmk_rc_compression         = -1039,
     pcmk_rc_ns_resolution       = -1038,

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -309,6 +309,7 @@ typedef struct pcmk__ipc_header_s {
     uint32_t size;
     uint32_t flags;
     uint8_t version;
+    uint16_t part_id;               // If this is a multipart message, which part is this?
 } pcmk__ipc_header_t;
 
 G_GNUC_INTERNAL

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1296,7 +1296,7 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
 
     iov_buffer = g_string_sized_new(1024);
     pcmk__xml_string(message, 0, iov_buffer, 0);
-    rc = pcmk__ipc_prepare_iov(id, iov_buffer, &iov, &bytes);
+    rc = pcmk__ipc_prepare_iov(id, iov_buffer, 0, &iov, &bytes);
 
     if (rc != pcmk_rc_ok) {
         crm_warn("Couldn't prepare %s IPC request: %s " QB_XS " rc=%d",

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1067,7 +1067,6 @@ crm_ipc_read(crm_ipc_t * client)
     do {
         ssize_t bytes = qb_ipcc_event_recv(client->ipc, buffer,
                                            crm_ipc_default_buffer_size(), 0);
-        pcmk__ipc_header_t *header = NULL;
 
         if (bytes <= 0) {
             crm_trace("No message received from %s IPC: %s",
@@ -1084,12 +1083,6 @@ crm_ipc_read(crm_ipc_t * client)
 
             break;
         }
-
-        header = (pcmk__ipc_header_t *)(void *) buffer;
-
-        crm_trace("Received %s IPC event %d size=%u rc=%zd text='%.100s'",
-                  client->server_name, header->qb.id, header->qb.size, bytes,
-                  buffer + sizeof(pcmk__ipc_header_t));
 
         rc = pcmk__ipc_msg_append(&client->buffer, buffer);
 
@@ -1353,9 +1346,11 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
             crm_trace("Sending %s IPC request %d (%spart %d) of %u bytes using %dms timeout",
                       client->server_name, header->qb.id, is_end ? "final " : "",
                       index, header->qb.size, ms_timeout);
+            crm_trace("Text = '%s'", (char *) iov[1].iov_base);
         } else {
             crm_trace("Sending %s IPC request %d of %u bytes using %dms timeout",
                       client->server_name, header->qb.id, header->qb.size, ms_timeout);
+            crm_trace("Text = '%s'", (char *) iov[1].iov_base);
         }
 
         /* Send the IPC request, respecting any timeout we were passed */

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1250,6 +1250,7 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
     struct iovec *iov;
     static uint32_t id = 0;
     pcmk__ipc_header_t *header;
+    GString *iov_buffer = NULL;
 
     if (client == NULL) {
         crm_notice("Can't send IPC request without connection (bug?): %.100s",
@@ -1292,10 +1293,15 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
 
     id++;
     CRM_LOG_ASSERT(id != 0); /* Crude wrap-around detection */
-    rc = pcmk__ipc_prepare_iov(id, message, &iov, &bytes);
+
+    iov_buffer = g_string_sized_new(1024);
+    pcmk__xml_string(message, 0, iov_buffer, 0);
+    rc = pcmk__ipc_prepare_iov(id, iov_buffer, &iov, &bytes);
+
     if (rc != pcmk_rc_ok) {
         crm_warn("Couldn't prepare %s IPC request: %s " QB_XS " rc=%d",
                  client->server_name, pcmk_rc_str(rc), rc);
+        g_string_free(iov_buffer, TRUE);
         return pcmk_rc2legacy(rc);
     }
 
@@ -1369,6 +1375,7 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
                  ((rc == 0)? "No bytes sent" : pcmk_strerror(rc)), rc);
     }
 
+    g_string_free(iov_buffer, TRUE);
     pcmk_free_ipc_event(iov);
     return rc;
 }

--- a/lib/common/ipc_common.c
+++ b/lib/common/ipc_common.c
@@ -70,3 +70,30 @@ pcmk__client_type_str(uint64_t client_type)
             return "unknown";
     }
 }
+
+bool
+pcmk__ipc_msg_is_multipart(void *data)
+{
+    pcmk__ipc_header_t *header = data;
+
+    CRM_LOG_ASSERT(data != NULL);
+    return pcmk_is_set(header->flags, crm_ipc_multipart);
+}
+
+bool
+pcmk__ipc_msg_is_multipart_end(void *data)
+{
+    pcmk__ipc_header_t *header = data;
+
+    CRM_LOG_ASSERT(data != NULL);
+    return pcmk_is_set(header->flags, crm_ipc_multipart_end);
+}
+
+uint16_t
+pcmk__ipc_multipart_id(void *data)
+{
+    pcmk__ipc_header_t *header = data;
+
+    CRM_LOG_ASSERT(data != NULL);
+    return header->part_id;
+}

--- a/lib/common/ipc_common.c
+++ b/lib/common/ipc_common.c
@@ -97,3 +97,91 @@ pcmk__ipc_multipart_id(void *data)
     CRM_LOG_ASSERT(data != NULL);
     return header->part_id;
 }
+
+/*!
+ * \internal
+ * \brief Add more data to a partial IPC message
+ *
+ * This function can be called repeatedly to build up a complete IPC message
+ * from smaller parts.  It does this by inspecting flags on the message.
+ * Most of the time, IPC messages will be small enough where this function
+ * won't get called more than once, but more complex clusters can end up with
+ * very large IPC messages that don't fit in a single buffer.
+ *
+ * Important return values:
+ *
+ * - EBADMSG - Something was wrong with the data.
+ * - pcmk_rc_ipc_more - \p data was a chunk of a partial message and there is
+ *                      more to come.  The caller should not process the message
+ *                      yet and should continue reading from the IPC connection.
+ * - pcmk_rc_ok - We have the complete message.  The caller should process
+ *                it and free the buffer to prepare for the next message.
+ *
+ * \param[in,out] c     The client to add this data to
+ * \param[in]     data  The received IPC message or message portion.  The
+ *                      caller is responsible for freeing this.
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__ipc_msg_append(GByteArray **buffer, void *data)
+{
+    pcmk__ipc_header_t *header = (pcmk__ipc_header_t *) data;
+    const guint8 *payload = (guint8 *) data + sizeof(pcmk__ipc_header_t);
+    int rc = pcmk_rc_ok;
+
+    if (!pcmk__valid_ipc_header(header)) {
+        return EBADMSG;
+    }
+
+    if (pcmk__ipc_msg_is_multipart_end(data)) {
+        /* This is the end of a multipart IPC message.  Add the payload of the
+         * received data (so, don't include the header) to the partial buffer.
+         * Remember that this needs to include the NULL terminating character.
+         */
+        g_byte_array_append(*buffer, payload, header->size);
+
+    } else if (pcmk__ipc_msg_is_multipart(data)) {
+        if (pcmk__ipc_multipart_id(data) == 0) {
+            /* This is the first part of a multipart IPC message.  Initialize
+             * the buffer with the entire message, including its header.  Do
+             * not include the NULL terminating character.
+             */
+            *buffer = g_byte_array_new();
+
+            /* Clear any multipart flags from the header of the incoming part
+             * so they'll be clear in the fully reassembled message.  This
+             * message is passed to pcmk__client_data2xml, which will extract
+             * the header flags and return them.  Those flags can then be used
+             * when constructing a reply, including ACKs.  We don't want these
+             * specific incoming flags to influence the reply.
+             */
+            pcmk__clear_ipc_flags(header->flags, "server",
+                                  crm_ipc_multipart | crm_ipc_multipart_end);
+
+            g_byte_array_append(*buffer, data,
+                                sizeof(pcmk__ipc_header_t) + header->size - 1);
+
+        } else {
+            /* This is some intermediate part of a multipart message.  Add
+             * the payload of the received data (so, don't include the header)
+             * to the partial buffer and return.  Do not include the NULL
+             * terminating character.
+             */
+            g_byte_array_append(*buffer, payload, header->size - 1);
+        }
+
+        rc = pcmk_rc_ipc_more;
+
+    } else {
+        /* This is a standalone IPC message.  For simplicity in the caller,
+         * copy the entire message over into a byte array so it can be handled
+         * the same as a multipart message.
+         */
+        *buffer = g_byte_array_new();
+        g_byte_array_append(*buffer, data,
+                            sizeof(pcmk__ipc_header_t) + header->size);
+    }
+
+    return rc;
+}

--- a/lib/common/ipc_common.c
+++ b/lib/common/ipc_common.c
@@ -141,7 +141,14 @@ pcmk__ipc_msg_append(GByteArray **buffer, void *data)
          */
         g_byte_array_append(*buffer, payload, header->size);
 
+        crm_trace("Received IPC request %d (final part %d) of %u bytes",
+                  header->qb.id, header->part_id, header->qb.size);
+        crm_trace("Text = '%s'", payload);
+        crm_trace("Buffer = '%s'", (*buffer)->data + sizeof(pcmk__ipc_header_t));
+
     } else if (pcmk__ipc_msg_is_multipart(data)) {
+        const char *initial_str = "";
+
         if (pcmk__ipc_multipart_id(data) == 0) {
             /* This is the first part of a multipart IPC message.  Initialize
              * the buffer with the entire message, including its header.  Do
@@ -161,6 +168,7 @@ pcmk__ipc_msg_append(GByteArray **buffer, void *data)
 
             g_byte_array_append(*buffer, data,
                                 sizeof(pcmk__ipc_header_t) + header->size - 1);
+            initial_str = "initial ";
 
         } else {
             /* This is some intermediate part of a multipart message.  Add
@@ -173,6 +181,11 @@ pcmk__ipc_msg_append(GByteArray **buffer, void *data)
 
         rc = pcmk_rc_ipc_more;
 
+        crm_trace("Received IPC request %d (%spart %d) of %u bytes",
+                  header->qb.id, initial_str, header->part_id, header->qb.size);
+        crm_trace("Text = '%s'", payload);
+        crm_trace("Buffer = '%s'", (*buffer)->data + sizeof(pcmk__ipc_header_t));
+
     } else {
         /* This is a standalone IPC message.  For simplicity in the caller,
          * copy the entire message over into a byte array so it can be handled
@@ -181,6 +194,11 @@ pcmk__ipc_msg_append(GByteArray **buffer, void *data)
         *buffer = g_byte_array_new();
         g_byte_array_append(*buffer, data,
                             sizeof(pcmk__ipc_header_t) + header->size);
+
+        crm_trace("Received IPC request %d of %u bytes", header->qb.id,
+                  header->qb.size);
+        crm_trace("Text = '%s'", payload);
+        crm_trace("Buffer = '%s'", (*buffer)->data + sizeof(pcmk__ipc_header_t));
     }
 
     return rc;

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -711,23 +711,40 @@ pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags)
 
     } else {
         ssize_t qb_rc;
+        char *part_text = NULL;
 
         CRM_LOG_ASSERT(header->qb.id != 0);     /* Replying to a specific request */
+
+        if (pcmk__ipc_msg_is_multipart_end(header)) {
+            part_text = crm_strdup_printf(" (final part %d) ", header->part_id);
+        } else if (pcmk__ipc_msg_is_multipart(header)) {
+            if (pcmk__ipc_multipart_id(header) == 0) {
+                part_text = crm_strdup_printf(" (initial part %d) ", header->part_id);
+            } else {
+                part_text = crm_strdup_printf(" (part %d) ", header->part_id);
+            }
+        } else {
+            part_text = crm_strdup_printf(" ");
+        }
 
         qb_rc = qb_ipcs_response_sendv(c->ipcs, iov, 2);
         if (qb_rc < header->qb.size) {
             if (qb_rc < 0) {
                 rc = (int) -qb_rc;
             }
-            crm_notice("Response %" PRId32 " to pid %u failed: %s "
+            crm_notice("Response %" PRId32 "%sto pid %u failed: %s "
                        QB_XS " bytes=%" PRId32 " rc=%zd ipcs=%p",
-                       header->qb.id, c->pid, pcmk_rc_str(rc),
+                       header->qb.id, part_text, c->pid, pcmk_rc_str(rc),
                        header->qb.size, qb_rc, c->ipcs);
+            crm_trace("Text = '%s'", (char *) iov[1].iov_base);
 
         } else {
-            crm_trace("Response %" PRId32 " sent, %zd bytes to %p[%u]",
-                      header->qb.id, qb_rc, c->ipcs, c->pid);
+            crm_trace("Response %" PRId32 "%ssent, %zd bytes to %p[%u]",
+                      header->qb.id, part_text, qb_rc, c->ipcs, c->pid);
+            crm_trace("Text = '%s'", (char *) iov[1].iov_base);
         }
+
+        free(part_text);
 
         if (flags & crm_ipc_server_free) {
             pcmk_free_ipc_event(iov);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -312,6 +312,12 @@ pcmk__free_client(pcmk__client_t *c)
     free(c->id);
     free(c->name);
     free(c->user);
+
+    if (c->buffer != NULL) {
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+    }
+
     if (c->remote) {
         if (c->remote->auth_timeout) {
             g_source_remove(c->remote->auth_timeout);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -425,8 +425,6 @@ pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
         pcmk__set_client_flags(c, pcmk__client_proxied);
     }
 
-    pcmk__assert(text[header->size - 1] == 0);
-
     xml = pcmk__xml_parse(text);
     crm_log_xml_trace(xml, "[IPC received]");
     return xml;

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -649,6 +649,14 @@ pcmk__ipc_prepare_iov(uint32_t request, const GString *message, uint16_t index,
     header->qb.size = iov[0].iov_len + iov[1].iov_len;
     header->qb.id = (int32_t)request;    /* Replying to a specific request */
 
+    if ((rc == pcmk_rc_ok) && (index != 0)) {
+        pcmk__set_ipc_flags(header->flags, "multipart ipc",
+                            crm_ipc_multipart | crm_ipc_multipart_end);
+    } else if (rc == pcmk_rc_ipc_more) {
+        pcmk__set_ipc_flags(header->flags, "multipart ipc",
+                            crm_ipc_multipart);
+    }
+
     *result = iov;
     pcmk__assert(header->qb.size > 0);
     if (bytes != NULL) {

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -550,21 +550,30 @@ crm_ipcs_flush_events(pcmk__client_t *c)
  * \internal
  * \brief Create an I/O vector for sending an IPC XML message
  *
- * \param[in]  request        Identifier for libqb response header
- * \param[in]  message        Message to send
- * \param[out] result         Where to store prepared I/O vector - NULL
- *                            on error
- * \param[out] bytes          Size of prepared data in bytes
+ * If the message is too large to fit into a single buffer, this function will
+ * prepare an I/O vector that only holds as much as fits.  The remainder can
+ * be prepared in a separate call by keeping a running count of
+ * \c result[1].iov_len and passing that in for \p offset.
+ *
+ * \param[in]  request      Identifier for libqb response header
+ * \param[in]  message      Message to send
+ * \param[in]  offset       How many bytes into \p buffer to start when
+ *                          building the message
+ * \param[out] result       Where to store prepared I/O vector - NULL
+ *                          on error
+ * \param[out] bytes        Size of prepared data in bytes (includes header)
  *
  * \return Standard Pacemaker return code
  */
 int
-pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
+pcmk__ipc_prepare_iov(uint32_t request, const GString *message, uint16_t index,
                       struct iovec **result, ssize_t *bytes)
 {
-    struct iovec *iov;
+    struct iovec *iov = NULL;
+    unsigned int payload_size = 0;
     unsigned int total = 0;
     unsigned int max_send_size = crm_ipc_default_buffer_size();
+    size_t offset = 0;
     pcmk__ipc_header_t *header = NULL;
     int rc = pcmk_rc_ok;
 
@@ -585,22 +594,58 @@ pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
     iov[0].iov_base = header;
 
     header->version = PCMK__IPC_VERSION;
-    header->size = message->len + 1;
-    total = iov[0].iov_len + header->size;
+
+    /* We are passed an index, which is basically how many times this function
+     * has been called.  This is how we support multi-part IPC messages.  We
+     * need to convert that into an offset into the buffer that we want to start
+     * reading from.
+     *
+     * Each call to this function can send max_send_size, but this also includes
+     * the header and a null terminator character for the end of the payload.
+     * We need to subtract those out here.
+     */
+    offset = index * (max_send_size - iov[0].iov_len - 1);
+
+    /* How much of message is left to send?  This does not include the null
+     * terminator character.
+     */
+    payload_size = message->len - offset;
+
+    /* How much would be transmitted, including the header size and null
+     * terminator character for the buffer?
+     */
+    total = iov[0].iov_len + payload_size + 1;
 
     if (total >= max_send_size) {
-        crm_trace("%s", message->str);
-        crm_err("Could not transmit message; message size %" PRIu32" bytes is "
-                "larger than the maximum of %" PRIu32, header->size,
-                max_send_size);
-        rc = EMSGSIZE;
-        pcmk_free_ipc_event(iov);
-        goto done;
+        /* The entire packet is too big to fit in a single buffer.  Calculate
+         * how much of it we can send - buffer size, minus header size, minus
+         * one for the null terminator.
+         */
+        payload_size = max_send_size - iov[0].iov_len - 1;
+
+        header->size = payload_size + 1;
+
+        iov[1].iov_base = strndup(message->str + offset, payload_size);
+        if (iov[1].iov_base == NULL) {
+            rc = ENOMEM;
+            pcmk_free_ipc_event(iov);
+            goto done;
+        }
+
+        iov[1].iov_len = header->size;
+        rc = pcmk_rc_ipc_more;
+
+    } else {
+        /* The entire packet fits in a single buffer.  We can copy the entirety
+         * of it into the payload.
+         */
+        header->size = payload_size + 1;
+
+        iov[1].iov_base = pcmk__str_copy(message->str + offset);
+        iov[1].iov_len = header->size;
     }
 
-    iov[1].iov_base = pcmk__str_copy(message->str);
-    iov[1].iov_len = header->size;
-
+    header->part_id = index;
     header->qb.size = iov[0].iov_len + iov[1].iov_len;
     header->qb.id = (int32_t)request;    /* Replying to a specific request */
 
@@ -707,7 +752,7 @@ pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request, const xmlNode *message,
 
     iov_buffer = g_string_sized_new(1024);
     pcmk__xml_string(message, 0, iov_buffer, 0);
-    rc = pcmk__ipc_prepare_iov(request, iov_buffer, &iov, NULL);
+    rc = pcmk__ipc_prepare_iov(request, iov_buffer, 0, &iov, NULL);
 
     if (rc == pcmk_rc_ok) {
         pcmk__set_ipc_flags(flags, "send data", crm_ipc_server_free);

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -430,6 +430,10 @@ static const struct pcmk__rc_info {
       "DC is not yet elected",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_ipc_more",
+      "More IPC message fragments to send",
+      -pcmk_err_generic,
+    },
 };
 
 /*!


### PR DESCRIPTION
There are currently cts-lab failures with the Reattach and Remote* tests caused by this PR that I am still in the middle of tracking down.