### PR TITLE
Test: cts: Ignore the "Local CIB ... differs from ..." message.

### DIFF
--- a/python/pacemaker/_cts/patterns.py
+++ b/python/pacemaker/_cts/patterns.py
@@ -37,6 +37,10 @@ class BasePatterns:
             # transition error logging their own error message, which should
             # always be the case.
             r"pacemaker-schedulerd.* Calculated transition .*/pe-error",
+
+            # This message comes up periodically but doesn't actually seem to
+            # be related to any specific test failure, so just ignore it.
+            r"pacemaker-based.* Local CIB .* differs from",
         ]
 
         self._commands = {


### PR DESCRIPTION
This doesn't seem to point at any specific problem that prevents ctslab from running and passing, but perhaps logging it is important to someone.  So, just ignore it in ctslab.