### PR TITLE
Fix IPC backlog problems

### DIFF
--- a/cts/cli/regression.crm_attribute.exp
+++ b/cts/cli/regression.crm_attribute.exp
@@ -111,8 +111,8 @@ Also known as properties, these are options that affect behavior across the enti
   * migration-limit: The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)
     * Possible values: integer (default: )
 
-  * cluster-ipc-limit: Maximum IPC message backlog before disconnecting a cluster daemon
-    * Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
+  * cluster-ipc-limit: Maximum IPC message backlog before disconnecting a client
+    * Raise this if log has "Evicting client" messages for cluster PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
     * Possible values: nonnegative_integer (default: )
 
   * stop-all-resources: Whether the cluster should stop all active resources
@@ -357,8 +357,8 @@ Also known as properties, these are options that affect behavior across the enti
         <content type="integer" default=""/>
       </parameter>
       <parameter name="cluster-ipc-limit" advanced="0" generated="0">
-        <longdesc lang="en">Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
-        <shortdesc lang="en">Maximum IPC message backlog before disconnecting a cluster daemon</shortdesc>
+        <longdesc lang="en">Raise this if log has "Evicting client" messages for cluster PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
+        <shortdesc lang="en">Maximum IPC message backlog before disconnecting a client</shortdesc>
         <content type="nonnegative_integer" default=""/>
       </parameter>
       <parameter name="stop-all-resources" advanced="0" generated="0">
@@ -537,8 +537,8 @@ Also known as properties, these are options that affect behavior across the enti
   * migration-limit: The number of live migration actions that the cluster is allowed to execute in parallel on a node (-1 means no limit)
     * Possible values: integer (default: )
 
-  * cluster-ipc-limit: Maximum IPC message backlog before disconnecting a cluster daemon
-    * Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
+  * cluster-ipc-limit: Maximum IPC message backlog before disconnecting a client
+    * Raise this if log has "Evicting client" messages for cluster PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
     * Possible values: nonnegative_integer (default: )
 
   * stop-all-resources: Whether the cluster should stop all active resources
@@ -818,8 +818,8 @@ Also known as properties, these are options that affect behavior across the enti
         <content type="integer" default=""/>
       </parameter>
       <parameter name="cluster-ipc-limit" advanced="0" generated="0">
-        <longdesc lang="en">Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
-        <shortdesc lang="en">Maximum IPC message backlog before disconnecting a cluster daemon</shortdesc>
+        <longdesc lang="en">Raise this if log has "Evicting client" messages for cluster PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).</longdesc>
+        <shortdesc lang="en">Maximum IPC message backlog before disconnecting a client</shortdesc>
         <content type="nonnegative_integer" default=""/>
       </parameter>
       <parameter name="stop-all-resources" advanced="0" generated="0">

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -21,10 +21,10 @@
     </parameter>
     <parameter name="cluster-ipc-limit">
       <longdesc lang="en">
-        Raise this if log has "Evicting client" messages for cluster daemon PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
+        Raise this if log has "Evicting client" messages for cluster PIDs (a good value is the number of resources in the cluster multiplied by the number of nodes).
       </longdesc>
       <shortdesc lang="en">
-        Maximum IPC message backlog before disconnecting a cluster daemon
+        Maximum IPC message backlog before disconnecting a client
       </shortdesc>
       <content type="integer" default=""/>
     </parameter>

--- a/doc/sphinx/Pacemaker_Explained/cluster-options.rst
+++ b/doc/sphinx/Pacemaker_Explained/cluster-options.rst
@@ -693,11 +693,13 @@ values, by running the ``man pacemaker-schedulerd`` and
        cluster-ipc-limit
      - :ref:`nonnegative integer <nonnegative_integer>`
      - 500
