### PR TITLE
Refactor: Standardize vim modelines in .in files.

### DIFF
--- a/agents/ocf/ClusterMon.in
+++ b/agents/ocf/ClusterMon.in
@@ -273,4 +273,4 @@ esac
 
 exit $?
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/Dummy.in
+++ b/agents/ocf/Dummy.in
@@ -320,4 +320,4 @@ rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/HealthCPU.in
+++ b/agents/ocf/HealthCPU.in
@@ -218,4 +218,4 @@ rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/HealthIOWait.in
+++ b/agents/ocf/HealthIOWait.in
@@ -210,4 +210,4 @@ rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/HealthSMART.in
+++ b/agents/ocf/HealthSMART.in
@@ -371,4 +371,4 @@ rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/Stateful.in
+++ b/agents/ocf/Stateful.in
@@ -264,4 +264,4 @@ esac
 
 exit $?
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/SysInfo.in
+++ b/agents/ocf/SysInfo.in
@@ -406,4 +406,4 @@ esac
 
 exit $?
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/attribute.in
+++ b/agents/ocf/attribute.in
@@ -238,4 +238,4 @@ esac
 
 exit $?
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/controld.in
+++ b/agents/ocf/controld.in
@@ -296,4 +296,4 @@ rc=$?
 
 exit $rc
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/ifspeed.in
+++ b/agents/ocf/ifspeed.in
@@ -554,4 +554,4 @@ esac
 
 exit $?
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/ping.in
+++ b/agents/ocf/ping.in
@@ -428,4 +428,4 @@ usage|help)     ping_usage
 esac
 exit $?
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/ocf/remote.in
+++ b/agents/ocf/remote.in
@@ -103,4 +103,4 @@ rc=$?
 ocf_log debug "${OCF_RESOURCE_INSTANCE} $__OCF_ACTION : $rc"
 exit $rc
 
-# vim: set filetype=sh expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/agents/stonith/fence_legacy.in
+++ b/agents/stonith/fence_legacy.in
@@ -269,3 +269,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# vim: set filetype=python:

--- a/agents/stonith/fence_watchdog.in
+++ b/agents/stonith/fence_watchdog.in
@@ -282,3 +282,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# vim: set filetype=python:

--- a/cts/benchmark/clubench.in
+++ b/cts/benchmark/clubench.in
@@ -198,3 +198,5 @@ for clusize in $SERIES; do
 	msg "Statistics for $clusize-node cluster saved"
 done
 msg "Tests done for series $SERIES, output in $CSV and $STATS"
+
+# vim: set filetype=sh:

--- a/cts/cluster_test.in
+++ b/cts/cluster_test.in
@@ -173,3 +173,5 @@ printf "\nAll set to go for %d iterations!\n" "$CTS_numtests"
 
 echo Now paste the following command into this shell:
 echo "@PYTHON@ `dirname "$0"`/cts-lab -L \"$CTS_logfile\" --syslog-facility \"$CTS_logfacility\" --no-unsafe-tests --stack \"$CTS_stack\" $CTS_adv --at-boot \"$CTS_boot\" $cts_extra \"$CTS_numtests\" --nodes \"$CTS_node_list\""
+
+# vim: set filetype=sh:

--- a/cts/cts-attrd.in
+++ b/cts/cts-attrd.in
@@ -412,3 +412,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# vim: set filetype=python:

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -3371,4 +3371,4 @@ def main():
 if __name__ == "__main__":
     main()
 
-# vim: set filetype=python expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=120:
+# vim: set filetype=python:

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -927,3 +927,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# vim: set filetype=python:

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -923,3 +923,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# vim: set filetype=python:

--- a/cts/cts-lab.in
+++ b/cts/cts-lab.in
@@ -133,4 +133,4 @@ if __name__ == '__main__':
     rc = environment.run(scenario, iters)
     sys.exit(rc)
 
-# vim: set filetype=python expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=120:
+# vim: set filetype=python:

--- a/cts/cts-regression.in
+++ b/cts/cts-regression.in
@@ -298,3 +298,5 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+# vim: set filetype=python:

--- a/cts/cts-scheduler.in
+++ b/cts/cts-scheduler.in
@@ -1734,4 +1734,4 @@ class CtsScheduler:
 if __name__ == "__main__":
     sys.exit(CtsScheduler().run())
 
-# vim: set filetype=python expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=120:
+# vim: set filetype=python:

--- a/cts/cts-schemas.in
+++ b/cts/cts-schemas.in
@@ -571,3 +571,5 @@ main() {
 }
 
 main "$@"
+
+# vim: set filetype=sh:

--- a/cts/cts.in
+++ b/cts/cts.in
@@ -402,3 +402,5 @@ else
     export cluster_name cluster_hosts cluster_log
     screen -S cts-$cluster_name bash
 fi
+
+# vim: set filetype=sh:

--- a/cts/support/LSBDummy.in
+++ b/cts/support/LSBDummy.in
@@ -83,3 +83,5 @@ esac
 rc=$?
 echo "`basename $0` $1 : $rc"
 exit $rc
+
+# vim: set filetype=sh:

--- a/cts/support/cts-support.in
+++ b/cts/support/cts-support.in
@@ -238,4 +238,4 @@ if __name__ == "__main__":
     if opts.subparser_name == "watch":
         cmd_watch(opts.filename, opts.limit, opts.offset, opts.prefix)
 
-# vim: set filetype=python expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=120:
+# vim: set filetype=python:

--- a/cts/support/fence_dummy.in
+++ b/cts/support/fence_dummy.in
@@ -507,3 +507,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# vim: set filetype=python:

