### PR TITLE
Error check snprintf

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -414,7 +414,7 @@ cib_digester_cb(gpointer data)
         free(ping_digest);
         ping_digest = NULL;
         ping_modified_since = FALSE;
-        snprintf(buffer, 32, "%" PRIu64, ping_seq);
+        pcmk__snprintf(buffer, 32, "%" PRIu64, ping_seq);
         crm_trace("Requesting peer digests (%s)", buffer);
 
         crm_xml_add(ping, PCMK__XA_T, PCMK__VALUE_CIB);

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the Pacemaker project contributors
+ * Copyright 2012-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -175,12 +175,12 @@ test_exit(crm_exit_t exit_code)
     }
 
 #define report_event(event)                                             \
-    snprintf(event_buf_v0, sizeof(event_buf_v0), "NEW_EVENT event_type:%s rsc_id:%s action:%s rc:%s op_status:%s", \
-             lrmd_event_type2str(event->type),                          \
-             event->rsc_id,                                             \
-             event->op_type ? event->op_type : "none",                  \
-             crm_exit_str((crm_exit_t) event->rc),                      \
-             pcmk_exec_status_str(event->op_status));                   \
+    pcmk__snprintf(event_buf_v0, sizeof(event_buf_v0), "NEW_EVENT event_type:%s rsc_id:%s action:%s rc:%s op_status:%s", \
+                   lrmd_event_type2str(event->type),                    \
+                   event->rsc_id,                                       \
+                   event->op_type ? event->op_type : "none",            \
+                   crm_exit_str((crm_exit_t) event->rc),                \
+                   pcmk_exec_status_str(event->op_status));             \
     crm_info("%s", event_buf_v0);
 
 static void

--- a/daemons/execd/remoted_pidone.c
+++ b/daemons/execd/remoted_pidone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 the Pacemaker project contributors
+ * Copyright 2017-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -277,7 +277,7 @@ remoted_spawn_pidone(int argc, char **argv, char **envp)
         i = strlen(name);
 
         /* We can overwrite individual argv[] arguments */
-        snprintf(argv[0], maxlen, "%s", name);
+        pcmk__snprintf(argv[0], maxlen, "%s", name);
 
         /* Now zero out everything else */
         p = &argv[0][i];

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -329,7 +329,7 @@ get_address_info(const char *bind_name, int port, struct addrinfo **res)
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
 
-    snprintf(port_str, sizeof(port_str), "%d", port);
+    pcmk__snprintf(port_str, sizeof(port_str), "%d", port);
     rc = getaddrinfo(bind_name, port_str, &hints, res);
     rc = pcmk__gaierror2rc(rc);
 

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -518,7 +518,7 @@ test_register_async_devices(int check_event)
                                     "custom_timeout_node1=1,2");
     params = stonith__key_value_add(params, "mode", "fail");
     params = stonith__key_value_add(params, "delay", "1000");
-    snprintf(buf, sizeof(buf) - 1, "%d", MAINLOOP_DEFAULT_TIMEOUT + CUSTOM_TIMEOUT_ADDITION);
+    pcmk__snprintf(buf, sizeof(buf) - 1, "%d", MAINLOOP_DEFAULT_TIMEOUT + CUSTOM_TIMEOUT_ADDITION);
     params = stonith__key_value_add(params, "pcmk_off_timeout", buf);
     st->cmds->register_device(st, st_opts, "false_custom_timeout", "stonith-ng", "fence_dummy",
                               params);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -286,7 +286,7 @@ get_action_timeout(const fenced_device_t *device, const char *action,
         }
 
         /* If the device config specified an action-specific timeout, use it */
