### PR TITLE
Support splitting up IPC server events

### DIFF
--- a/cts/cli/regression.error_codes.exp
+++ b/cts/cli/regression.error_codes.exp
@@ -145,6 +145,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: Get negative Pacemaker return code (with name) (XML) - OK (0) =#=#=#=
 * Passed: crm_error             - Get negative Pacemaker return code (with name) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) =#=#=#=
+-1041: More IPC message fragments to send
 -1040: DC is not yet elected
 -1039: Compression/decompression error
 -1038: Nameserver resolution error
@@ -190,6 +191,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error             - List Pacemaker return codes (non-positive)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -l -r --output-as=xml">
+  <result-code code="-1041" description="More IPC message fragments to send"/>
   <result-code code="-1040" description="DC is not yet elected"/>
   <result-code code="-1039" description="Compression/decompression error"/>
   <result-code code="-1038" description="Nameserver resolution error"/>
@@ -235,6 +237,7 @@ pcmk_rc_node_unknown - Node not found
 =#=#=#= End test: List Pacemaker return codes (non-positive) (XML) - OK (0) =#=#=#=
 * Passed: crm_error             - List Pacemaker return codes (non-positive) (XML)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) =#=#=#=
+-1041: pcmk_rc_ipc_more            More IPC message fragments to send
 -1040: pcmk_rc_no_dc               DC is not yet elected
 -1039: pcmk_rc_compression         Compression/decompression error
 -1038: pcmk_rc_ns_resolution       Nameserver resolution error
@@ -280,6 +283,7 @@ pcmk_rc_node_unknown - Node not found
 * Passed: crm_error             - List Pacemaker return codes (non-positive) (with names)
 =#=#=#= Begin test: List Pacemaker return codes (non-positive) (with names) (XML) =#=#=#=
 <pacemaker-result api-version="X" request="crm_error -n -l -r --output-as=xml">
+  <result-code code="-1041" name="pcmk_rc_ipc_more" description="More IPC message fragments to send"/>
   <result-code code="-1040" name="pcmk_rc_no_dc" description="DC is not yet elected"/>
   <result-code code="-1039" name="pcmk_rc_compression" description="Compression/decompression error"/>
   <result-code code="-1038" name="pcmk_rc_ns_resolution" description="Nameserver resolution error"/>

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -106,9 +106,13 @@ cib_notify_send(const xmlNode *xml)
 {
     struct iovec *iov;
     struct cib_notification_s update;
-
+    GString *iov_buffer = NULL;
     ssize_t bytes = 0;
-    int rc = pcmk__ipc_prepare_iov(0, xml, &iov, &bytes);
+    int rc = pcmk_rc_ok;
+
+    iov_buffer = g_string_sized_new(1024);
+    pcmk__xml_string(xml, 0, iov_buffer, 0);
+    rc = pcmk__ipc_prepare_iov(0, iov_buffer, &iov, &bytes);
 
     if (rc == pcmk_rc_ok) {
         update.msg = xml;
@@ -121,6 +125,8 @@ cib_notify_send(const xmlNode *xml)
         crm_notice("Could not notify clients: %s " QB_XS " rc=%d",
                    pcmk_rc_str(rc), rc);
     }
+
+    g_string_free(iov_buffer, TRUE);
 }
 
 void

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -112,7 +112,7 @@ cib_notify_send(const xmlNode *xml)
 
     iov_buffer = g_string_sized_new(1024);
     pcmk__xml_string(xml, 0, iov_buffer, 0);
-    rc = pcmk__ipc_prepare_iov(0, iov_buffer, &iov, &bytes);
+    rc = pcmk__ipc_prepare_iov(0, iov_buffer, 0, &iov, &bytes);
 
     if (rc == pcmk_rc_ok) {
         update.msg = xml;

--- a/include/crm/common/ipc.h
+++ b/include/crm/common/ipc.h
@@ -150,6 +150,10 @@ enum crm_ipc_flags
     //! All replies to proxied connections are sent as events.  This flag
     //! preserves whether the events should be treated as an Event or a Response
     crm_ipc_proxied_relay_response  = (UINT32_C(1) << 18),
+    //! This is a multi-part IPC message
+    crm_ipc_multipart               = (UINT32_C(1) << 19),
+    //! This is the end of a multi-part IPC message
+    crm_ipc_multipart_end           = (UINT32_C(1) << 20),
 };
 
 typedef struct crm_ipc_s crm_ipc_t;

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -245,6 +245,7 @@ int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);
 void pcmk__ipc_free_client_buffer(crm_ipc_t *client);
