### PR TITLE
Refactor: controller: Use GQueue for FSA message queue

### DIFF
--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -387,10 +387,10 @@ peer_update_callback(enum pcmk__node_update type, pcmk__node_status_t *node,
 gboolean
 crm_fsa_trigger(gpointer user_data)
 {
-    crm_trace("Invoked (queue len: %d)",
-              g_list_length(controld_globals.fsa_message_queue));
+    crm_trace("Invoking FSA (queue len: %u)",
+              controld_fsa_message_queue_length());
     s_crmd_fsa(C_FSA_INTERNAL);
-    crm_trace("Exited  (queue len: %d)",
-              g_list_length(controld_globals.fsa_message_queue));
-    return TRUE;
+    crm_trace("Exited FSA (queue len: %u)",
+              controld_fsa_message_queue_length());
+    return G_SOURCE_CONTINUE;
 }

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -209,20 +209,10 @@ crmd_exit(crm_exit_t exit_code)
 
 /* Clean up as much memory as possible for valgrind */
 
-    for (GList *iter = controld_globals.fsa_message_queue; iter != NULL;
-         iter = iter->next) {
-        fsa_data_t *fsa_data = (fsa_data_t *) iter->data;
-
-        crm_info("Dropping %s: [ state=%s cause=%s origin=%s ]",
-                 fsa_input2string(fsa_data->fsa_input),
-                 fsa_state2string(controld_globals.fsa_state),
-                 fsa_cause2string(fsa_data->fsa_cause), fsa_data->origin);
-        delete_fsa_input(fsa_data);
-    }
-
     controld_clear_fsa_input_flags(R_MEMBERSHIP);
 
-    g_list_free(controld_globals.fsa_message_queue);
+    g_list_free_full(controld_globals.fsa_message_queue,
+                     (GDestroyNotify) delete_fsa_input);
     controld_globals.fsa_message_queue = NULL;
 
     controld_free_node_pending_timers();

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -211,8 +211,8 @@ crmd_exit(crm_exit_t exit_code)
 
     controld_clear_fsa_input_flags(R_MEMBERSHIP);
 
-    g_list_free_full(controld_globals.fsa_message_queue,
-                     (GDestroyNotify) delete_fsa_input);
+    g_queue_free_full(controld_globals.fsa_message_queue,
+                      (GDestroyNotify) delete_fsa_input);
     controld_globals.fsa_message_queue = NULL;
 
     controld_free_node_pending_timers();

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -180,9 +180,20 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
     if ((controld_fsa_message_queue_length() == 0)
         && (controld_globals.fsa_actions != A_NOTHING)) {
 
-        /* Fake the first message so we can get into the loop.
-         * We can't call register_fsa_input() because it won't add a message
-         * with I_NULL and A_NOTHING.
+        /* Fake the first message so that we can enter the loop.
+         *
+         * There are already actions to perform. Everything in the loop is a
+         * no-op for this fake message, except the following:
+         * * controld_clear_fsa_action_flags(startup_actions)
+         * * s_crmd_fsa_actions(fsa_data)
+         *
+         * We would still need this fake message even if we changed the loop
+         * condition. s_crmd_fsa_actions() needs an fsa_data_t object so that we
+         * can process the already-pending actions. So a larger refactor would
+         * be required in order to get rid of this.
+         *
+         * We can't call register_fsa_input() because it currently won't add a
+         * message with I_NULL and A_NOTHING (like this one).
          */
         fsa_data = pcmk__assert_alloc(1, sizeof(fsa_data_t));
         fsa_data->fsa_input = I_NULL;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -182,8 +182,10 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
         crm_trace("Checking messages (%u remaining)",
                   controld_fsa_message_queue_length());
 
-        fsa_data = get_message();
-        if(fsa_data == NULL) {
+        fsa_data =
+            (fsa_data_t *) g_queue_pop_head(controld_globals.fsa_message_queue);
+
+        if (fsa_data == NULL) {
             continue;
         }
 

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -136,7 +136,7 @@ log_fsa_data(gpointer data, gpointer user_data)
     fsa_data_t *fsa_data = data;
     unsigned int *offset = user_data;
 
-    crm_debug("queue[%u.%d]: input %s submitted by %s (%p.%d) (cause=%s)",
+    crm_trace("queue[%u.%d]: input %s submitted by %s (%p.%d) (cause=%s)",
               (*offset)++, fsa_data->id, fsa_input2string(fsa_data->fsa_input),
               fsa_data->origin, fsa_data->data, fsa_data->data_type,
               fsa_cause2string(fsa_data->fsa_cause));
@@ -150,7 +150,6 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
     uint64_t register_copy = controld_globals.fsa_input_register;
     uint64_t new_actions = A_NOTHING;
     enum crmd_fsa_state last_state;
-    unsigned int offset = 0;
 
     crm_trace("FSA invoked with Cause: %s\tState: %s",
               fsa_cause2string(cause),
@@ -258,7 +257,15 @@ s_crmd_fsa(enum crmd_fsa_cause cause)
     }
 
     fsa_dump_actions(controld_globals.fsa_actions, "Remaining");
-    g_list_foreach(controld_globals.fsa_message_queue, log_fsa_data, &offset);
+    pcmk__if_tracing(
+        {
+            unsigned int offset = 0;
+
+            g_list_foreach(controld_globals.fsa_message_queue, log_fsa_data,
+                           &offset);
+        },
+        {}
+    );
 
     return globals->fsa_state;
 }

--- a/daemons/controld/controld_globals.h
+++ b/daemons/controld/controld_globals.h
@@ -13,7 +13,7 @@
 #include <crm_internal.h>       // pcmk__output_t, etc.
 
 #include <stdint.h>             // uint32_t, uint64_t
-#include <glib.h>               // GList, GMainLoop
+#include <glib.h>               // GMainLoop, GQueue, guint, etc.
 #include <crm/cib.h>            // cib_t
 #include <pacemaker-internal.h> // pcmk__graph_t
 #include <controld_fsa.h>       // enum crmd_fsa_state
@@ -35,7 +35,7 @@ typedef struct {
     uint64_t fsa_input_register;
 
     // FSA message queue
-    GList *fsa_message_queue;
+    GQueue *fsa_message_queue;
 
 
     /* CIB */
@@ -107,6 +107,21 @@ typedef struct {
 } controld_globals_t;
 
 extern controld_globals_t controld_globals;
+
+/*!
+ * \internal
+ * \brief Get number of messages in the controller FSA message queue
+ *
+ * \return Length of the queue, or 0 if the queue is \c NULL
+ */
+static inline guint
+controld_fsa_message_queue_length(void)
+{
+    if (controld_globals.fsa_message_queue == NULL) {
+        return 0;
+    }
+    return controld_globals.fsa_message_queue->length;
+}
 
 /*!
  * \internal

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -218,16 +218,6 @@ delete_fsa_input(fsa_data_t * fsa_data)
     free(fsa_data);
 }
 
-/* returns the next message */
-fsa_data_t *
-get_message(void)
-{
-    fsa_data_t *message = g_queue_pop_head(controld_globals.fsa_message_queue);
-
-    crm_trace("Processing input %d", message->id);
-    return message;
-}
-
 void *
 fsa_typed_data_adv(fsa_data_t * fsa_data, enum fsa_data_type a_type, const char *caller)
 {

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -161,23 +161,6 @@ register_fsa_input_adv(enum crmd_fsa_cause cause, enum crmd_fsa_input input,
     }
 }
 
-void
-fsa_dump_queue(int log_level)
-{
-    int offset = 0;
-
-    for (GList *iter = controld_globals.fsa_message_queue; iter != NULL;
-         iter = iter->next) {
-        fsa_data_t *data = (fsa_data_t *) iter->data;
-
-        do_crm_log_unlikely(log_level,
-                            "queue[%d.%d]: input %s raised by %s(%p.%d)\t(cause=%s)",
-                            offset++, data->id, fsa_input2string(data->fsa_input),
-                            data->origin, data->data, data->data_type,
-                            fsa_cause2string(data->fsa_cause));
-    }
-}
-
 ha_msg_input_t *
 copy_ha_msg_input(ha_msg_input_t * orig)
 {

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -40,7 +40,6 @@ void register_fsa_input_adv(enum crmd_fsa_cause cause,
                             uint64_t with_actions, gboolean prepend,
                             const char *raised_from);
 
-extern void fsa_dump_queue(int log_level);
 extern void route_message(enum crmd_fsa_cause cause, xmlNode * input);
 
 #  define crmd_fsa_stall(suppress) do {                                 \

--- a/daemons/controld/controld_messages.h
+++ b/daemons/controld/controld_messages.h
@@ -65,8 +65,6 @@ extern void route_message(enum crmd_fsa_cause cause, xmlNode * input);
 
 void delete_fsa_input(fsa_data_t * fsa_data);
 
-fsa_data_t *get_message(void);
-
 extern gboolean relay_message(xmlNode * relay_message, gboolean originated_locally);
 
 gboolean crmd_is_proxy_session(const char *session);


### PR DESCRIPTION
This makes more semantic sense, and it avoids expensive linked list traversals to append to the message queue. `g_queue_push_tail()` jumps straight to the end.