-        snprintf(buffer, sizeof(buffer), "pcmk_%s_timeout", action);
+        pcmk__snprintf(buffer, sizeof(buffer), "pcmk_%s_timeout", action);
         value = g_hash_table_lookup(device->params, buffer);
         if (value) {
             long long timeout_ms = crm_get_msec(value);

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 the Pacemaker project contributors
+ * Copyright 2010-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -361,7 +361,7 @@ pacemakerd_read_config(void)
 
         } else {
             char key[PATH_MAX];
-            snprintf(key, PATH_MAX, "uidgid.gid.%u", gid);
+            pcmk__snprintf(key, PATH_MAX, "uidgid.gid.%u", gid);
             rc = cmap_set_uint8(local_handle, key, 1);
             if (rc != CS_OK) {
                 crm_warn("Could not authorize group with Corosync: %s " QB_XS

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the Pacemaker project contributors
+ * Copyright 2015-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -49,6 +49,9 @@ void pcmk__add_separated_word(GString **list, size_t init_size,
                               const char *word, const char *separator);
 int pcmk__compress(const char *data, unsigned int length, unsigned int max,
                    char **result, unsigned int *result_len);
+
+int pcmk__snprintf(char *str, size_t size, const char *format, ...)
+    G_GNUC_PRINTF(3, 4);
 
 int pcmk__scan_ll(const char *text, long long *result, long long default_value);
 int pcmk__scan_min_int(const char *text, int *result, int minimum);

--- a/lib/common/attrs.c
+++ b/lib/common/attrs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2024 the Pacemaker project contributors
+ * Copyright 2011-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -45,10 +45,10 @@ pcmk__node_attr_target(const char *name)
         const char *target = NULL;
         const char *host_physical = NULL;
 
-        snprintf(buf + offset, sizeof(buf) - offset, "%s", target_var);
+        pcmk__snprintf(buf + offset, sizeof(buf) - offset, "%s", target_var);
         target = getenv(buf);
 
-        snprintf(buf + offset, sizeof(buf) - offset, "%s", phys_var);
+        pcmk__snprintf(buf + offset, sizeof(buf) - offset, "%s", phys_var);
         host_physical = getenv(buf);
 
         // It is important to use the name by which the scheduler knows us

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the Pacemaker project contributors
+ * Copyright 2005-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -2239,10 +2239,10 @@ pcmk__readable_interval(guint interval_ms)
             offset += snprintf(str + offset, MAXSTR - offset, ".%03u",
                                interval_ms);
         }
-        (void) snprintf(str + offset, MAXSTR - offset, "s");
+        snprintf(str + offset, MAXSTR - offset, "s");
 
     } else if (interval_ms > 0) {
-        (void) snprintf(str + offset, MAXSTR - offset, "%ums", interval_ms);
+        snprintf(str + offset, MAXSTR - offset, "%ums", interval_ms);
 
     } else if (str[0] == '\0') {
         strcpy(str, "0s");

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -488,9 +488,9 @@ crm_time_get_isoweek(const crm_time_t *dt, uint32_t *y, uint32_t *w,
 static inline void
 sec_usec_as_string(long long sec, int usec, char *buf, size_t *offset)
 {
-    *offset += snprintf(buf + *offset, DATE_MAX - *offset, "%s%lld.%06d",
-                        ((sec == 0) && (usec < 0))? "-" : "",
-                        sec, QB_ABS(usec));
+    *offset += pcmk__snprintf(buf + *offset, DATE_MAX - *offset, "%s%lld.%06d",
+                              ((sec == 0) && (usec < 0))? "-" : "",
+                              sec, QB_ABS(usec));
 }
 
 /*!
@@ -511,16 +511,16 @@ crm_duration_as_string(const crm_time_t *dt, int usec, bool show_usec,
     pcmk__assert(valid_sec_usec(dt->seconds, usec));
 
     if (dt->years) {
-        offset += snprintf(result + offset, DATE_MAX - offset, "%4d year%s ",
-                           dt->years, pcmk__plural_s(dt->years));
+        offset += pcmk__snprintf(result + offset, DATE_MAX - offset, "%4d year%s ",
+                                 dt->years, pcmk__plural_s(dt->years));
     }
     if (dt->months) {
-        offset += snprintf(result + offset, DATE_MAX - offset, "%2d month%s ",
-                           dt->months, pcmk__plural_s(dt->months));
+        offset += pcmk__snprintf(result + offset, DATE_MAX - offset, "%2d month%s ",
+                                 dt->months, pcmk__plural_s(dt->months));
     }
     if (dt->days) {
-        offset += snprintf(result + offset, DATE_MAX - offset, "%2d day%s ",
-                           dt->days, pcmk__plural_s(dt->days));
+        offset += pcmk__snprintf(result + offset, DATE_MAX - offset, "%2d day%s ",
+                                 dt->days, pcmk__plural_s(dt->days));
     }
 
     // At least print seconds (and optionally usecs)
@@ -528,11 +528,11 @@ crm_duration_as_string(const crm_time_t *dt, int usec, bool show_usec,
         if (show_usec) {
             sec_usec_as_string(dt->seconds, usec, result, &offset);
         } else {
-            offset += snprintf(result + offset, DATE_MAX - offset, "%d",
-                               dt->seconds);
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset, "%d",
+                                     dt->seconds);
         }
-        offset += snprintf(result + offset, DATE_MAX - offset, " second%s",
-                           pcmk__plural_s(dt->seconds));
+        offset += pcmk__snprintf(result + offset, DATE_MAX - offset, " second%s",
+                                 pcmk__plural_s(dt->seconds));
     }
 
     // More than one minute, so provide a more readable breakdown into units
@@ -546,32 +546,32 @@ crm_duration_as_string(const crm_time_t *dt, int usec, bool show_usec,
         crm_time_get_sec(dt->seconds, &h, &m, &s);
         print_sec_component = ((s != 0) || (show_usec && (u != 0)));
 
-        offset += snprintf(result + offset, DATE_MAX - offset, " (");
+        offset += pcmk__snprintf(result + offset, DATE_MAX - offset, " (");
 
         if (h) {
-            offset += snprintf(result + offset, DATE_MAX - offset,
-                               "%" PRIu32 " hour%s%s", h, pcmk__plural_s(h),
-                               ((m != 0) || print_sec_component)? " " : "");
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                     "%" PRIu32 " hour%s%s", h, pcmk__plural_s(h),
+                                     ((m != 0) || print_sec_component)? " " : "");
         }
 
         if (m) {
-            offset += snprintf(result + offset, DATE_MAX - offset,
-                               "%" PRIu32 " minute%s%s", m, pcmk__plural_s(m),
-                               print_sec_component? " " : "");
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                     "%" PRIu32 " minute%s%s", m, pcmk__plural_s(m),
+                                     print_sec_component? " " : "");
         }
 
         if (print_sec_component) {
             if (show_usec) {
                 sec_usec_as_string(s, u, result, &offset);
             } else {
-                offset += snprintf(result + offset, DATE_MAX - offset,
-                                   "%" PRIu32, s);
+                offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                         "%" PRIu32, s);
             }
-            offset += snprintf(result + offset, DATE_MAX - offset, " second%s",
-                               pcmk__plural_s(dt->seconds));
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset, " second%s",
+                                     pcmk__plural_s(dt->seconds));
         }
 
-        offset += snprintf(result + offset, DATE_MAX - offset, ")");
+        offset += pcmk__snprintf(result + offset, DATE_MAX - offset, ")");
     }
 }
 
@@ -622,7 +622,7 @@ time_as_string_common(const crm_time_t *dt, int usec, uint32_t flags,
         if (pcmk_is_set(flags, crm_time_usecs)) {
             sec_usec_as_string(seconds, usec, result, &offset);
         } else {
-            snprintf(result, DATE_MAX, "%lld", seconds);
+            pcmk__snprintf(result, DATE_MAX, "%lld", seconds);
         }
         return;
     }
@@ -643,9 +643,9 @@ time_as_string_common(const crm_time_t *dt, int usec, uint32_t flags,
             uint32_t d = 0;
 
             if (crm_time_get_isoweek(dt, &y, &w, &d)) {
-                offset += snprintf(result + offset, DATE_MAX - offset,
-                                   "%" PRIu32 "-W%.2" PRIu32 "-%" PRIu32,
-                                   y, w, d);
+                offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                         "%" PRIu32 "-W%.2" PRIu32 "-%" PRIu32,
+                                         y, w, d);
             }
 
         } else if (pcmk_is_set(flags, crm_time_ordinal)) { // YYYY-DDD
@@ -653,8 +653,8 @@ time_as_string_common(const crm_time_t *dt, int usec, uint32_t flags,
             uint32_t d = 0;
 
             if (crm_time_get_ordinal(dt, &y, &d)) {
-                offset += snprintf(result + offset, DATE_MAX - offset,
-                                   "%" PRIu32 "-%.3" PRIu32, y, d);
+                offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                         "%" PRIu32 "-%.3" PRIu32, y, d);
             }
 
         } else { // YYYY-MM-DD
@@ -663,9 +663,9 @@ time_as_string_common(const crm_time_t *dt, int usec, uint32_t flags,
             uint32_t d = 0;
 
             if (crm_time_get_gregorian(dt, &y, &m, &d)) {
-                offset += snprintf(result + offset, DATE_MAX - offset,
-                                   "%.4" PRIu32 "-%.2" PRIu32 "-%.2" PRIu32,
-                                   y, m, d);
+                offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                         "%.4" PRIu32 "-%.2" PRIu32 "-%.2" PRIu32,
+                                         y, m, d);
             }
         }
     }
@@ -674,28 +674,28 @@ time_as_string_common(const crm_time_t *dt, int usec, uint32_t flags,
         uint32_t h = 0, m = 0, s = 0;
 
         if (offset > 0) {
-            offset += snprintf(result + offset, DATE_MAX - offset, " ");
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset, " ");
         }
 
         if (crm_time_get_timeofday(dt, &h, &m, &s)) {
-            offset += snprintf(result + offset, DATE_MAX - offset,
-                               "%.2" PRIu32 ":%.2" PRIu32 ":%.2" PRIu32,
-                               h, m, s);
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                     "%.2" PRIu32 ":%.2" PRIu32 ":%.2" PRIu32,
+                                     h, m, s);
 
             if (pcmk_is_set(flags, crm_time_usecs)) {
-                offset += snprintf(result + offset, DATE_MAX - offset,
-                                   ".%06" PRIu32, QB_ABS(usec));
+                offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                         ".%06" PRIu32, QB_ABS(usec));
             }
         }
 
         if (pcmk_is_set(flags, crm_time_log_with_timezone)
             && (dt->offset != 0)) {
             crm_time_get_sec(dt->offset, &h, &m, &s);
-            offset += snprintf(result + offset, DATE_MAX - offset,
-                               " %c%.2" PRIu32 ":%.2" PRIu32,
-                               ((dt->offset < 0)? '-' : '+'), h, m);
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset,
+                                     " %c%.2" PRIu32 ":%.2" PRIu32,
+                                     ((dt->offset < 0)? '-' : '+'), h, m);
         } else {
-            offset += snprintf(result + offset, DATE_MAX - offset, "Z");
+            offset += pcmk__snprintf(result + offset, DATE_MAX - offset, "Z");
         }
     }
 
@@ -2117,8 +2117,8 @@ pcmk__time_format_hr(const char *format, const pcmk__time_hr_t *hr_dt)
             if (date_len >= sizeof(date_s)) {
                 return NULL; // No room to add nanoseconds
             }
-            nc = snprintf(&date_s[date_len], sizeof(date_s) - date_len,
-                          "%.*s", nano_digits, nano_s);
+            nc = pcmk__snprintf(&date_s[date_len], sizeof(date_s) - date_len,
+                                "%.*s", nano_digits, nano_s);
 
             if ((nc < 0) || (nc == (sizeof(date_s) - date_len))) {
                 return NULL; // Error or would overflow buffer
@@ -2215,34 +2215,34 @@ pcmk__readable_interval(guint interval_ms)
 
     str[0] = '\0';
     if (interval_ms >= MS_IN_D) {
-        offset += snprintf(str + offset, MAXSTR - offset, "%ud",
-                           interval_ms / MS_IN_D);
+        offset += pcmk__snprintf(str + offset, MAXSTR - offset, "%ud",
+                                 interval_ms / MS_IN_D);
         interval_ms -= (interval_ms / MS_IN_D) * MS_IN_D;
     }
     if (interval_ms >= MS_IN_H) {
-        offset += snprintf(str + offset, MAXSTR - offset, "%uh",
-                           interval_ms / MS_IN_H);
+        offset += pcmk__snprintf(str + offset, MAXSTR - offset, "%uh",
+                                 interval_ms / MS_IN_H);
         interval_ms -= (interval_ms / MS_IN_H) * MS_IN_H;
     }
     if (interval_ms >= MS_IN_M) {
-        offset += snprintf(str + offset, MAXSTR - offset, "%um",
-                           interval_ms / MS_IN_M);
+        offset += pcmk__snprintf(str + offset, MAXSTR - offset, "%um",
+                                 interval_ms / MS_IN_M);
         interval_ms -= (interval_ms / MS_IN_M) * MS_IN_M;
     }
 
     // Ns, N.NNNs, or NNNms
     if (interval_ms >= MS_IN_S) {
-        offset += snprintf(str + offset, MAXSTR - offset, "%u",
-                           interval_ms / MS_IN_S);
+        offset += pcmk__snprintf(str + offset, MAXSTR - offset, "%u",
+                                 interval_ms / MS_IN_S);
         interval_ms -= (interval_ms / MS_IN_S) * MS_IN_S;
         if (interval_ms > 0) {
-            offset += snprintf(str + offset, MAXSTR - offset, ".%03u",
-                               interval_ms);
+            offset += pcmk__snprintf(str + offset, MAXSTR - offset, ".%03u",
+                                     interval_ms);
         }
-        snprintf(str + offset, MAXSTR - offset, "s");
+        pcmk__snprintf(str + offset, MAXSTR - offset, "s");
 
     } else if (interval_ms > 0) {
-        snprintf(str + offset, MAXSTR - offset, "%ums", interval_ms);
+        pcmk__snprintf(str + offset, MAXSTR - offset, "%ums", interval_ms);
 
     } else if (str[0] == '\0') {
         strcpy(str, "0s");

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -180,21 +180,21 @@ set_format_string(int method, const char *daemon, pid_t use_pid,
 
         if (method > QB_LOG_STDERR) {
             // If logging to file, prefix with timestamp, node name, daemon ID
-            offset += snprintf(fmt + offset, FMT_MAX - offset,
-                               TIMESTAMP_FORMAT_SPEC " %s %-20s[%lu] ",
-                                use_nodename, daemon, (unsigned long) use_pid);
+            offset += pcmk__snprintf(fmt + offset, FMT_MAX - offset,
+                                     TIMESTAMP_FORMAT_SPEC " %s %-20s[%lu] ",
+                                     use_nodename, daemon, (unsigned long) use_pid);
         }
 
         // Add function name (in parentheses)
-        offset += snprintf(fmt + offset, FMT_MAX - offset, "(%%n");
+        offset += pcmk__snprintf(fmt + offset, FMT_MAX - offset, "(%%n");
         if (crm_tracing_enabled()) {
             // When tracing, add file and line number
-            offset += snprintf(fmt + offset, FMT_MAX - offset, "@%%f:%%l");
+            offset += pcmk__snprintf(fmt + offset, FMT_MAX - offset, "@%%f:%%l");
         }
-        offset += snprintf(fmt + offset, FMT_MAX - offset, ")");
+        offset += pcmk__snprintf(fmt + offset, FMT_MAX - offset, ")");
 
         // Add tag (if any), severity, and actual message
-        offset += snprintf(fmt + offset, FMT_MAX - offset, " %%g\t%%p: %%b");
+        offset += pcmk__snprintf(fmt + offset, FMT_MAX - offset, " %%g\t%%p: %%b");
 
         CRM_LOG_ASSERT(offset > 0);
         qb_log_format_set(method, fmt);
@@ -538,7 +538,7 @@ crm_write_blackbox(int nsig, const struct qb_log_callsite *cs)
                 return;
             }
 
-            snprintf(buffer, NAME_MAX, "%s.%d", blackbox_file_prefix, counter++);
+            pcmk__snprintf(buffer, NAME_MAX, "%s.%d", blackbox_file_prefix, counter++);
             if (nsig == SIGTRAP) {
                 crm_notice("Blackbox dump requested, please see %s for contents", buffer);
 
@@ -670,7 +670,7 @@ crm_log_filter(struct qb_log_callsite *cs)
             do {
                 offset = next;
                 next = strchrnul(offset, ',');
-                snprintf(token, sizeof(token), "%.*s", (int)(next - offset), offset);
+                pcmk__snprintf(token, sizeof(token), "%.*s", (int)(next - offset), offset);
 
                 tag = g_quark_from_string(token);
                 crm_info("Created GQuark %u from token '%s' in '%s'", tag, token, trace_tags);

--- a/lib/common/mock.c
+++ b/lib/common/mock.c
@@ -458,4 +458,27 @@ __wrap_strdup(const char *s)
     return NULL;
 }
 
+/* vsnprintf()
+ *
+ * If pcmk__mock_vsnprintf is set to true, later calls to vsnprintf()
+ * must be preceded by:
+ *
+ *     will_return(__wrap_vsnprintf, return_value_for_vsnprintf);
+ *
+ * The mocked function will then return the specified 'return_value_for_vsnprintf'.
+ * This is primarily used to test error handling paths by forcing a negative
+ * return value. Otherwise, if pcmk__mock_vsnprintf is false, __real_vsnprintf
+ * is called.
+ */
+bool pcmk__mock_vsnprintf = false;
+
+int
+__wrap_vsnprintf(char *str, size_t size, const char *format, va_list ap)
+{
+    if (!pcmk__mock_vsnprintf) {
+        return __real_vsnprintf(str, size, format, ap);
+    }
+    return mock_type(int);
+}
+
 // LCOV_EXCL_STOP

--- a/lib/common/mock_private.h
+++ b/lib/common/mock_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the Pacemaker project contributors
+ * Copyright 2021-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -89,6 +89,10 @@ ssize_t __wrap_readlink(const char *restrict path, char *restrict buf,
 extern bool pcmk__mock_strdup;
 char *__real_strdup(const char *s);
 char *__wrap_strdup(const char *s);
+
+extern bool pcmk__mock_vsnprintf;
+int __real_vsnprintf(char *str, size_t size, const char *format, va_list ap) G_GNUC_PRINTF(3, 0);
+int __wrap_vsnprintf(char *str, size_t size, const char *format, va_list ap) G_GNUC_PRINTF(3, 0);
 
 #ifdef __cplusplus
 }

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1081,7 +1081,7 @@ pcmk__env_option(const char *option)
     CRM_CHECK(!pcmk__str_empty(option), return NULL);
 
     for (int i = 0; i < PCMK__NELEM(prefixes); i++) {
-        int rv = snprintf(env_name, NAME_MAX, "%s%s", prefixes[i], option);
+        int rv = pcmk__snprintf(env_name, NAME_MAX, "%s%s", prefixes[i], option);
 
         if (rv < 0) {
             crm_err("Failed to write %s%s to buffer: %s", prefixes[i], option,
@@ -1132,7 +1132,7 @@ pcmk__set_env_option(const char *option, const char *value, bool compat)
               return);
 
     for (int i = 0; i < PCMK__NELEM(prefixes); i++) {
-        int rv = snprintf(env_name, NAME_MAX, "%s%s", prefixes[i], option);
+        int rv = pcmk__snprintf(env_name, NAME_MAX, "%s%s", prefixes[i], option);
 
         if (rv < 0) {
             crm_err("Failed to write %s%s to buffer: %s", prefixes[i], option,

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the Pacemaker project contributors
+ * Copyright 2019-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -209,9 +209,9 @@ log_list_item(pcmk__output_t *out, const char *name, const char *format, ...) {
 
     for (GList* gIter = priv->prefixes->head; gIter; gIter = gIter->next) {
         if (strcmp(prefix, "") != 0) {
-            offset += snprintf(prefix + offset, LINE_MAX - offset, ": %s", (char *)gIter->data);
+            offset += pcmk__snprintf(prefix + offset, LINE_MAX - offset, ": %s", (char *)gIter->data);
         } else {
-            offset = snprintf(prefix, LINE_MAX, "%s", (char *)gIter->data);
+            offset = pcmk__snprintf(prefix, LINE_MAX, "%s", (char *)gIter->data);
         }
     }
 

--- a/lib/common/pid.c
+++ b/lib/common/pid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -78,10 +78,10 @@ pcmk__pid_active(pid_t pid, const char *daemon)
         }
 
         if (daemon[0] != '/') {
-            rc = snprintf(myexe_path, sizeof(myexe_path), CRM_DAEMON_DIR"/%s",
-                          daemon);
+            rc = pcmk__snprintf(myexe_path, sizeof(myexe_path), CRM_DAEMON_DIR"/%s",
+                                daemon);
         } else {
-            rc = snprintf(myexe_path, sizeof(myexe_path), "%s", daemon);
+            rc = pcmk__snprintf(myexe_path, sizeof(myexe_path), "%s", daemon);
         }
 
         if (rc > 0 && rc < sizeof(myexe_path) && !strcmp(exe_path, myexe_path)) {
@@ -225,7 +225,7 @@ pcmk__lock_pidfile(const char *filename, const char *name)
         return errno;
     }
 
-    snprintf(buf, sizeof(buf), "%*lld\n", LOCKSTRLEN - 1, (long long) mypid);
+    pcmk__snprintf(buf, sizeof(buf), "%*lld\n", LOCKSTRLEN - 1, (long long) mypid);
     rc = write(fd, buf, LOCKSTRLEN);
     close(fd);
 

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the Pacemaker project contributors
+ * Copyright 2015-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -206,8 +206,8 @@ pcmk__procfs_pid2path(pid_t pid, char path[], size_t path_size)
     char procfs_exe_path[PATH_MAX];
     ssize_t link_rc;
 
-    if (snprintf(procfs_exe_path, PATH_MAX, "/proc/%lld/exe",
-                 (long long) pid) >= PATH_MAX) {
+    if (pcmk__snprintf(procfs_exe_path, PATH_MAX, "/proc/%lld/exe",
+                       (long long) pid) >= PATH_MAX) {
         return ENAMETOOLONG; // Truncated (shouldn't be possible in practice)
     }
 

--- a/lib/common/scores.c
+++ b/lib/common/scores.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,7 +9,7 @@
 
 #include <crm_internal.h>
 
-#include <stdio.h>      // snprintf(), NULL
+#include <stdio.h>      // pcmk__snprintf(), NULL
 #include <string.h>     // strcpy(), strdup()
 #include <sys/types.h>  // size_t
 
@@ -112,7 +112,7 @@ pcmk_readable_score(int score)
 
     } else {
         // Range is limited to +/-1000000, so no chance of overflow
-        snprintf(score_s, sizeof(score_s), "%d", score);
+        pcmk__snprintf(score_s, sizeof(score_s), "%d", score);
     }
 
     return score_s;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,14 +9,15 @@
 
 #include <crm_internal.h>
 
-#include <regex.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <float.h>  // DBL_MIN
-#include <limits.h>
 #include <bzlib.h>
+#include <ctype.h>
+#include <float.h> // DBL_MIN
+#include <limits.h>
+#include <regex.h>
+#include <stdarg.h> // Required for va_list, va_start, va_end
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 
 /*!
@@ -899,6 +900,41 @@ crm_strdup_printf(char const *format, ...)
     pcmk__assert(len > 0);
     va_end(ap);
     return string;
+}
+
+/*!
+ * \internal
+ * \brief Safely format a string, asserting on encoding errors.
+ *
+ * This function wraps vsnprintf and checks its return value.
+ * If vsnprintf returns a negative value (indicating an encoding error),
+ * this function will call pcmk__assert to halt execution in debug builds
+ * or log a critical error in release builds.
+ *
+ * \param[out] str     Buffer to store the formatted string.
+ * \param[in]  size    Size of the buffer.
+ * \param[in]  format  Format string.
+ * \param[in]  ...     Variable arguments for the format string.
+ *
+ * \return Number of characters that would have been written if \p size was
+ *         sufficiently large (not including the terminating null byte),
+ *         or a negative value if an encoding error occurred (though this
+ *         function asserts in that case).
+ * \note The behavior is otherwise identical to snprintf.
+ */
+int
+pcmk__snprintf(char *str, size_t size, const char *format, ...)
+{
+    va_list ap;
+    int retval;
+
+    va_start(ap, format);
+    retval = vsnprintf(str, size, format, ap);
+    va_end(ap);
+
+    pcmk__assert(retval >= 0);
+
+    return retval;
 }
 
 int

--- a/lib/common/tests/options/pcmk__env_option_test.c
+++ b/lib/common/tests/options/pcmk__env_option_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -70,7 +70,7 @@ input_too_long_for_pcmk(void **state)
     /* NULL/non-NULL retval doesn't really matter here; just testing that we
      * call getenv() for "HA_" prefix after too long for "PCMK_".
      */
-    snprintf(buf, NAME_MAX, "HA_%s", long_opt);
+    pcmk__snprintf(buf, NAME_MAX, "HA_%s", long_opt);
     expect_string(__wrap_getenv, name, buf);
     will_return(__wrap_getenv, "value");
     assert_string_equal(pcmk__env_option(long_opt), "value");

--- a/lib/common/tests/options/pcmk__set_env_option_test.c
+++ b/lib/common/tests/options/pcmk__set_env_option_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the Pacemaker project contributors
+ * Copyright 2022-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -78,7 +78,7 @@ input_too_long_for_pcmk(void **state)
     }
     long_opt[NAME_MAX - 5] = '\0';
 
-    snprintf(buf, NAME_MAX, "HA_%s", long_opt);
+    pcmk__snprintf(buf, NAME_MAX, "HA_%s", long_opt);
 
     // Call setenv() for "HA_" only
     pcmk__mock_setenv = true;

--- a/lib/common/tests/procfs/pcmk__procfs_has_pids_false_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_has_pids_false_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,7 +23,7 @@ no_pids(void **state)
 {
     char path[PATH_MAX];
 
-    snprintf(path, PATH_MAX, "/proc/%u/exe", getpid());
+    pcmk__snprintf(path, PATH_MAX, "/proc/%u/exe", getpid());
 
     // Set readlink() errno and link contents (for /proc/PID/exe)
     pcmk__mock_readlink = true;

--- a/lib/common/tests/procfs/pcmk__procfs_has_pids_true_test.c
+++ b/lib/common/tests/procfs/pcmk__procfs_has_pids_true_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the Pacemaker project contributors
+ * Copyright 2022-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,7 +22,7 @@ has_pids(void **state)
 {
     char path[PATH_MAX];
 
-    snprintf(path, PATH_MAX, "/proc/%u/exe", getpid());
+    pcmk__snprintf(path, PATH_MAX, "/proc/%u/exe", getpid());
 
     // Set readlink() errno and link contents (for /proc/PID/exe)
     pcmk__mock_readlink = true;

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2024 the Pacemaker project contributors
+# Copyright 2020-2025 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -36,6 +36,7 @@ check_PROGRAMS = crm_get_msec_test 		\
 		 pcmk__strcmp_test 		\
 		 pcmk__strkey_table_test 	\
 		 pcmk__strikey_table_test 	\
-		 pcmk__trim_test
+		 pcmk__trim_test                \
+		 pcmk__snprintf_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/strings/pcmk__scan_double_test.c
+++ b/lib/common/tests/strings/pcmk__scan_double_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -97,11 +97,11 @@ typical_case(void **state)
     assert_int_equal(pcmk__scan_double("-1.0", &result, NULL, NULL), pcmk_rc_ok);
     assert_float_equal(result, -1.0, DBL_EPSILON);
 
-    snprintf(str, LOCAL_BUF_SIZE, "%f", DBL_MAX);
+    pcmk__snprintf(str, LOCAL_BUF_SIZE, "%f", DBL_MAX);
     assert_int_equal(pcmk__scan_double(str, &result, NULL, NULL), pcmk_rc_ok);
     assert_float_equal(result, DBL_MAX, DBL_EPSILON);
 
-    snprintf(str, LOCAL_BUF_SIZE, "%f", -DBL_MAX);
+    pcmk__snprintf(str, LOCAL_BUF_SIZE, "%f", -DBL_MAX);
     assert_int_equal(pcmk__scan_double(str, &result, NULL, NULL), pcmk_rc_ok);
     assert_float_equal(result, -DBL_MAX, DBL_EPSILON);
 }
@@ -116,11 +116,11 @@ double_overflow(void **state)
      * 1e(DBL_MAX_10_EXP + 1) produces an inf value
      * Can't use assert_float_equal() because (inf - inf) == NaN
      */
-    snprintf(str, LOCAL_BUF_SIZE, "1e%d", DBL_MAX_10_EXP + 1);
+    pcmk__snprintf(str, LOCAL_BUF_SIZE, "1e%d", DBL_MAX_10_EXP + 1);
     assert_int_equal(pcmk__scan_double(str, &result, NULL, NULL), EOVERFLOW);
     assert_true(result > DBL_MAX);
 
-    snprintf(str, LOCAL_BUF_SIZE, "-1e%d", DBL_MAX_10_EXP + 1);
+    pcmk__snprintf(str, LOCAL_BUF_SIZE, "-1e%d", DBL_MAX_10_EXP + 1);
     assert_int_equal(pcmk__scan_double(str, &result, NULL, NULL), EOVERFLOW);
     assert_true(result < -DBL_MAX);
 }
@@ -137,12 +137,12 @@ double_underflow(void **state)
      *
      * C99/C11: result will be **no greater than** DBL_MIN
      */
-    snprintf(str, LOCAL_BUF_SIZE, "1e%d", DBL_MIN_10_EXP - 1);
+    pcmk__snprintf(str, LOCAL_BUF_SIZE, "1e%d", DBL_MIN_10_EXP - 1);
     assert_int_equal(pcmk__scan_double(str, &result, NULL, NULL), pcmk_rc_underflow);
     assert_true(result >= 0.0);
     assert_true(result <= DBL_MIN);
 
-    snprintf(str, LOCAL_BUF_SIZE, "-1e%d", DBL_MIN_10_EXP - 1);
+    pcmk__snprintf(str, LOCAL_BUF_SIZE, "-1e%d", DBL_MIN_10_EXP - 1);
     assert_int_equal(pcmk__scan_double(str, &result, NULL, NULL), pcmk_rc_underflow);
     assert_true(result <= 0.0);
     assert_true(result >= -DBL_MIN);

--- a/lib/common/tests/strings/pcmk__snprintf_test.c
+++ b/lib/common/tests/strings/pcmk__snprintf_test.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h> /* Should come first */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <crm/common/strings_internal.h>
+#include <crm/common/unittest_internal.h>
+#include "mock_private.h"
+
+static int
+group_setup_vsnprintf_mock(void **state)
+{
+    pcmk__mock_vsnprintf = false;
+    return 0;
+}
+
+static int
+group_teardown_vsnprintf_mock(void **state)
+{
+    pcmk__mock_vsnprintf = false;
+    return 0;
+}
+
+static void
+test_basic_functionality(void **state)
+{
+    char buffer[100];
+    const char *name = "world";
+    int expected_ret;
+    int actual_ret;
+
+    pcmk__mock_vsnprintf = false;
+    expected_ret = snprintf(NULL, 0, "Hello, %s!", name);
+    actual_ret = pcmk__snprintf(buffer, sizeof(buffer), "Hello, %s!", name);
+
+    assert_int_equal(actual_ret, expected_ret);
+    assert_string_equal(buffer, "Hello, world!");
+}
+
+static void
+test_buffer_truncation(void **state)
+{
+    char buffer[10];
+    int expected_ret;
+    int actual_ret;
+
+    pcmk__mock_vsnprintf = false;
+    expected_ret = snprintf(NULL, 0, "This is a long string");
+    actual_ret = pcmk__snprintf(buffer, sizeof(buffer), "This is a long string");
+
+    assert_int_equal(actual_ret, expected_ret);
+    assert_string_equal(buffer, "This is a");
+    assert_int_equal(strlen(buffer), sizeof(buffer) - 1);
+}
+
+static void
+test_zero_size_buffer(void **state)
+{
+    char buffer[1];
+    int expected_ret;
+    int actual_ret;
+
+    pcmk__mock_vsnprintf = false;
+    expected_ret = snprintf(NULL, 0, "Test");
+    actual_ret = pcmk__snprintf(buffer, 0, "Test");
+
+    assert_int_equal(actual_ret, expected_ret);
+}
+
+static void
+test_assertion_on_negative_return(void **state)
+{
+    char buffer[100];
+
+    pcmk__mock_vsnprintf = true;
+
+    pcmk__assert_asserts({
+        will_return(__wrap_vsnprintf, -1);
+        pcmk__snprintf(buffer, sizeof(buffer), "format %s", "string"); });
+}
+
+PCMK__UNIT_TEST(group_setup_vsnprintf_mock, group_teardown_vsnprintf_mock,
+                cmocka_unit_test(test_basic_functionality),
+                cmocka_unit_test(test_buffer_truncation),
+                cmocka_unit_test(test_zero_size_buffer),
+                cmocka_unit_test(test_assertion_on_negative_return));

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1121,7 +1121,7 @@ crm_xml_add_ll(xmlNode *xml, const char *name, long long value)
 {
     char s[LLSTRSIZE] = { '\0', };
 
-    if (snprintf(s, LLSTRSIZE, "%lld", (long long) value) == LLSTRSIZE) {
+    if (pcmk__snprintf(s, LLSTRSIZE, "%lld", (long long) value) == LLSTRSIZE) {
         return NULL;
     }
     return crm_xml_add(xml, name, s);

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -135,7 +135,7 @@ make_args(const char *agent, const char *action, const char *target,
     if (device_args) {
         char buffer[512];
 
-        snprintf(buffer, sizeof(buffer), "pcmk_%s_action", action);
+        pcmk__snprintf(buffer, sizeof(buffer), "pcmk_%s_action", action);
         value = g_hash_table_lookup(device_args, buffer);
         if (value) {
             crm_debug("Substituting '%s' for fence action %s targeting %s",
@@ -273,7 +273,7 @@ stonith__action_create(const char *agent, const char *action_name,
         char buffer[512];
         const char *value = NULL;
 
-        snprintf(buffer, sizeof(buffer), "pcmk_%s_retries", action_name);
+        pcmk__snprintf(buffer, sizeof(buffer), "pcmk_%s_retries", action_name);
         value = g_hash_table_lookup(device_args, buffer);
 
         if (value) {

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the Pacemaker project contributors
+ * Copyright 2015-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -179,12 +179,12 @@ exec_alert_list(lrmd_t *lrmd, const GList *alert_list,
                 free(timestamp);
             }
 
-            snprintf(timestamp_epoch, sizeof(timestamp_epoch), "%lld",
-                     (long long) epoch);
+            pcmk__snprintf(timestamp_epoch, sizeof(timestamp_epoch), "%lld",
+                           (long long) epoch);
             copy_params = alert_key2param(copy_params,
                                           PCMK__alert_key_timestamp_epoch,
                                           timestamp_epoch);
-            snprintf(timestamp_usec, sizeof(timestamp_usec), "%06d", now->useconds);
+            pcmk__snprintf(timestamp_usec, sizeof(timestamp_usec), "%06d", now->useconds);
             copy_params = alert_key2param(copy_params,
                                           PCMK__alert_key_timestamp_usec,
                                           timestamp_usec);

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the Pacemaker project contributors
+ * Copyright 2019-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -2359,7 +2359,7 @@ result_code_text(pcmk__output_t *out, va_list args)
      */
     if (code_width == 0) {
         long long most_negative = pcmk_rc_error - (long long) pcmk__n_rc + 1;
-        code_width = (int) snprintf(NULL, 0, "%lld", most_negative);
+        code_width = (int) pcmk__snprintf(NULL, 0, "%lld", most_negative);
     }
 
     if ((name != NULL) && (desc != NULL)) {

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1524,15 +1524,15 @@ pe__bundle_replica_output_html(pcmk__output_t *out,
     }
 
     if (replica->remote) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s",
-                           rsc_printable_id(replica->remote));
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, "%s",
+                                 rsc_printable_id(replica->remote));
     } else {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s",
-                           rsc_printable_id(replica->container));
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, "%s",
+                                 rsc_printable_id(replica->container));
     }
     if (replica->ipaddr) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, " (%s)",
-                           replica->ipaddr);
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, " (%s)",
+                                 replica->ipaddr);
     }
 
     pe__common_output_html(out, rsc, buffer, node, show_opts);
@@ -1688,15 +1688,15 @@ pe__bundle_replica_output_text(pcmk__output_t *out,
     }
 
     if (replica->remote) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s",
-                           rsc_printable_id(replica->remote));
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, "%s",
+                                 rsc_printable_id(replica->remote));
     } else {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s",
-                           rsc_printable_id(replica->container));
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, "%s",
+                                 rsc_printable_id(replica->container));
     }
     if (replica->ipaddr) {
-        offset += snprintf(buffer + offset, LINE_MAX - offset, " (%s)",
-                           replica->ipaddr);
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, " (%s)",
+                                 replica->ipaddr);
     }
 
     pe__common_output_text(out, rsc, buffer, node, show_opts);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -761,9 +761,9 @@ pe__resource_xml(pcmk__output_t *out, va_list args)
     }
 
     // Resource information
-    snprintf(ra_name, LINE_MAX, "%s%s%s:%s", class,
-             ((prov == NULL)? "" : ":"), ((prov == NULL)? "" : prov),
-             crm_element_value(rsc->priv->xml, PCMK_XA_TYPE));
+    pcmk__snprintf(ra_name, LINE_MAX, "%s%s%s:%s", class,
+                   ((prov == NULL)? "" : ":"), ((prov == NULL)? "" : prov),
+                   crm_element_value(rsc->priv->xml, PCMK_XA_TYPE));
 
     target_role = g_hash_table_lookup(rsc->priv->meta,
                                       PCMK_META_TARGET_ROLE);
@@ -966,17 +966,17 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
             continue;
         }
 