+int pcmk__ipc_msg_append(GByteArray **buffer, guint8 *data);
 xmlNode *pcmk__client_data2xml(pcmk__client_t *c, void *data,
                                uint32_t *id, uint32_t *flags);
 

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -244,6 +244,7 @@ int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);
+void pcmk__ipc_free_client_buffer(crm_ipc_t *client);
 xmlNode *pcmk__client_data2xml(pcmk__client_t *c, void *data,
                                uint32_t *id, uint32_t *flags);
 

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -240,7 +240,7 @@ int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
     pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (tag), (ver), (st))
 
 int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
-                          struct iovec **result, ssize_t *bytes);
+                          uint16_t index, struct iovec **result, ssize_t *bytes);
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -239,7 +239,7 @@ int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
 #define pcmk__ipc_send_ack(c, req, flags, tag, ver, st) \
     pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (tag), (ver), (st))
 
-int pcmk__ipc_prepare_iov(uint32_t request, const xmlNode *message,
+int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
                           struct iovec **result, ssize_t *bytes);
 int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
                        const xmlNode *message, uint32_t flags);

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -110,6 +110,7 @@ enum pcmk_rc_e {
     /* When adding new values, use consecutively lower numbers, update the array
      * in lib/common/results.c, and test with crm_error.
      */
+    pcmk_rc_ipc_more            = -1041,
     pcmk_rc_no_dc               = -1040,
     pcmk_rc_compression         = -1039,
     pcmk_rc_ns_resolution       = -1038,

--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -309,6 +309,7 @@ typedef struct pcmk__ipc_header_s {
     uint32_t size;
     uint32_t flags;
     uint8_t version;
+    uint16_t part_id;               // If this is a multipart message, which part is this?
 } pcmk__ipc_header_t;
 
 G_GNUC_INTERNAL

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -428,6 +428,7 @@ pcmk_dispatch_ipc(pcmk_ipc_api_t *api)
     while (crm_ipc_ready(api->ipc) > 0) {
         if (crm_ipc_read(api->ipc) > 0) {
             dispatch_ipc_data(crm_ipc_buffer(api->ipc), api);
+            pcmk__ipc_free_client_buffer(api->ipc);
         }
     }
 }
@@ -699,6 +700,7 @@ pcmk__send_ipc_request(pcmk_ipc_api_t *api, const xmlNode *request)
             }
 
             rc = dispatch_ipc_data(crm_ipc_buffer(api->ipc), api);
+            pcmk__ipc_free_client_buffer(api->ipc);
 
             if (rc == pcmk_rc_ok) {
                 more = false;

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1266,9 +1266,9 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
 
     iov_buffer = g_string_sized_new(1024);
     pcmk__xml_string(message, 0, iov_buffer, 0);
-    rc = pcmk__ipc_prepare_iov(id, iov_buffer, &iov, &bytes);
+    rc = pcmk__ipc_prepare_iov(id, iov_buffer, 0, &iov, &bytes);
 
-    if (rc != pcmk_rc_ok) {
+    if ((rc != pcmk_rc_ok) && (rc != pcmk_rc_ipc_more)) {
         crm_warn("Couldn't prepare %s IPC request: %s " QB_XS " rc=%d",
                  client->server_name, pcmk_rc_str(rc), rc);
         g_string_free(iov_buffer, TRUE);

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1136,6 +1136,7 @@ const char *
 crm_ipc_buffer(crm_ipc_t * client)
 {
     pcmk__assert(client != NULL);
+    CRM_CHECK(client->buffer != NULL, return NULL);
     return (const char *) (client->buffer->data + sizeof(pcmk__ipc_header_t));
 }
 

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -822,7 +822,7 @@ struct crm_ipc_s {
     unsigned int buf_size;     // size of allocated buffer
     int msg_size;
     int need_reply;
-    char *buffer;
+    GByteArray *buffer;
     char *server_name;          // server IPC name being connected to
     qb_ipcc_connection_t *ipc;
 };
@@ -860,16 +860,9 @@ crm_ipc_new(const char *name, size_t max_size)
         free(client);
         return NULL;
     }
-    client->buf_size = crm_ipc_default_buffer_size();
-    client->buffer = malloc(client->buf_size);
-    if (client->buffer == NULL) {
-        crm_err("Could not create %s IPC connection: %s",
-                name, strerror(errno));
-        free(client->server_name);
-        free(client);
-        return NULL;
-    }
 
+    client->buf_size = crm_ipc_default_buffer_size();
+    client->buffer = NULL;
     client->pfd.fd = -1;
     client->pfd.events = POLLIN;
     client->pfd.revents = 0;
@@ -969,7 +962,11 @@ crm_ipc_destroy(crm_ipc_t * client)
             crm_trace("Destroying inactive %s IPC connection",
                       client->server_name);
         }
-        free(client->buffer);
+
+        if (client->buffer != NULL) {
+            pcmk__ipc_free_client_buffer(client);
+        }
+
         free(client->server_name);
         free(client);
     }
