### PR TITLE
Fix: tools: Handle large timeouts correctly in crm_resource --wait

### DIFF
--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -832,7 +832,9 @@ static GOptionEntry addl_entries[] = {
       "ID" },
     { "timeout", 'T', G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK, timeout_cb,
       "(Advanced) Abort if command does not finish in this time (with\n"
-      INDENT "--restart, --wait, --force-*)",
+      INDENT "--restart, --wait, --force-*). The --restart command uses a\n"
+      INDENT "two-second granularity and the --wait command uses a one-second\n"
+      INDENT "granularity, with rounding.",
       "N" },
     { "all", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &options.all,
       "List all options, including advanced and deprecated (with\n"

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -63,15 +63,15 @@ resource_checks_t *cli_check_resource(pcmk_resource_t *rsc, char *role_s,
 /* ban */
 int cli_resource_prefer(pcmk__output_t *out, const char *rsc_id, const char *host,
                         const char *move_lifetime, cib_t *cib_conn,
-                        gboolean promoted_role_only, const char *promoted_role);
+                        bool promoted_role_only, const char *promoted_role);
 int cli_resource_ban(pcmk__output_t *out, const char *rsc_id, const char *host,
                      const char *move_lifetime, cib_t *cib_conn,
-                     gboolean promoted_role_only, const char *promoted_role);
+                     bool promoted_role_only, const char *promoted_role);
 int cli_resource_clear(const char *rsc_id, const char *host, GList *allnodes,
-                       cib_t *cib_conn, bool clear_ban_constraints,
-                       gboolean force);
+                       cib_t *cib_conn, bool clear_ban_constraints, bool force);
 int cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn,
-                                   const char *rsc, const char *node, gboolean promoted_role_only);
+                                   const char *rsc, const char *node,
+                                   bool promoted_role_only);
 
 /* print */
 void cli_resource_print_cts(pcmk_resource_t *rsc, pcmk__output_t *out);
@@ -97,8 +97,8 @@ int cli_cleanup_all(pcmk_ipc_api_t *controld_api, pcmk_node_t *node,
                     pcmk_scheduler_t *scheduler);
 int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                          const pcmk_node_t *node, const char *move_lifetime,
-                         guint timeout_ms, cib_t *cib,
-                         gboolean promoted_role_only, gboolean force);
+                         guint timeout_ms, cib_t *cib, bool promoted_role_only,
+                         bool force);
 int cli_resource_move(pcmk_resource_t *rsc, const char *rsc_id,
                       const pcmk_node_t *node, const char *move_lifetime,
                       cib_t *cib, bool promoted_role_only, bool force);
@@ -108,7 +108,7 @@ crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc
                                             GHashTable *params, GHashTable *override_hash,
                                             guint timeout_ms,
                                             int resource_verbose,
-                                            gboolean force, int check_level);
+                                            bool force, int check_level);
 crm_exit_t cli_resource_execute(pcmk_resource_t *rsc,
                                 const char *requested_name,
                                 const char *rsc_action,
@@ -121,15 +121,15 @@ int cli_resource_update_attribute(pcmk_resource_t *rsc,
                                   const char *requested_name,
                                   const char *attr_set, const char *attr_set_type,
                                   const char *attr_id, const char *attr_name,
-                                  const char *attr_value, gboolean recursive,
+                                  const char *attr_value, bool recursive,
                                   cib_t *cib, xmlNode *cib_xml_orig,
-                                  gboolean force);
+                                  bool force);
 int cli_resource_delete_attribute(pcmk_resource_t *rsc,
                                   const char *requested_name,
                                   const char *attr_set, const char *attr_set_type,
                                   const char *attr_id, const char *attr_name,
                                   cib_t *cib, xmlNode *cib_xml_orig,
-                                  gboolean force);
+                                  bool force);
 
 int update_scheduler_input(pcmk__output_t *out, pcmk_scheduler_t *scheduler,
                            cib_t *cib, xmlNode **cib_xml_orig);

