### PR TITLE
libcib and based refactors: Simplify cib_perform_op() further, drop args from cib__op_fn_t

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -597,7 +597,7 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
     input = prepare_input(request, operation->type, &section);
 
     if (!pcmk__is_set(operation->flags, cib__op_attr_modifies)) {
-        rc = cib__perform_query(op, call_options, op_function, section, request,
+        rc = cib__perform_query(call_options, op_function, section, request,
                                 input, &the_cib, &output);
         goto done;
     }
@@ -609,7 +609,7 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
      * It's not important whether the client variant is cib_native or
      * cib_remote.
      */
-    rc = cib_perform_op(cib_undefined, op, call_options, op_function, section,
+    rc = cib_perform_op(cib_undefined, call_options, op_function, section,
                         request, input, &config_changed, &the_cib, &result_cib,
                         &cib_diff, &output);
 

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -517,7 +517,6 @@ forward_request(xmlNode *request)
  * \brief Get a CIB operation's input from the request XML
  *
  * \param[in]  request  CIB request XML
- * \param[in]  type     CIB operation type
  * \param[out] section  Where to store CIB section name
  *
  * \return Input XML for CIB operation
@@ -526,18 +525,13 @@ forward_request(xmlNode *request)
  *       \p request. The caller should not free it directly.
  */
 static xmlNode *
-prepare_input(const xmlNode *request, enum cib__op_type type,
-              const char **section)
+prepare_input(const xmlNode *request, const char **section)
 {
     xmlNode *wrapper = pcmk__xe_first_child(request, PCMK__XE_CIB_CALLDATA,
                                             NULL, NULL);
     xmlNode *input = pcmk__xe_first_child(wrapper, NULL, NULL, NULL);
 
-    if (type == cib__op_apply_patch) {
-        *section = NULL;
-    } else {
-        *section = pcmk__xe_get(request, PCMK__XA_CIB_SECTION);
-    }
+    *section = pcmk__xe_get(request, PCMK__XA_CIB_SECTION);
 
     // Grab the specified section
     if ((*section != NULL) && pcmk__xe_is(input, PCMK_XE_CIB)) {
@@ -594,7 +588,7 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
         goto done;
     }
 
-    input = prepare_input(request, operation->type, &section);
+    input = prepare_input(request, &section);
 
     if (!pcmk__is_set(operation->flags, cib__op_attr_modifies)) {
         rc = cib__perform_query(op_function, section, request, input, &the_cib,

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -603,13 +603,10 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
         goto done;
     }
 
-    /* @COMPAT: Handle a valid write action (legacy)
-     *
-     * @TODO: Re-evaluate whether this is truly legacy. PCMK__XA_CIB_UPDATE may
-     * be set by a sync operation even in non-legacy mode, and manage_counters
-     * tells xml_create_patchset() whether to update version/epoch info.
-     */
     if (pcmk__xe_attr_is_true(request, PCMK__XA_CIB_UPDATE)) {
+        /* This is a replace operation as a reply to a sync request. Keep
+         * whatever versions are in the received CIB.
+         */
         manage_counters = false;
         CRM_LOG_ASSERT(pcmk__str_eq(op, PCMK__CIB_REQUEST_REPLACE,
                                     pcmk__str_none));

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -522,7 +522,6 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
     uint32_t call_options = cib_none;
 
     const char *op = pcmk__xe_get(request, PCMK__XA_CIB_OP);
-    const char *section = pcmk__xe_get(request, PCMK__XA_CIB_SECTION);
     const char *call_id = pcmk__xe_get(request, PCMK__XA_CIB_CALLID);
     const char *client_id = pcmk__xe_get(request, PCMK__XA_CIB_CLIENTID);
     const char *client_name = pcmk__xe_get(request, PCMK__XA_CIB_CLIENTNAME);
@@ -558,8 +557,7 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
     }
 
     if (!pcmk__is_set(operation->flags, cib__op_attr_modifies)) {
-        rc = cib__perform_query(op_function, section, request, &the_cib,
-                                &output);
+        rc = cib__perform_query(op_function, request, &the_cib, &output);
         goto done;
     }
 
@@ -570,9 +568,8 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
      * It's not important whether the client variant is cib_native or
      * cib_remote.
      */
-    rc = cib_perform_op(cib_undefined, op_function, section, request,
-                        &config_changed, &the_cib, &result_cib, &cib_diff,
-                        &output);
+    rc = cib_perform_op(cib_undefined, op_function, request, &config_changed,
+                        &the_cib, &result_cib, &cib_diff, &output);
 
     /* Always write to disk for successful ops with the flag set. This also
      * negates the need to detect ordering changes.

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -568,8 +568,9 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
      * It's not important whether the client variant is cib_native or
      * cib_remote.
      */
+    result_cib = the_cib;
     rc = cib_perform_op(cib_undefined, op_function, request, &config_changed,
-                        &the_cib, &result_cib, &cib_diff, &output);
+                        &result_cib, &cib_diff, &output);
 
     /* Always write to disk for successful ops with the flag set. This also
      * negates the need to detect ordering changes.

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -568,7 +568,6 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
     int rc = pcmk_rc_ok;
 
     bool config_changed = false;
-    bool manage_counters = true;
 
     static mainloop_timer_t *digest_timer = NULL;
 
@@ -603,15 +602,6 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
         goto done;
     }
 
-    if (pcmk__xe_attr_is_true(request, PCMK__XA_CIB_UPDATE)) {
-        /* This is a replace operation as a reply to a sync request. Keep
-         * whatever versions are in the received CIB.
-         */
-        manage_counters = false;
-        CRM_LOG_ASSERT(pcmk__str_eq(op, PCMK__CIB_REQUEST_REPLACE,
-                                    pcmk__str_none));
-    }
-
     ping_modified_since = true;
 
     /* result_cib must not be modified after cib_perform_op() returns.
@@ -620,8 +610,8 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
      * cib_remote.
      */
     rc = cib_perform_op(cib_undefined, op, call_options, op_function, section,
-                        request, input, manage_counters, &config_changed,
-                        &the_cib, &result_cib, &cib_diff, &output);
+                        request, input, &config_changed, &the_cib, &result_cib,
+                        &cib_diff, &output);
 
     /* Always write to disk for successful ops with the flag set. This also
      * negates the need to detect ordering changes.

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -597,8 +597,8 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
     input = prepare_input(request, operation->type, &section);
 
     if (!pcmk__is_set(operation->flags, cib__op_attr_modifies)) {
-        rc = cib__perform_query(call_options, op_function, section, request,
-                                input, &the_cib, &output);
+        rc = cib__perform_query(op_function, section, request, input, &the_cib,
+                                &output);
         goto done;
     }
 
@@ -609,9 +609,9 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
      * It's not important whether the client variant is cib_native or
      * cib_remote.
      */
-    rc = cib_perform_op(cib_undefined, call_options, op_function, section,
-                        request, input, &config_changed, &the_cib, &result_cib,
-                        &cib_diff, &output);
+    rc = cib_perform_op(cib_undefined, op_function, section, request, input,
+                        &config_changed, &the_cib, &result_cib, &cib_diff,
+                        &output);
 
     /* Always write to disk for successful ops with the flag set. This also
      * negates the need to detect ordering changes.

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -248,37 +248,32 @@ process_ping_reply(xmlNode *reply)
         if (!pcmk__str_eq(ping_digest, digest, pcmk__str_casei)) {
             xmlNode *wrapper = pcmk__xe_first_child(pong, PCMK__XE_CIB_CALLDATA,
                                                     NULL, NULL);
-            xmlNode *remote_cib = pcmk__xe_first_child(wrapper, NULL, NULL, NULL);
+            xmlNode *remote_versions = pcmk__xe_first_child(wrapper, NULL, NULL,
+                                                            NULL);
 
             const char *admin_epoch_s = NULL;
             const char *epoch_s = NULL;
             const char *num_updates_s = NULL;
 
-            if (remote_cib != NULL) {
-                admin_epoch_s = pcmk__xe_get(remote_cib, PCMK_XA_ADMIN_EPOCH);
-                epoch_s = pcmk__xe_get(remote_cib, PCMK_XA_EPOCH);
-                num_updates_s = pcmk__xe_get(remote_cib, PCMK_XA_NUM_UPDATES);
+            if (remote_versions != NULL) {
+                admin_epoch_s = pcmk__xe_get(remote_versions,
+                                             PCMK_XA_ADMIN_EPOCH);
+                epoch_s = pcmk__xe_get(remote_versions,
+                                       PCMK_XA_EPOCH);
+                num_updates_s = pcmk__xe_get(remote_versions,
+                                             PCMK_XA_NUM_UPDATES);
             }
 
-            pcmk__notice("Local CIB %s.%s.%s.%s differs from %s: %s.%s.%s.%s "
-                         "%p",
+            pcmk__notice("Local CIB %s.%s.%s.%s differs from %s: %s.%s.%s.%s",
                          pcmk__xe_get(the_cib, PCMK_XA_ADMIN_EPOCH),
                          pcmk__xe_get(the_cib, PCMK_XA_EPOCH),
                          pcmk__xe_get(the_cib, PCMK_XA_NUM_UPDATES),
                          ping_digest, host,
                          pcmk__s(admin_epoch_s, "_"),
                          pcmk__s(epoch_s, "_"),
-                         pcmk__s(num_updates_s, "_"),
-                         digest, remote_cib);
+                         pcmk__s(num_updates_s, "_"), digest);
 
-            if(remote_cib && remote_cib->children) {
-                // Additional debug
-                pcmk__xml_mark_changes(the_cib, remote_cib);
-                pcmk__log_xml_changes(LOG_INFO, remote_cib);
-                pcmk__trace("End of differences");
-            }
-
-            pcmk__xml_free(remote_cib);
+            pcmk__xml_free(remote_versions);
             sync_our_cib(reply, false);
         }
     }

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -37,7 +37,6 @@ xmlNode *the_cib = NULL;
  * \internal
  * \brief Process a \c PCMK__CIB_REQUEST_ABS_DELETE
  *
- * \param[in] options  Ignored
  * \param[in] section  Ignored
  * \param[in] req      Ignored
  * \param[in] input    Ignored
@@ -49,8 +48,8 @@ xmlNode *the_cib = NULL;
  * \note This is unimplemented and simply returns an error.
  */
 int
-based_process_abs_delete(int options, const char *section, xmlNode *req,
-                         xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_abs_delete(const char *section, xmlNode *req, xmlNode *input,
+                         xmlNode **cib, xmlNode **answer)
 {
     /* @COMPAT Remove when PCMK__CIB_REQUEST_ABS_DELETE is removed. Note that
      * external clients with Pacemaker versions < 3.0.0 can send it.
@@ -59,8 +58,8 @@ based_process_abs_delete(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_commit_transact(int options, const char *section, xmlNode *req,
-                              xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_commit_transact(const char *section, xmlNode *req, xmlNode *input,
+                              xmlNode **cib, xmlNode **answer)
 {
     /* On success, our caller will activate *cib locally, trigger a replace
      * notification if appropriate, and sync *cib to all nodes. On failure, our
@@ -84,8 +83,8 @@ based_process_commit_transact(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_is_primary(int options, const char *section, xmlNode *req,
-                         xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_is_primary(const char *section, xmlNode *req, xmlNode *input,
+                         xmlNode **cib, xmlNode **answer)
 {
     // @COMPAT Pacemaker Remote clients <3.0.0 may send this
     return (based_is_primary? pcmk_rc_ok : EPERM);
@@ -93,16 +92,16 @@ based_process_is_primary(int options, const char *section, xmlNode *req,
 
 // @COMPAT: Remove when PCMK__CIB_REQUEST_NOOP is removed
 int
-based_process_noop(int options, const char *section, xmlNode *req,
-                   xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_noop(const char *section, xmlNode *req, xmlNode *input,
+                   xmlNode **cib, xmlNode **answer)
 {
     *answer = NULL;
     return pcmk_rc_ok;
 }
 
 int
-based_process_ping(int options, const char *section, xmlNode *req,
-                   xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_ping(const char *section, xmlNode *req, xmlNode *input,
+                   xmlNode **cib, xmlNode **answer)
 {
     /* existing_cib and *cib should be identical. In the absence of ACL
      * filtering, they should also match the_cib. However, they may be copies
@@ -145,8 +144,8 @@ based_process_ping(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_primary(int options, const char *section, xmlNode *req,
-                      xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_primary(const char *section, xmlNode *req, xmlNode *input,
+                      xmlNode **cib, xmlNode **answer)
 {
     if (!based_is_primary) {
         pcmk__info("We are now in R/W mode");
@@ -160,8 +159,8 @@ based_process_primary(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_schemas(int options, const char *section, xmlNode *req,
-                      xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_schemas(const char *section, xmlNode *req, xmlNode *input,
+                      xmlNode **cib, xmlNode **answer)
 {
     xmlNode *wrapper = NULL;
     xmlNode *data = NULL;
@@ -205,8 +204,8 @@ based_process_schemas(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_secondary(int options, const char *section, xmlNode *req,
-                        xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_secondary(const char *section, xmlNode *req, xmlNode *input,
+                        xmlNode **cib, xmlNode **answer)
 {
     if (based_is_primary) {
         pcmk__info("We are now in R/O mode");
@@ -220,8 +219,8 @@ based_process_secondary(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_shutdown(int options, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_shutdown(const char *section, xmlNode *req, xmlNode *input,
+                       xmlNode **cib, xmlNode **answer)
 {
     const char *host = pcmk__xe_get(req, PCMK__XA_SRC);
 
@@ -243,15 +242,15 @@ based_process_shutdown(int options, const char *section, xmlNode *req,
 }
 
 int
-based_process_sync(int options, const char *section, xmlNode *req,
-                   xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_sync(const char *section, xmlNode *req, xmlNode *input,
+                   xmlNode **cib, xmlNode **answer)
 {
     return sync_our_cib(req, true);
 }
 
 int
-based_process_upgrade(int options, const char *section, xmlNode *req,
-                      xmlNode *input, xmlNode **cib, xmlNode **answer)
+based_process_upgrade(const char *section, xmlNode *req, xmlNode *input,
+                      xmlNode **cib, xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
 
@@ -263,7 +262,7 @@ based_process_upgrade(int options, const char *section, xmlNode *req,
          * re-broadcasts the request with PCMK__XA_CIB_SCHEMA_MAX, and each node
          * performs the upgrade (and notifies its local clients) here.
          */
-        return cib__process_upgrade(options, section, req, input, cib, answer);
+        return cib__process_upgrade(section, req, input, cib, answer);
 
     } else {
         xmlNode *scratch = pcmk__xml_copy(NULL, *cib);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -133,21 +133,10 @@ based_process_ping(const char *op, int options, const char *section,
 
     if (*cib != NULL) {
         // Use *cib so that ACL filtering is applied to the answer
-        pcmk__if_tracing(
-            {
-                /* Append additional detail so the receiver can log the
-                 * differences
-                 */
-                pcmk__xml_copy(wrapper, *cib);
-            },
-            {
-                // Always include at least the version details
-                const char *name = (const char *) (*cib)->name;
-                xmlNode *shallow = pcmk__xe_create(wrapper, name);
+        xmlNode *shallow = pcmk__xe_create(wrapper,
+                                           (const char *) (*cib)->name);
 
-                pcmk__xe_copy_attrs(shallow, *cib, pcmk__xaf_none);
-            }
-        );
+        pcmk__xe_copy_attrs(shallow, *cib, pcmk__xaf_none);
     }
 
     pcmk__info("Reporting our current digest to %s: %s for %s.%s.%s",

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -37,7 +37,6 @@ xmlNode *the_cib = NULL;
  * \internal
  * \brief Process a \c PCMK__CIB_REQUEST_ABS_DELETE
  *
- * \param[in] section  Ignored
  * \param[in] req      Ignored
  * \param[in] input    Ignored
  * \param[in] cib      Ignored
@@ -48,8 +47,8 @@ xmlNode *the_cib = NULL;
  * \note This is unimplemented and simply returns an error.
  */
 int
-based_process_abs_delete(const char *section, xmlNode *req, xmlNode *input,
-                         xmlNode **cib, xmlNode **answer)
+based_process_abs_delete(xmlNode *req, xmlNode *input, xmlNode **cib,
+                         xmlNode **answer)
 {
     /* @COMPAT Remove when PCMK__CIB_REQUEST_ABS_DELETE is removed. Note that
      * external clients with Pacemaker versions < 3.0.0 can send it.
@@ -58,8 +57,8 @@ based_process_abs_delete(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_commit_transact(const char *section, xmlNode *req, xmlNode *input,
-                              xmlNode **cib, xmlNode **answer)
+based_process_commit_transact(xmlNode *req, xmlNode *input, xmlNode **cib,
+                              xmlNode **answer)
 {
     /* On success, our caller will activate *cib locally, trigger a replace
      * notification if appropriate, and sync *cib to all nodes. On failure, our
@@ -83,8 +82,8 @@ based_process_commit_transact(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_is_primary(const char *section, xmlNode *req, xmlNode *input,
-                         xmlNode **cib, xmlNode **answer)
+based_process_is_primary(xmlNode *req, xmlNode *input, xmlNode **cib,
+                         xmlNode **answer)
 {
     // @COMPAT Pacemaker Remote clients <3.0.0 may send this
     return (based_is_primary? pcmk_rc_ok : EPERM);
@@ -92,16 +91,16 @@ based_process_is_primary(const char *section, xmlNode *req, xmlNode *input,
 
 // @COMPAT: Remove when PCMK__CIB_REQUEST_NOOP is removed
 int
-based_process_noop(const char *section, xmlNode *req, xmlNode *input,
-                   xmlNode **cib, xmlNode **answer)
+based_process_noop(xmlNode *req, xmlNode *input, xmlNode **cib,
+                   xmlNode **answer)
 {
     *answer = NULL;
     return pcmk_rc_ok;
 }
 
 int
-based_process_ping(const char *section, xmlNode *req, xmlNode *input,
-                   xmlNode **cib, xmlNode **answer)
+based_process_ping(xmlNode *req, xmlNode *input, xmlNode **cib,
+                   xmlNode **answer)
 {
     /* existing_cib and *cib should be identical. In the absence of ACL
      * filtering, they should also match the_cib. However, they may be copies
@@ -144,8 +143,8 @@ based_process_ping(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_primary(const char *section, xmlNode *req, xmlNode *input,
-                      xmlNode **cib, xmlNode **answer)
+based_process_primary(xmlNode *req, xmlNode *input, xmlNode **cib,
+                      xmlNode **answer)
 {
     if (!based_is_primary) {
         pcmk__info("We are now in R/W mode");
@@ -159,8 +158,8 @@ based_process_primary(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_schemas(const char *section, xmlNode *req, xmlNode *input,
-                      xmlNode **cib, xmlNode **answer)
+based_process_schemas(xmlNode *req, xmlNode *input, xmlNode **cib,
+                      xmlNode **answer)
 {
     xmlNode *wrapper = NULL;
     xmlNode *data = NULL;
@@ -204,8 +203,8 @@ based_process_schemas(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_secondary(const char *section, xmlNode *req, xmlNode *input,
-                        xmlNode **cib, xmlNode **answer)
+based_process_secondary(xmlNode *req, xmlNode *input, xmlNode **cib,
+                        xmlNode **answer)
 {
     if (based_is_primary) {
         pcmk__info("We are now in R/O mode");
@@ -219,8 +218,8 @@ based_process_secondary(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_shutdown(const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **cib, xmlNode **answer)
+based_process_shutdown(xmlNode *req, xmlNode *input, xmlNode **cib,
+                       xmlNode **answer)
 {
     const char *host = pcmk__xe_get(req, PCMK__XA_SRC);
 
@@ -242,15 +241,15 @@ based_process_shutdown(const char *section, xmlNode *req, xmlNode *input,
 }
 
 int
-based_process_sync(const char *section, xmlNode *req, xmlNode *input,
-                   xmlNode **cib, xmlNode **answer)
+based_process_sync(xmlNode *req, xmlNode *input, xmlNode **cib,
+                   xmlNode **answer)
 {
     return sync_our_cib(req, true);
 }
 
 int
-based_process_upgrade(const char *section, xmlNode *req, xmlNode *input,
-                      xmlNode **cib, xmlNode **answer)
+based_process_upgrade(xmlNode *req, xmlNode *input, xmlNode **cib,
+                      xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
 
@@ -262,7 +261,7 @@ based_process_upgrade(const char *section, xmlNode *req, xmlNode *input,
          * re-broadcasts the request with PCMK__XA_CIB_SCHEMA_MAX, and each node
          * performs the upgrade (and notifies its local clients) here.
          */
-        return cib__process_upgrade(section, req, input, cib, answer);
+        return cib__process_upgrade(req, input, cib, answer);
 
     } else {
         xmlNode *scratch = pcmk__xml_copy(NULL, *cib);

--- a/daemons/based/based_messages.c
+++ b/daemons/based/based_messages.c
@@ -37,7 +37,6 @@ xmlNode *the_cib = NULL;
  * \internal
  * \brief Process a \c PCMK__CIB_REQUEST_ABS_DELETE
  *
- * \param[in] op       Ignored
  * \param[in] options  Ignored
  * \param[in] section  Ignored
  * \param[in] req      Ignored
@@ -50,9 +49,8 @@ xmlNode *the_cib = NULL;
  * \note This is unimplemented and simply returns an error.
  */
 int
-based_process_abs_delete(const char *op, int options, const char *section,
-                         xmlNode *req, xmlNode *input, xmlNode **cib,
-                         xmlNode **answer)
+based_process_abs_delete(int options, const char *section, xmlNode *req,
+                         xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     /* @COMPAT Remove when PCMK__CIB_REQUEST_ABS_DELETE is removed. Note that
      * external clients with Pacemaker versions < 3.0.0 can send it.
@@ -61,9 +59,8 @@ based_process_abs_delete(const char *op, int options, const char *section,
 }
 
 int
-based_process_commit_transact(const char *op, int options, const char *section,
-                              xmlNode *req, xmlNode *input, xmlNode **cib,
-                              xmlNode **answer)
+based_process_commit_transact(int options, const char *section, xmlNode *req,
+                              xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     /* On success, our caller will activate *cib locally, trigger a replace
      * notification if appropriate, and sync *cib to all nodes. On failure, our
@@ -87,9 +84,8 @@ based_process_commit_transact(const char *op, int options, const char *section,
 }
 
 int
-based_process_is_primary(const char *op, int options, const char *section,
-                         xmlNode *req, xmlNode *input, xmlNode **cib,
-                         xmlNode **answer)
+based_process_is_primary(int options, const char *section, xmlNode *req,
+                         xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     // @COMPAT Pacemaker Remote clients <3.0.0 may send this
     return (based_is_primary? pcmk_rc_ok : EPERM);
@@ -97,18 +93,16 @@ based_process_is_primary(const char *op, int options, const char *section,
 
 // @COMPAT: Remove when PCMK__CIB_REQUEST_NOOP is removed
 int
-based_process_noop(const char *op, int options, const char *section,
-                   xmlNode *req, xmlNode *input, xmlNode **cib,
-                   xmlNode **answer)
+based_process_noop(int options, const char *section, xmlNode *req,
+                   xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     *answer = NULL;
     return pcmk_rc_ok;
 }
 
 int
-based_process_ping(const char *op, int options, const char *section,
-                   xmlNode *req, xmlNode *input, xmlNode **cib,
-                   xmlNode **answer)
+based_process_ping(int options, const char *section, xmlNode *req,
+                   xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     /* existing_cib and *cib should be identical. In the absence of ACL
      * filtering, they should also match the_cib. However, they may be copies
@@ -151,9 +145,8 @@ based_process_ping(const char *op, int options, const char *section,
 }
 
 int
-based_process_primary(const char *op, int options, const char *section,
-                      xmlNode *req, xmlNode *input, xmlNode **cib,
-                      xmlNode **answer)
+based_process_primary(int options, const char *section, xmlNode *req,
+                      xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     if (!based_is_primary) {
         pcmk__info("We are now in R/W mode");
@@ -167,9 +160,8 @@ based_process_primary(const char *op, int options, const char *section,
 }
 
 int
-based_process_schemas(const char *op, int options, const char *section,
-                      xmlNode *req, xmlNode *input, xmlNode **cib,
-                      xmlNode **answer)
+based_process_schemas(int options, const char *section, xmlNode *req,
+                      xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     xmlNode *wrapper = NULL;
     xmlNode *data = NULL;
@@ -213,9 +205,8 @@ based_process_schemas(const char *op, int options, const char *section,
 }
 
 int
-based_process_secondary(const char *op, int options, const char *section,
-                        xmlNode *req, xmlNode *input, xmlNode **cib,
-                        xmlNode **answer)
+based_process_secondary(int options, const char *section, xmlNode *req,
+                        xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     if (based_is_primary) {
         pcmk__info("We are now in R/O mode");
@@ -229,9 +220,8 @@ based_process_secondary(const char *op, int options, const char *section,
 }
 
 int
-based_process_shutdown(const char *op, int options, const char *section,
-                       xmlNode *req, xmlNode *input, xmlNode **cib,
-                       xmlNode **answer)
+based_process_shutdown(int options, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     const char *host = pcmk__xe_get(req, PCMK__XA_SRC);
 
@@ -253,17 +243,15 @@ based_process_shutdown(const char *op, int options, const char *section,
 }
 
 int
-based_process_sync(const char *op, int options, const char *section,
-                   xmlNode *req, xmlNode *input, xmlNode **cib,
-                   xmlNode **answer)
+based_process_sync(int options, const char *section, xmlNode *req,
+                   xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     return sync_our_cib(req, true);
 }
 
 int
-based_process_upgrade(const char *op, int options, const char *section,
-                      xmlNode *req, xmlNode *input, xmlNode **cib,
-                      xmlNode **answer)
+based_process_upgrade(int options, const char *section, xmlNode *req,
+                      xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
 
@@ -275,8 +263,7 @@ based_process_upgrade(const char *op, int options, const char *section,
          * re-broadcasts the request with PCMK__XA_CIB_SCHEMA_MAX, and each node
          * performs the upgrade (and notifies its local clients) here.
          */
-        return cib__process_upgrade(op, options, section, req, input, cib,
-                                    answer);
+        return cib__process_upgrade(options, section, req, input, cib, answer);
 
     } else {
         xmlNode *scratch = pcmk__xml_copy(NULL, *cib);

--- a/daemons/based/based_messages.h
+++ b/daemons/based/based_messages.h
@@ -17,42 +17,42 @@
 extern bool based_is_primary;
 extern xmlNode *the_cib;
 
-int based_process_abs_delete(int options, const char *section, xmlNode *req,
-                             xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_abs_delete(const char *section, xmlNode *req, xmlNode *input,
+                             xmlNode **cib, xmlNode **answer);
 
-int based_process_apply_patch(int options, const char *section, xmlNode *req,
-                              xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_apply_patch(const char *section, xmlNode *req, xmlNode *input,
+                              xmlNode **cib, xmlNode **answer);
 
-int based_process_commit_transact(int options, const char *section,
-                                  xmlNode *req, xmlNode *input, xmlNode **cib,
+int based_process_commit_transact(const char *section, xmlNode *req,
+                                  xmlNode *input, xmlNode **cib,
                                   xmlNode **answer);
 
-int based_process_is_primary(int options, const char *section, xmlNode *req,
-                             xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_is_primary(const char *section, xmlNode *req, xmlNode *input,
+                             xmlNode **cib, xmlNode **answer);
 
-int based_process_noop(int options, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_noop(const char *section, xmlNode *req, xmlNode *input,
+                       xmlNode **cib, xmlNode **answer);
 
-int based_process_ping(int options, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_ping(const char *section, xmlNode *req, xmlNode *input,
+                       xmlNode **cib, xmlNode **answer);
 
-int based_process_primary(int options, const char *section, xmlNode *req,
-                          xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_primary(const char *section, xmlNode *req, xmlNode *input,
+                          xmlNode **cib, xmlNode **answer);
 
-int based_process_schemas(int options, const char *section, xmlNode *req,
-                          xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_schemas(const char *section, xmlNode *req, xmlNode *input,
+                          xmlNode **cib, xmlNode **answer);
 
-int based_process_secondary(int options, const char *section, xmlNode *req,
-                            xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_secondary(const char *section, xmlNode *req, xmlNode *input,
+                            xmlNode **cib, xmlNode **answer);
 
-int based_process_shutdown(int options, const char *section, xmlNode *req,
-                           xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_shutdown(const char *section, xmlNode *req, xmlNode *input,
+                           xmlNode **cib, xmlNode **answer);
 
-int based_process_sync(int options, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_sync(const char *section, xmlNode *req, xmlNode *input,
+                       xmlNode **cib, xmlNode **answer);
 
-int based_process_upgrade(int options, const char *section, xmlNode *req,
-                          xmlNode *input, xmlNode **cib, xmlNode **answer);
+int based_process_upgrade(const char *section, xmlNode *req, xmlNode *input,
+                          xmlNode **cib, xmlNode **answer);
 
 int sync_our_cib(xmlNode *request, bool all);
 

--- a/daemons/based/based_messages.h
+++ b/daemons/based/based_messages.h
@@ -17,42 +17,41 @@
 extern bool based_is_primary;
 extern xmlNode *the_cib;
 
-int based_process_abs_delete(const char *section, xmlNode *req, xmlNode *input,
-                             xmlNode **cib, xmlNode **answer);
+int based_process_abs_delete(xmlNode *req, xmlNode *input, xmlNode **cib,
+                             xmlNode **answer);
 
-int based_process_apply_patch(const char *section, xmlNode *req, xmlNode *input,
-                              xmlNode **cib, xmlNode **answer);
+int based_process_apply_patch(xmlNode *req, xmlNode *input, xmlNode **cib,
+                              xmlNode **answer);
 
-int based_process_commit_transact(const char *section, xmlNode *req,
-                                  xmlNode *input, xmlNode **cib,
+int based_process_commit_transact(xmlNode *req, xmlNode *input, xmlNode **cib,
                                   xmlNode **answer);
 
-int based_process_is_primary(const char *section, xmlNode *req, xmlNode *input,
-                             xmlNode **cib, xmlNode **answer);
+int based_process_is_primary(xmlNode *req, xmlNode *input, xmlNode **cib,
+                             xmlNode **answer);
 
-int based_process_noop(const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **cib, xmlNode **answer);
+int based_process_noop(xmlNode *req, xmlNode *input, xmlNode **cib,
+                       xmlNode **answer);
 
-int based_process_ping(const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **cib, xmlNode **answer);
+int based_process_ping(xmlNode *req, xmlNode *input, xmlNode **cib,
+                       xmlNode **answer);
 
-int based_process_primary(const char *section, xmlNode *req, xmlNode *input,
-                          xmlNode **cib, xmlNode **answer);
+int based_process_primary(xmlNode *req, xmlNode *input, xmlNode **cib,
+                          xmlNode **answer);
 
-int based_process_schemas(const char *section, xmlNode *req, xmlNode *input,
-                          xmlNode **cib, xmlNode **answer);
+int based_process_schemas(xmlNode *req, xmlNode *input, xmlNode **cib,
+                          xmlNode **answer);
 
-int based_process_secondary(const char *section, xmlNode *req, xmlNode *input,
-                            xmlNode **cib, xmlNode **answer);
+int based_process_secondary(xmlNode *req, xmlNode *input, xmlNode **cib,
+                            xmlNode **answer);
 
-int based_process_shutdown(const char *section, xmlNode *req, xmlNode *input,
-                           xmlNode **cib, xmlNode **answer);
+int based_process_shutdown(xmlNode *req, xmlNode *input, xmlNode **cib,
+                           xmlNode **answer);
 
-int based_process_sync(const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **cib, xmlNode **answer);
+int based_process_sync(xmlNode *req, xmlNode *input, xmlNode **cib,
+                       xmlNode **answer);
 
-int based_process_upgrade(const char *section, xmlNode *req, xmlNode *input,
-                          xmlNode **cib, xmlNode **answer);
+int based_process_upgrade(xmlNode *req, xmlNode *input, xmlNode **cib,
+                          xmlNode **answer);
 
 int sync_our_cib(xmlNode *request, bool all);
 

--- a/daemons/based/based_messages.h
+++ b/daemons/based/based_messages.h
@@ -17,54 +17,42 @@
 extern bool based_is_primary;
 extern xmlNode *the_cib;
 
-int based_process_abs_delete(const char *op, int options, const char *section,
-                             xmlNode *req, xmlNode *input, xmlNode **cib,
-                             xmlNode **answer);
+int based_process_abs_delete(int options, const char *section, xmlNode *req,
+                             xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_apply_patch(const char *op, int options, const char *section,
-                              xmlNode *req, xmlNode *input, xmlNode **cib,
-                              xmlNode **answer);
+int based_process_apply_patch(int options, const char *section, xmlNode *req,
+                              xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_commit_transact(const char *op, int options,
-                                  const char *section, xmlNode *req,
-                                  xmlNode *input, xmlNode **cib,
+int based_process_commit_transact(int options, const char *section,
+                                  xmlNode *req, xmlNode *input, xmlNode **cib,
                                   xmlNode **answer);
 
-int based_process_is_primary(const char *op, int options, const char *section,
-                             xmlNode *req, xmlNode *input, xmlNode **cib,
-                             xmlNode **answer);
+int based_process_is_primary(int options, const char *section, xmlNode *req,
+                             xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_noop(const char *op, int options, const char *section,
-                       xmlNode *req, xmlNode *input, xmlNode **cib,
-                       xmlNode **answer);
+int based_process_noop(int options, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_ping(const char *op, int options, const char *section,
-                       xmlNode *req, xmlNode *input, xmlNode **cib,
-                       xmlNode **answer);
+int based_process_ping(int options, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_primary(const char *op, int options, const char *section,
-                          xmlNode *req, xmlNode *input, xmlNode **cib,
-                          xmlNode **answer);
+int based_process_primary(int options, const char *section, xmlNode *req,
+                          xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_schemas(const char *op, int options, const char *section,
-                          xmlNode *req, xmlNode *input, xmlNode **cib,
-                          xmlNode **answer);
+int based_process_schemas(int options, const char *section, xmlNode *req,
+                          xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_secondary(const char *op, int options, const char *section,
-                            xmlNode *req, xmlNode *input, xmlNode **cib,
-                            xmlNode **answer);
+int based_process_secondary(int options, const char *section, xmlNode *req,
+                            xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_shutdown(const char *op, int options, const char *section,
-                           xmlNode *req, xmlNode *input, xmlNode **cib,
-                           xmlNode **answer);
+int based_process_shutdown(int options, const char *section, xmlNode *req,
+                           xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_sync(const char *op, int options, const char *section,
-                       xmlNode *req, xmlNode *input, xmlNode **cib,
-                       xmlNode **answer);
+int based_process_sync(int options, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int based_process_upgrade(const char *op, int options, const char *section,
-                          xmlNode *req, xmlNode *input, xmlNode **cib,
-                          xmlNode **answer);
+int based_process_upgrade(int options, const char *section, xmlNode *req,
+                          xmlNode *input, xmlNode **cib, xmlNode **answer);
 
 int sync_our_cib(xmlNode *request, bool all);
 

--- a/daemons/based/based_transaction.c
+++ b/daemons/based/based_transaction.c
@@ -130,20 +130,12 @@ based_commit_transaction(xmlNode *transaction, const pcmk__client_t *client,
     int rc = pcmk_rc_ok;
     char *source = NULL;
 
-    pcmk__assert(result_cib != NULL);
+    // *result_cib should be a copy of the_cib (created by cib_perform_op())
+    pcmk__assert((result_cib != NULL) && (*result_cib != NULL)
+                 && (*result_cib != the_cib));
 
     CRM_CHECK(pcmk__xe_is(transaction, PCMK__XE_CIB_TRANSACTION),
               return pcmk_rc_no_transaction);
-
-    /* *result_cib should be a copy of the_cib (created by cib_perform_op()). If
-     * not, make a copy now. Change tracking isn't strictly required here
-     * because:
-     * * Each request in the transaction will have changes tracked and ACLs
-     *   checked if appropriate.
-     * * cib_perform_op() will infer changes for the commit request at the end.
-     */
-    CRM_CHECK((*result_cib != NULL) && (*result_cib != the_cib),
-              *result_cib = pcmk__xml_copy(NULL, the_cib));
 
     source = based_transaction_source_str(client, origin);
     pcmk__trace("Committing transaction for %s to working CIB", source);

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -528,25 +528,17 @@ update_cib_cache_cb(const char *event, xmlNode * msg)
         patchset = pcmk__xe_first_child(wrapper, NULL, NULL, NULL);
 
         rc = xml_apply_patchset(local_cib, patchset, TRUE);
-        switch (rc) {
-            case pcmk_ok:
-            case -pcmk_err_old_data:
-                /* @TODO Full refresh (with or without query) in case of
-                 * -pcmk_err_old_data? It seems wrong to call
-                 * stonith_device_remove() based on primitive deletion in an
-                 * old diff.
-                 */
-                break;
-            case -pcmk_err_diff_failed:
+
+        if (rc != pcmk_ok) {
+            if ((rc == -pcmk_err_old_data) || (rc == -pcmk_err_diff_failed)) {
                 pcmk__notice("[%s] Patch aborted: %s (%d)", event,
                              pcmk_strerror(rc), rc);
-                g_clear_pointer(&local_cib, pcmk__xml_free);
-                break;
-            default:
+            } else {
                 pcmk__warn("[%s] ABORTED: %s (%d)", event, pcmk_strerror(rc),
                            rc);
-                g_clear_pointer(&local_cib, pcmk__xml_free);
-                break;
+            }
+
+            g_clear_pointer(&local_cib, pcmk__xml_free);
         }
     }
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -184,9 +184,9 @@ int cib__perform_query(const char *op, uint32_t call_options, cib__op_fn_t fn,
 
 int cib_perform_op(enum cib_variant variant, const char *op,
                    uint32_t call_options, cib__op_fn_t fn, const char *section,
-                   xmlNode *req, xmlNode *input, bool manage_counters,
-                   bool *config_changed, xmlNode **current_cib,
-                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
+                   xmlNode *req, xmlNode *input, bool *config_changed,
+                   xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
+                   xmlNode **output);
 
 int cib__create_op(cib_t *cib, const char *op, const char *host,
                    const char *section, xmlNode *data, int call_options,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -178,13 +178,12 @@ cib__client_triggers_refresh(const char *name)
 
 int cib__get_notify_patchset(const xmlNode *msg, const xmlNode **patchset);
 
-int cib__perform_query(cib__op_fn_t fn, const char *section, xmlNode *req,
-                       xmlNode **current_cib, xmlNode **output);
+int cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
+                       xmlNode **output);
 
-int cib_perform_op(enum cib_variant variant, cib__op_fn_t fn,
-                   const char *section, xmlNode *req, bool *config_changed,
-                   xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
-                   xmlNode **output);
+int cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
+                   bool *config_changed, xmlNode **current_cib,
+                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
 
 int cib__create_op(cib_t *cib, const char *op, const char *host,
                    const char *section, xmlNode *data, int call_options,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -178,15 +178,14 @@ cib__client_triggers_refresh(const char *name)
 
 int cib__get_notify_patchset(const xmlNode *msg, const xmlNode **patchset);
 
-int cib__perform_query(const char *op, uint32_t call_options, cib__op_fn_t fn,
+int cib__perform_query(uint32_t call_options, cib__op_fn_t fn,
                        const char *section, xmlNode *req, xmlNode *input,
                        xmlNode **current_cib, xmlNode **output);
 
-int cib_perform_op(enum cib_variant variant, const char *op,
-                   uint32_t call_options, cib__op_fn_t fn, const char *section,
-                   xmlNode *req, xmlNode *input, bool *config_changed,
-                   xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
-                   xmlNode **output);
+int cib_perform_op(enum cib_variant variant, uint32_t call_options,
+                   cib__op_fn_t fn, const char *section, xmlNode *req,
+                   xmlNode *input, bool *config_changed, xmlNode **current_cib,
+                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
 
 int cib__create_op(cib_t *cib, const char *op, const char *host,
                    const char *section, xmlNode *data, int call_options,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -103,9 +103,8 @@ enum cib__op_type {
  * replace *cib, but the replacement must become the root of the original
  * document.
  */
-typedef int (*cib__op_fn_t)(const char *op, int options, const char *section,
-                            xmlNode *request, xmlNode *input, xmlNode **cib,
-                            xmlNode **output);
+typedef int (*cib__op_fn_t)(int options, const char *section, xmlNode *request,
+                            xmlNode *input, xmlNode **cib, xmlNode **output);
 
 typedef struct {
     const char *name;
@@ -208,41 +207,32 @@ void cib_native_notify(gpointer data, gpointer user_data);
 
 int cib__get_operation(const char *op, const cib__operation_t **operation);
 
-int cib__process_apply_patch(const char *op, int options, const char *section,
-                             xmlNode *req, xmlNode *input, xmlNode **cib,
-                             xmlNode **answer);
+int cib__process_apply_patch(int options, const char *section, xmlNode *req,
+                             xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_bump(const char *op, int options, const char *section,
-                      xmlNode *req, xmlNode *input, xmlNode **cib,
-                      xmlNode **answer);
+int cib__process_bump(int options, const char *section, xmlNode *req,
+                      xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_create(const char *op, int options, const char *section,
-                        xmlNode *req, xmlNode *input, xmlNode **cib,
-                        xmlNode **answer);
+int cib__process_create(int options, const char *section, xmlNode *req,
+                        xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_delete(const char *op, int options, const char *section,
-                        xmlNode *req, xmlNode *input, xmlNode **cib,
-                        xmlNode **answer);
+int cib__process_delete(int options, const char *section, xmlNode *req,
+                        xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_erase(const char *op, int options, const char *section,
-                       xmlNode *req, xmlNode *input, xmlNode **cib,
-                       xmlNode **answer);
+int cib__process_erase(int options, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_modify(const char *op, int options, const char *section,
-                        xmlNode *req, xmlNode *input, xmlNode **cib,
-                        xmlNode **answer);
+int cib__process_modify(int options, const char *section, xmlNode *req,
+                        xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_query(const char *op, int options, const char *section,
-                       xmlNode *req, xmlNode *input, xmlNode **cib,
-                       xmlNode **answer);
+int cib__process_query(int options, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_replace(const char *op, int options, const char *section,
-                         xmlNode *req, xmlNode *input, xmlNode **cib,
-                         xmlNode **answer);
+int cib__process_replace(int options, const char *section, xmlNode *req,
+                         xmlNode *input, xmlNode **cib, xmlNode **answer);
 
-int cib__process_upgrade(const char *op, int options, const char *section,
-                         xmlNode *req, xmlNode *input, xmlNode **cib,
-                         xmlNode **answer);
+int cib__process_upgrade(int options, const char *section, xmlNode *req,
+                         xmlNode *input, xmlNode **cib, xmlNode **answer);
 
 int cib_internal_op(cib_t * cib, const char *op, const char *host,
                     const char *section, xmlNode * data,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -193,8 +193,8 @@ int cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
                        xmlNode **output);
 
 int cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
-                   bool *config_changed, xmlNode **current_cib,
-                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
+                   bool *config_changed, xmlNode **cib, xmlNode **diff,
+                   xmlNode **output);
 
 int cib__create_op(cib_t *cib, const char *op, const char *host,
                    const char *section, xmlNode *data, int call_options,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -178,13 +178,12 @@ cib__client_triggers_refresh(const char *name)
 
 int cib__get_notify_patchset(const xmlNode *msg, const xmlNode **patchset);
 
-int cib__perform_query(uint32_t call_options, cib__op_fn_t fn,
-                       const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **current_cib, xmlNode **output);
+int cib__perform_query(cib__op_fn_t fn, const char *section, xmlNode *req,
+                       xmlNode *input, xmlNode **current_cib, xmlNode **output);
 
-int cib_perform_op(enum cib_variant variant, uint32_t call_options,
-                   cib__op_fn_t fn, const char *section, xmlNode *req,
-                   xmlNode *input, bool *config_changed, xmlNode **current_cib,
+int cib_perform_op(enum cib_variant variant, cib__op_fn_t fn,
+                   const char *section, xmlNode *req, xmlNode *input,
+                   bool *config_changed, xmlNode **current_cib,
                    xmlNode **result_cib, xmlNode **diff, xmlNode **output);
 
 int cib__create_op(cib_t *cib, const char *op, const char *host,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -93,8 +93,19 @@ enum cib__op_type {
     cib__op_upgrade,
 };
 
-typedef int (*cib__op_fn_t)(const char *, int, const char *, xmlNode *,
-                            xmlNode *, xmlNode **, xmlNode **);
+/* A cib__op_fn_t must not alter the document private data except for adding to
+ * the deleted_objs list, and (*cib)->doc must point to the same value before
+ * and after the function call. This allows us to make the useful assumptions
+ * that change tracking and ACLs remain enabled if they were enabled initially,
+ * and that any ACLs are still unpacked in the xml_doc_private_t:acls list.
+ *
+ * *cib should be the root element of its document. A cib__op_fn_t may free and
+ * replace *cib, but the replacement must become the root of the original
+ * document.
+ */
+typedef int (*cib__op_fn_t)(const char *op, int options, const char *section,
+                            xmlNode *request, xmlNode *input, xmlNode **cib,
+                            xmlNode **output);
 
 typedef struct {
     const char *name;

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -103,8 +103,8 @@ enum cib__op_type {
  * replace *cib, but the replacement must become the root of the original
  * document.
  */
-typedef int (*cib__op_fn_t)(const char *section, xmlNode *request,
-                            xmlNode *input, xmlNode **cib, xmlNode **output);
+typedef int (*cib__op_fn_t)(xmlNode *request, xmlNode *input, xmlNode **cib,
+                            xmlNode **output);
 
 typedef struct {
     const char *name;
@@ -207,32 +207,32 @@ void cib_native_notify(gpointer data, gpointer user_data);
 
 int cib__get_operation(const char *op, const cib__operation_t **operation);
 
-int cib__process_apply_patch(const char *section, xmlNode *req, xmlNode *input,
-                             xmlNode **cib, xmlNode **answer);
+int cib__process_apply_patch(xmlNode *req, xmlNode *input, xmlNode **cib,
+                             xmlNode **answer);
 
-int cib__process_bump(const char *section, xmlNode *req, xmlNode *input,
-                      xmlNode **cib, xmlNode **answer);
+int cib__process_bump(xmlNode *req, xmlNode *input, xmlNode **cib,
+                      xmlNode **answer);
 
-int cib__process_create(const char *section, xmlNode *req, xmlNode *input,
-                        xmlNode **cib, xmlNode **answer);
+int cib__process_create(xmlNode *req, xmlNode *input, xmlNode **cib,
+                        xmlNode **answer);
 
-int cib__process_delete(const char *section, xmlNode *req, xmlNode *input,
-                        xmlNode **cib, xmlNode **answer);
+int cib__process_delete(xmlNode *req, xmlNode *input, xmlNode **cib,
+                        xmlNode **answer);
 
-int cib__process_erase(const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **cib, xmlNode **answer);
+int cib__process_erase(xmlNode *req, xmlNode *input, xmlNode **cib,
+                       xmlNode **answer);
 
-int cib__process_modify(const char *section, xmlNode *req, xmlNode *input,
-                        xmlNode **cib, xmlNode **answer);
+int cib__process_modify(xmlNode *req, xmlNode *input, xmlNode **cib,
+                        xmlNode **answer);
 
-int cib__process_query(const char *section, xmlNode *req, xmlNode *input,
-                       xmlNode **cib, xmlNode **answer);
+int cib__process_query(xmlNode *req, xmlNode *input, xmlNode **cib,
+                       xmlNode **answer);
 
-int cib__process_replace(const char *section, xmlNode *req, xmlNode *input,
-                         xmlNode **cib, xmlNode **answer);
+int cib__process_replace(xmlNode *req, xmlNode *input, xmlNode **cib,
+                         xmlNode **answer);
 
-int cib__process_upgrade(const char *section, xmlNode *req, xmlNode *input,
-                         xmlNode **cib, xmlNode **answer);
+int cib__process_upgrade(xmlNode *req, xmlNode *input, xmlNode **cib,
+                         xmlNode **answer);
 
 int cib_internal_op(cib_t * cib, const char *op, const char *host,
                     const char *section, xmlNode * data,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -103,7 +103,7 @@ enum cib__op_type {
  * replace *cib, but the replacement must become the root of the original
  * document.
  */
-typedef int (*cib__op_fn_t)(int options, const char *section, xmlNode *request,
+typedef int (*cib__op_fn_t)(const char *section, xmlNode *request,
                             xmlNode *input, xmlNode **cib, xmlNode **output);
 
 typedef struct {
@@ -207,32 +207,32 @@ void cib_native_notify(gpointer data, gpointer user_data);
 
 int cib__get_operation(const char *op, const cib__operation_t **operation);
 
-int cib__process_apply_patch(int options, const char *section, xmlNode *req,
-                             xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_apply_patch(const char *section, xmlNode *req, xmlNode *input,
+                             xmlNode **cib, xmlNode **answer);
 
-int cib__process_bump(int options, const char *section, xmlNode *req,
-                      xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_bump(const char *section, xmlNode *req, xmlNode *input,
+                      xmlNode **cib, xmlNode **answer);
 
-int cib__process_create(int options, const char *section, xmlNode *req,
-                        xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_create(const char *section, xmlNode *req, xmlNode *input,
+                        xmlNode **cib, xmlNode **answer);
 
-int cib__process_delete(int options, const char *section, xmlNode *req,
-                        xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_delete(const char *section, xmlNode *req, xmlNode *input,
+                        xmlNode **cib, xmlNode **answer);
 
-int cib__process_erase(int options, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_erase(const char *section, xmlNode *req, xmlNode *input,
+                       xmlNode **cib, xmlNode **answer);
 
-int cib__process_modify(int options, const char *section, xmlNode *req,
-                        xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_modify(const char *section, xmlNode *req, xmlNode *input,
+                        xmlNode **cib, xmlNode **answer);
 
-int cib__process_query(int options, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_query(const char *section, xmlNode *req, xmlNode *input,
+                       xmlNode **cib, xmlNode **answer);
 
-int cib__process_replace(int options, const char *section, xmlNode *req,
-                         xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_replace(const char *section, xmlNode *req, xmlNode *input,
+                         xmlNode **cib, xmlNode **answer);
 
-int cib__process_upgrade(int options, const char *section, xmlNode *req,
-                         xmlNode *input, xmlNode **cib, xmlNode **answer);
+int cib__process_upgrade(const char *section, xmlNode *req, xmlNode *input,
+                         xmlNode **cib, xmlNode **answer);
 
 int cib_internal_op(cib_t * cib, const char *op, const char *host,
                     const char *section, xmlNode * data,

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -179,12 +179,12 @@ cib__client_triggers_refresh(const char *name)
 int cib__get_notify_patchset(const xmlNode *msg, const xmlNode **patchset);
 
 int cib__perform_query(cib__op_fn_t fn, const char *section, xmlNode *req,
-                       xmlNode *input, xmlNode **current_cib, xmlNode **output);
+                       xmlNode **current_cib, xmlNode **output);
 
 int cib_perform_op(enum cib_variant variant, cib__op_fn_t fn,
-                   const char *section, xmlNode *req, xmlNode *input,
-                   bool *config_changed, xmlNode **current_cib,
-                   xmlNode **result_cib, xmlNode **diff, xmlNode **output);
+                   const char *section, xmlNode *req, bool *config_changed,
+                   xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
+                   xmlNode **output);
 
 int cib__create_op(cib_t *cib, const char *op, const char *host,
                    const char *section, xmlNode *data, int call_options,

--- a/include/crm/common/results.h
+++ b/include/crm/common/results.h
@@ -76,6 +76,7 @@ extern "C" {
 #define pcmk_err_diff_failed          206
 
 // NOTE: sbd (as of at least 1.5.2) uses this
+//! \deprecated Do not use
 #define pcmk_err_diff_resync          207
 
 #define pcmk_err_cib_modified         208
@@ -142,7 +143,10 @@ enum pcmk_rc_e {
     pcmk_rc_transform_failed    = -1014,
     pcmk_rc_old_data            = -1013,
     pcmk_rc_diff_failed         = -1012,
+
+    //! \deprecated Do not use
     pcmk_rc_diff_resync         = -1011,
+
     pcmk_rc_cib_modified        = -1010,
     pcmk_rc_cib_backup          = -1009,
     pcmk_rc_cib_save            = -1008,

--- a/include/crm/common/schemas_internal.h
+++ b/include/crm/common/schemas_internal.h
@@ -36,8 +36,7 @@ GList *pcmk__get_schema(const char *name);
 const char *pcmk__highest_schema_name(void);
 int pcmk__cmp_schemas_by_name(const char *schema1_name,
                               const char *schema2_name);
-bool pcmk__validate_xml(xmlNode *xml_blob, const char *validation,
-                        xmlRelaxNGValidityErrorFunc error_handler,
+bool pcmk__validate_xml(xmlNode *xml, xmlRelaxNGValidityErrorFunc error_handler,
                         void *error_handler_context);
 bool pcmk__configured_schema_validates(xmlNode *xml);
 int pcmk__update_schema(xmlNode **xml, const char *max_schema_name,

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -180,7 +180,7 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
                                 data, &private->cib_xml, output);
     } else {
         rc = cib_perform_op(cib_file, op, call_options, op_function, section,
-                            request, data, true, &changed, &private->cib_xml,
+                            request, data, &changed, &private->cib_xml,
                             &result_cib, &cib_diff, output);
     }
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -176,12 +176,12 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     }
 
     if (read_only) {
-        rc = cib__perform_query(call_options, op_function, section, request,
-                                data, &private->cib_xml, output);
+        rc = cib__perform_query(op_function, section, request, data,
+                                &private->cib_xml, output);
     } else {
-        rc = cib_perform_op(cib_file, call_options, op_function, section,
-                            request, data, &changed, &private->cib_xml,
-                            &result_cib, &cib_diff, output);
+        rc = cib_perform_op(cib_file, op_function, section, request, data,
+                            &changed, &private->cib_xml, &result_cib, &cib_diff,
+                            output);
     }
 
     if (pcmk__is_set(call_options, cib_transaction)) {

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -301,9 +301,8 @@ commit_transaction(cib_t *cib, xmlNode *transaction, xmlNode **result_cib)
 }
 
 static int
-process_commit_transact(const char *op, int options, const char *section,
-                        xmlNode *req, xmlNode *input, xmlNode **cib_xml,
-                        xmlNode **answer)
+process_commit_transact(int options, const char *section, xmlNode *req,
+                        xmlNode *input, xmlNode **cib_xml, xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
     const char *client_id = pcmk__xe_get(req, PCMK__XA_CIB_CLIENTID);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -176,10 +176,10 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     }
 
     if (read_only) {
-        rc = cib__perform_query(op, call_options, op_function, section, request,
+        rc = cib__perform_query(call_options, op_function, section, request,
                                 data, &private->cib_xml, output);
     } else {
-        rc = cib_perform_op(cib_file, op, call_options, op_function, section,
+        rc = cib_perform_op(cib_file, call_options, op_function, section,
                             request, data, &changed, &private->cib_xml,
                             &result_cib, &cib_diff, output);
     }

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -141,10 +141,8 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     const cib__operation_t *operation = NULL;
     cib__op_fn_t op_function = NULL;
 
-    int call_id = 0;
     uint32_t call_options = cib_none;
     const char *op = pcmk__xe_get(request, PCMK__XA_CIB_OP);
-    const char *section = pcmk__xe_get(request, PCMK__XA_CIB_SECTION);
 
     bool changed = false;
     bool read_only = false;
@@ -157,7 +155,6 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     cib__get_operation(op, &operation);
     op_function = get_op_function(operation);
 
-    pcmk__xe_get_int(request, PCMK__XA_CIB_CALLID, &call_id);
     rc = pcmk__xe_get_flags(request, PCMK__XA_CIB_CALLOPT, &call_options,
                             cib_none);
     if (rc != pcmk_rc_ok) {
@@ -167,10 +164,10 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     read_only = !pcmk__is_set(operation->flags, cib__op_attr_modifies);
 
     if (read_only) {
-        rc = cib__perform_query(op_function, section, request,
-                                &private->cib_xml, output);
+        rc = cib__perform_query(op_function, request, &private->cib_xml,
+                                output);
     } else {
-        rc = cib_perform_op(cib_file, op_function, section, request, &changed,
+        rc = cib_perform_op(cib_file, op_function, request, &changed,
                             &private->cib_xml, &result_cib, &cib_diff, output);
     }
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -301,8 +301,8 @@ commit_transaction(cib_t *cib, xmlNode *transaction, xmlNode **result_cib)
 }
 
 static int
-process_commit_transact(int options, const char *section, xmlNode *req,
-                        xmlNode *input, xmlNode **cib_xml, xmlNode **answer)
+process_commit_transact(const char *section, xmlNode *req, xmlNode *input,
+                        xmlNode **cib_xml, xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
     const char *client_id = pcmk__xe_get(req, PCMK__XA_CIB_CLIENTID);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -145,9 +145,6 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
     uint32_t call_options = cib_none;
     const char *op = pcmk__xe_get(request, PCMK__XA_CIB_OP);
     const char *section = pcmk__xe_get(request, PCMK__XA_CIB_SECTION);
-    xmlNode *wrapper = pcmk__xe_first_child(request, PCMK__XE_CIB_CALLDATA,
-                                            NULL, NULL);
-    xmlNode *data = pcmk__xe_first_child(wrapper, NULL, NULL, NULL);
 
     bool changed = false;
     bool read_only = false;
@@ -169,19 +166,12 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
 
     read_only = !pcmk__is_set(operation->flags, cib__op_attr_modifies);
 
-    // Mirror the logic in prepare_input() in the CIB manager
-    if ((section != NULL) && pcmk__xe_is(data, PCMK_XE_CIB)) {
-
-        data = pcmk_find_cib_element(data, section);
-    }
-
     if (read_only) {
-        rc = cib__perform_query(op_function, section, request, data,
+        rc = cib__perform_query(op_function, section, request,
                                 &private->cib_xml, output);
     } else {
-        rc = cib_perform_op(cib_file, op_function, section, request, data,
-                            &changed, &private->cib_xml, &result_cib, &cib_diff,
-                            output);
+        rc = cib_perform_op(cib_file, op_function, section, request, &changed,
+                            &private->cib_xml, &result_cib, &cib_diff, output);
     }
 
     if (pcmk__is_set(call_options, cib_transaction)) {

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -167,8 +167,9 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
         rc = cib__perform_query(op_function, request, &private->cib_xml,
                                 output);
     } else {
+        result_cib = private->cib_xml;
         rc = cib_perform_op(cib_file, op_function, request, &changed,
-                            &private->cib_xml, &result_cib, &cib_diff, output);
+                            &result_cib, &cib_diff, output);
     }
 
     if (pcmk__is_set(call_options, cib_transaction)) {

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -263,18 +263,14 @@ commit_transaction(cib_t *cib, xmlNode *transaction, xmlNode **result_cib)
     file_opaque_t *private = cib->variant_opaque;
     xmlNode *saved_cib = private->cib_xml;
 
+    /* *result_cib should be a copy of private->cib_xml (created by
+     * cib_perform_op())
+     */
+    pcmk__assert((result_cib != NULL) && (*result_cib != NULL)
+                 && (*result_cib != private->cib_xml));
+
     CRM_CHECK(pcmk__xe_is(transaction, PCMK__XE_CIB_TRANSACTION),
               return pcmk_rc_no_transaction);
-
-    /* *result_cib should be a copy of private->cib_xml (created by
-     * cib_perform_op()). If not, make a copy now. Change tracking isn't
-     * strictly required here because:
-     * * Each request in the transaction will have changes tracked and ACLs
-     *   checked if appropriate.
-     * * cib_perform_op() will infer changes for the commit request at the end.
-     */
-    CRM_CHECK((*result_cib != NULL) && (*result_cib != private->cib_xml),
-              *result_cib = pcmk__xml_copy(NULL, private->cib_xml));
 
     pcmk__trace("Committing transaction for CIB file client (%s) on file '%s' "
                 "to working CIB",

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -301,8 +301,8 @@ commit_transaction(cib_t *cib, xmlNode *transaction, xmlNode **result_cib)
 }
 
 static int
-process_commit_transact(const char *section, xmlNode *req, xmlNode *input,
-                        xmlNode **cib_xml, xmlNode **answer)
+process_commit_transact(xmlNode *req, xmlNode *input, xmlNode **cib_xml,
+                        xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
     const char *client_id = pcmk__xe_get(req, PCMK__XA_CIB_CLIENTID);

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -180,7 +180,7 @@ process_request(cib_t *cib, xmlNode *request, xmlNode **output)
 
     if (rc == pcmk_rc_schema_validation) {
         // Show validation errors to stderr
-        pcmk__validate_xml(result_cib, NULL, NULL, NULL);
+        pcmk__validate_xml(result_cib, NULL, NULL);
 
     } else if ((rc == pcmk_rc_ok) && !read_only) {
         if (result_cib != private->cib_xml) {

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -827,11 +827,11 @@ replace_cib(xmlNode *request, xmlNode *input, xmlNode **cib)
 
 static int
 process_replace_xpath(const char *op, int options, const char *xpath,
-                      xmlNode *input, xmlNode *cib)
+                      xmlNode *request, xmlNode *input, xmlNode **cib)
 {
     int num_results = 0;
     int rc = pcmk_rc_ok;
-    xmlXPathObject *xpath_obj = pcmk__xpath_search(cib->doc, xpath);
+    xmlXPathObject *xpath_obj = pcmk__xpath_search((*cib)->doc, xpath);
 
     num_results = pcmk__xpath_num_results(xpath_obj);
     if (num_results == 0) {
@@ -853,6 +853,11 @@ process_replace_xpath(const char *op, int options, const char *xpath,
         path = xmlGetNodePath(match);
         pcmk__debug("Processing %s op for %s with %s", op, xpath, path);
         free(path);
+
+        if (match == *cib) {
+            rc = replace_cib(request, input, cib);
+            break;
+        }
 
         parent = match->parent;
 
@@ -911,7 +916,7 @@ cib__process_replace(const char *op, int options, const char *section,
                      xmlNode **answer)
 {
     if (pcmk__is_set(options, cib_xpath)) {
-        return process_replace_xpath(op, options, section, input, *cib);
+        return process_replace_xpath(op, options, section, req, input, cib);
     }
 
     return process_replace_section(section, req, input, cib);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -299,25 +299,19 @@ cib__process_create(const char *op, int options, const char *section,
     int rc = pcmk_rc_ok;
     xmlNode *update_section = NULL;
 
-    if (pcmk__str_eq(PCMK__XE_ALL, section, pcmk__str_casei)) {
-        section = NULL;
-
-    } else if (pcmk__str_eq(section, PCMK_XE_CIB, pcmk__str_casei)) {
-        section = NULL;
-
-    } else if (pcmk__xe_is(input, PCMK_XE_CIB)) {
-        section = NULL;
+    if ((section != NULL) && pcmk__xe_is(input, PCMK_XE_CIB)) {
+        input = pcmk_find_cib_element(input, section);
     }
-
-    CRM_CHECK(strcmp(op, PCMK__CIB_REQUEST_CREATE) == 0, return -EINVAL);
 
     if (input == NULL) {
         pcmk__err("Cannot perform modification with no data");
         return EINVAL;
     }
 
-    if (section == NULL) {
-        return cib__process_modify(op, options, section, req, input, cib,
+    if (pcmk__strcase_any_of(section, PCMK__XE_ALL, PCMK_XE_CIB, NULL)
+        || pcmk__xe_is(input, PCMK_XE_CIB)) {
+
+        return cib__process_modify(op, options, NULL, req, input, cib,
                                    answer);
     }
 
@@ -445,6 +439,10 @@ process_delete_section(const char *section, xmlNode *input, xmlNode *cib)
 {
     xmlNode *obj_root = NULL;
 
+    if ((section != NULL) && pcmk__xe_is(input, PCMK_XE_CIB)) {
+        input = pcmk_find_cib_element(input, section);
+    }
+
     if (input == NULL) {
         pcmk__err("Cannot find matching section to delete with no input data");
         return EINVAL;
@@ -554,6 +552,10 @@ process_modify_section(int options, const char *section, xmlNode *input,
     const bool score = pcmk__is_set(options, cib_score_update);
     const uint32_t flags = (score? pcmk__xaf_score_update : pcmk__xaf_none);
     xmlNode *obj_root = NULL;
+
+    if ((section != NULL) && pcmk__xe_is(input, PCMK_XE_CIB)) {
+        input = pcmk_find_cib_element(input, section);
+    }
 
     if (input == NULL) {
         pcmk__err("Cannot complete CIB modify request with no input data");
@@ -873,6 +875,10 @@ process_replace_section(const char *section, xmlNode *request, xmlNode *input,
 {
     int rc = pcmk_rc_ok;
     xmlNode *obj_root = NULL;
+
+    if ((section != NULL) && pcmk__xe_is(input, PCMK_XE_CIB)) {
+        input = pcmk_find_cib_element(input, section);
+    }
 
     if (input == NULL) {
         pcmk__err("Cannot find matching section to replace with no input data");

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -163,9 +163,8 @@ cib__get_operation(const char *op, const cib__operation_t **operation)
 }
 
 int
-cib__process_apply_patch(const char *op, int options, const char *section,
-                         xmlNode *req, xmlNode *input, xmlNode **cib,
-                         xmlNode **answer)
+cib__process_apply_patch(int options, const char *section, xmlNode *req,
+                         xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     int rc = xml_apply_patchset(*cib, input, true);
 
@@ -190,8 +189,8 @@ update_counter(xmlNode *xml, const char *field, bool reset)
 }
 
 int
-cib__process_bump(const char *op, int options, const char *section,
-                  xmlNode *req, xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_bump(int options, const char *section, xmlNode *req,
+                  xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     update_counter(*cib, PCMK_XA_EPOCH, false);
     return pcmk_rc_ok;
@@ -291,10 +290,10 @@ done:
 }
 
 int
-cib__process_create(const char *op, int options, const char *section,
-                    xmlNode *req, xmlNode *input, xmlNode **cib,
-                    xmlNode **answer)
+cib__process_create(int options, const char *section, xmlNode *req,
+                    xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
+    const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
     xmlNode *failed = NULL;
     int rc = pcmk_rc_ok;
     xmlNode *update_section = NULL;
@@ -311,8 +310,7 @@ cib__process_create(const char *op, int options, const char *section,
     if (pcmk__strcase_any_of(section, PCMK__XE_ALL, PCMK_XE_CIB, NULL)
         || pcmk__xe_is(input, PCMK_XE_CIB)) {
 
-        return cib__process_modify(op, options, NULL, req, input, cib,
-                                   answer);
+        return cib__process_modify(options, NULL, req, input, cib, answer);
     }
 
     // @COMPAT Deprecated since 2.1.8
@@ -461,11 +459,12 @@ process_delete_section(const char *section, xmlNode *input, xmlNode *cib)
 }
 
 int
-cib__process_delete(const char *op, int options, const char *section,
-                    xmlNode *req, xmlNode *input, xmlNode **cib,
-                    xmlNode **answer)
+cib__process_delete(int options, const char *section, xmlNode *req,
+                    xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     if (pcmk__is_set(options, cib_xpath)) {
+        const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
+
         return process_delete_xpath(op, options, section, *cib);
     }
 
@@ -473,9 +472,8 @@ cib__process_delete(const char *op, int options, const char *section,
 }
 
 int
-cib__process_erase(const char *op, int options, const char *section,
-                   xmlNode *req, xmlNode *input, xmlNode **cib,
-                   xmlNode **answer)
+cib__process_erase(int options, const char *section, xmlNode *req,
+                   xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     xmlNode *empty = createEmptyCib(0);
     xmlNode *empty_config = pcmk__xe_first_child(empty, PCMK_XE_CONFIGURATION,
@@ -596,11 +594,12 @@ process_modify_section(int options, const char *section, xmlNode *input,
 }
 
 int
-cib__process_modify(const char *op, int options, const char *section,
-                    xmlNode *req, xmlNode *input, xmlNode **cib,
-                    xmlNode **answer)
+cib__process_modify(int options, const char *section, xmlNode *req,
+                    xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     if (pcmk__is_set(options, cib_xpath)) {
+        const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
+
         return process_modify_xpath(op, options, section, input, *cib);
     }
 
@@ -730,10 +729,12 @@ process_query_section(int options, const char *section, xmlNode *cib,
 }
 
 int
-cib__process_query(const char *op, int options, const char *section,
-                   xmlNode *req, xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_query(int options, const char *section, xmlNode *req,
+                   xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     if (pcmk__is_set(options, cib_xpath)) {
+        const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
+
         return process_query_xpath(op, options, section, *cib, answer);
     }
 
@@ -911,11 +912,12 @@ process_replace_section(const char *section, xmlNode *request, xmlNode *input,
 }
 
 int
-cib__process_replace(const char *op, int options, const char *section,
-                     xmlNode *req, xmlNode *input, xmlNode **cib,
-                     xmlNode **answer)
+cib__process_replace(int options, const char *section, xmlNode *req,
+                     xmlNode *input, xmlNode **cib, xmlNode **answer)
 {
     if (pcmk__is_set(options, cib_xpath)) {
+        const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
+
         return process_replace_xpath(op, options, section, req, input, cib);
     }
 
@@ -923,7 +925,7 @@ cib__process_replace(const char *op, int options, const char *section,
 }
 
 int
-cib__process_upgrade(const char *op, int options, const char *section,
+cib__process_upgrade(int options, const char *section,
                      xmlNode *req, xmlNode *input, xmlNode **cib,
                      xmlNode **answer)
 {

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -10,6 +10,7 @@
 #include <crm_internal.h>
 
 #include <stdbool.h>
+#include <stdint.h>                     // uint32_t
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -163,8 +164,8 @@ cib__get_operation(const char *op, const cib__operation_t **operation)
 }
 
 int
-cib__process_apply_patch(int options, const char *section, xmlNode *req,
-                         xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_apply_patch(const char *section, xmlNode *req, xmlNode *input,
+                         xmlNode **cib, xmlNode **answer)
 {
     int rc = xml_apply_patchset(*cib, input, true);
 
@@ -189,8 +190,8 @@ update_counter(xmlNode *xml, const char *field, bool reset)
 }
 
 int
-cib__process_bump(int options, const char *section, xmlNode *req,
-                  xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_bump(const char *section, xmlNode *req, xmlNode *input,
+                  xmlNode **cib, xmlNode **answer)
 {
     update_counter(*cib, PCMK_XA_EPOCH, false);
     return pcmk_rc_ok;
@@ -290,8 +291,8 @@ done:
 }
 
 int
-cib__process_create(int options, const char *section, xmlNode *req,
-                    xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_create(const char *section, xmlNode *req, xmlNode *input,
+                    xmlNode **cib, xmlNode **answer)
 {
     const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
     xmlNode *failed = NULL;
@@ -310,7 +311,7 @@ cib__process_create(int options, const char *section, xmlNode *req,
     if (pcmk__strcase_any_of(section, PCMK__XE_ALL, PCMK_XE_CIB, NULL)
         || pcmk__xe_is(input, PCMK_XE_CIB)) {
 
-        return cib__process_modify(options, NULL, req, input, cib, answer);
+        return cib__process_modify(NULL, req, input, cib, answer);
     }
 
     // @COMPAT Deprecated since 2.1.8
@@ -459,9 +460,13 @@ process_delete_section(const char *section, xmlNode *input, xmlNode *cib)
 }
 
 int
-cib__process_delete(int options, const char *section, xmlNode *req,
-                    xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_delete(const char *section, xmlNode *req, xmlNode *input,
+                    xmlNode **cib, xmlNode **answer)
 {
+    uint32_t options = cib_none;
+
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &options, cib_none);
+
     if (pcmk__is_set(options, cib_xpath)) {
         const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
 
@@ -472,8 +477,8 @@ cib__process_delete(int options, const char *section, xmlNode *req,
 }
 
 int
-cib__process_erase(int options, const char *section, xmlNode *req,
-                   xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_erase(const char *section, xmlNode *req, xmlNode *input,
+                   xmlNode **cib, xmlNode **answer)
 {
     xmlNode *empty = createEmptyCib(0);
     xmlNode *empty_config = pcmk__xe_first_child(empty, PCMK_XE_CONFIGURATION,
@@ -594,9 +599,13 @@ process_modify_section(int options, const char *section, xmlNode *input,
 }
 
 int
-cib__process_modify(int options, const char *section, xmlNode *req,
-                    xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_modify(const char *section, xmlNode *req, xmlNode *input,
+                    xmlNode **cib, xmlNode **answer)
 {
+    uint32_t options = cib_none;
+
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &options, cib_none);
+
     if (pcmk__is_set(options, cib_xpath)) {
         const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
 
@@ -729,9 +738,13 @@ process_query_section(int options, const char *section, xmlNode *cib,
 }
 
 int
-cib__process_query(int options, const char *section, xmlNode *req,
-                   xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_query(const char *section, xmlNode *req, xmlNode *input,
+                   xmlNode **cib, xmlNode **answer)
 {
+    uint32_t options = cib_none;
+
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &options, cib_none);
+
     if (pcmk__is_set(options, cib_xpath)) {
         const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
 
@@ -912,9 +925,13 @@ process_replace_section(const char *section, xmlNode *request, xmlNode *input,
 }
 
 int
-cib__process_replace(int options, const char *section, xmlNode *req,
-                     xmlNode *input, xmlNode **cib, xmlNode **answer)
+cib__process_replace(const char *section, xmlNode *req, xmlNode *input,
+                     xmlNode **cib, xmlNode **answer)
 {
+    uint32_t options = cib_none;
+
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &options, cib_none);
+
     if (pcmk__is_set(options, cib_xpath)) {
         const char *op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
 
@@ -925,15 +942,17 @@ cib__process_replace(int options, const char *section, xmlNode *req,
 }
 
 int
-cib__process_upgrade(int options, const char *section,
-                     xmlNode *req, xmlNode *input, xmlNode **cib,
-                     xmlNode **answer)
+cib__process_upgrade(const char *section, xmlNode *req, xmlNode *input,
+                     xmlNode **cib, xmlNode **answer)
 {
     int rc = pcmk_rc_ok;
+    uint32_t options = cib_none;
     const char *max_schema = pcmk__xe_get(req, PCMK__XA_CIB_SCHEMA_MAX);
     char *original_schema = NULL;
     const char *new_schema = NULL;
     xmlNode *updated = pcmk__xml_copy(NULL, *cib);
+
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &options, cib_none);
 
     // pcmk__update_schema() may free the original validate-with string
     original_schema = pcmk__xe_get_copy(*cib, PCMK_XA_VALIDATE_WITH);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -931,12 +931,16 @@ cib__process_upgrade(const char *op, int options, const char *section,
     const char *max_schema = pcmk__xe_get(req, PCMK__XA_CIB_SCHEMA_MAX);
     char *original_schema = NULL;
     const char *new_schema = NULL;
+    xmlNode *updated = pcmk__xml_copy(NULL, *cib);
 
     // pcmk__update_schema() may free the original validate-with string
     original_schema = pcmk__xe_get_copy(*cib, PCMK_XA_VALIDATE_WITH);
 
-    rc = pcmk__update_schema(cib, max_schema, true,
+    rc = pcmk__update_schema(&updated, max_schema, true,
                              !pcmk__is_set(options, cib_verbose));
+    *cib = pcmk__xml_replace_with_copy(*cib, updated);
+    pcmk__xml_free(updated);
+
     new_schema = pcmk__xe_get(*cib, PCMK_XA_VALIDATE_WITH);
 
     if (pcmk__cmp_schemas_by_name(new_schema, original_schema) > 0) {

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -170,13 +170,13 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 }
 
 int
-cib__perform_query(uint32_t call_options, cib__op_fn_t fn, const char *section,
-                   xmlNode *req, xmlNode *input, xmlNode **current_cib,
-                   xmlNode **output)
+cib__perform_query(cib__op_fn_t fn, const char *section, xmlNode *req,
+                   xmlNode *input, xmlNode **current_cib, xmlNode **output)
 {
     int rc = pcmk_rc_ok;
     const char *op = NULL;
     const char *user = NULL;
+    uint32_t call_options = cib_none;
 
     xmlNode *cib = NULL;
     xmlNode *cib_filtered = NULL;
@@ -187,6 +187,7 @@ cib__perform_query(uint32_t call_options, cib__op_fn_t fn, const char *section,
 
     op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
     user = pcmk__xe_get(req, PCMK__XA_CIB_USER);
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &call_options, cib_none);
     cib = *current_cib;
 
     if (cib_acl_enabled(*current_cib, user)
@@ -441,10 +442,10 @@ set_update_origin(xmlNode *new_cib, const xmlNode *request)
 }
 
 int
-cib_perform_op(enum cib_variant variant, uint32_t call_options, cib__op_fn_t fn,
-               const char *section, xmlNode *req, xmlNode *input,
-               bool *config_changed, xmlNode **current_cib,
-               xmlNode **result_cib, xmlNode **diff, xmlNode **output)
+cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, const char *section,
+               xmlNode *req, xmlNode *input, bool *config_changed,
+               xmlNode **current_cib, xmlNode **result_cib, xmlNode **diff,
+               xmlNode **output)
 {
     int rc = pcmk_rc_ok;
 
@@ -459,6 +460,7 @@ cib_perform_op(enum cib_variant variant, uint32_t call_options, cib__op_fn_t fn,
 
     const char *op = NULL;
     const char *user = NULL;
+    uint32_t call_options = cib_none;
     bool enable_acl = false;
     bool manage_version = true;
 
@@ -471,6 +473,8 @@ cib_perform_op(enum cib_variant variant, uint32_t call_options, cib__op_fn_t fn,
 
     op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
     user = pcmk__xe_get(req, PCMK__XA_CIB_USER);
+    pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &call_options, cib_none);
+
     enable_acl = cib_acl_enabled(*current_cib, user);
 
     if (!should_copy_cib(op, section, call_options)) {

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -185,11 +185,12 @@ get_op_input(const xmlNode *request)
 }
 
 int
-cib__perform_query(cib__op_fn_t fn, const char *section, xmlNode *req,
-                   xmlNode **current_cib, xmlNode **output)
+cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
+                   xmlNode **output)
 {
     int rc = pcmk_rc_ok;
     const char *op = NULL;
+    const char *section = NULL;
     const char *user = NULL;
     uint32_t call_options = cib_none;
     xmlNode *input = NULL;
@@ -202,6 +203,7 @@ cib__perform_query(cib__op_fn_t fn, const char *section, xmlNode *req,
                  && (output != NULL) && (*output == NULL));
 
     op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
+    section = pcmk__xe_get(req, PCMK__XA_CIB_SECTION);
     user = pcmk__xe_get(req, PCMK__XA_CIB_USER);
     pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &call_options, cib_none);
 
@@ -460,13 +462,14 @@ set_update_origin(xmlNode *new_cib, const xmlNode *request)
 }
 
 int
-cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, const char *section,
-               xmlNode *req, bool *config_changed, xmlNode **current_cib,
+cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
+               bool *config_changed, xmlNode **current_cib,
                xmlNode **result_cib, xmlNode **diff, xmlNode **output)
 {
     int rc = pcmk_rc_ok;
 
     const char *op = NULL;
+    const char *section = NULL;
     const char *user = NULL;
     uint32_t call_options = cib_none;
     xmlNode *input = NULL;
@@ -490,6 +493,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, const char *section,
                  && (output != NULL) && (*output == NULL));
 
     op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
+    section = pcmk__xe_get(req, PCMK__XA_CIB_SECTION);
     user = pcmk__xe_get(req, PCMK__XA_CIB_USER);
     pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &call_options, cib_none);
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -170,20 +170,22 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 }
 
 int
-cib__perform_query(const char *op, uint32_t call_options, cib__op_fn_t fn,
-                   const char *section, xmlNode *req, xmlNode *input,
-                   xmlNode **current_cib, xmlNode **output)
+cib__perform_query(uint32_t call_options, cib__op_fn_t fn, const char *section,
+                   xmlNode *req, xmlNode *input, xmlNode **current_cib,
+                   xmlNode **output)
 {
     int rc = pcmk_rc_ok;
+    const char *op = NULL;
     const char *user = NULL;
 
     xmlNode *cib = NULL;
     xmlNode *cib_filtered = NULL;
 
-    pcmk__assert((op != NULL) && (fn != NULL) && (req != NULL)
+    pcmk__assert((fn != NULL) && (req != NULL)
                  && (current_cib != NULL) && (*current_cib != NULL)
                  && (output != NULL) && (*output == NULL));
 
+    op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
     user = pcmk__xe_get(req, PCMK__XA_CIB_USER);
     cib = *current_cib;
 
@@ -439,9 +441,9 @@ set_update_origin(xmlNode *new_cib, const xmlNode *request)
 }
 
 int
-cib_perform_op(enum cib_variant variant, const char *op, uint32_t call_options,
-               cib__op_fn_t fn, const char *section, xmlNode *req,
-               xmlNode *input, bool *config_changed, xmlNode **current_cib,
+cib_perform_op(enum cib_variant variant, uint32_t call_options, cib__op_fn_t fn,
+               const char *section, xmlNode *req, xmlNode *input,
+               bool *config_changed, xmlNode **current_cib,
                xmlNode **result_cib, xmlNode **diff, xmlNode **output)
 {
     int rc = pcmk_rc_ok;
@@ -455,17 +457,19 @@ cib_perform_op(enum cib_variant variant, const char *op, uint32_t call_options,
     xmlNode *top = NULL;
     xmlNode *working_cib = NULL;
 
+    const char *op = NULL;
     const char *user = NULL;
     bool enable_acl = false;
     bool manage_version = true;
 
-    pcmk__assert((op != NULL) && (fn != NULL) && (req != NULL)
+    pcmk__assert((fn != NULL) && (req != NULL)
                  && (config_changed != NULL) && (!*config_changed)
                  && (current_cib != NULL) && (*current_cib != NULL)
                  && (result_cib != NULL) && (*result_cib == NULL)
                  && (diff != NULL) && (*diff == NULL)
                  && (output != NULL) && (*output == NULL));
 
+    op = pcmk__xe_get(req, PCMK__XA_CIB_OP);
     user = pcmk__xe_get(req, PCMK__XA_CIB_USER);
     enable_acl = cib_acl_enabled(*current_cib, user);
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -171,23 +171,17 @@ cib_acl_enabled(xmlNode *xml, const char *user)
 
 /*!
  * \internal
- * \brief Get input data from a CIB request, based on section and call data
+ * \brief Get input data from a CIB request
  *
  * \param[in] request  CIB request XML
  */
 static xmlNode *
 get_op_input(const xmlNode *request)
 {
-    const char *section = pcmk__xe_get(request, PCMK__XA_CIB_SECTION);
     xmlNode *wrapper = pcmk__xe_first_child(request, PCMK__XE_CIB_CALLDATA,
                                             NULL, NULL);
-    xmlNode *input = pcmk__xe_first_child(wrapper, NULL, NULL, NULL);
 
-    if ((section == NULL) || !pcmk__xe_is(input, PCMK_XE_CIB)) {
-        return input;
-    }
-
-    return pcmk_find_cib_element(input, section);
+    return pcmk__xe_first_child(wrapper, NULL, NULL, NULL);
 }
 
 int

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -226,7 +226,7 @@ cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
                 pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
     pcmk__log_xml_trace(req, "request");
 
-    rc = fn(section, req, input, &cib, output);
+    rc = fn(req, input, &cib, output);
 
     if (*output == NULL) {
         // Do nothing
@@ -530,7 +530,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         }
     }
 
-    rc = fn(section, req, input, cib, output);
+    rc = fn(req, input, cib, output);
     if (rc != pcmk_rc_ok) {
         goto done;
     }
@@ -891,7 +891,7 @@ cib_apply_patch_event(xmlNode *event, xmlNode *input, xmlNode **output,
         *output = pcmk__xml_copy(NULL, input);
     }
 
-    rc = cib__process_apply_patch(NULL, event, diff, output, NULL);
+    rc = cib__process_apply_patch(event, diff, output, NULL);
     rc = pcmk_rc2legacy(rc);
     if (rc == pcmk_ok) {
         return pcmk_ok;

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -226,7 +226,7 @@ cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
                 pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
     pcmk__log_xml_trace(req, "request");
 
-    rc = fn(op, call_options, section, req, input, &cib, output);
+    rc = fn(call_options, section, req, input, &cib, output);
 
     if (*output == NULL) {
         // Do nothing
@@ -530,7 +530,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         }
     }
 
-    rc = fn(op, call_options, section, req, input, cib, output);
+    rc = fn(call_options, section, req, input, cib, output);
     if (rc != pcmk_rc_ok) {
         goto done;
     }
@@ -891,8 +891,7 @@ cib_apply_patch_event(xmlNode *event, xmlNode *input, xmlNode **output,
         *output = pcmk__xml_copy(NULL, input);
     }
 
-    rc = cib__process_apply_patch(NULL, cib_none, NULL, event, diff, output,
-                                  NULL);
+    rc = cib__process_apply_patch(cib_none, NULL, event, diff, output, NULL);
     rc = pcmk_rc2legacy(rc);
     if (rc == pcmk_ok) {
         return pcmk_ok;

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -226,7 +226,7 @@ cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
                 pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
     pcmk__log_xml_trace(req, "request");
 
-    rc = fn(call_options, section, req, input, &cib, output);
+    rc = fn(section, req, input, &cib, output);
 
     if (*output == NULL) {
         // Do nothing
@@ -530,7 +530,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         }
     }
 
-    rc = fn(call_options, section, req, input, cib, output);
+    rc = fn(section, req, input, cib, output);
     if (rc != pcmk_rc_ok) {
         goto done;
     }
@@ -891,7 +891,7 @@ cib_apply_patch_event(xmlNode *event, xmlNode *input, xmlNode **output,
         *output = pcmk__xml_copy(NULL, input);
     }
 
-    rc = cib__process_apply_patch(cib_none, NULL, event, diff, output, NULL);
+    rc = cib__process_apply_patch(NULL, event, diff, output, NULL);
     rc = pcmk_rc2legacy(rc);
     if (rc == pcmk_ok) {
         return pcmk_ok;

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -508,37 +508,29 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         pcmk__xe_copy_attrs(top, *cib, pcmk__xaf_none);
         old_versions = top;
 
-        if (pcmk__is_set(call_options, cib_transaction)) {
-            /* This is a request within a transaction, so don't commit changes
-             * yet. On success, we'll commit when we finish performing the whole
-             * commit-transaction operation. The tracking flag is already set,
-             * and ACLs have already been unpacked and applied.
-             */
-            pcmk__assert(pcmk__xml_doc_all_flags_set((*cib)->doc,
-                                                     pcmk__xf_tracking));
-
-        } else {
-            pcmk__xml_commit_changes((*cib)->doc);
-            pcmk__xml_doc_set_flags((*cib)->doc, pcmk__xf_tracking);
-            if (enable_acl) {
-                pcmk__enable_acls((*cib)->doc, (*cib)->doc, user);
-            }
-        }
-
-        rc = fn(op, call_options, section, req, input, cib, output);
-
     } else {
         old_versions = *cib;
         *cib = pcmk__xml_copy(NULL, *cib);
+    }
 
+    if (pcmk__is_set(call_options, cib_transaction)) {
+        /* This is a request within a transaction, so don't commit changes yet.
+         * On success, we'll commit when we finish performing the whole commit-
+         * transaction operation. The tracking flag is already set, and ACLs
+         * have already been unpacked and applied.
+         */
+        pcmk__assert(pcmk__xml_doc_all_flags_set((*cib)->doc,
+                                                 pcmk__xf_tracking));
+
+    } else {
+        pcmk__xml_commit_changes((*cib)->doc);
         pcmk__xml_doc_set_flags((*cib)->doc, pcmk__xf_tracking);
         if (enable_acl) {
             pcmk__enable_acls((*cib)->doc, (*cib)->doc, user);
         }
-
-        rc = fn(op, call_options, section, req, input, cib, output);
     }
 
+    rc = fn(op, call_options, section, req, input, cib, output);
     if (rc != pcmk_rc_ok) {
         goto done;
     }

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -500,6 +500,10 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     input = get_op_input(req);
     enable_acl = cib_acl_enabled(*current_cib, user);
 
+    pcmk__trace("Processing %s for section '%s', user '%s'", op,
+                pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
+    pcmk__log_xml_trace(req, "request");
+
     if (!should_copy_cib(op, section, call_options)) {
         // Make a copy of the top-level element to store version details
         top = pcmk__xe_create(NULL, (const char *) (*current_cib)->name);
@@ -524,10 +528,6 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
             }
         }
 
-        pcmk__trace("Processing %s for section '%s', user '%s'", op,
-                    pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
-        pcmk__log_xml_trace(req, "request");
-
         rc = fn(op, call_options, section, req, input, current_cib, output);
 
         /* Set working_cib to *current_cib after fn(), in case *current_cib
@@ -544,10 +544,6 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         if (enable_acl) {
             pcmk__enable_acls((*current_cib)->doc, working_cib->doc, user);
         }
-
-        pcmk__trace("Processing %s for section '%s', user '%s'", op,
-                    pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
-        pcmk__log_xml_trace(req, "request");
 
         rc = fn(op, call_options, section, req, input, &working_cib, output);
     }

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -560,9 +560,6 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         pcmk__assert(*current_cib != working_cib);
     }
 
-    // Allow ourselves to make any additional necessary changes
-    xml_acl_disable(working_cib);
-
     if (rc != pcmk_rc_ok) {
         goto done;
     }
@@ -571,6 +568,9 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         rc = EINVAL;
         goto done;
     }
+
+    // Allow ourselves to make any additional necessary changes
+    xml_acl_disable(working_cib);
 
     if (xml_acl_denied(working_cib)) {
         pcmk__trace("ACL rejected part or all of the proposed changes");

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -463,8 +463,8 @@ set_update_origin(xmlNode *new_cib, const xmlNode *request)
 
 int
 cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
-               bool *config_changed, xmlNode **current_cib,
-               xmlNode **result_cib, xmlNode **diff, xmlNode **output)
+               bool *config_changed, xmlNode **cib, xmlNode **diff,
+               xmlNode **output)
 {
     int rc = pcmk_rc_ok;
 
@@ -487,8 +487,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
 
     pcmk__assert((fn != NULL) && (req != NULL)
                  && (config_changed != NULL) && (!*config_changed)
-                 && (current_cib != NULL) && (*current_cib != NULL)
-                 && (result_cib != NULL) && (*result_cib == NULL)
+                 && (cib != NULL) && (*cib != NULL)
                  && (diff != NULL) && (*diff == NULL)
                  && (output != NULL) && (*output == NULL));
 
@@ -498,7 +497,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     pcmk__xe_get_flags(req, PCMK__XA_CIB_CALLOPT, &call_options, cib_none);
 
     input = get_op_input(req);
-    enable_acl = cib_acl_enabled(*current_cib, user);
+    enable_acl = cib_acl_enabled(*cib, user);
 
     pcmk__trace("Processing %s for section '%s', user '%s'", op,
                 pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
@@ -506,8 +505,8 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
 
     if (!should_copy_cib(op, section, call_options)) {
         // Make a copy of the top-level element to store version details
-        top = pcmk__xe_create(NULL, (const char *) (*current_cib)->name);
-        pcmk__xe_copy_attrs(top, *current_cib, pcmk__xaf_none);
+        top = pcmk__xe_create(NULL, (const char *) (*cib)->name);
+        pcmk__xe_copy_attrs(top, *cib, pcmk__xaf_none);
         old_versions = top;
 
         if (pcmk__is_set(call_options, cib_transaction)) {
@@ -516,33 +515,31 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
              * commit-transaction operation. The tracking flag is already set,
              * and ACLs have already been unpacked and applied.
              */
-            pcmk__assert(pcmk__xml_doc_all_flags_set((*current_cib)->doc,
+            pcmk__assert(pcmk__xml_doc_all_flags_set((*cib)->doc,
                                                      pcmk__xf_tracking));
 
         } else {
-            pcmk__xml_commit_changes((*current_cib)->doc);
-            pcmk__xml_doc_set_flags((*current_cib)->doc, pcmk__xf_tracking);
+            pcmk__xml_commit_changes((*cib)->doc);
+            pcmk__xml_doc_set_flags((*cib)->doc, pcmk__xf_tracking);
             if (enable_acl) {
-                pcmk__enable_acls((*current_cib)->doc, (*current_cib)->doc,
-                                  user);
+                pcmk__enable_acls((*cib)->doc, (*cib)->doc, user);
             }
         }
 
-        rc = fn(op, call_options, section, req, input, current_cib, output);
+        rc = fn(op, call_options, section, req, input, cib, output);
 
-        /* Set working_cib to *current_cib after fn(), in case *current_cib
-         * points somewhere else now (for example, after a erase or full-CIB
-         * replace op).
+        /* Set working_cib to *cib after fn(), in case *cib points somewhere
+         * else now (for example, after a full-CIB replace op).
          */
-        working_cib = *current_cib;
+        working_cib = *cib;
 
     } else {
-        working_cib = pcmk__xml_copy(NULL, *current_cib);
-        old_versions = *current_cib;
+        working_cib = pcmk__xml_copy(NULL, *cib);
+        old_versions = *cib;
 
         pcmk__xml_doc_set_flags(working_cib->doc, pcmk__xf_tracking);
         if (enable_acl) {
-            pcmk__enable_acls((*current_cib)->doc, working_cib->doc, user);
+            pcmk__enable_acls((*cib)->doc, working_cib->doc, user);
         }
 
         rc = fn(op, call_options, section, req, input, &working_cib, output);
@@ -635,15 +632,15 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     }
 
 done:
-    *result_cib = working_cib;
+    *cib = working_cib;
 
     /* @TODO This may not work correctly when !should_copy_cib(), since we don't
      * keep the original CIB.
      */
     if ((rc != pcmk_rc_ok) && cib_acl_enabled(old_versions, user)
-        && xml_acl_filtered_copy(user, old_versions, working_cib, result_cib)) {
+        && xml_acl_filtered_copy(user, old_versions, working_cib, cib)) {
 
-        if (*result_cib == NULL) {
+        if (*cib == NULL) {
             pcmk__debug("Pre-filtered the entire cib result");
         }
         pcmk__xml_free(working_cib);

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -197,6 +197,8 @@ cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
 
     xmlNode *cib = NULL;
     xmlNode *cib_filtered = NULL;
+    const xmlNode *saved_cib = NULL;
+    const xmlDoc *saved_doc = NULL;
 
     pcmk__assert((fn != NULL) && (req != NULL)
                  && (current_cib != NULL) && (*current_cib != NULL)
@@ -226,7 +228,16 @@ cib__perform_query(cib__op_fn_t fn, xmlNode *req, xmlNode **current_cib,
                 pcmk__s(section, "(null)"), pcmk__s(user, "(null)"));
     pcmk__log_xml_trace(req, "request");
 
+    saved_cib = cib;
+    saved_doc = cib->doc;
+
     rc = fn(req, input, &cib, output);
+
+    /* Sanity check: op should be read-only (but this does not check children,
+     * attributes, or private data)
+     */
+    pcmk__assert((cib == saved_cib) && (cib->doc == saved_doc)
+                 && (cib == xmlDocGetRootElement(cib->doc)));
 
     if (*output == NULL) {
         // Do nothing
@@ -483,6 +494,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     xmlNode *old_versions = NULL;
 
     xmlNode *top = NULL;
+    const xmlDoc *saved_doc = NULL;
 
     pcmk__assert((fn != NULL) && (req != NULL)
                  && (config_changed != NULL) && (!*config_changed)
@@ -530,6 +542,8 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         }
     }
 
+    saved_doc = (*cib)->doc;
+
     rc = fn(req, input, cib, output);
     if (rc != pcmk_rc_ok) {
         goto done;
@@ -539,6 +553,10 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         rc = EINVAL;
         goto done;
     }
+
+    // Sanity check: doc should not change and *cib must be the root
+    pcmk__assert(((*cib)->doc == saved_doc)
+                 && (*cib == xmlDocGetRootElement((*cib)->doc)));
 
     // Tracking flag should still be set after operation
     pcmk__assert(pcmk__xml_doc_all_flags_set((*cib)->doc, pcmk__xf_tracking));

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -483,7 +483,6 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     xmlNode *old_versions = NULL;
 
     xmlNode *top = NULL;
-    xmlNode *working_cib = NULL;
 
     pcmk__assert((fn != NULL) && (req != NULL)
                  && (config_changed != NULL) && (!*config_changed)
@@ -528,40 +527,34 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
 
         rc = fn(op, call_options, section, req, input, cib, output);
 
-        /* Set working_cib to *cib after fn(), in case *cib points somewhere
-         * else now (for example, after a full-CIB replace op).
-         */
-        working_cib = *cib;
-
     } else {
-        working_cib = pcmk__xml_copy(NULL, *cib);
         old_versions = *cib;
+        *cib = pcmk__xml_copy(NULL, *cib);
 
-        pcmk__xml_doc_set_flags(working_cib->doc, pcmk__xf_tracking);
+        pcmk__xml_doc_set_flags((*cib)->doc, pcmk__xf_tracking);
         if (enable_acl) {
-            pcmk__enable_acls((*cib)->doc, working_cib->doc, user);
+            pcmk__enable_acls((*cib)->doc, (*cib)->doc, user);
         }
 
-        rc = fn(op, call_options, section, req, input, &working_cib, output);
+        rc = fn(op, call_options, section, req, input, cib, output);
     }
 
     if (rc != pcmk_rc_ok) {
         goto done;
     }
 
-    if (working_cib == NULL) {
+    if (*cib == NULL) {
         rc = EINVAL;
         goto done;
     }
 
     // Tracking flag should still be set after operation
-    pcmk__assert(pcmk__xml_doc_all_flags_set(working_cib->doc,
-                                             pcmk__xf_tracking));
+    pcmk__assert(pcmk__xml_doc_all_flags_set((*cib)->doc, pcmk__xf_tracking));
 
     // Allow ourselves to make any additional necessary changes
-    xml_acl_disable(working_cib);
+    xml_acl_disable(*cib);
 
-    if (xml_acl_denied(working_cib)) {
+    if (xml_acl_denied(*cib)) {
         pcmk__trace("ACL rejected part or all of the proposed changes");
         rc = EACCES;
         goto done;
@@ -572,15 +565,15 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
      * is checked elsewhere.
      */
     if (variant != cib_file) {
-        rc = check_new_feature_set(working_cib);
+        rc = check_new_feature_set(*cib);
         if (rc != pcmk_rc_ok) {
             goto done;
         }
     }
 
-    rc = check_cib_versions(old_versions, working_cib, req, input);
+    rc = check_cib_versions(old_versions, *cib, req, input);
 
-    pcmk__strip_xml_text(working_cib);
+    pcmk__strip_xml_text(*cib);
 
     if (pcmk__xe_attr_is_true(req, PCMK__XA_CIB_UPDATE)) {
         /* This is a replace operation as a reply to a sync request. Keep
@@ -592,7 +585,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     /* If we didn't make a copy, the diff will only be accurate for the
      * top-level PCMK_XE_CIB element
      */
-    *diff = xml_create_patchset(0, old_versions, working_cib, config_changed,
+    *diff = xml_create_patchset(0, old_versions, *cib, config_changed,
                                 manage_version);
 
     /* pcmk__xml_commit_changes() resets document private data, so call it even
@@ -600,7 +593,7 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
      * commit changes later, as part of the commit-transaction operation.
      */
     if (!pcmk__is_set(call_options, cib_transaction)) {
-        pcmk__xml_commit_changes(working_cib->doc);
+        pcmk__xml_commit_changes((*cib)->doc);
     }
 
     if (*diff == NULL) {
@@ -612,12 +605,12 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
      */
     pcmk__log_xml_patchset(LOG_INFO, *diff);
 
-    /* working_cib must not be modified after this point, except for the
-     * attributes for which pcmk__xa_filterable() returns true
+    /* *cib must not be modified after this point, except for the attributes for
+     * which pcmk__xa_filterable() returns true
      */
 
     if (*config_changed && !pcmk__is_set(call_options, cib_no_mtime)) {
-        rc = set_update_origin(working_cib, req);
+        rc = set_update_origin(*cib, req);
         if (rc != pcmk_rc_ok) {
             goto done;
         }
@@ -626,24 +619,24 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
     // Skip validation for status-only updates, since we allow anything there
     if ((rc == pcmk_rc_ok)
         && !pcmk__str_eq(section, PCMK_XE_STATUS, pcmk__str_casei)
-        && !pcmk__configured_schema_validates(working_cib)) {
+        && !pcmk__configured_schema_validates(*cib)) {
 
         rc = pcmk_rc_schema_validation;
     }
 
 done:
-    *cib = working_cib;
-
     /* @TODO This may not work correctly when !should_copy_cib(), since we don't
      * keep the original CIB.
      */
-    if ((rc != pcmk_rc_ok) && cib_acl_enabled(old_versions, user)
-        && xml_acl_filtered_copy(user, old_versions, working_cib, cib)) {
+    if ((rc != pcmk_rc_ok) && cib_acl_enabled(old_versions, user)) {
+        xmlNode *saved_cib = *cib;
 
-        if (*cib == NULL) {
-            pcmk__debug("Pre-filtered the entire cib result");
+        if (xml_acl_filtered_copy(user, old_versions, *cib, cib)) {
+            if (*cib == NULL) {
+                pcmk__debug("Pre-filtered the entire cib result");
+            }
+            pcmk__xml_free(saved_cib);
         }
-        pcmk__xml_free(working_cib);
     }
 
     pcmk__xml_free(top);

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -506,10 +506,22 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         pcmk__xe_copy_attrs(top, *current_cib, pcmk__xaf_none);
         old_versions = top;
 
-        pcmk__xml_commit_changes((*current_cib)->doc);
-        pcmk__xml_doc_set_flags((*current_cib)->doc, pcmk__xf_tracking);
-        if (enable_acl) {
-            pcmk__enable_acls((*current_cib)->doc, (*current_cib)->doc, user);
+        if (pcmk__is_set(call_options, cib_transaction)) {
+            /* This is a request within a transaction, so don't commit changes
+             * yet. On success, we'll commit when we finish performing the whole
+             * commit-transaction operation. The tracking flag is already set,
+             * and ACLs have already been unpacked and applied.
+             */
+            pcmk__assert(pcmk__xml_doc_all_flags_set((*current_cib)->doc,
+                                                     pcmk__xf_tracking));
+
+        } else {
+            pcmk__xml_commit_changes((*current_cib)->doc);
+            pcmk__xml_doc_set_flags((*current_cib)->doc, pcmk__xf_tracking);
+            if (enable_acl) {
+                pcmk__enable_acls((*current_cib)->doc, (*current_cib)->doc,
+                                  user);
+            }
         }
 
         pcmk__trace("Processing %s for section '%s', user '%s'", op,
@@ -523,11 +535,6 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
          * replace op).
          */
         working_cib = *current_cib;
-
-        /* @TODO Enable tracking and ACLs and calculate changes? If working_cib
-         * and *current_cib point to a new object, then change tracking and
-         * unpacked ACLs didn't carry over to it.
-         */
 
     } else {
         working_cib = pcmk__xml_copy(NULL, *current_cib);
@@ -543,21 +550,6 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         pcmk__log_xml_trace(req, "request");
 
         rc = fn(op, call_options, section, req, input, &working_cib, output);
-
-        /* @TODO This appears to be a hack to determine whether working_cib
-         * points to a new object now, without saving the old pointer (which may
-         * be invalid now) for comparison. Confirm this, and check more clearly.
-         */
-        if (!pcmk__xml_doc_all_flags_set(working_cib->doc, pcmk__xf_tracking)) {
-            pcmk__trace("Inferring changes after %s op", op);
-            pcmk__xml_commit_changes(working_cib->doc);
-            if (enable_acl) {
-                pcmk__enable_acls((*current_cib)->doc, working_cib->doc, user);
-            }
-            pcmk__xml_mark_changes(*current_cib, working_cib);
-        }
-
-        pcmk__assert(*current_cib != working_cib);
     }
 
     if (rc != pcmk_rc_ok) {
@@ -568,6 +560,10 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
         rc = EINVAL;
         goto done;
     }
+
+    // Tracking flag should still be set after operation
+    pcmk__assert(pcmk__xml_doc_all_flags_set(working_cib->doc,
+                                             pcmk__xf_tracking));
 
     // Allow ourselves to make any additional necessary changes
     xml_acl_disable(working_cib);
@@ -607,14 +603,20 @@ cib_perform_op(enum cib_variant variant, cib__op_fn_t fn, xmlNode *req,
                                 manage_version);
 
     /* pcmk__xml_commit_changes() resets document private data, so call it even
-     * if there were no changes.
+     * if there were no changes. If this request is part of a transaction, we'll
+     * commit changes later, as part of the commit-transaction operation.
      */
-    pcmk__xml_commit_changes(working_cib->doc);
+    if (!pcmk__is_set(call_options, cib_transaction)) {
+        pcmk__xml_commit_changes(working_cib->doc);
+    }
 
     if (*diff == NULL) {
         goto done;
     }
 
+    /* If this request is within a transaction, *diff is the cumulative set of
+     * changes so far, since we don't commit changes between requests.
+     */
     pcmk__log_xml_patchset(LOG_INFO, *diff);
 
     /* working_cib must not be modified after this point, except for the

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -1018,7 +1018,7 @@ apply_transformation(xmlDoc *doc, const char *transform, bool to_logs)
  * \internal
  * \brief Perform all transformations needed to upgrade XML to next schema
  *
- * \param[in] input_xml     XML to transform
+ * \param[in] input_doc     XML document to transform
  * \param[in] schema_index  Index of schema that successfully validates
  *                          \p original_xml
  * \param[in] to_logs       If false, certain validation errors will be sent to
@@ -1026,14 +1026,14 @@ apply_transformation(xmlDoc *doc, const char *transform, bool to_logs)
  *
  * \return XML result of schema transforms if successful, otherwise NULL
  */
-static xmlNode *
-apply_upgrade(const xmlNode *input_xml, int schema_index, gboolean to_logs)
+static xmlDoc *
+apply_upgrade(xmlDoc *input_doc, int schema_index, bool to_logs)
 {
     pcmk__schema_t *schema = g_list_nth_data(known_schemas, schema_index);
     pcmk__schema_t *upgraded_schema = g_list_nth_data(known_schemas,
                                                       schema_index + 1);
 
-    xmlNode *old_xml = NULL;
+    xmlDoc *old_doc = NULL;
     xmlDoc *new_doc = NULL;
     xmlNode *new_xml = NULL;
     xmlRelaxNGValidityErrorFunc error_handler = NULL;
@@ -1051,22 +1051,23 @@ apply_upgrade(const xmlNode *input_xml, int schema_index, gboolean to_logs)
         pcmk__debug("Upgrading schema from %s to %s: applying XSL transform %s",
                     schema->name, upgraded_schema->name, transform);
 
-        new_doc = apply_transformation(input_xml->doc, transform, to_logs);
-        pcmk__xml_free(old_xml);
+        new_doc = apply_transformation(input_doc, transform, to_logs);
+        pcmk__xml_free_doc(old_doc);
 
         if (new_doc == NULL) {
             pcmk__err("XSL transform %s failed, aborting upgrade", transform);
             return NULL;
         }
 
-        new_xml = xmlDocGetRootElement(new_doc);
-        input_xml = new_xml;
-        old_xml = new_xml;
+        input_doc = new_doc;
+        old_doc = new_doc;
     }
 
     // Final result document from upgrade pipeline needs private data
+    pcmk__xml_new_private_data((xmlNode *) new_doc);
+
+    new_xml = xmlDocGetRootElement(new_doc);
     pcmk__assert(new_xml != NULL);
-    pcmk__xml_new_private_data((xmlNode *) new_xml->doc);
 
     // Ensure result validates with its new schema
     if (!validate_with(new_xml, upgraded_schema, error_handler,
@@ -1081,7 +1082,7 @@ apply_upgrade(const xmlNode *input_xml, int schema_index, gboolean to_logs)
 
     pcmk__info("Schema upgrade from %s to %s succeeded", schema->name,
                upgraded_schema->name);
-    return new_xml;
+    return new_doc;
 }
 
 /*!
@@ -1125,11 +1126,14 @@ pcmk__update_schema(xmlNode **xml, const char *max_schema_name, bool transform,
     GList *entry = NULL;
     pcmk__schema_t *best_schema = NULL;
     pcmk__schema_t *original_schema = NULL;
-    xmlRelaxNGValidityErrorFunc error_handler = 
-        to_logs ? (xmlRelaxNGValidityErrorFunc) xml_log : NULL;
+    xmlRelaxNGValidityErrorFunc error_handler = NULL;
 
     CRM_CHECK((xml != NULL) && (*xml != NULL) && ((*xml)->doc != NULL),
               return EINVAL);
+
+    if (to_logs) {
+        error_handler = (xmlRelaxNGValidityErrorFunc) xml_log;
+    }
 
     if (max_schema_name != NULL) {
         GList *max_entry = pcmk__get_schema(max_schema_name);
@@ -1155,7 +1159,7 @@ pcmk__update_schema(xmlNode **xml, const char *max_schema_name, bool transform,
 
     for (; entry != NULL; entry = entry->next) {
         pcmk__schema_t *current_schema = entry->data;
-        xmlNode *upgrade = NULL;
+        xmlDoc *upgrade = NULL;
 
         if (current_schema->schema_index > max_schema_index) {
             break;
@@ -1189,17 +1193,19 @@ pcmk__update_schema(xmlNode **xml, const char *max_schema_name, bool transform,
             continue;
         }
 
-        upgrade = apply_upgrade(*xml, current_schema->schema_index, to_logs);
+        upgrade = apply_upgrade((*xml)->doc, current_schema->schema_index,
+                                to_logs);
         if (upgrade == NULL) {
             /* The transform failed, so this schema can't be used. Later
              * schemas are unlikely to validate, but try anyway until we
              * run out of options.
              */
             rc = pcmk_rc_transform_failed;
+
         } else {
             best_schema = current_schema;
             pcmk__xml_free(*xml);
-            *xml = upgrade;
+            *xml = xmlDocGetRootElement(upgrade);
         }
     }
 

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -785,11 +785,13 @@ validate_with(xmlDoc *doc, pcmk__schema_t *schema,
 }
 
 static bool
-validate_with_silent(xmlNode *xml, pcmk__schema_t *schema)
+validate_with_silent(xmlDoc *doc, pcmk__schema_t *schema)
 {
-    bool rc, sl_backup = silent_logging;
+    bool rc = false;
+    bool sl_backup = silent_logging;
+
     silent_logging = TRUE;
-    rc = validate_with(xml->doc, schema, (xmlRelaxNGValidityErrorFunc) xml_log,
+    rc = validate_with(doc, schema, (xmlRelaxNGValidityErrorFunc) xml_log,
                        GUINT_TO_POINTER(LOG_ERR));
     silent_logging = sl_backup;
     return rc;
@@ -1185,7 +1187,7 @@ pcmk__update_schema(xmlNode **xml, const char *max_schema_name, bool transform,
 
         // coverity[null_field] The index check ensures entry->next is not NULL
         if (!transform || (current_schema->transforms == NULL)
-            || validate_with_silent(*xml, entry->next->data)) {
+            || validate_with_silent((*xml)->doc, entry->next->data)) {
             /* The next schema either doesn't require a transform or validates
              * successfully even without the transform. Skip the transform and
              * try the next schema with the same XML.

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -967,23 +967,21 @@ cib_upgrade_err(void *ctx, const char *fmt, ...)
 
 /*!
  * \internal
- * \brief Apply a single XSL transformation to given XML
+ * \brief Apply a single XSL transformation to the given XML document
  *
- * \param[in] xml        XML to transform
+ * \param[in] doc        XML document
  * \param[in] transform  XSL name
  * \param[in] to_logs    If false, certain validation errors will be sent to
  *                       stderr rather than logged
  *
  * \return Transformed XML on success, otherwise NULL
  */
-static xmlNode *
-apply_transformation(const xmlNode *xml, const char *transform,
-                     gboolean to_logs)
+static xmlDoc *
+apply_transformation(xmlDoc *doc, const char *transform, bool to_logs)
 {
     char *xform = NULL;
-    xmlNode *out = NULL;
-    xmlDocPtr res = NULL;
     xsltStylesheet *xslt = NULL;
+    xmlDoc *result_doc = NULL;
 
     xform = pcmk__xml_artefact_path(pcmk__xml_artefact_ns_legacy_xslt,
                                     transform);
@@ -1001,12 +999,10 @@ apply_transformation(const xmlNode *xml, const char *transform,
     /* Caller allocates private data for final result document. Intermediate
      * result documents are temporary and don't need private data.
      */
-    res = xsltApplyStylesheet(xslt, xml->doc, NULL);
-    CRM_CHECK(res != NULL, goto cleanup);
+    result_doc = xsltApplyStylesheet(xslt, doc, NULL);
+    CRM_CHECK(result_doc != NULL, goto cleanup);
 
     xsltSetGenericErrorFunc(NULL, NULL);  /* restore default one */
-
-    out = xmlDocGetRootElement(res);
 
   cleanup:
     if (xslt) {
@@ -1015,7 +1011,7 @@ apply_transformation(const xmlNode *xml, const char *transform,
 
     free(xform);
 
-    return out;
+    return result_doc;
 }
 
 /*!
@@ -1038,6 +1034,7 @@ apply_upgrade(const xmlNode *input_xml, int schema_index, gboolean to_logs)
                                                       schema_index + 1);
 
     xmlNode *old_xml = NULL;
+    xmlDoc *new_doc = NULL;
     xmlNode *new_xml = NULL;
     xmlRelaxNGValidityErrorFunc error_handler = NULL;
 
@@ -1054,13 +1051,15 @@ apply_upgrade(const xmlNode *input_xml, int schema_index, gboolean to_logs)
         pcmk__debug("Upgrading schema from %s to %s: applying XSL transform %s",
                     schema->name, upgraded_schema->name, transform);
 
-        new_xml = apply_transformation(input_xml, transform, to_logs);
+        new_doc = apply_transformation(input_xml->doc, transform, to_logs);
         pcmk__xml_free(old_xml);
 
-        if (new_xml == NULL) {
+        if (new_doc == NULL) {
             pcmk__err("XSL transform %s failed, aborting upgrade", transform);
             return NULL;
         }
+
+        new_xml = xmlDocGetRootElement(new_doc);
         input_xml = new_xml;
         old_xml = new_xml;
     }

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -798,18 +798,16 @@ validate_with_silent(xmlDoc *doc, pcmk__schema_t *schema)
 }
 
 bool
-pcmk__validate_xml(xmlNode *xml_blob, const char *validation,
-                   xmlRelaxNGValidityErrorFunc error_handler,
+pcmk__validate_xml(xmlNode *xml, xmlRelaxNGValidityErrorFunc error_handler,
                    void *error_handler_context)
 {
+    const char *validation = NULL;
     GList *entry = NULL;
     pcmk__schema_t *schema = NULL;
 
-    CRM_CHECK((xml_blob != NULL) && (xml_blob->doc != NULL), return false);
+    CRM_CHECK((xml != NULL) && (xml->doc != NULL), return false);
 
-    if (validation == NULL) {
-        validation = pcmk__xe_get(xml_blob, PCMK_XA_VALIDATE_WITH);
-    }
+    validation = pcmk__xe_get(xml, PCMK_XA_VALIDATE_WITH);
     pcmk__warn_if_schema_deprecated(validation);
 
     entry = pcmk__get_schema(validation);
@@ -821,7 +819,7 @@ pcmk__validate_xml(xmlNode *xml_blob, const char *validation,
     }
 
     schema = entry->data;
-    return validate_with(xml_blob->doc, schema, error_handler,
+    return validate_with(xml->doc, schema, error_handler,
                          error_handler_context);
 }
 
@@ -836,8 +834,7 @@ pcmk__validate_xml(xmlNode *xml_blob, const char *validation,
 bool
 pcmk__configured_schema_validates(xmlNode *xml)
 {
-    return pcmk__validate_xml(xml, NULL,
-                              (xmlRelaxNGValidityErrorFunc) xml_log,
+    return pcmk__validate_xml(xml, (xmlRelaxNGValidityErrorFunc) xml_log,
                               GUINT_TO_POINTER(LOG_ERR));
 }
 

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -748,7 +748,7 @@ pcmk__cmp_schemas_by_name(const char *schema1_name, const char *schema2_name)
 }
 
 static bool
-validate_with(xmlNode *xml, pcmk__schema_t *schema,
+validate_with(xmlDoc *doc, pcmk__schema_t *schema,
               xmlRelaxNGValidityErrorFunc error_handler,
               void *error_handler_context)
 {
@@ -772,7 +772,8 @@ validate_with(xmlNode *xml, pcmk__schema_t *schema,
     switch (schema->validator) {
         case pcmk__schema_validator_rng:
             cache = (relaxng_ctx_cache_t **) &(schema->cache);
-            valid = validate_with_relaxng(xml->doc, error_handler, error_handler_context, file, cache);
+            valid = validate_with_relaxng(doc, error_handler,
+                                          error_handler_context, file, cache);
             break;
         default:
             pcmk__err("Unknown validator type: %d", schema->validator);
@@ -788,7 +789,8 @@ validate_with_silent(xmlNode *xml, pcmk__schema_t *schema)
 {
     bool rc, sl_backup = silent_logging;
     silent_logging = TRUE;
-    rc = validate_with(xml, schema, (xmlRelaxNGValidityErrorFunc) xml_log, GUINT_TO_POINTER(LOG_ERR));
+    rc = validate_with(xml->doc, schema, (xmlRelaxNGValidityErrorFunc) xml_log,
+                       GUINT_TO_POINTER(LOG_ERR));
     silent_logging = sl_backup;
     return rc;
 }
@@ -817,7 +819,7 @@ pcmk__validate_xml(xmlNode *xml_blob, const char *validation,
     }
 
     schema = entry->data;
-    return validate_with(xml_blob, schema, error_handler,
+    return validate_with(xml_blob->doc, schema, error_handler,
                          error_handler_context);
 }
 
@@ -1035,7 +1037,6 @@ apply_upgrade(xmlDoc *input_doc, int schema_index, bool to_logs)
 
     xmlDoc *old_doc = NULL;
     xmlDoc *new_doc = NULL;
-    xmlNode *new_xml = NULL;
     xmlRelaxNGValidityErrorFunc error_handler = NULL;
 
     pcmk__assert((schema != NULL) && (upgraded_schema != NULL));
@@ -1065,18 +1066,17 @@ apply_upgrade(xmlDoc *input_doc, int schema_index, bool to_logs)
 
     // Final result document from upgrade pipeline needs private data
     pcmk__xml_new_private_data((xmlNode *) new_doc);
-
-    new_xml = xmlDocGetRootElement(new_doc);
-    pcmk__assert(new_xml != NULL);
+    pcmk__assert(new_doc != NULL);
 
     // Ensure result validates with its new schema
-    if (!validate_with(new_xml, upgraded_schema, error_handler,
+    if (!validate_with(new_doc, upgraded_schema, error_handler,
                        GUINT_TO_POINTER(LOG_ERR))) {
         pcmk__err("Schema upgrade from %s to %s failed: XSL transform pipeline "
                   "produced an invalid configuration",
                   schema->name, upgraded_schema->name);
-        pcmk__log_xml_debug(new_xml, "bad-transform-result");
-        pcmk__xml_free(new_xml);
+        pcmk__log_xml_debug(xmlDocGetRootElement(new_doc),
+                            "bad-transform-result");
+        pcmk__xml_free_doc(new_doc);
         return NULL;
     }
 
@@ -1165,7 +1165,7 @@ pcmk__update_schema(xmlNode **xml, const char *max_schema_name, bool transform,
             break;
         }
 
-        if (!validate_with(*xml, current_schema, error_handler,
+        if (!validate_with((*xml)->doc, current_schema, error_handler,
                            GUINT_TO_POINTER(LOG_ERR))) {
             pcmk__debug("Schema %s does not validate", current_schema->name);
             if (best_schema != NULL) {

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 the Pacemaker project contributors
+ * Copyright 2021-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -404,7 +404,7 @@ profile_file(const char *xml_file, unsigned int repeat,
         goto done;
     }
 
-    if (!pcmk__validate_xml(cib_object, NULL, NULL, NULL)) {
+    if (!pcmk__validate_xml(cib_object, NULL, NULL)) {
         goto done;
     }
 

--- a/lib/pacemaker/pcmk_verify.c
+++ b/lib/pacemaker/pcmk_verify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the Pacemaker project contributors
+ * Copyright 2023-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -83,8 +83,8 @@ pcmk__verify(pcmk_scheduler_t *scheduler, pcmk__output_t *out,
         pcmk__xe_create(*cib_object, PCMK_XE_STATUS);
     }
 
-    if (!pcmk__validate_xml(*cib_object, NULL,
-                            (xmlRelaxNGValidityErrorFunc) out->err, out)) {
+    if (!pcmk__validate_xml(*cib_object, (xmlRelaxNGValidityErrorFunc) out->err,
+                            out)) {
         pcmk__config_has_error = true;
         rc = pcmk_rc_schema_validation;
         goto verify_done;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -349,7 +349,7 @@ cibadmin_post_default(pcmk__output_t *out, cib_t *cib_conn, int call_options,
             && pcmk__xe_is(output, PCMK_XE_CIB)) {
 
             // Show validation errors to stderr
-            pcmk__validate_xml(output, NULL, NULL, NULL);
+            pcmk__validate_xml(output, NULL, NULL);
         }
         return pcmk_rc2exitc(cib_rc);
     }

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -381,7 +381,7 @@ setup_input(pcmk__output_t *out, const char *input, const char *output,
         return rc;
     }
 
-    if (!pcmk__validate_xml(cib_object, NULL, NULL, NULL)) {
+    if (!pcmk__validate_xml(cib_object, NULL, NULL)) {
         pcmk__xml_free(cib_object);
         return pcmk_rc_schema_validation;
     }


### PR DESCRIPTION
Next batch from #4011.

At time of opening this PR, I still need to run cts-lab.