### PR TITLE
Low: controller: address format-overflow warning

### DIFF
--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -327,7 +327,6 @@ get_cancel_action(const char *id, const char *node)
 
             task = crm_element_value(action->xml, PCMK__XA_OPERATION_KEY);
             if (!pcmk__str_eq(task, id, pcmk__str_casei)) {
-                crm_trace("Wrong key %s for %s on %s", task, id, node);
                 continue;
             }
 


### PR DESCRIPTION
When using -O3 to build pacemaker, gcc (14) will throw a format-overflow warning for a possibly null '%s' directive argument. We address this warning by removing the meaningless log entry.

This patch is only missing in the `3.0` branch - it has been applied to `main` in #3794 and to `2.1` in #3795 .