### PR TITLE
Low: sysconfig: Remove --leak-check=full from default VALGRIND_OPTS.

### DIFF
--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -424,5 +424,11 @@
 # is specified because pacemaker-execd can lower privileges when executing
 # commands, which would otherwise leave a bunch of unremovable files in /tmp.
 #
+# These options will also be passed to the callgrind tool if it's enabled.
+# However, callgrind does not support all the same options as valgrind (in
+# particular, it does not support "--leak-check=").  If you need that option
+# or any other valgrind-specific options, add those here and make sure to set
+# PCMK_callgrind_enabled="no".
+#
 # Default: VALGRIND_OPTS=""
-VALGRIND_OPTS="--leak-check=full --trace-children=no --vgdb=no --num-callers=25 --log-file=@PCMK__PERSISTENT_DATA_DIR@/valgrind-%p --suppressions=@datadir@/pacemaker/tests/valgrind-pcmk.suppressions --gen-suppressions=all"
+VALGRIND_OPTS="--trace-children=no --vgdb=no --num-callers=25 --log-file=@PCMK__PERSISTENT_DATA_DIR@/valgrind-%p --suppressions=@datadir@/pacemaker/tests/valgrind-pcmk.suppressions --gen-suppressions=all"


### PR DESCRIPTION
Both the valgrind and callgrind tools read this environment variable. However, callgrind does not support --leak-check=.  It does support all the other options we enable by default.  If it sees an option it doesn't understand, it prints an error message and quits.  This means that if you enable callgrind and don't change our default VALGRIND_OPTS, you'll get a bunch of errors in the pacemaker log about daemons not starting, but the reason why is undiscoverable due to closing file descriptors when we fork off the subdaemons.

I considered two other ways of fixing this:

(1) Filtering out --leak-check= from the environment variable.  However, there are probably other options that callgrind does not support and I don't want to constantly have to chase that down.  Further, I think our default setting should work with all the valgrind-related tools that we expose a flag for.

(2) Having two settings in sysconfig and choosing the right one depending on which tool is enabled.  This seems unnecessarily confusing.

Fixes T988