### PR TITLE
Drop workarounds for GnuTLS <3.4.6

### DIFF
--- a/include/crm/common/tls_internal.h
+++ b/include/crm/common/tls_internal.h
@@ -84,8 +84,8 @@ int pcmk__init_tls_dh(gnutls_dh_params_t *dh_params);
  * \internal
  * \brief Initialize a new TLS session
  *
- * \param[in] tls         A TLS environment object
- * \param[in] csock       Connected socket for TLS session
+ * \param[in] tls    TLS environment object
+ * \param[in] csock  Connected TCP socket for TLS session
  *
  * \return Pointer to newly created session object, or NULL on error
  */

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -173,8 +173,6 @@ pcmk__free_tls(pcmk__tls_t *tls)
 
     free(tls);
     tls = NULL;
-
-    gnutls_global_deinit();
 }
 
 int
@@ -190,14 +188,6 @@ pcmk__init_tls(pcmk__tls_t **tls, bool server, gnutls_credentials_type_t cred_ty
 
     signal(SIGPIPE, SIG_IGN);
 
-    /* gnutls_global_init is safe to call multiple times, but we have to call
-     * gnutls_global_deinit the same number of times for that function to do
-     * anything.
-     *
-     * FIXME: When we can use gnutls >= 3.3.0, we don't have to call
-     * gnutls_global_init anymore.
-     */
-    gnutls_global_init();
     gnutls_global_set_log_level(8);
     gnutls_global_set_log_function(_gnutls_log_func);
 

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -14,8 +14,6 @@
 #include <gnutls/x509.h>
 #include <stdlib.h>
 
-#include <glib.h>           // gpointer, GPOINTER_TO_INT(), GINT_TO_POINTER()
-
 #include <crm/common/tls_internal.h>
 
 static char *
@@ -349,8 +347,7 @@ pcmk__new_tls_session(pcmk__tls_t *tls, int csock)
         goto error;
     }
 
-    gnutls_transport_set_ptr(session,
-                             (gnutls_transport_ptr_t) GINT_TO_POINTER(csock));
+    gnutls_transport_set_int(session, csock);
 
     /* gnutls does not make this easy */
     if (tls->cred_type == GNUTLS_CRD_ANON && tls->server) {
@@ -417,12 +414,9 @@ error:
 int
 pcmk__tls_get_client_sock(const pcmk__remote_t *remote)
 {
-    gpointer sock_ptr = NULL;
-
     pcmk__assert((remote != NULL) && (remote->tls_session != NULL));
 
-    sock_ptr = (gpointer) gnutls_transport_get_ptr(remote->tls_session);
-    return GPOINTER_TO_INT(sock_ptr);
+    return gnutls_transport_get_int(remote->tls_session);
 }
 
 int

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -99,44 +99,6 @@ tls_load_x509_data(pcmk__tls_t *tls)
     return pcmk_rc_ok;
 }
 
-/*!
- * \internal
- * \brief Verify a peer's certificate
- *
- * \return 0 if the certificate is trusted and the gnutls handshake should
- *         continue, -1 otherwise
- */
-static int
-verify_peer_cert(gnutls_session_t session)
-{
-    int rc;
-    int type;
-    unsigned int status;
-    gnutls_datum_t out;
-
-    /* NULL = no hostname comparison will be performed */
-    rc = gnutls_certificate_verify_peers3(session, NULL, &status);
-
-    /* Success means it was able to perform the verification.  We still have
-     * to check status to see whether the cert is valid or not.
-     */
-    if (rc != GNUTLS_E_SUCCESS) {
-        crm_err("Failed to verify peer certificate: %s", gnutls_strerror(rc));
-        return -1;
-    }
-
-    if (status == 0) {
-        /* The certificate is trusted. */
-        return 0;
-    }
-
-    type = gnutls_certificate_type_get(session);
-    gnutls_certificate_verification_status_print(status, type, &out, 0);
-    crm_err("Peer certificate invalid: %s", out.data);
-    gnutls_free(out.data);
-    return GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR;
-}
-
 static void
 _gnutls_log_func(int level, const char *msg)
 {
@@ -368,12 +330,8 @@ pcmk__new_tls_session(pcmk__tls_t *tls, int csock)
             gnutls_certificate_server_set_request(session, GNUTLS_CERT_REQUIRE);
         }
 
-        /* Register a function to verify the peer's certificate.
-         *
-         * FIXME: When we can require gnutls >= 3.4.6, remove verify_peer_cert
-         * and use gnutls_session_set_verify_cert instead.
-         */
-        gnutls_certificate_set_verify_function(tls->credentials.cert, verify_peer_cert);
+        // Register a function to verify the peer's certificate
+        gnutls_session_set_verify_cert(session, NULL, 0);
     }
 
     return session;

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -449,6 +449,8 @@ pcmk__timeout_ms2s(guint timeout_ms)
 // Deprecated functions kept only for backward API compatibility
 // LCOV_EXCL_START
 
+#include <gnutls/gnutls.h>          // gnutls_global_init(), etc.
+
 #include <crm/common/util_compat.h>
 
 static void


### PR DESCRIPTION
This is #3790 with an extra patch on top to improve error reporting.  I think we could probably go farther with improving gnutls-related error reporting, but I'm not willing to work on that right now.  I'm a little pessimistic on this kind of error reporting in the first place since it all just goes out the logging firehose, and someone has to know to go digging around in there when their cluster doesn't work.

There are no code changes in the first three patches.

I tested the following:

* Expired certificates (that's how I discovered we needed to add the error reporting code back)
* Certificates are valid
* Certificate required by server, but not supplied by client
* Certificate not required by server, but supplied by client anyway
* The previous three for remote CIB operations as well