### PR TITLE
Fix: libcrmcommon: Increase poll() timeout to 5s for liveness checks on sub-daemons

### DIFF
--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1623,7 +1623,7 @@ pcmk__ipc_is_authentic_process_active(const char *name, uid_t refuid,
 #ifdef HAVE_QB_IPCC_CONNECT_ASYNC
     pollfd.events = POLLIN;
     do {
-        poll_rc = poll(&pollfd, 1, 2000);
+        poll_rc = poll(&pollfd, 1, 5000);
     } while ((poll_rc == -1) && (errno == EINTR));
 
     /* If poll() failed, given that disconnect function is not registered yet,


### PR DESCRIPTION
If a node is temporarily running into a difficult situation, for the liveness checks on sub-daemons by pacemakerd, the 5 `PCMK_PROCESS_CHECK_RETRIES` offer a certain degree of tolerance. But in practice with the current 2s of poll() timeout, if the situation is a little too difficult, the liveness checks seem to run into 5 failures in a row rather easily while the situation still seems acceptable.

This commit offers a longer timeout of 5s for a sub-daemon to respond to a liveness check.

See discussion at:
https://github.com/ClusterLabs/pacemaker/pull/2588#discussion_r2122975853

Backport https://github.com/ClusterLabs/pacemaker/pull/3900 to 2.1