### PR TITLE
Change remote fencing behavior

### DIFF
--- a/cts/cli/regression.crm_attribute.exp
+++ b/cts/cli/regression.crm_attribute.exp
@@ -272,6 +272,11 @@ Also known as properties, these are options that affect behavior across the enti
         <shortdesc lang="en">Whether the cluster should check for active resources during start-up</shortdesc>
         <content type="boolean" default=""/>
       </parameter>
+      <parameter name="fence-remote-without-quorum" advanced="1" generated="0">
+        <longdesc lang="en">By default, an inquorate node can not fence Pacemaker Remote nodes that are part of its partition as long as the cluster thinks they can be restarted.  If true, inquorate nodes will be able to fence remote nodes regardless.</longdesc>
+        <shortdesc lang="en">Whether remote nodes can be fenced without quorum</shortdesc>
+        <content type="boolean" default=""/>
+      </parameter>
       <parameter name="stonith-enabled" advanced="1" generated="0">
         <longdesc lang="en">If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.</longdesc>
         <shortdesc lang="en">Whether nodes may be fenced as part of recovery</shortdesc>
@@ -598,6 +603,10 @@ Also known as properties, these are options that affect behavior across the enti
       * Delay cluster recovery for this much time to allow for additional events to occur. Useful if your configuration is sensitive to the order in which ping updates arrive.
       * Possible values: duration (default: )
 
+    * fence-remote-without-quorum: Whether remote nodes can be fenced without quorum
+      * By default, an inquorate node can not fence Pacemaker Remote nodes that are part of its partition as long as the cluster thinks they can be restarted.  If true, inquorate nodes will be able to fence remote nodes regardless.
+      * Possible values: boolean (default: )
+
     * stonith-enabled: Whether nodes may be fenced as part of recovery
       * If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.
       * Possible values: boolean (default: )
@@ -722,6 +731,11 @@ Also known as properties, these are options that affect behavior across the enti
       <parameter name="enable-startup-probes" advanced="0" generated="0">
         <longdesc lang="en">Whether the cluster should check for active resources during start-up</longdesc>
         <shortdesc lang="en">Whether the cluster should check for active resources during start-up</shortdesc>
+        <content type="boolean" default=""/>
+      </parameter>
+      <parameter name="fence-remote-without-quorum" advanced="1" generated="0">
+        <longdesc lang="en">By default, an inquorate node can not fence Pacemaker Remote nodes that are part of its partition as long as the cluster thinks they can be restarted.  If true, inquorate nodes will be able to fence remote nodes regardless.</longdesc>
+        <shortdesc lang="en">Whether remote nodes can be fenced without quorum</shortdesc>
         <content type="boolean" default=""/>
       </parameter>
       <parameter name="stonith-enabled" advanced="1" generated="0">

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -514,6 +514,15 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
+    <parameter name="fence-remote-without-quorum">
+      <longdesc lang="en">
+        By default, an inquorate node can not fence Pacemaker Remote nodes that are part of its partition as long as the cluster thinks they can be restarted.  If true, inquorate nodes will be able to fence remote nodes regardless.
+      </longdesc>
+      <shortdesc lang="en">
+        *** Advanced Use Only *** Whether remote nodes can be fenced without quorum
+      </shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
     <parameter name="stonith-enabled">
       <longdesc lang="en">
         If false, unresponsive nodes are immediately assumed to be harmless, and resources that were active on them may be recovered elsewhere. This can result in a "split-brain" situation, potentially leading to data loss and/or service unavailability.

--- a/include/crm/common/options.h
+++ b/include/crm/common/options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -37,6 +37,7 @@ extern     "C" {
 #define PCMK_OPT_ENABLE_ACL                     "enable-acl"
 #define PCMK_OPT_ENABLE_STARTUP_PROBES          "enable-startup-probes"
 #define PCMK_OPT_FENCE_REACTION                 "fence-reaction"
+#define PCMK_OPT_FENCE_REMOTE_WITHOUT_QUORUM    "fence-remote-without-quorum"
 #define PCMK_OPT_HAVE_WATCHDOG                  "have-watchdog"
 #define PCMK_OPT_JOIN_FINALIZATION_TIMEOUT      "join-finalization-timeout"
 #define PCMK_OPT_JOIN_INTEGRATION_TIMEOUT       "join-integration-timeout"

--- a/include/crm/common/scheduler_internal.h
+++ b/include/crm/common/scheduler_internal.h
@@ -154,6 +154,11 @@ enum pcmk__scheduler_flags {
      * applying node-specific location criteria, assignment, etc.)
      */
     pcmk__sched_validate_only           = (1ULL << 27),
+
+    /* Can Pacemaker Remote nodes be fenced even from a node that doesn't
+     * have quorum?
+     */
+    pcmk__sched_fence_remote_no_quorum  = (1ULL << 28),
 };
 
 // Implementation of pcmk__scheduler_private_t

