### PR TITLE
Test: cts-cli: Make crm_diff test pass again

### DIFF
--- a/cts/cli/regression.crm_diff.exp
+++ b/cts/cli/regression.crm_diff.exp
@@ -6,6 +6,7 @@
   </version>
   <change operation="delete" path="/cib/configuration/comment" position="0"/>
   <change operation="delete" path="/cib/configuration/comment" position="1"/>
+  <change operation="delete" path="/cib/configuration/comment" position="2"/>
   <change operation="delete" path="/cib/configuration/resources/comment" position="0"/>
   <change operation="delete" path="/cib/configuration/resources/primitive[@id='Fencing']/operations/op[@id='Fencing-start-0']"/>
   <change operation="modify" path="/cib/configuration/crm_config/cluster_property_set[@id='cib-bootstrap-options']/nvpair[@id='cib-bootstrap-options-cluster-name']">
@@ -19,6 +20,9 @@
   </change>
   <change operation="create" path="/cib/configuration/nodes" position="4">
     <node id="4" uname="node4"/>
+  </change>
+  <change operation="create" path="/cib/configuration" position="2">
+    <!-- test: add a new comment below this one -->
   </change>
   <change operation="create" path="/cib/configuration" position="3">
     <!-- hello world -->


### PR DESCRIPTION
Commit bb20fd93 introduced a regression. However, there were about four weeks between the last time CI tests were run against the corresponding PR and when the PR was merged. In the interim, a cts-cli test for crm_diff was added. (In particular, it was re-added after a mistaken deletion).

It turns out commit bb20fd93 breaks that test.

This should be wholly insignificant in practice. The result is that a comment that was unchanged may appear in a diff as a deletion followed by a creation, if preceding sibling nodes were deleted or moved. The pcmk__xf_skip flag is no longer being added to deleted nodes before we check whether a comment's old position matches its new position.

This is looking like a pain to fix, and I want to ensure that other PRs don't fail CI due to this issue. That is the purpose of this commit.

As an aside, I don't think we should support diffing XML comments, since Pacemaker doesn't care about them. This support complicates our XML diff code CONSIDERABLY.