### PR TITLE
Test: cts-cli: Escape special characters in the path for a pattern

### DIFF
--- a/cts/cts-cli.in
+++ b/cts/cts-cli.in
@@ -254,7 +254,7 @@ def sanitize_output(s):
         (r'\(crm_time_parse_duration@.*\.c:[0-9]+\)', r'crm_time_parse_duration'),
         (r'\(crm_time_parse_period@.*\.c:[0-9]+\)', r'crm_time_parse_period'),
         (r'\(crm_time_parse_sec@.*\.c:[0-9]+\)', r'crm_time_parse_sec'),
-        (cts_cli_data, r'CTS_CLI_DATA'),
+        (re.escape(cts_cli_data), r'CTS_CLI_DATA'),
         (r' default="[^"]*"', r' default=""'),
         (r' end="[0-9][-+: 0-9]*Z*"', r' end=""'),
         (r'last_change time=".*"', r'last_change time=""'),


### PR DESCRIPTION
In case there are special characters in cts_cli_data such as `+`.