### PR TITLE
Low: cts: Don't try to shlex.split(None) for fencing params.

### DIFF
--- a/python/pacemaker/_cts/environment.py
+++ b/python/pacemaker/_cts/environment.py
@@ -276,6 +276,7 @@ class Environment:
                           help="Agent to use for a fencing resource")
         grp3.add_argument("--fencing-params",
                           metavar="PARAMS",
+                          default="",
                           help="Parameters for the fencing resource (as NAME=VALUE), separated by whitespace")
         grp3.add_argument("--once",
                           action="store_true",


### PR DESCRIPTION
From the python documentation:

Changed in version 3.12: Passing None for s argument now raises an exception, rather than reading sys.stdin.