--- a/include/crm/crm.h
+++ b/include/crm/crm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -63,7 +63,7 @@ extern "C" {
  * >=3.2.0:  DC supports PCMK_EXEC_INVALID and PCMK_EXEC_NOT_CONNECTED
  * >=3.19.0: DC supports PCMK__CIB_REQUEST_COMMIT_TRANSACT
  */
-#define CRM_FEATURE_SET "3.20.0"
+#define CRM_FEATURE_SET "3.20.1"
 
 /* Pacemaker's CPG protocols use fixed-width binary fields for the sender and
  * recipient of a CPG message. This imposes an arbitrary limit on cluster node

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -229,6 +229,16 @@ static const pcmk__cluster_option_t cluster_options[] = {
     },
 
     // Fencing-related options
+    {
+        PCMK_OPT_FENCE_REMOTE_WITHOUT_QUORUM, NULL, PCMK_VALUE_BOOLEAN, NULL,
+        PCMK_VALUE_FALSE, pcmk__valid_boolean,
+        pcmk__opt_schedulerd|pcmk__opt_advanced,
+        N_("Whether remote nodes can be fenced without quorum"),
+        N_("By default, an inquorate node can not fence Pacemaker Remote nodes "
+           "that are part of its partition as long as the cluster thinks they "
+           "can be restarted.  If true, inquorate nodes will be able to fence "
+           "remote nodes regardless."),
+     },
     {
         PCMK_OPT_STONITH_ENABLED, NULL, PCMK_VALUE_BOOLEAN, NULL,
         PCMK_VALUE_TRUE, pcmk__valid_boolean,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -423,6 +423,14 @@ unpack_config(xmlNode *config, pcmk_scheduler_t *scheduler)
                   pcmk__readable_interval(scheduler->priv->node_pending_ms));
     }
 
+    set_config_flag(scheduler, PCMK_OPT_FENCE_REMOTE_WITHOUT_QUORUM,
+                    pcmk__sched_fence_remote_no_quorum);
+    if (pcmk_is_set(scheduler->flags, pcmk__sched_fence_remote_no_quorum)) {
+        crm_trace("Pacemaker Remote nodes may be fenced without quorum");
+    } else {
+        crm_trace("Pacemaker Remote nodes require quorum to be fenced");
+    }
+
     return TRUE;
 }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -62,10 +62,10 @@ pe_can_fence(const pcmk_scheduler_t *scheduler, const pcmk_node_t *node)
     } else if (scheduler->no_quorum_policy == pcmk_no_quorum_ignore) {
         return true;
 
-    } else if(node == NULL) {
+    } else if (node == NULL) {
         return false;
 
-    } else if(node->details->online) {
+    } else if (node->details->online) {
         crm_notice("We can fence %s without quorum because they're in our membership",
                    pcmk__node_name(node));
         return true;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -66,6 +66,39 @@ pe_can_fence(const pcmk_scheduler_t *scheduler, const pcmk_node_t *node)
         return false;
 
     } else if (node->details->online) {
+        /* Remote nodes are marked online when we assign their resource to a
+         * node, not when they are actually started (see remote_connection_assigned)
+         * so the above test by itself isn't good enough.
+         */
+        if (pcmk__is_pacemaker_remote_node(node)) {
+            /* If we're on a system without quorum, it's entirely possible that
+             * the remote resource was automatically moved to a node on the
+             * partition with quorum.  We can't tell that from this node - the
+             * best we can do is check if it's possible for the resource to run
+             * on another node in the partition with quorum.  If so, it has
+             * likely been moved and we shouldn't fence it.
+             *
+             * NOTE:  This condition appears to only come up in very limited
+             * circumstances.  It at least requires some very lengthy fencing
+             * timeouts set, some way for fencing to still take place (a second
+             * NIC is how I've reproduced it in testing, but fence_scsi or
+             * sbd could work too), and a resource that runs on the remote node.
+             */
+            pcmk_resource_t *rsc = node->priv->remote;
+            pcmk_node_t *n = NULL;
+            GHashTableIter iter;
+
+            g_hash_table_iter_init(&iter, rsc->priv->allowed_nodes);
+            while (g_hash_table_iter_next(&iter, NULL, (void **) &n)) {
+                /* A node that's not online according to this non-quorum node
+                 * is a node that's in another partition.
+                 */
+                if (!n->details->online) {
+                    return false;
+                }
+            }
+        }
+
         crm_notice("We can fence %s without quorum because they're in our membership",
                    pcmk__node_name(node));
         return true;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -70,7 +70,8 @@ pe_can_fence(const pcmk_scheduler_t *scheduler, const pcmk_node_t *node)
          * node, not when they are actually started (see remote_connection_assigned)
          * so the above test by itself isn't good enough.
          */
-        if (pcmk__is_pacemaker_remote_node(node)) {
+        if (pcmk__is_pacemaker_remote_node(node)
+            && !pcmk_is_set(scheduler->flags, pcmk__sched_fence_remote_no_quorum)) {
             /* If we're on a system without quorum, it's entirely possible that
              * the remote resource was automatically moved to a node on the
              * partition with quorum.  We can't tell that from this node - the


### PR DESCRIPTION
This is a patch against the main branch to change remote fencing behavior.  It is substantially different from #3856 and followup PRs, though it addresses the same issue.  Here, we use a scheduler flag and the `set_config_flag` function to grab it.  This gets rid of the need for the followup PRs.  We also default to the new behavior now, and adding the CIB setting changes back to the older behavior.

This is untested (it's a real chore to test), but I suppose I should try to do that again before this actually gets merged.  In the meantime, it's worth making sure I got all these double negatives right.  I also wonder if there's some way we should draw further attention to this change.