### PR TITLE
Test: libcrmcommon: Fix _wrap_readlink for 32-bit platforms.

### DIFF
--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -419,7 +419,7 @@ __wrap_readlink(const char *restrict path, char *restrict buf,
         const char *contents = NULL;
 
         check_expected_ptr(path);
-        check_expected_ptr(buf);
+        check_expected(buf);
         check_expected(bufsize);
         errno = mock_type(int);
         contents = mock_ptr_type(const char *);


### PR DESCRIPTION
See: clbz#5546