### PR TITLE
Fix: libcrmcommon: Show deprecated option aliases in outputs

### DIFF
--- a/cts/cli/regression.crm_attribute.exp
+++ b/cts/cli/regression.crm_attribute.exp
@@ -371,9 +371,25 @@ Also known as properties, these are options that affect behavior across the enti
         <shortdesc lang="en">Whether to stop resources that were removed from the configuration</shortdesc>
         <content type="boolean" default=""/>
       </parameter>
+      <parameter name="stop-orphan-resources" advanced="0" generated="0">
+        <deprecated>
+          <replaced-with name="stop-removed-resources"/>
+        </deprecated>
+        <longdesc lang="en">Deprecated alias for stop-removed-resources</longdesc>
+        <shortdesc lang="en">Deprecated alias for stop-removed-resources</shortdesc>
+        <content type="boolean" default=""/>
+      </parameter>
       <parameter name="stop-removed-actions" advanced="0" generated="0">
         <longdesc lang="en">Whether to cancel recurring actions removed from the configuration</longdesc>
         <shortdesc lang="en">Whether to cancel recurring actions removed from the configuration</shortdesc>
+        <content type="boolean" default=""/>
+      </parameter>
+      <parameter name="stop-orphan-actions" advanced="0" generated="0">
+        <deprecated>
+          <replaced-with name="stop-removed-actions"/>
+        </deprecated>
+        <longdesc lang="en">Deprecated alias for stop-removed-actions</longdesc>
+        <shortdesc lang="en">Deprecated alias for stop-removed-actions</shortdesc>
         <content type="boolean" default=""/>
       </parameter>
       <parameter name="pe-error-series-max" advanced="0" generated="0">
@@ -619,6 +635,12 @@ Also known as properties, these are options that affect behavior across the enti
 
     * concurrent-fencing: Allow performing fencing operations in parallel
       * Possible values: boolean (default: )
+
+    * stop-orphan-resources: Deprecated alias for stop-removed-resources
+      * Possible values: boolean (default: )
+
+    * stop-orphan-actions: Deprecated alias for stop-removed-actions
+      * Possible values: boolean (default: )
 =#=#=#= End test: List all available cluster options - OK (0) =#=#=#=
 * Passed: crm_attribute         - List all available cluster options
 =#=#=#= Begin test: List all available cluster options (XML) =#=#=#=
@@ -832,9 +854,25 @@ Also known as properties, these are options that affect behavior across the enti
         <shortdesc lang="en">Whether to stop resources that were removed from the configuration</shortdesc>
         <content type="boolean" default=""/>
       </parameter>
+      <parameter name="stop-orphan-resources" advanced="0" generated="0">
+        <deprecated>
+          <replaced-with name="stop-removed-resources"/>
+        </deprecated>
+        <longdesc lang="en">Deprecated alias for stop-removed-resources</longdesc>
+        <shortdesc lang="en">Deprecated alias for stop-removed-resources</shortdesc>
+        <content type="boolean" default=""/>
+      </parameter>
       <parameter name="stop-removed-actions" advanced="0" generated="0">
         <longdesc lang="en">Whether to cancel recurring actions removed from the configuration</longdesc>
         <shortdesc lang="en">Whether to cancel recurring actions removed from the configuration</shortdesc>
+        <content type="boolean" default=""/>
+      </parameter>
+      <parameter name="stop-orphan-actions" advanced="0" generated="0">
+        <deprecated>
+          <replaced-with name="stop-removed-actions"/>
+        </deprecated>
+        <longdesc lang="en">Deprecated alias for stop-removed-actions</longdesc>
+        <shortdesc lang="en">Deprecated alias for stop-removed-actions</shortdesc>
         <content type="boolean" default=""/>
       </parameter>
       <parameter name="pe-error-series-max" advanced="0" generated="0">

