### PR TITLE
Refactor: scheduler: Lower fencing log message to debug level.

### DIFF
--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -452,8 +452,8 @@ unpack_config(xmlNode *config, pcmk_scheduler_t *scheduler)
     value = pcmk__cluster_option(config_hash,
                                  PCMK__OPT_FENCE_REMOTE_WITHOUT_QUORUM);
     if ((value != NULL) && !crm_is_true(value)) {
-        crm_warn(PCMK__OPT_FENCE_REMOTE_WITHOUT_QUORUM " disabled - remote "
-                 "nodes may not be fenced in inquorate partition");
+        crm_debug(PCMK__OPT_FENCE_REMOTE_WITHOUT_QUORUM " disabled - remote "
+                  "nodes may not be fenced in inquorate partition");
         scheduler->fence_remote_without_quorum = false;
     } else {
         scheduler->fence_remote_without_quorum = true;


### PR DESCRIPTION
Most other things in unpack_config are logged at debug or trace level. Having the fencing message at the warn level makes it come up quite often.