--- a/tools/crm_resource_ban.c
+++ b/tools/crm_resource_ban.c
@@ -64,7 +64,7 @@ parse_cli_lifetime(pcmk__output_t *out, const char *move_lifetime)
 int
 cli_resource_ban(pcmk__output_t *out, const char *rsc_id, const char *host,
                  const char *move_lifetime, cib_t *cib_conn,
-                 gboolean promoted_role_only, const char *promoted_role)
+                 bool promoted_role_only, const char *promoted_role)
 {
     char *later_s = NULL;
     int rc = pcmk_rc_ok;
@@ -151,7 +151,7 @@ cli_resource_ban(pcmk__output_t *out, const char *rsc_id, const char *host,
 int
 cli_resource_prefer(pcmk__output_t *out,const char *rsc_id, const char *host,
                     const char *move_lifetime, cib_t *cib_conn,
-                    gboolean promoted_role_only, const char *promoted_role)
+                    bool promoted_role_only, const char *promoted_role)
 {
     char *later_s = parse_cli_lifetime(out, move_lifetime);
     int rc = pcmk_rc_ok;
@@ -281,7 +281,7 @@ resource_clear_node_in_expr(const char *rsc_id, const char *host,
 // \return Standard Pacemaker return code
 static int
 resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * cib_conn,
-                                bool clear_ban_constraints, gboolean force)
+                                bool clear_ban_constraints, bool force)
 {
     int rc = pcmk_rc_ok;
     xmlNode *fragment = NULL;
@@ -289,14 +289,14 @@ resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * ci
 
     fragment = pcmk__xe_create(NULL, PCMK_XE_CONSTRAINTS);
 
-    if (clear_ban_constraints == TRUE) {
+    if (clear_ban_constraints) {
         location = pcmk__xe_create(fragment, PCMK_XE_RSC_LOCATION);
         pcmk__xe_set_id(location, "cli-ban-%s-on-%s", rsc_id, host);
     }
 
     location = pcmk__xe_create(fragment, PCMK_XE_RSC_LOCATION);
     pcmk__xe_set_id(location, "cli-prefer-%s", rsc_id);
-    if (force == FALSE) {
+    if (!force) {
         pcmk__xe_set(location, PCMK_XE_NODE, host);
     }
 
@@ -316,7 +316,7 @@ resource_clear_node_in_location(const char *rsc_id, const char *host, cib_t * ci
 // \return Standard Pacemaker return code
 int
 cli_resource_clear(const char *rsc_id, const char *host, GList *allnodes, cib_t * cib_conn,
-                   bool clear_ban_constraints, gboolean force)
+                   bool clear_ban_constraints, bool force)
 {
     int rc = pcmk_rc_ok;
 
@@ -443,7 +443,7 @@ build_clear_xpath_string(GString *buf, const xmlNode *constraint_node,
 // \return Standard Pacemaker return code
 int
 cli_resource_clear_all_expired(xmlNode *root, cib_t *cib_conn, const char *rsc,
-                               const char *node, gboolean promoted_role_only)
+                               const char *node, bool promoted_role_only)
 {
     GString *buf = NULL;
     xmlXPathObject *xpathObj = NULL;

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -56,14 +56,14 @@ void
 cli_resource_print_cts(pcmk_resource_t *rsc, pcmk__output_t *out)
 {
     const char *host = NULL;
-    bool needs_quorum = TRUE;
+    bool needs_quorum = true;
     const char *rtype = pcmk__xe_get(rsc->priv->xml, PCMK_XA_TYPE);
     const char *rprov = pcmk__xe_get(rsc->priv->xml, PCMK_XA_PROVIDER);
     const char *rclass = pcmk__xe_get(rsc->priv->xml, PCMK_XA_CLASS);
     pcmk_node_t *node = pcmk__current_node(rsc);
 
     if (pcmk__is_set(rsc->flags, pcmk__rsc_fence_device)) {
-        needs_quorum = FALSE;
+        needs_quorum = false;
     } else {
         // @TODO check requires in resource meta-data and rsc_defaults
     }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -225,7 +225,7 @@ find_matching_attr_resources(pcmk__output_t *out, pcmk_resource_t *rsc,
                              const char * rsc_id, const char * attr_set,
                              const char * attr_set_type, const char * attr_id,
                              const char * attr_name, cib_t * cib, const char * cmd,
-                             gboolean force)
+                             bool force)
 {
     int rc = pcmk_rc_ok;
     char *lookup_id = NULL;
@@ -234,7 +234,7 @@ find_matching_attr_resources(pcmk__output_t *out, pcmk_resource_t *rsc,
     /* If --force is used, update only the requested resource (clone or primitive).
      * Otherwise, if the primitive has the attribute, use that.
      * Otherwise use the clone. */
-    if(force == TRUE) {
+    if (force) {
         return g_list_append(result, rsc);
     }
     if (pcmk__is_clone(rsc->priv->parent)) {
@@ -324,7 +324,7 @@ static int
 resources_with_attr(pcmk__output_t *out, cib_t *cib, pcmk_resource_t *rsc,
                     const char *requested_name, const char *attr_set,
                     const char *attr_set_type, const char *attr_id,
-                    const char *attr_name, const char *top_id, gboolean force,
+                    const char *attr_name, const char *top_id, bool force,
                     GList **resources)
 {
     if (pcmk__str_eq(attr_set_type, PCMK_XE_INSTANCE_ATTRIBUTES,
@@ -405,8 +405,8 @@ static int
 update_attribute(pcmk_resource_t *rsc, const char *requested_name,
                  const char *attr_set, const char *attr_set_type,
                  const char *attr_id, const char *attr_name,
-                 const char *attr_value, gboolean recursive, cib_t *cib,
-                 xmlNode *cib_xml_orig, gboolean force, GList **results)
+                 const char *attr_value, bool recursive, cib_t *cib,
+                 xmlNode *cib_xml_orig, bool force, GList **results)
 {
     pcmk__output_t *out = rsc->priv->scheduler->priv->out;
     int rc = pcmk_rc_ok;
@@ -572,8 +572,8 @@ int
 cli_resource_update_attribute(pcmk_resource_t *rsc, const char *requested_name,
                               const char *attr_set, const char *attr_set_type,
                               const char *attr_id, const char *attr_name,
-                              const char *attr_value, gboolean recursive,
-                              cib_t *cib, xmlNode *cib_xml_orig, gboolean force)
+                              const char *attr_value, bool recursive,
+                              cib_t *cib, xmlNode *cib_xml_orig, bool force)
 {
     static bool need_init = true;
     int rc = pcmk_rc_ok;
@@ -620,7 +620,7 @@ int
 cli_resource_delete_attribute(pcmk_resource_t *rsc, const char *requested_name,
                               const char *attr_set, const char *attr_set_type,
                               const char *attr_id, const char *attr_name,
-                              cib_t *cib, xmlNode *cib_xml_orig, gboolean force)
+                              cib_t *cib, xmlNode *cib_xml_orig, bool force)
 {
     pcmk__output_t *out = rsc->priv->scheduler->priv->out;
     int rc = pcmk_rc_ok;
@@ -1669,8 +1669,8 @@ wait_time_estimate(pcmk_scheduler_t *scheduler, const GList *resources)
 int
 cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                      const pcmk_node_t *node, const char *move_lifetime,
-                     guint timeout_ms, cib_t *cib, gboolean promoted_role_only,
-                     gboolean force)
+                     guint timeout_ms, cib_t *cib, bool promoted_role_only,
+                     bool force)
 {
     int rc = pcmk_rc_ok;
     int lpc = 0;
@@ -1820,7 +1820,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
         rc = cli_resource_update_attribute(rsc, rsc_id, NULL,
                                            PCMK_XE_META_ATTRIBUTES, NULL,
                                            PCMK_META_TARGET_ROLE,
-                                           PCMK_ACTION_STOPPED, FALSE, cib,
+                                           PCMK_ACTION_STOPPED, false, cib,
                                            cib_xml_orig, force);
     }
     if(rc != pcmk_rc_ok) {
@@ -1902,7 +1902,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
         rc = cli_resource_update_attribute(rsc, rsc_id, NULL,
                                            PCMK_XE_META_ATTRIBUTES, NULL,
                                            PCMK_META_TARGET_ROLE,
-                                           orig_target_role, FALSE, cib,
+                                           orig_target_role, false, cib,
                                            cib_xml_orig, force);
         free(orig_target_role);
         orig_target_role = NULL;
@@ -1987,7 +1987,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
         cli_resource_update_attribute(rsc, rsc_id, NULL,
                                       PCMK_XE_META_ATTRIBUTES, NULL,
                                       PCMK_META_TARGET_ROLE, orig_target_role,
-                                      FALSE, cib, cib_xml_orig, force);
+                                      false, cib, cib_xml_orig, force);
         free(orig_target_role);
     } else {
         cli_resource_delete_attribute(rsc, rsc_id, NULL,
@@ -2273,7 +2273,7 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                  const char *rsc_type, const char *rsc_action,
                                  GHashTable *params, GHashTable *override_hash,
                                  guint timeout_ms, int resource_verbose,
-                                 gboolean force, int check_level)
+                                 bool force, int check_level)
 {
     const char *class = rsc_class;
     const char *action = get_action(rsc_action);
@@ -2386,7 +2386,7 @@ cli_resource_execute(pcmk_resource_t *rsc, const char *requested_name,
         if (pcmk__is_clone(rsc)) {
             GList *nodes = cli_resource_search(rsc, requested_name);
 
-            if(nodes != NULL && force == FALSE) {
+            if ((nodes != NULL) && !force) {
                 out->err(out, "It is not safe to %s %s here: the cluster claims it is already active",
                          rsc_action, rsc->id);
                 out->err(out,

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1672,13 +1672,13 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                      guint timeout_ms, cib_t *cib, bool promoted_role_only,
                      bool force)
 {
-    int rc = pcmk_rc_ok;
-    guint step_timeout_s = 0;
-
     /* @TODO Due to this sleep interval, a timeout <2s will cause problems and
      * should be rejected
      */
-    guint sleep_interval = 2U;
+    static const guint sleep_interval = 2U;
+
+    int rc = pcmk_rc_ok;
+    guint step_timeout_s = 0;
     guint timeout = pcmk__timeout_ms2s(timeout_ms);
 
     bool stop_via_ban = false;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -2109,7 +2109,7 @@ wait_till_stable(pcmk__output_t *out, guint timeout_ms, cib_t * cib)
     if (timeout_ms == 0) {
         expire_time += WAIT_DEFAULT_TIMEOUT_S;
     } else {
-        expire_time += pcmk__timeout_ms2s(timeout_ms + 999);
+        expire_time += pcmk__timeout_ms2s(timeout_ms);
     }
 
     scheduler = pcmk_new_scheduler();

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1673,7 +1673,6 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                      bool force)
 {
     int rc = pcmk_rc_ok;
-    int lpc = 0;
     int before = 0;
     guint step_timeout_s = 0;
 
@@ -1859,7 +1858,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
         }
 
         /* We probably don't need the entire step timeout */
-        for(lpc = 0; (lpc < step_timeout_s) && (list_delta != NULL); lpc++) {
+        for (int i = 0; (i < step_timeout_s) && (list_delta != NULL); i++) {
             sleep(sleep_interval);
             if(timeout) {
                 timeout -= sleep_interval;
@@ -1938,7 +1937,9 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
         }
 
         /* We probably don't need the entire step timeout */
-        for (lpc = 0; (lpc < step_timeout_s) && waiting_for_starts(list_delta, rsc, host); lpc++) {
+        for (int i = 0;
+             (i < step_timeout_s) && waiting_for_starts(list_delta, rsc, host);
+             i++) {
 
             sleep(sleep_interval);
             if(timeout) {

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1673,7 +1673,6 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                      bool force)
 {
     int rc = pcmk_rc_ok;
-    int before = 0;
     guint step_timeout_s = 0;
 
     /* @TODO Due to this sleep interval, a timeout <2s will cause problems and
@@ -1851,7 +1850,8 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
 
     step_timeout_s = timeout / sleep_interval;
     while (list_delta != NULL) {
-        before = g_list_length(list_delta);
+        guint before = g_list_length(list_delta);
+
         if(timeout_ms == 0) {
             step_timeout_s = wait_time_estimate(scheduler, list_delta)
                              / sleep_interval;
@@ -1883,7 +1883,8 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
             dump_list(list_delta, "Delta");
         }
 
-        crm_trace("%d (was %d) resources remaining", g_list_length(list_delta), before);
+        crm_trace("%u (was %u) resources remaining", g_list_length(list_delta),
+                  before);
         if(before == g_list_length(list_delta)) {
             /* aborted during stop phase, print the contents of list_delta */
             out->err(out, "Could not complete shutdown of %s, %d resources remaining", rsc_id, g_list_length(list_delta));
@@ -1930,7 +1931,8 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
 
     step_timeout_s = timeout / sleep_interval;
     while (waiting_for_starts(list_delta, rsc, host)) {
-        before = g_list_length(list_delta);
+        guint before = g_list_length(list_delta);
+
         if(timeout_ms == 0) {
             step_timeout_s = wait_time_estimate(scheduler, list_delta)
                              / sleep_interval;


### PR DESCRIPTION
Previously, if the --timeout value parsed to a value greater than (UINT_MAX - 999), the wait timeout would overflow. The effective timeout would be either 0 seconds or 1 second. This is because 999 was added to the guint value before passing it to pcmk__timeout_ms2s().

Now, we simply pass the timeout in milliseconds to pcmk__timeout_ms2s(), without adding 999.

This implies a slight behavior change. Previously, timeouts were always rounded up to the next greatest second. Now, they're rounded to the nearest second. For example, previously:
* timeout values between 1ms and 500ms => wait timeout of 1 second
* timeout values between 501ms and 1500ms => wait timeout of 2 seconds
* timeout values between 1501ms and 2500ms => wait timeout of 3 seconds
* and so on

Now:
* timeout values between 1ms and 1499ms => wait timeout of 1 second
* timeout values between 1500ms and 2499ms => wait timeout of 2 seconds
* timeout values between 2500ms and 3499ms => wait timeout of 3 seconds
* and so on

The previous rounding behavior has existed since crm_resource --wait was added by 424afcdf.

Fixes RHEL-45869
Fixes RHEL-86148
Closes T841