--- a/cts/support/pacemaker-cts-dummyd.in
+++ b/cts/support/pacemaker-cts-dummyd.in
@@ -60,3 +60,5 @@ if __name__ == "__main__":
     # This isn't a "proper" daemon, but that would be overkill for testing purposes
     while True:
         time.sleep(600.0)
+
+# vim: set filetype=python:

--- a/cts/support/pacemaker-cts-dummyd@.service.in
+++ b/cts/support/pacemaker-cts-dummyd@.service.in
@@ -7,3 +7,5 @@ ExecStart=@CRM_DAEMON_DIR@/pacemaker-cts-dummyd %i
 
 [Install]
 DefaultInstance=0
+
+# vim: set filetype=systemd:

--- a/daemons/execd/pacemaker_remote.in
+++ b/daemons/execd/pacemaker_remote.in
@@ -174,3 +174,5 @@ stop)
 esac
 
 exit $rtrn
+
+# vim: set filetype=sh:

--- a/daemons/execd/pacemaker_remote.service.in
+++ b/daemons/execd/pacemaker_remote.service.in
@@ -50,3 +50,5 @@ Restart=on-failure
 # crm_perror() writes directly to stderr, so ignore it here
 # to avoid double-logging with the wrong format
 StandardError=null
+
+# vim: set filetype=systemd:

--- a/daemons/pacemakerd/pacemaker.service.in
+++ b/daemons/pacemakerd/pacemaker.service.in
@@ -101,3 +101,5 @@ Restart=on-failure
 # crm_perror() writes directly to stderr, so ignore it here
 # to avoid double-logging with the wrong format
 StandardError=null
+
+# vim: set filetype=systemd:

--- a/maint/bumplibs.in
+++ b/maint/bumplibs.in
@@ -296,3 +296,5 @@ done
 
 # Show all proposed changes
 git --no-pager diff --color -w
+
+# vim: set filetype=sh:

--- a/python/pacemaker/buildoptions.py.in
+++ b/python/pacemaker/buildoptions.py.in
@@ -87,3 +87,5 @@ class BuildOptions:
 
     XMLLINT_PATH = "@XMLLINT_PATH@"
     """Path to the xmllint program."""
+
+# vim: set filetype=python:

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -18,3 +18,5 @@ setup(name='pacemaker',
       description='Python libraries for Pacemaker',
       packages=['pacemaker', 'pacemaker._cts', 'pacemaker._cts.tests'],
      )
+
+# vim: set filetype=python:

--- a/tools/cibsecret.in
+++ b/tools/cibsecret.in
@@ -437,4 +437,4 @@ if [ $rc -ne 0 ]; then
     fatal $CRM_EX_ERROR "$cmd(): failed with rc: $rc"
 fi
 
-# vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/tools/cluster-clean.in
+++ b/tools/cluster-clean.in
@@ -97,3 +97,5 @@ cluster-helper $target -- logger -i -p daemon.info __clean_logs__
 
 #touch $cluster_log
 echo `date` ": Clean complete"
+
+# vim: set filetype=sh:

--- a/tools/cluster-helper.in
+++ b/tools/cluster-helper.in
@@ -199,3 +199,5 @@ elif [ $command = xargs ]; then
 	eval `echo $* | sed 's@'$replace'@'$n'@'`
     done
 fi
+
+# vim: set filetype=sh:

--- a/tools/crm_failcount.in
+++ b/tools/crm_failcount.in
@@ -291,3 +291,5 @@ if [ "$command" = "--query" ]; then
 else
 	clear_failcount "$target" "$resource" "$operation" "$interval"
 fi
+
+# vim: set filetype=sh:

--- a/tools/crm_master.in
+++ b/tools/crm_master.in
@@ -90,3 +90,5 @@ if [ -z "$OCF_RESOURCE_INSTANCE" ]; then
 fi
 
 crm_attribute -n master-$OCF_RESOURCE_INSTANCE $options
+
+# vim: set filetype=sh:

--- a/tools/crm_report.in
+++ b/tools/crm_report.in
@@ -478,4 +478,4 @@ else
     fatal "Not sure what to do, no tests or time ranges to extract"
 fi
 
-# vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/tools/crm_standby.in
+++ b/tools/crm_standby.in
@@ -156,3 +156,5 @@ if [ $lifetime -eq 0 ]; then
 fi
 
 crm_attribute $options
+
+# vim: set filetype=sh:

--- a/tools/pcmk_simtimes.in
+++ b/tools/pcmk_simtimes.in
@@ -156,4 +156,4 @@ if __name__ == "__main__":
 
     sys.exit(ExitStatus.OK)
 
-# vim: set filetype=python expandtab tabstop=4 softtabstop=4 shiftwidth=4 textwidth=120:
+# vim: set filetype=python:

--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -882,4 +882,4 @@ elif [ "$REPORT_MASTER" != "$REPORT_TARGET" ]; then
     fi
 fi
 
-# vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:

--- a/tools/report.common.in
+++ b/tools/report.common.in
@@ -887,4 +887,4 @@ fi
 LC_ALL="C"
 export LC_ALL
 
-# vim: set expandtab tabstop=8 softtabstop=4 shiftwidth=4 textwidth=80:
+# vim: set filetype=sh:


### PR DESCRIPTION
If it's a .in file that vim has syntax highlighting support for, add a modeline to the bottom of the file that sets the filetype.

If there was already a modeline, reduce it down to just setting the filetype.  Other settings are global and should either be in a top-level vimrc file (which we don't have, and I don't know if vim supports but still) or in personal config files.