### PR TITLE
Low: daemons: Get rid of some logged warnings in execd.

### DIFF
--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -88,7 +88,7 @@ void ipc_proxy_init(void);
 void ipc_proxy_cleanup(void);
 void ipc_proxy_add_provider(pcmk__client_t *client);
 void ipc_proxy_remove_provider(pcmk__client_t *client);
-void ipc_proxy_forward_client(pcmk__client_t *client, xmlNode *xml);
+int ipc_proxy_forward_client(pcmk__client_t *client, xmlNode *xml);
 pcmk__client_t *ipc_proxy_get_provider(void);
 int ipc_proxy_shutdown_req(pcmk__client_t *ipc_proxy);
 void remoted_spawn_pidone(int argc, char **argv);

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -151,7 +151,7 @@ cib_proxy_accept_ro(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
     return ipc_proxy_accept(c, uid, gid, PCMK__SERVER_BASED_RO);
 }
 
-void
+int
 ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
 {
     const char *session = pcmk__xe_get(xml, PCMK__XA_LRMD_IPC_SESSION);
@@ -166,12 +166,12 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
 
     if (pcmk__str_eq(msg_type, LRMD_IPC_OP_SHUTDOWN_ACK, pcmk__str_casei)) {
         handle_shutdown_ack();
-        return;
+        return rc;
     }
 
     if (pcmk__str_eq(msg_type, LRMD_IPC_OP_SHUTDOWN_NACK, pcmk__str_casei)) {
         handle_shutdown_nack();
-        return;
+        return rc;
     }
 
     ipc_client = pcmk__find_client_by_id(session);
@@ -181,7 +181,7 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
         pcmk__xe_set(msg, PCMK__XA_LRMD_IPC_SESSION, session);
         lrmd_server_send_notify(ipc_proxy, msg);
         pcmk__xml_free(msg);
-        return;
+        return rc;
     }
 
     /* This is an event or response from the ipc provider
@@ -223,6 +223,8 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
         crm_warn("Could not proxy IPC to client %s: %s " QB_XS " rc=%d",
                  ipc_client->id, pcmk_rc_str(rc), rc);
     }
+
+    return rc;
 }
 
 static int32_t


### PR DESCRIPTION
handle_ipc_fwd_request and handle_poke_request are pretty obvious. These two functions need to call pcmk__set_result to set the rc value into the result object or else execd will log a message about "Unknown status (bug?)".  This should have been done as part of #3915 which converted execd to use pcmk__request_t.

The other changes in ipc_proxy_forward_client are just to enable setting the proper rc value for handle_ipc_fwd_request.

handle_rsc_info_request is a little less obvious because ENODEV seems like something we should definitely be logging.  However, this will be returned as part of regular processing - see the existing comment. Logging the error ENODEV message is alarming, and before execd used pcmk__request_t it wasn't treated as an error.  So we'll restore that here.