### PR TITLE
Refactor: cts: Condense $PATH code into a single function

### DIFF
--- a/cts/cts-attrd.in
+++ b/cts/cts-attrd.in
@@ -29,28 +29,9 @@ if os.path.exists("@abs_top_builddir@/python") and "@abs_top_builddir@" != "@abs
 from pacemaker.buildoptions import BuildOptions
 from pacemaker.exitstatus import ExitStatus
 from pacemaker._cts.corosync import Corosync
+from pacemaker._cts.environment import set_cts_path
 from pacemaker._cts.process import killall, exit_if_proc_running
 from pacemaker._cts.test import Test, Tests
-
-TEST_DIR = sys.path[0]
-
-
-def update_path():
-    """Set the PATH environment variable appropriately for the tests."""
-    new_path = os.environ['PATH']
-    if os.path.exists(f"{TEST_DIR}/cts-attrd.in"):
-        # pylint: disable=protected-access
-        print(f"Running tests from the source tree: {BuildOptions._BUILD_DIR} ({TEST_DIR})")
-        # For pacemaker-attrd
-        new_path = f"{BuildOptions._BUILD_DIR}/daemons/attrd:{new_path}"
-
-    else:
-        print(f"Running tests from the install tree: {BuildOptions.DAEMON_DIR} (not {TEST_DIR})")
-        # For pacemaker-attrd
-        new_path = f"{BuildOptions.DAEMON_DIR}:{new_path}"
-
-    print(f'Using PATH="{new_path}"')
-    os.environ['PATH'] = new_path
 
 
 class AttributeTest(Test):
@@ -363,7 +344,7 @@ def build_options():
 
 def main():
     """Run attrd regression tests as specified by arguments."""
-    update_path()
+    set_cts_path()
 
     # Ensure all command output is in portable locale for comparison
     os.environ['LC_ALL'] = "C"

--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -38,6 +38,7 @@ if os.path.exists("@abs_top_srcdir@/python"):
 if os.path.exists("@abs_top_builddir@/python") and "@abs_top_builddir@" != "@abs_top_srcdir@":
     sys.path.insert(0, "@abs_top_builddir@/python")
 
+from pacemaker._cts.environment import set_cts_path
 from pacemaker._cts.errors import XmlValidationError
 from pacemaker._cts.validate import validate
 from pacemaker.buildoptions import BuildOptions
@@ -3262,35 +3263,6 @@ def setup_environment(valgrind):
         os.environ["PCMK_trace_functions"] = ""
 
 
-def path_prepend(p):
-    """Add another directory to the front of $PATH."""
-    old = os.environ["PATH"]
-    os.environ["PATH"] = f"{p}:{old}"
-
-
-def setup_path(opts_path):
-    """Set the PATH environment variable appropriately for the tests."""
-    srcdir = os.path.dirname(test_home)
-
-    # Add any search paths given on the command line
-    for p in opts_path:
-        path_prepend(p)
-
-    if os.path.exists(f"{srcdir}/tools/crm_simulate"):
-        print(f"Using local binaries from: {srcdir}")
-
-        path_prepend(f"{srcdir}/tools")
-
-        for daemon in ["based", "controld", "fenced", "schedulerd"]:
-            path_prepend(f"{srcdir}/daemons/{daemon}")
-
-        print(f"Using local schemas from: {srcdir}/xml")
-        os.environ["PCMK_schema_directory"] = f"{srcdir}/xml"
-    else:
-        path_prepend(BuildOptions.DAEMON_DIR)
-        os.environ["PCMK_schema_directory"] = BuildOptions.SCHEMA_DIR
-
-
 def _run_one(valgrind, r):
     """Run and return a TestGroup object."""
     # See comments in run_regression_tests.
@@ -3425,7 +3397,7 @@ def main():
     opts = build_options()
 
     setup_environment(opts.valgrind)
-    setup_path(opts.path)
+    set_cts_path(extra=opts.path)
 
     # Filter the list of all regression test classes to include only those that
     # were requested on the command line.  If empty, this defaults to default_tests.

--- a/cts/cts-exec.in
+++ b/cts/cts-exec.in
@@ -18,10 +18,6 @@ import subprocess
 import shutil
 import tempfile
 
-# Where to find test binaries
-# Prefer the source tree if available
-TEST_DIR = sys.path[0]
-
 # These imports allow running from a source checkout after running `make`.
 # Note that while this doesn't necessarily mean it will successfully run tests,
 # but being able to see --help output can be useful.
@@ -35,36 +31,12 @@ if os.path.exists("@abs_top_builddir@/python") and "@abs_top_builddir@" != "@abs
 from pacemaker.buildoptions import BuildOptions
 from pacemaker.exitstatus import ExitStatus
 from pacemaker._cts.corosync import Corosync
