### PR TITLE
[2.1] Drop deprecated xmlSetBufferAllocationScheme() call (fix builds on debian-experimental)

### DIFF
--- a/lib/common/tests/xml/crm_xml_init_test.c
+++ b/lib/common/tests/xml/crm_xml_init_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the Pacemaker project contributors
+ * Copyright 2023-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,12 +14,6 @@
 #include "crmcommon_private.h"
 
 static void
-buffer_scheme_test(void **state)
-{
-    assert_int_equal(XML_BUFFER_ALLOC_DOUBLEIT, xmlGetBufferAllocationScheme());
-}
-
-static void
 schemas_initialized(void **state)
 {
     assert_non_null(pcmk__find_x_0_schema());
@@ -27,5 +21,4 @@ schemas_initialized(void **state)
 
 // The group setup/teardown functions call crm_xml_init()/crm_xml_cleanup()
 PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
-                cmocka_unit_test(buffer_scheme_test),
                 cmocka_unit_test(schemas_initialized))

--- a/lib/common/unittest.c
+++ b/lib/common/unittest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -84,7 +84,7 @@ pcmk__assert_validates(xmlNode *xml)
 int
 pcmk__xml_test_setup_group(void **state)
 {
-    // Load schemas and set libxml2 buffer allocation scheme
+    // Load schemas
     crm_xml_init();
     return 0;
 }

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -2146,13 +2146,6 @@ crm_xml_init(void)
 
     if(init) {
         init = false;
-        /* The default allocator XML_BUFFER_ALLOC_EXACT does far too many
-         * pcmk__realloc()s and it can take upwards of 18 seconds (yes, seconds)
-         * to dump a 28kb tree which XML_BUFFER_ALLOC_DOUBLEIT can do in
-         * less than 1 second.
-         */
-        xmlSetBufferAllocationScheme(XML_BUFFER_ALLOC_DOUBLEIT);
-
         crm_schema_init();
     }
 }


### PR DESCRIPTION
The important part of #3870 for 2.1