-        offset += snprintf(buffer + offset, LINE_MAX - offset, "%s", class);
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, "%s", class);
         if (pcmk_is_set(pcmk_get_ra_caps(class), pcmk_ra_cap_provider)) {
             const char *prov = crm_element_value(rsc->priv->xml,
                                                  PCMK_XA_PROVIDER);
 
             if (prov != NULL) {
-                offset += snprintf(buffer + offset, LINE_MAX - offset,
-                                   ":%s", prov);
+                offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset,
+                                         ":%s", prov);
             }
         }
-        offset += snprintf(buffer + offset, LINE_MAX - offset, ":%s", kind);
+        offset += pcmk__snprintf(buffer + offset, LINE_MAX - offset, ":%s", kind);
         CRM_LOG_ASSERT(offset > 0);
 
         if (rsc_table) {

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -413,7 +413,9 @@ set_ocf_env_with_prefix(gpointer key, gpointer value, gpointer user_data)
 {
     char buffer[500];
 
-    snprintf(buffer, sizeof(buffer), strcmp(key, "OCF_CHECK_LEVEL") != 0 ? "OCF_RESKEY_%s" : "%s", (char *)key);
+    pcmk__snprintf(buffer, sizeof(buffer),
+                   strcmp(key, "OCF_CHECK_LEVEL") != 0 ? "OCF_RESKEY_%s" : "%s",
+                   (char *)key);
     set_ocf_env(buffer, value, user_data);
 }
 
@@ -1419,7 +1421,7 @@ services_os_get_single_directory_list(const char *root, gboolean files, gboolean
             continue;
         }
 
-        snprintf(buffer, sizeof(buffer), "%s/%s", root, namelist[lpc]->d_name);
+        pcmk__snprintf(buffer, sizeof(buffer), "%s/%s", root, namelist[lpc]->d_name);
 
         if (stat(buffer, &sb)) {
             continue;

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2024 the Pacemaker project contributors
+ * Copyright 2010-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -117,10 +117,10 @@ services__get_lsb_metadata(const char *type, char **output)
     bool in_header = FALSE;
 
     if (type[0] == '/') {
-        snprintf(ra_pathname, sizeof(ra_pathname), "%s", type);
+        pcmk__snprintf(ra_pathname, sizeof(ra_pathname), "%s", type);
     } else {
-        snprintf(ra_pathname, sizeof(ra_pathname), "%s/%s",
-                 PCMK__LSB_INIT_DIR, type);
+        pcmk__snprintf(ra_pathname, sizeof(ra_pathname), "%s/%s",
+                       PCMK__LSB_INIT_DIR, type);
     }
 
     crm_trace("Looking into %s", ra_pathname);

--- a/mk/tap.mk
+++ b/mk/tap.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2021-2024 the Pacemaker project contributors
+# Copyright 2021-2025 the Pacemaker project contributors
 #
 # The version control history for this file may have further details.
 #
@@ -30,7 +30,8 @@ WRAPPED = abort 		\
 	  setenv		\
 	  setgrent		\
 	  strdup 		\
-	  unsetenv
+	  unsetenv \
+	  vsnprintf
 
 if WRAPPABLE_FOPEN64
 WRAPPED	+= fopen64


### PR DESCRIPTION
These patches add a new pcmk__snprintf function that asserts if snprintf returns an error code, as well as unit tests.

I generated these patches with google jules (hence the committer name), and then did some light cleanups and error fixing.  However, I didn't go through and change absolutely everything I didn't like in what it did, since the point here is to let everyone else see what kind of code results.  I'm not sure this was a time saver, but it's worth talking about.

@nrwahl2 @wenningerk I'd love your thoughts on this not only as a patch, but as a general discussion about whether this is something we should even be doing.