### PR TITLE
Support splitting up IPC messages

### DIFF
--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -576,7 +576,7 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        xml = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        xml = pcmk__client_data2xml(client, &id, &flags);
         g_byte_array_free(client->buffer, TRUE);
         client->buffer = NULL;
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -324,8 +324,7 @@ cib_common_callback(qb_ipcs_connection_t * c, void *data, size_t size, gboolean 
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        op_request = pcmk__client_data2xml(cib_client, cib_client->buffer->data,
-                                           &id, &flags);
+        op_request = pcmk__client_data2xml(cib_client, &id, &flags);
         g_byte_array_free(cib_client->buffer, TRUE);
         cib_client->buffer = NULL;
 

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -394,7 +394,7 @@ dispatch_controller_ipc(qb_ipcs_connection_t * c, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        msg = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        msg = pcmk__client_data2xml(client, &id, &flags);
         g_byte_array_free(client->buffer, TRUE);
         client->buffer = NULL;
 

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -123,15 +123,44 @@ lrmd_ipc_created(qb_ipcs_connection_t * c)
 static int32_t
 lrmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     pcmk__client_t *client = pcmk__find_client(c);
-    xmlNode *request = pcmk__client_data2xml(client, data, &id, &flags);
+    xmlNode *request = NULL;
 
     CRM_CHECK(client != NULL, crm_err("Invalid client");
               return FALSE);
     CRM_CHECK(client->id != NULL, crm_err("Invalid client: %p", client);
               return FALSE);
+
+    rc = pcmk__ipc_msg_append(&client->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        request = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        g_byte_array_free(client->buffer, TRUE);
+        client->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (client->buffer != NULL) {
+            g_byte_array_free(client->buffer, TRUE);
+            client->buffer = NULL;
+        }
+
+        return 0;
+    }
 
     CRM_CHECK(flags & crm_ipc_client_response, crm_err("Invalid client request: %p", client);
               return FALSE);

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -144,7 +144,7 @@ lrmd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        request = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        request = pcmk__client_data2xml(client, &id, &flags);
         g_byte_array_free(client->buffer, TRUE);
         client->buffer = NULL;
 

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -260,7 +260,7 @@ lrmd_server_send_reply(pcmk__client_t *client, uint32_t id, xmlNode *reply)
     crm_trace("Sending reply (%d) to client (%s)", id, client->id);
     switch (PCMK__CLIENT_TYPE(client)) {
         case pcmk__client_ipc:
-            return pcmk__ipc_send_xml(client, id, reply, FALSE);
+            return pcmk__ipc_send_xml(client, id, reply, crm_ipc_flags_none);
 #ifdef PCMK__COMPILE_REMOTE
         case pcmk__client_tls:
             return lrmd__remote_send_xml(client->remote, reply, id, "reply");

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -264,7 +264,7 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        request = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        request = pcmk__client_data2xml(client, &id, &flags);
         g_byte_array_free(client->buffer, TRUE);
         client->buffer = NULL;
 

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -206,7 +206,7 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
 
         crm_element_value_int(xml, PCMK__XA_LRMD_IPC_MSG_ID, &msg_id);
         crm_trace("Sending response to %d - %s", ipc_client->request_id, ipc_client->id);
-        rc = pcmk__ipc_send_xml(ipc_client, msg_id, msg, FALSE);
+        rc = pcmk__ipc_send_xml(ipc_client, msg_id, msg, crm_ipc_flags_none);
 
         CRM_LOG_ASSERT(msg_id == ipc_client->request_id);
         ipc_client->request_id = 0;

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the Pacemaker project contributors
+ * Copyright 2012-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -227,6 +227,7 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
 static int32_t
 ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     pcmk__client_t *client = pcmk__find_client(c);
@@ -253,7 +254,33 @@ ipc_proxy_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
      * This function is receiving a request from connection
      * 1 and forwarding it to connection 2.
      */
-    request = pcmk__client_data2xml(client, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&client->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        request = pcmk__client_data2xml(client, client->buffer->data, &id, &flags);
+        g_byte_array_free(client->buffer, TRUE);
+        client->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (client->buffer != NULL) {
+            g_byte_array_free(client->buffer, TRUE);
+            client->buffer = NULL;
+        }
+
+        return 0;
+    }
 
     if (!request) {
         return 0;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -100,12 +100,38 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         return 0;
     }
 
-    request = pcmk__client_data2xml(c, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&c->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        request = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (c->buffer != NULL) {
+            g_byte_array_free(c->buffer, TRUE);
+            c->buffer = NULL;
+        }
+
+        return 0;
+    }
+
     if (request == NULL) {
         pcmk__ipc_send_ack(c, id, flags, PCMK__XE_NACK, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
-
 
     op = crm_element_value(request, PCMK__XA_CRM_TASK);
     if(pcmk__str_eq(op, CRM_OP_RM_NODE_CACHE, pcmk__str_casei)) {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -110,7 +110,7 @@ st_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        request = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        request = pcmk__client_data2xml(c, &id, &flags);
         g_byte_array_free(c->buffer, TRUE);
         c->buffer = NULL;
 

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -229,7 +229,7 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        msg = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        msg = pcmk__client_data2xml(c, &id, &flags);
         g_byte_array_free(c->buffer, TRUE);
         c->buffer = NULL;
 

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 the Pacemaker project contributors
+ * Copyright 2010-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -207,6 +207,7 @@ pcmk_ipc_destroy(qb_ipcs_connection_t * c)
 static int32_t
 pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     xmlNode *msg = NULL;
@@ -218,7 +219,34 @@ pcmk_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         pcmkd_register_handlers();
     }
 
-    msg = pcmk__client_data2xml(c, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&c->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        msg = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (c->buffer != NULL) {
+            g_byte_array_free(c->buffer, TRUE);
+            c->buffer = NULL;
+        }
+
+        return 0;
+    }
+
     if (msg == NULL) {
         pcmk__ipc_send_ack(c, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
         return 0;

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -223,6 +223,7 @@ pe_ipc_accept(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
 static int32_t
 pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
 {
+    int rc = pcmk_rc_ok;
     uint32_t id = 0;
     uint32_t flags = 0;
     xmlNode *msg = NULL;
@@ -235,7 +236,34 @@ pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         schedulerd_register_handlers();
     }
 
-    msg = pcmk__client_data2xml(c, data, &id, &flags);
+    rc = pcmk__ipc_msg_append(&c->buffer, data);
+
+    if (rc == pcmk_rc_ipc_more) {
+        /* We haven't read the complete message yet, so just return. */
+        return 0;
+
+    } else if (rc == pcmk_rc_ok) {
+        /* We've read the complete message and there's already a header on
+         * the front.  Pass it off for processing.
+         */
+        msg = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+
+    } else {
+        /* Some sort of error occurred reassembling the message.  All we can
+         * do is clean up, log an error and return.
+         */
+        crm_err("Error when reading IPC message: %s", pcmk_rc_str(rc));
+
+        if (c->buffer != NULL) {
+            g_byte_array_free(c->buffer, TRUE);
+            c->buffer = NULL;
+        }
+
+        return 0;
+    }
+
     if (msg == NULL) {
         pcmk__ipc_send_ack(c, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
         return 0;

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -246,7 +246,7 @@ pe_ipc_dispatch(qb_ipcs_connection_t * qbc, void *data, size_t size)
         /* We've read the complete message and there's already a header on
          * the front.  Pass it off for processing.
          */
-        msg = pcmk__client_data2xml(c, c->buffer->data, &id, &flags);
+        msg = pcmk__client_data2xml(c, &id, &flags);
         g_byte_array_free(c->buffer, TRUE);
         c->buffer = NULL;
 

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -251,8 +251,7 @@ int pcmk__ipc_send_xml(pcmk__client_t *c, uint32_t request,
 int pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags);
 void pcmk__ipc_free_client_buffer(crm_ipc_t *client);
 int pcmk__ipc_msg_append(GByteArray **buffer, guint8 *data);
-xmlNode *pcmk__client_data2xml(pcmk__client_t *c, void *data,
-                               uint32_t *id, uint32_t *flags);
+xmlNode *pcmk__client_data2xml(pcmk__client_t *c, uint32_t *id, uint32_t *flags);
 
 int pcmk__client_pid(qb_ipcs_connection_t *c);
 

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -172,6 +172,11 @@ struct pcmk__client_s {
     int event_timer;
     GQueue *event_queue;
 
+    /* Buffer used to store a multipart IPC message when we are building it
+     * up over multiple reads.
+     */
+    GByteArray *buffer;
+
     /* Depending on the client type, only some of the following will be
      * populated/valid. @TODO Maybe convert to a union.
      */

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1322,13 +1322,13 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
              enum crm_ipc_flags flags, int32_t ms_timeout, xmlNode **reply)
 {
     int rc = 0;
-    time_t timeout = 0;
-    ssize_t qb_rc = 0;
     ssize_t bytes = 0;
-    struct iovec *iov;
+    ssize_t sent_bytes = 0;
+    struct iovec *iov = NULL;
     static uint32_t id = 0;
     pcmk__ipc_header_t *header;
     GString *iov_buffer = NULL;
+    uint16_t index = 0;
 
     if (client == NULL) {
         crm_notice("Can't send IPC request without connection (bug?): %.100s",
@@ -1363,39 +1363,82 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
 
     iov_buffer = g_string_sized_new(1024);
     pcmk__xml_string(message, 0, iov_buffer, 0);
-    rc = pcmk__ipc_prepare_iov(id, iov_buffer, 0, &iov, &bytes);
-
-    if ((rc != pcmk_rc_ok) && (rc != pcmk_rc_ipc_more)) {
-        crm_warn("Couldn't prepare %s IPC request: %s " QB_XS " rc=%d",
-                 client->server_name, pcmk_rc_str(rc), rc);
-        g_string_free(iov_buffer, TRUE);
-        return pcmk_rc2legacy(rc);
-    }
-
-    header = iov[0].iov_base;
-    pcmk__set_ipc_flags(header->flags, client->server_name, flags);
-
-    if (pcmk_is_set(flags, crm_ipc_proxied)) {
-        /* Don't look for a synchronous response */
-        pcmk__clear_ipc_flags(flags, "client", crm_ipc_client_response);
-    }
-
-    crm_trace("Sending %s IPC request %d of %u bytes using %dms timeout",
-              client->server_name, header->qb.id, header->qb.size, ms_timeout);
-
-    /* Send the IPC request, respecting any timeout we were passed */
-    if (ms_timeout > 0) {
-        timeout = time(NULL) + 1 + pcmk__timeout_ms2s(ms_timeout);
-    }
 
     do {
-        qb_rc = qb_ipcc_sendv(client->ipc, iov, 2);
-    } while ((qb_rc == -EAGAIN) && ((timeout == 0) || (time(NULL) < timeout)));
+        ssize_t qb_rc = 0;
+        time_t timeout = 0;
 
-    rc = (int) qb_rc; // Negative of system errno, or bytes sent
-    if (qb_rc <= 0) {
-        goto send_cleanup;
-    }
+        rc = pcmk__ipc_prepare_iov(id, iov_buffer, index, &iov, &bytes);
+
+        if ((rc != pcmk_rc_ok) && (rc != pcmk_rc_ipc_more)) {
+            crm_warn("Couldn't prepare %s IPC request: %s " QB_XS " rc=%d",
+                     client->server_name, pcmk_rc_str(rc), rc);
+            g_string_free(iov_buffer, TRUE);
+            return pcmk_rc2legacy(rc);
+        }
+
+        header = iov[0].iov_base;
+        pcmk__set_ipc_flags(header->flags, client->server_name, flags);
+
+        if (pcmk_is_set(flags, crm_ipc_proxied)) {
+            /* Don't look for a synchronous response */
+            pcmk__clear_ipc_flags(flags, "client", crm_ipc_client_response);
+        }
+
+        if (pcmk_is_set(header->flags, crm_ipc_multipart)) {
+            bool is_end = pcmk_is_set(header->flags, crm_ipc_multipart_end);
+            crm_trace("Sending %s IPC request %" PRId32 " (%spart %" PRIu16 ") of "
+                      "%" PRId32 " bytes using %dms timeout",
+                      client->server_name, header->qb.id, is_end ? "final " : "",
+                      index, header->qb.size, ms_timeout);
+            crm_trace("Text = %s", (char *) iov[1].iov_base);
+        } else {
+            crm_trace("Sending %s IPC request %" PRId32 " of %" PRId32 " bytes "
+                      "using %dms timeout",
+                      client->server_name, header->qb.id, header->qb.size,
+                      ms_timeout);
+            crm_trace("Text = %s", (char *) iov[1].iov_base);
+        }
+
+        /* Send the IPC request, respecting any timeout we were passed */
+        if (ms_timeout > 0) {
+            timeout = time(NULL) + 1 + pcmk__timeout_ms2s(ms_timeout);
+        }
+
+        do {
+            qb_rc = qb_ipcc_sendv(client->ipc, iov, 2);
+        } while ((qb_rc == -EAGAIN) && ((timeout == 0) || (time(NULL) < timeout)));
+
+        /* An error occurred when sending. */
+        if (qb_rc <= 0) {
+            rc = (int) qb_rc;   // Negative of system errno
+            goto send_cleanup;
+        }
+
+        /* Sending succeeded.  The next action depends on whether this was a
+         * multipart IPC message or not.
+         */
+        if (rc == pcmk_rc_ok) {
+            /* This was either a standalone IPC message or the last part of
+             * a multipart message.  Set the return value and break out of
+             * this processing loop.
+             */
+            sent_bytes += qb_rc;
+            rc = (int) sent_bytes;
+            break;
+        } else {
+            /* There's no way to get here for any value other than rc == pcmk_rc_more
+             * given the check right after pcmk__ipc_prepare_iov.
+             *
+             * This was a multipart message, loop to process the next chunk.
+             */
+            sent_bytes += qb_rc;
+            index++;
+        }
+
+        pcmk_free_ipc_event(iov);
+        iov = NULL;
+    } while (true);
 
     /* If we should not wait for a response, bail now */
     if (!pcmk_is_set(flags, crm_ipc_client_response)) {

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1447,6 +1447,7 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
         goto send_cleanup;
     }
 
+    pcmk__ipc_free_client_buffer(client);
     rc = internal_ipc_get_reply(client, header->qb.id, ms_timeout, &bytes, reply);
     if (rc == pcmk_rc_ok) {
         rc = (int) bytes; // Size of reply received

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -312,6 +312,12 @@ pcmk__free_client(pcmk__client_t *c)
     free(c->id);
     free(c->name);
     free(c->user);
+
+    if (c->buffer != NULL) {
+        g_byte_array_free(c->buffer, TRUE);
+        c->buffer = NULL;
+    }
+
     if (c->remote) {
         if (c->remote->auth_timeout) {
             g_source_remove(c->remote->auth_timeout);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -392,27 +392,26 @@ pcmk__client_pid(qb_ipcs_connection_t *c)
  * \brief Retrieve message XML from data read from client IPC
  *
  * \param[in,out]  c       IPC client connection
- * \param[in]      data    Data read from client connection
  * \param[out]     id      Where to store message ID from libqb header
  * \param[out]     flags   Where to store flags from libqb header
  *
  * \return Message XML on success, NULL otherwise
  */
 xmlNode *
-pcmk__client_data2xml(pcmk__client_t *c, void *data, uint32_t *id,
-                      uint32_t *flags)
+pcmk__client_data2xml(pcmk__client_t *c, uint32_t *id, uint32_t *flags)
 {
     xmlNode *xml = NULL;
-    char *text = ((char *)data) + sizeof(pcmk__ipc_header_t);
-    pcmk__ipc_header_t *header = data;
+    pcmk__ipc_header_t *header = (void *) c->buffer->data;
+    char *text = (char *) header + sizeof(pcmk__ipc_header_t);
 
     if (!pcmk__valid_ipc_header(header)) {
         return NULL;
     }
 
     if (id) {
-        *id = ((struct qb_ipc_response_header *)data)->id;
+        *id = header->qb.id;
     }
+
     if (flags) {
         *flags = header->flags;
     }


### PR DESCRIPTION
This is it - the last PR necessary for splitting up IPC messages.  There are definitely still problems around scaling the IPC code, but at this point they shouldn't be due to the size of messages, and those problems were pre-existing.