-     - The maximum IPC message backlog before one cluster daemon will
-       disconnect another. This is of use in large clusters, for which a good
-       value is the number of resources in the cluster multiplied by the number
-       of nodes. The default of 500 is also the minimum. Raise this if you see
-       "Evicting client" log messages for cluster daemon process IDs.
+     - The maximum IPC message backlog before a cluster daemon will disconnect
+       a client.  Other cluster daemons are not subject to this limit as long as
+       they are still processing messages.  This is of use in large clusters,
+       for which a good value is the number of resources in the cluster
+       multiplied by the number of nodes. The default of 500 is also the
+       minimum. Raise this if you see "Evicting client" log messages for
+       cluster process IDs.
    * - .. _pe_error_series_max:
 
        .. index::

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -477,16 +477,18 @@ crm_ipcs_flush_events(pcmk__client_t *c)
 
     if (c == NULL) {
         return rc;
+    }
 
-    } else if (c->event_timer) {
+    if (c->event_timer != 0) {
         /* There is already a timer, wait until it goes off */
         crm_trace("Timer active for %p - %d", c->ipcs, c->event_timer);
         return rc;
     }
 
-    if (c->event_queue) {
+    if (c->event_queue != NULL) {
         queue_len = g_queue_get_length(c->event_queue);
     }
+
     while (sent < 100) {
         pcmk__ipc_header_t *header = NULL;
         struct iovec *event = NULL;

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -513,16 +513,16 @@ crm_ipcs_flush_events(pcmk__client_t *c)
         for (unsigned int retries = 5; retries > 0; retries--) {
             qb_rc = qb_ipcs_event_sendv(c->ipcs, event, 2);
 
-            if (qb_rc < 0) {
-                if (retries == 1 || qb_rc != -EAGAIN) {
-                    rc = (int) -qb_rc;
-                    goto no_more_retries;
-                } else {
-                    pcmk__sleep_ms(5);
-                }
-            } else {
+            if (qb_rc >= 0) {
                 break;
             }
+
+            if (retries == 1 || qb_rc != -EAGAIN) {
+                rc = (int) -qb_rc;
+                goto no_more_retries;
+            }
+
+            pcmk__sleep_ms(5);
         }
 
         event = g_queue_pop_head(c->event_queue);

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -491,13 +491,12 @@ crm_ipcs_flush_events(pcmk__client_t *c)
         pcmk__ipc_header_t *header = NULL;
         struct iovec *event = NULL;
 
-        if (c->event_queue) {
-            // We don't pop unless send is successful
-            event = g_queue_peek_head(c->event_queue);
-        }
-        if (event == NULL) { // Queue is empty
+        if ((c->event_queue == NULL) || g_queue_is_empty(c->event_queue)) {
             break;
         }
+
+        // We don't pop unless send is successful
+        event = g_queue_peek_head(c->event_queue);
 
         /* Retry sending the event up to five times.  If we get -EAGAIN, sleep
          * a very short amount of time (too long here is bad) and try again.

--- a/lib/common/options.c
+++ b/lib/common/options.c
@@ -416,10 +416,10 @@ static const pcmk__cluster_option_t cluster_options[] = {
         PCMK_OPT_CLUSTER_IPC_LIMIT, NULL, PCMK_VALUE_NONNEGATIVE_INTEGER, NULL,
         "500", pcmk__valid_positive_int,
         pcmk__opt_based,
-        N_("Maximum IPC message backlog before disconnecting a cluster daemon"),
+        N_("Maximum IPC message backlog before disconnecting a client"),
         N_("Raise this if log has \"Evicting client\" messages for cluster "
-            "daemon PIDs (a good value is the number of resources in the "
-            "cluster multiplied by the number of nodes)."),
+            "PIDs (a good value is the number of resources in the cluster "
+            "multiplied by the number of nodes)."),
     },
 
     // Stopping resources and removed resources


### PR DESCRIPTION
This almost seems too easy.  The next step is getting some stress testing done on it, but before I start asking around about that, we should do patch review and perhaps consider whether to allow other clients to bypass the queue limit check as well.

I'm also undecided on whether this actually takes care of T38 or not.  It definitely makes the scalability of the queue much less of an issue, perhaps enough to where we can consider it closed.  I'm not sure that there's anything else we could do in this area before considering it closed.