--- a/cts/cli/regression.daemons.exp
+++ b/cts/cli/regression.daemons.exp
@@ -643,12 +643,30 @@
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>
+    <parameter name="stop-orphan-resources">
+      <longdesc lang="en">
+        Deprecated alias for stop-removed-resources
+      </longdesc>
+      <shortdesc lang="en">
+        *** Deprecated *** *** Replaced with stop-removed-resources ***
+      </shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
     <parameter name="stop-removed-actions">
       <longdesc lang="en">
         Whether to cancel recurring actions removed from the configuration
       </longdesc>
       <shortdesc lang="en">
         Whether to cancel recurring actions removed from the configuration
+      </shortdesc>
+      <content type="boolean" default=""/>
+    </parameter>
+    <parameter name="stop-orphan-actions">
+      <longdesc lang="en">
+        Deprecated alias for stop-removed-actions
+      </longdesc>
+      <shortdesc lang="en">
+        *** Deprecated *** *** Replaced with stop-removed-actions ***
       </shortdesc>
       <content type="boolean" default=""/>
     </parameter>

--- a/include/crm/common/xml_names.h
+++ b/include/crm/common/xml_names.h
@@ -170,6 +170,7 @@ extern "C" {
 #define PCMK_XE_PSEUDO_ACTION               "pseudo_action"
 #define PCMK_XE_REASON                      "reason"
 #define PCMK_XE_RECIPIENT                   "recipient"
+#define PCMK_XE_REPLACED_WITH               "replaced-with"
 #define PCMK_XE_REPLICA                     "replica"
 #define PCMK_XE_RESOURCE                    "resource"
 #define PCMK_XE_RESOURCE_AGENT              "resource-agent"

--- a/lib/common/options_display.c
+++ b/lib/common/options_display.c
@@ -368,14 +368,14 @@ add_option_metadata_xml(pcmk__output_t *out,
             }
 
             if (deprecated) {
-                pcmk__add_separated_word(&desc_short_legacy, init_sz,
-                                         "*** Deprecated ***", NULL);
+                pcmk__add_word(&desc_short_legacy, init_sz,
+                               "*** Deprecated ***");
             }
             if (advanced) {
-                pcmk__add_separated_word(&desc_short_legacy, init_sz,
-                                         "*** Advanced Use Only ***", NULL);
+                pcmk__add_word(&desc_short_legacy, init_sz,
+                               "*** Advanced Use Only ***");
             }
-            pcmk__add_separated_word(&desc_short_legacy, 0, desc_short, NULL);
+            pcmk__add_word(&desc_short_legacy, 0, desc_short);
 
             desc_short = desc_short_legacy->str;
         }

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -245,8 +245,11 @@ partition_list_default(pcmk__output_t *out, va_list args)
 
     for (GList *node_iter = nodes; node_iter != NULL; node_iter = node_iter->next) {
         pcmk_controld_api_node_t *node = node_iter->data;
-        if (pcmk__str_eq(node->state, "member", pcmk__str_none)) {
-            pcmk__add_separated_word(&buffer, 128, pcmk__s(node->uname, ""), " ");
+
+        if (pcmk__str_eq(node->state, "member", pcmk__str_none)
+            && !pcmk__str_empty(node->uname)) {
+
+            pcmk__add_word(&buffer, 128, node->uname);
         }
     }
 


### PR DESCRIPTION
This fixes a regression introduced by commits 37b87dca and c0d90ba1. The options "stop-orphan-resources" and "stop-orphan-actions" no longer appeared in the output of crm_attribute --list-options=cluster. This broke workflows that use pcs to set those properties.

The issue is not specific to those two options, but rather affects any option with the alt_name field set. Those are currently the only ones, however.

For the "default" display, we build up the aliases list separately from the deprecated list. Creating a temporary pcmk__cluster_option_t object on the stack and allocating/freeing only one desc string at a time turns out to be simpler than building a list of heap-allocated temporary pcmk__cluster_option_t objects.

Fixes T998
Fixes RHEL-112591