### PR TITLE
Med: daemons: Add a return to do_pe_invoke_callback.

### DIFF
--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -488,6 +488,7 @@ do_pe_invoke_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
                   (num_cib_op_callbacks() - 1));
         cib_retry_timer = mainloop_timer_add("cib_retry", 1000, FALSE, sleep_timer, NULL);
         mainloop_timer_start(cib_retry_timer);
+        return;
     }
 
     CRM_LOG_ASSERT(output != NULL);


### PR DESCRIPTION
676b54728f needs to return after adding the timer.  It used to do this before there was a timer.  Without the return, in my testing, resources will not even try to start perhaps one time out of five.