### PR TITLE
Log: tools: Prevent crm_verify from stating configuration is "invalid" if it only has warnings

### DIFF
--- a/cts/cli/regression.crm_verify.exp
+++ b/cts/cli/regression.crm_verify.exp
@@ -1,5 +1,5 @@
 =#=#=#= Begin test: Verify a file-specified invalid configuration =#=#=#=
-Configuration invalid (with errors) (-V may provide more detail)
+Configuration invalid (-V may provide more detail)
 =#=#=#= End test: Verify a file-specified invalid configuration - Invalid configuration (78) =#=#=#=
 * Passed: crm_verify            - Verify a file-specified invalid configuration
 =#=#=#= Begin test: Verify a file-specified invalid configuration (XML) =#=#=#=
@@ -9,7 +9,7 @@ Configuration invalid (with errors) (-V may provide more detail)
       <error>error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
       <error>error: Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
       <error>error: CIB did not pass schema validation</error>
-      <error>Configuration invalid (with errors)</error>
+      <error>Configuration invalid</error>
     </errors>
   </status>
 </pacemaker-result>
@@ -20,7 +20,7 @@ unpack_config 	warning: Blind faith: not fencing unseen nodes
 error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource
 error: Ignoring <clone> resource 'test2-clone' because configuration is invalid
 error: CIB did not pass schema validation
-Configuration invalid (with errors)
+Configuration invalid
 =#=#=#= End test: Verify a file-specified invalid configuration (verbose) - Invalid configuration (78) =#=#=#=
 * Passed: crm_verify            - Verify a file-specified invalid configuration (verbose)
 =#=#=#= Begin test: Verify a file-specified invalid configuration (verbose) (XML) =#=#=#=
@@ -31,7 +31,7 @@ unpack_config 	warning: Blind faith: not fencing unseen nodes
       <error>error: Resource test2:0 is of type systemd and therefore cannot be used as a promotable clone resource</error>
       <error>error: Ignoring &lt;clone&gt; resource 'test2-clone' because configuration is invalid</error>
       <error>error: CIB did not pass schema validation</error>
-      <error>Configuration invalid (with errors)</error>
+      <error>Configuration invalid</error>
     </errors>
   </status>
 </pacemaker-result>
@@ -60,7 +60,7 @@ unpack_config 	warning: Blind faith: not fencing unseen nodes
       <error>warning: Node pcmk-1 is unclean but cannot be fenced</error>
       <error>warning: Node pcmk-2 is unclean but cannot be fenced</error>
       <error>error: CIB did not pass schema validation</error>
-      <error>Configuration invalid (with errors)</error>
+      <error>Configuration invalid</error>
     </errors>
   </status>
 </pacemaker-result>

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -260,14 +260,14 @@ main(int argc, char **argv)
         const char *verbose_hint = "";
 
         if (pcmk__config_has_error) {
-            failure_type = " (with errors)";
+            failure_type = "invalid";
         } else if (pcmk__config_has_warning) {
-            failure_type = " (with warnings)";
+            failure_type = "may need attention";
         }
         if (options.verbosity == 0) {
             verbose_hint = " (-V may provide more detail)";
         }
-        out->err(out, "Configuration invalid%s%s", failure_type, verbose_hint);
+        out->err(out, "Configuration %s%s", failure_type, verbose_hint);
     }
 
     pcmk_free_scheduler(scheduler);


### PR DESCRIPTION
Configuration warnings generally indicate that users need to pay attention to their configuration regarding deprecations and so on. Technically it doesn't mean that the configuration is literally "invalid". Previously this wording was too harsh and fearsome.