### PR TITLE
Doc: ChangeLog: update for 3.0.1 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
-# Pacemaker-3.0.1 (30 Jul 2025)
-* 773 commits with 283 files changed, 11593 insertions(+), 7746 deletions(-)
+# Pacemaker-3.0.1 (07 Aug 2025)
+* 775 commits with 283 files changed, 11592 insertions(+), 7745 deletions(-)
 
 ## Features added since Pacemaker-3.0.0
 


### PR DESCRIPTION
Note:  The only code difference between this and the last changelog update is the ECONNREFUSED fix.  That fixes a regression introduced after 3.0.0.  It's not mentioned anywhere in the changelog because it's just an update to another fix and was not in a final release anywhere.

Thus, this patch just modifies the changelog summary.