@@ -1063,30 +1060,33 @@ long
 crm_ipc_read(crm_ipc_t * client)
 {
     pcmk__ipc_header_t *header = NULL;
+    guint8 *buffer = NULL;
+    long rc = -ENOMSG;
 
-    pcmk__assert((client != NULL) && (client->ipc != NULL)
-                 && (client->buffer != NULL));
+    pcmk__assert((client != NULL) && (client->ipc != NULL));
 
-    client->buffer[0] = 0;
-    client->msg_size = qb_ipcc_event_recv(client->ipc, client->buffer,
+    buffer = g_malloc0(crm_ipc_default_buffer_size());
+    client->msg_size = qb_ipcc_event_recv(client->ipc, buffer,
                                           client->buf_size, 0);
+
     if (client->msg_size >= 0) {
-        header = (pcmk__ipc_header_t *)(void*)client->buffer;
+        header = (pcmk__ipc_header_t *)(void*) buffer;
         if (!pcmk__valid_ipc_header(header)) {
-            return -EBADMSG;
+            rc = -EBADMSG;
+            goto done;
         }
 
         crm_trace("Received %s IPC event %d size=%u rc=%d text='%.100s'",
                   client->server_name, header->qb.id, header->qb.size,
-                  client->msg_size,
-                  client->buffer + sizeof(pcmk__ipc_header_t));
+                  client->msg_size, buffer + sizeof(pcmk__ipc_header_t));
 
     } else {
         crm_trace("No message received from %s IPC: %s",
                   client->server_name, pcmk_strerror(client->msg_size));
 
         if (client->msg_size == -EAGAIN) {
-            return -EAGAIN;
+            rc = -EAGAIN;
+            goto done;
         }
     }
 
@@ -1095,17 +1095,35 @@ crm_ipc_read(crm_ipc_t * client)
     }
 
     if (header) {
-        /* Data excluding the header */
-        return header->size;
+        client->buffer = g_byte_array_sized_new(client->buf_size);
+        g_byte_array_append(client->buffer, (const guint8 *) buffer,
+                            client->msg_size);
+
+        /* Data length excluding the header */
+        rc = header->size;
     }
-    return -ENOMSG;
+
+done:
+    g_free(buffer);
+    return rc;
+}
+
+void
+pcmk__ipc_free_client_buffer(crm_ipc_t *client)
+{
+    pcmk__assert(client != NULL);
+
+    if (client->buffer != NULL) {
+        g_byte_array_free(client->buffer, TRUE);
+        client->buffer = NULL;
+    }
 }
 
 const char *
 crm_ipc_buffer(crm_ipc_t * client)
 {
     pcmk__assert(client != NULL);
-    return client->buffer + sizeof(pcmk__ipc_header_t);
+    return (const char *) (client->buffer->data + sizeof(pcmk__ipc_header_t));
 }
 
 uint32_t
@@ -1118,7 +1136,7 @@ crm_ipc_buffer_flags(crm_ipc_t * client)
         return 0;
     }
 
-    header = (pcmk__ipc_header_t *)(void*)client->buffer;
+    header = (pcmk__ipc_header_t *)(void*) client->buffer->data;
     return header->flags;
 }
 