+from pacemaker._cts.environment import set_cts_path
 from pacemaker._cts.process import killall, exit_if_proc_running, stdout_from_command
 from pacemaker._cts.test import Test, Tests
 
 # File permissions for executable scripts we create
 EXECMODE = stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH
-
-
-def update_path():
-    # pylint: disable=protected-access
-    """Set the PATH environment variable appropriately for the tests."""
-    new_path = os.environ['PATH']
-
-    if os.path.exists(f"{TEST_DIR}/cts-exec.in"):
-        print(f"Running tests from the source tree: {BuildOptions._BUILD_DIR} ({TEST_DIR})")
-        # For pacemaker-execd, cts-exec-helper, and pacemaker-remoted
-        new_path = f"{BuildOptions._BUILD_DIR}/daemons/execd:{new_path}"
-        new_path = f"{BuildOptions._BUILD_DIR}/tools:{new_path}"  # For crm_resource
-        # For pacemaker-fenced
-        new_path = f"{BuildOptions._BUILD_DIR}/daemons/fenced:{new_path}"
-        # For cts-support
-        new_path = f"{BuildOptions._BUILD_DIR}/cts/support:{new_path}"
-
-    else:
-        print(f"Running tests from the install tree: {BuildOptions.DAEMON_DIR} (not {TEST_DIR})")
-        # For cts-exec-helper, cts-support, pacemaker-execd, pacemaker-fenced,
-        # and pacemaker-remoted
-        new_path = f"{BuildOptions.DAEMON_DIR}:{new_path}"
-
-    print(f'Using PATH="{new_path}"')
-    os.environ['PATH'] = new_path
 
 
 class ExecTest(Test):
@@ -875,7 +847,7 @@ def build_options():
 
 def main():
     """Run pacemaker-execd regression tests as specified by arguments."""
-    update_path()
+    set_cts_path()
 
     # Ensure all command output is in portable locale for comparison
     os.environ['LC_ALL'] = "C"

--- a/cts/cts-fencing.in
+++ b/cts/cts-fencing.in
@@ -26,33 +26,11 @@ if os.path.exists("@abs_top_srcdir@/python"):
 if os.path.exists("@abs_top_builddir@/python") and "@abs_top_builddir@" != "@abs_top_srcdir@":
     sys.path.insert(0, "@abs_top_builddir@/python")
 
-from pacemaker.buildoptions import BuildOptions
 from pacemaker.exitstatus import ExitStatus
 from pacemaker._cts.corosync import Corosync, localname
+from pacemaker._cts.environment import set_cts_path
 from pacemaker._cts.process import killall, exit_if_proc_running
 from pacemaker._cts.test import Test, Tests
-
-TEST_DIR = sys.path[0]
-
-
-def update_path():
-    """Set the PATH environment variable appropriately for the tests."""
-    new_path = os.environ['PATH']
-    if os.path.exists(f"{TEST_DIR}/cts-fencing.in"):
-        # pylint: disable=protected-access
-        print(f"Running tests from the source tree: {BuildOptions._BUILD_DIR} ({TEST_DIR})")
-        # For pacemaker-fenced and cts-fence-helper
-        new_path = f"{BuildOptions._BUILD_DIR}/daemons/fenced:{new_path}"
-        new_path = f"{BuildOptions._BUILD_DIR}/tools:{new_path}"  # For stonith_admin
-        new_path = f"{BuildOptions._BUILD_DIR}/cts/support:{new_path}"  # For cts-support
-
-    else:
-        print(f"Running tests from the install tree: {BuildOptions.DAEMON_DIR} (not {TEST_DIR})")
-        # For pacemaker-fenced, cts-fence-helper, and cts-support
-        new_path = f"{BuildOptions.DAEMON_DIR}:{new_path}"
-
-    print(f'Using PATH="{new_path}"')
-    os.environ['PATH'] = new_path
 
 
 class FenceTest(Test):
@@ -866,7 +844,7 @@ def build_options():
 
 def main():
     """Run fencing regression tests as specified by arguments."""
-    update_path()
+    set_cts_path()
 
     # Ensure all command output is in portable locale for comparison
     os.environ['LC_ALL'] = "C"


### PR DESCRIPTION
Each tool was doing the same thing, just checking for a different executable before deciding how to set the path.  It really doesn't matter which executable we search for, though - as long as we can tell if we're in the source directory or not.  It also doesn't matter if we add the directory for every single daemon or not, so just do it to make the code simpler.

This also fixes a bug:  sys.path[0] is going to be a directory containing python source code.  It's likely to be python/ under the source tree, given how we set up paths at the top of each of these files.  TEST_DIR/cts-attrd.in therefore is not going to exist (it'll be something like ~/src/pacemaker/python/cts-attrd.in) which means we will never use the source directory for these tests.

Ref T970