### PR TITLE
Deprecate iso8601 command line tool

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,8 +60,7 @@ Also:
 * valgrind (if running valgrind tests in cts-cli or cts-scheduler, or if
   running Pacemaker daemons under valgrind)
 * python3-psutil (if running any CTS tests)
-* python3-dateutil and python3-systemd (if running CTS lab on cluster nodes
-  running systemd)
+* python3-systemd (if running CTS lab on cluster nodes running systemd)
 * nmap (if not specifying an IP address base)
 * dlm (to log DLM debugging info after CTS lab tests)
 * xmllint (to validate tool output in cts-cli)

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the Pacemaker project contributors
+ * Copyright 2005-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
 #include <crm/common/util.h>
 #include <unistd.h>
 
-#define SUMMARY "Display and parse ISO 8601 dates and times"
+#define SUMMARY "DEPRECATED: This tool will be removed in a future release"
 
 static pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,


### PR DESCRIPTION
This PR drops the only internal user. Only pcs remains. But pcs requires python-dateutil >= 2.7, so it can use `dateutil.isoparser` instead.

NOTE: I still need to test this by building RPMs and running cts-lab. It looks straightforward, but broken things often do.