### PR TITLE
Fix: libpacemaker: Prevent CIB growth during crm_simulate --profile

### DIFF
--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -405,13 +405,10 @@ profile_file(const char *xml_file, unsigned int repeat,
     for (int i = 0; i < repeat; ++i) {
         pcmk_reset_scheduler(scheduler);
 
-        scheduler->input = cib_object;
+        scheduler->input = pcmk__xml_copy(NULL, cib_object);
         pcmk__set_scheduler_flags(scheduler, flags);
         set_effective_date(scheduler, false, use_date);
         pcmk__schedule_actions(scheduler);
-
-        // Avoid freeing cib_object in pcmk_reset_scheduler()
-        scheduler->input = NULL;
     }
 
     pcmk_reset_scheduler(scheduler);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -58,6 +58,16 @@ check_for_deprecated_rules(pcmk_scheduler_t *scheduler)
  *  - A list of nodes that need to be stonith'd
  *  - A list of nodes that need to be shutdown
  *  - A list of the possible stop/start actions (without dependencies)
+ *
+ * @TODO Currently this function can modify scheduler->input by creating
+ * primitive elements for guest nodes. Commit 5dbc819 aimed to make this
+ * function idempotent. It seems to be idempotent now, except that if
+ * scheduler->input is reused, it may gain duplicate primitive elements for
+ * guest nodes each time.
+ *
+ * Investigate whether we can leave scheduler->input unmodified without a lot of
+ * unnecessary XML copying. Otherwise, just document that scheduler->input may
+ * be modified.
  */
 gboolean
 cluster_status(pcmk_scheduler_t * scheduler)


### PR DESCRIPTION
This fixes a regression introduced by commit https://github.com/ClusterLabs/pacemaker/commit/8b9caadbdfe7063ef3d15e54a5d8eca7dcdf8137. It has not made itinto a release yet but may make it into 3.0.1.

That commit assumed that `cluster_status()` and `pcmk__schedule_actions()` did not modify `scheduler->input`. However, if `scheduler->input` contains guest nodes, then `cluster_status()` modifies it by creating a primitive element for each guest node:
```
cluster_status
-> unpack_remote_nodes()
   -> expand_remote_rsc_meta()
      -> pe_create_remote_xml()
```

As a result, if we run `crm_simulate --profile --repeat=N`, the `scheduler->input` CIB grows with each repeat. At each iteration, any guest nodes are unpacked into primitive elements, creating an increasing number of duplicates.

The increasing input CIB size causes superlinear slowdowns in `crm_simulate --profile` as the number of repeats increases.