@@ -1134,6 +1152,7 @@ static int
 internal_ipc_get_reply(crm_ipc_t *client, int request_id, int ms_timeout,
                        ssize_t *bytes, xmlNode **reply)
 {
+    guint8 *buffer = NULL;
     pcmk__ipc_header_t *hdr = NULL;
     time_t timeout = 0;
     int32_t qb_timeout = -1;
@@ -1148,11 +1167,16 @@ internal_ipc_get_reply(crm_ipc_t *client, int request_id, int ms_timeout,
     crm_trace("Expecting reply to %s IPC message %d", client->server_name,
               request_id);
 
+    buffer = g_malloc0(client->buf_size);
+
     do {
+        guint8 *data = NULL;
         xmlNode *xml = NULL;
 
-        *bytes = qb_ipcc_recv(client->ipc, client->buffer, client->buf_size,
+        *bytes = qb_ipcc_recv(client->ipc, buffer, client->buf_size,
                               qb_timeout);
+
+        hdr = (pcmk__ipc_header_t *) (void *) buffer;
 
         if (*bytes <= 0) {
             if (!crm_ipc_connected(client)) {
@@ -1162,16 +1186,26 @@ internal_ipc_get_reply(crm_ipc_t *client, int request_id, int ms_timeout,
             }
 
             continue;
-        }
 
-        hdr = (pcmk__ipc_header_t *)(void*) client->buffer;
-
-        if (hdr->qb.id == request_id) {
-            /* Got the reply we were expecting. */
+        } else if (*bytes != hdr->size + sizeof(pcmk__ipc_header_t)) {
+            crm_trace("Message size does not match header");
+            rc = -EBADMSG;
             break;
         }
 
-        xml = pcmk__xml_parse(crm_ipc_buffer(client));
+        if (hdr->qb.id == request_id) {
+            /* Got the reply we were expecting. */
+            if (client->buffer != NULL) {
+                pcmk__ipc_free_client_buffer(client);
+            }
+
+            client->buffer = g_byte_array_sized_new(client->buf_size);
+            g_byte_array_append(client->buffer, (const guint8 *) buffer, *bytes);
+            break;
+        }
+
+        data = buffer + sizeof(pcmk__ipc_header_t);
+        xml = pcmk__xml_parse((const char *) data);
 
         if (hdr->qb.id < request_id) {
             crm_err("Discarding old reply %d (need %d)", hdr->qb.id, request_id);
@@ -1202,6 +1236,12 @@ internal_ipc_get_reply(crm_ipc_t *client, int request_id, int ms_timeout,
      * the callers to take appropriate action after that.
      */
 
+    /* Once we've parsed the client buffer as XML and saved it to reply,
+     * there's no need to keep the client buffer around anymore.  Free it here
+     * to avoid having to do this anywhere crm_ipc_send is called.
+     */
+    pcmk__ipc_free_client_buffer(client);
+    g_free(buffer);
     return rc;
 }
 
@@ -1247,8 +1287,17 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
         ms_timeout = 5000;
     }
 
+    /* This loop exists only to clear out any old replies that we haven't
+     * yet read.  We don't care about their contents since it's too late to
+     * do anything with them, so we just read and throw them away.
+     */
     if (client->need_reply) {
-        qb_rc = qb_ipcc_recv(client->ipc, client->buffer, client->buf_size, ms_timeout);
+        char *buffer = pcmk__assert_alloc(crm_ipc_default_buffer_size(),
+                                          sizeof(char));
+
+        qb_rc = qb_ipcc_recv(client->ipc, buffer, client->buf_size, ms_timeout);
+        free(buffer);
+
         if (qb_rc < 0) {
             crm_warn("Sending %s IPC disabled until pending reply received",
                      client->server_name);

--- a/lib/common/ipc_common.c
+++ b/lib/common/ipc_common.c
@@ -70,3 +70,121 @@ pcmk__client_type_str(uint64_t client_type)
             return "unknown";
     }
 }
+
+/*!
+ * \internal
+ * \brief Add more data to a received partial IPC message
+ *
+ * This function can be called repeatedly to build up a complete IPC message
+ * from smaller parts.  It does this by inspecting flags on the message.
+ * Most of the time, IPC messages will be small enough where this function
+ * won't get called more than once, but more complex clusters can end up with
+ * very large IPC messages that don't fit in a single buffer.
+ *
+ * Important return values:
+ *
+ * - EBADMSG - Something was wrong with the data.
+ * - pcmk_rc_ipc_more - \p data was a chunk of a partial message and there is
+ *                      more to come.  The caller should not process the message
+ *                      yet and should continue reading from the IPC connection.
+ * - pcmk_rc_ok - We have the complete message.  The caller should process
+ *                it and free the buffer to prepare for the next message.
+ *
+ * \param[in,out] buffer The buffer to add this data to
+ * \param[in]     data   The received IPC message or message portion.
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__ipc_msg_append(GByteArray **buffer, guint8 *data)
+{
+    pcmk__ipc_header_t *full_header = NULL;
+    pcmk__ipc_header_t *header = (pcmk__ipc_header_t *) (void *) data;
+    const guint8 *payload = (guint8 *) data + sizeof(pcmk__ipc_header_t);
+    int rc = pcmk_rc_ok;
+
+    if (!pcmk__valid_ipc_header(header)) {
+        return EBADMSG;
+    }
+
+    if (pcmk_is_set(header->flags, crm_ipc_multipart_end)) {
+        full_header = (pcmk__ipc_header_t *) (void *) (*buffer)->data;
+
+        /* This is the end of a multipart IPC message.  Add the payload of the
+         * received data (so, don't include the header) to the partial buffer.
+         * Remember that this needs to include the null terminating character.
+         */
+        CRM_CHECK(buffer != NULL && *buffer != NULL && header->part_id != 0,
+                  return EINVAL);
+        CRM_CHECK(full_header->qb.id == header->qb.id, return EBADMSG);
+        g_byte_array_append(*buffer, payload, header->size);
+
+        crm_trace("Received IPC message %" PRId32 " (final part %" PRIu16 ") of %"
+                  PRId32 " bytes",
+                  header->qb.id, header->part_id, header->qb.size);
+
+    } else if (pcmk_is_set(header->flags, crm_ipc_multipart)) {
+        if (header->part_id == 0) {
+            /* This is the first part of a multipart IPC message.  Initialize
+             * the buffer with the entire message, including its header.  Do
+             * not include the null terminating character.
+             */
+            CRM_CHECK(buffer != NULL && *buffer == NULL, return EINVAL);
+            *buffer = g_byte_array_new();
+
+            /* Clear any multipart flags from the header of the incoming part
+             * so they'll be clear in the fully reassembled message.  This
+             * message is passed to pcmk__client_data2xml, which will extract
+             * the header flags and return them.  Those flags can then be used
+             * when constructing a reply, including ACKs.  We don't want these
+             * specific incoming flags to influence the reply.
+             */
+            pcmk__clear_ipc_flags(header->flags, "server", crm_ipc_multipart);
+
+            g_byte_array_append(*buffer, data,
+                                sizeof(pcmk__ipc_header_t) + header->size - 1);
+
+        } else {
+            full_header = (pcmk__ipc_header_t *) (void *) (*buffer)->data;
+
+            /* This is some intermediate part of a multipart message.  Add
+             * the payload of the received data (so, don't include the header)
+             * to the partial buffer and return.  Do not include the null
+             * terminating character.
+             */
+            CRM_CHECK(buffer != NULL && *buffer != NULL, return EINVAL);
+            CRM_CHECK(full_header->qb.id == header->qb.id, return EBADMSG);
+            g_byte_array_append(*buffer, payload, header->size - 1);
+        }
+
+        crm_trace("Received IPC message %" PRId32 " (part %" PRIu16 ") of %"
+                  PRId32 " bytes",
+                  header->qb.id, header->part_id, header->qb.size);
+
+        rc = pcmk_rc_ipc_more;
+
+    } else {
+        /* This is a standalone IPC message.  For simplicity in the caller,
+         * copy the entire message over into a byte array so it can be handled
+         * the same as a multipart message.
+         */
+        CRM_CHECK(buffer != NULL && *buffer == NULL, return EINVAL);
+        *buffer = g_byte_array_new();
+        g_byte_array_append(*buffer, data,
+                            sizeof(pcmk__ipc_header_t) + header->size);
+
+        crm_trace("Received IPC message %" PRId32 " of %" PRId32 " bytes",
+                  header->qb.id, header->qb.size);
+    }
+
+    crm_trace("Text = %s", payload);
+    crm_trace("Buffer = %s", (*buffer)->data + sizeof(pcmk__ipc_header_t));
+
+    /* The buffer's header should have a size that matches the full size of
+     * the received message, not just the last chunk of it.
+     */
+    full_header = (pcmk__ipc_header_t *) (void *) (*buffer)->data;
+    full_header->size = (*buffer)->len - sizeof(pcmk__ipc_header_t);
+
+    return rc;
+}

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -691,7 +691,17 @@ pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags)
 
     pcmk__set_ipc_flags(header->flags, "server event", flags);
     if (pcmk_is_set(flags, crm_ipc_server_event)) {
-        header->qb.id = id++;   /* We don't really use it, but doesn't hurt to set one */
+        /* Server events don't use an ID, though we do set one in
+         * pcmk__ipc_prepare_iov if the event is in response to a particular
+         * request.  In that case, we don't want to set a new ID here that
+         * overwrites that one.
+         *
+         * @TODO: Since server event IDs aren't used anywhere, do we really
+         * need to set this for any reason other than ease of logging?
+         */
+        if (header->qb.id == 0) {
+            header->qb.id = id++;
+        }
 
         if (pcmk_is_set(flags, crm_ipc_server_free)) {
             crm_trace("Sending the original to %p[%d]", c->ipcs, c->pid);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -650,6 +650,14 @@ pcmk__ipc_prepare_iov(uint32_t request, const GString *message, uint16_t index,
     header->qb.size = iov[0].iov_len + iov[1].iov_len;
     header->qb.id = (int32_t)request;    /* Replying to a specific request */
 
+    if ((rc == pcmk_rc_ok) && (index != 0)) {
+        pcmk__set_ipc_flags(header->flags, "multipart ipc",
+                            crm_ipc_multipart | crm_ipc_multipart_end);
+    } else if (rc == pcmk_rc_ipc_more) {
+        pcmk__set_ipc_flags(header->flags, "multipart ipc",
+                            crm_ipc_multipart);
+    }
+
     *result = iov;
     pcmk__assert(header->qb.size > 0);
     if (bytes != NULL) {

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -729,6 +729,10 @@ mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, gpointer data)
                     crm_trace("Could not read IPC message from %s: %s (%ld)",
                               client->name, pcmk_strerror(read_rc), read_rc);
 
+                    if (read_rc == -EAGAIN) {
+                        continue;
+                    }
+
                 } else if (client->dispatch_fn_ipc) {
                     const char *buffer = crm_ipc_buffer(client->ipc);
 
@@ -740,6 +744,8 @@ mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, gpointer data)
                         rc = G_SOURCE_REMOVE;
                     }
                 }
+
+                pcmk__ipc_free_client_buffer(client->ipc);
 
             } while ((rc == G_SOURCE_CONTINUE) && (read_rc > 0) && --max > 0);
 

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -430,6 +430,10 @@ static const struct pcmk__rc_info {
       "DC is not yet elected",
       -pcmk_err_generic,
     },
+    { "pcmk_rc_ipc_more",
+      "More IPC message fragments to send",
+      -pcmk_err_generic,
+    },
 };
 
 /*!

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1685,6 +1685,7 @@ stonith__api_dispatch(stonith_t *stonith_api)
             const char *msg = crm_ipc_buffer(private->ipc);
 
             stonith_dispatch_internal(msg, strlen(msg), stonith_api);
+            pcmk__ipc_free_client_buffer(private->ipc);
         }
 
         if (!crm_ipc_connected(private->ipc)) {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -538,6 +538,7 @@ lrmd_dispatch(lrmd_t * lrmd)
                     const char *msg = crm_ipc_buffer(private->ipc);
 
                     lrmd_ipc_dispatch(msg, strlen(msg), lrmd);
+                    pcmk__ipc_free_client_buffer(private->ipc);
                 }
             }
             break;


### PR DESCRIPTION
There's two kinds of IPC messages - regular ones (these don't really have a name), and server events.  These use different libqb channels, different libqb send/recv functions, and for the most part different pacemaker functions.  Server events are much easier to deal with from a split up perspective: they are added to a send queue that is periodically flushed, which means there's no need to worry with EAGAIN.  They also, for the most part, seem to be smaller so they don't get split up as much which means less traffic bogging down the network.

This PR takes a lot of code from #3868 and rearranges some of the patches to be in a more logical order, but changes the patches to handle the sending and receiving.  I think this should make it easier to review as well since there's a whole lot less going on.  I'm going to leave the old PR open for the moment and leave this one as a draft given the last commit.