### PR TITLE
 Remove NACKs from IPC code 

### DIFF
--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -596,8 +596,7 @@ attrd_ipc_dispatch(qb_ipcs_connection_t * c, void *data, size_t size)
 
     if (xml == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
         return 0;
 
     } else {

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -382,8 +382,7 @@ confirmation_timeout_cb(gpointer data)
                         client->id);
             pcmk__ipc_send_ack(client, action->ipc_id,
                                action->flags|crm_ipc_client_response,
-                               PCMK__XE_ACK, ATTRD_PROTOCOL_VERSION,
-                               CRM_EX_TIMEOUT);
+                               ATTRD_PROTOCOL_VERSION, CRM_EX_TIMEOUT);
 
             g_hash_table_iter_remove(&iter);
             pcmk__trace("%u requests now in expected confirmations table",

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -53,9 +53,9 @@
 #define ATTRD_SUPPORTS_MULTI_MESSAGE(x) ((x) >= 4)
 #define ATTRD_SUPPORTS_CONFIRMATION(x)  ((x) >= 5)
 
-#define attrd_send_ack(client, id, flags)                       \
-    pcmk__ipc_send_ack((client), (id), (flags), PCMK__XE_ACK,   \
-                       ATTRD_PROTOCOL_VERSION, CRM_EX_INDETERMINATE)
+#define attrd_send_ack(client, id, flags)                               \
+    pcmk__ipc_send_ack((client), (id), (flags), ATTRD_PROTOCOL_VERSION, \
+                       CRM_EX_INDETERMINATE)
 
 void attrd_init_mainloop(void);
 void attrd_run_mainloop(void);

--- a/daemons/based/based_ipc.c
+++ b/daemons/based/based_ipc.c
@@ -122,8 +122,7 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
 
     if (msg == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
 
@@ -200,7 +199,7 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
             status = CRM_EX_INVALID_PARAM;
         }
 
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL, status);
+        pcmk__ipc_send_ack(client, id, flags, NULL, status);
         return 0;
     }
 

--- a/daemons/based/based_ipc.c
+++ b/daemons/based/based_ipc.c
@@ -122,7 +122,7 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
 
     if (msg == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_NACK, NULL,
+        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
                            CRM_EX_PROTOCOL);
         return 0;
     }

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -403,12 +403,10 @@ dispatch_controller_ipc(qb_ipcs_connection_t * c, void *data, size_t size)
     }
 
     if (msg == NULL) {
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
-    pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                       CRM_EX_INDETERMINATE);
+    pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_INDETERMINATE);
 
     pcmk__assert(client->user != NULL);
     pcmk__update_acl_user(msg, PCMK__XA_CRM_USER, client->user);

--- a/daemons/execd/execd_ipc.c
+++ b/daemons/execd/execd_ipc.c
@@ -170,7 +170,7 @@ execd_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if ((msg == NULL) || execd_invalid_msg(msg)) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_NACK, NULL, CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
     } else {
         pcmk__request_t request = {
             .ipc_client     = client,

--- a/daemons/execd/execd_ipc.c
+++ b/daemons/execd/execd_ipc.c
@@ -170,7 +170,7 @@ execd_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if ((msg == NULL) || execd_invalid_msg(msg)) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
     } else {
         pcmk__request_t request = {
             .ipc_client     = client,

--- a/daemons/execd/execd_messages.c
+++ b/daemons/execd/execd_messages.c
@@ -395,7 +395,7 @@ static xmlNode *
 handle_unknown_request(pcmk__request_t *request)
 {
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_NACK, NULL, CRM_EX_PROTOCOL);
+                       PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
 
     pcmk__format_result(&request->result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
                         "Unknown request type '%s' (bug?)",

--- a/daemons/execd/execd_messages.c
+++ b/daemons/execd/execd_messages.c
@@ -395,7 +395,7 @@ static xmlNode *
 handle_unknown_request(pcmk__request_t *request)
 {
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
+                       NULL, CRM_EX_PROTOCOL);
 
     pcmk__format_result(&request->result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
                         "Unknown request type '%s' (bug?)",

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -127,16 +127,9 @@ lrmd_remote_client_msg(gpointer data)
 
     msg = pcmk__remote_message_xml(client->remote);
 
-    if (msg == NULL) {
-        pcmk__debug("Unrecognizable IPC data from PID %d", client->pid);
-    } else if (execd_invalid_msg(msg)) {
-        int id = 0;
-
+    if ((msg == NULL) || execd_invalid_msg(msg)) {
         pcmk__debug("Unrecognizable IPC data from PID %d", client->pid);
 
-        pcmk__xe_get_int(msg, PCMK__XA_LRMD_REMOTE_MSG_ID, &id);
-        pcmk__ipc_send_ack(client, id, crm_ipc_client_response, PCMK__XE_NACK,
-                           NULL, CRM_EX_PROTOCOL);
     } else {
         pcmk__request_t request = {
             .ipc_client     = client,

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -3418,8 +3418,7 @@ handle_notify_request(pcmk__request_t *request)
     pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
     pcmk__set_request_flags(request, pcmk__request_reuse_options);
 
-    return pcmk__ipc_create_ack(request->ipc_flags, PCMK__XE_ACK, NULL,
-                                CRM_EX_OK);
+    return pcmk__ipc_create_ack(request->ipc_flags, NULL, CRM_EX_OK);
 }
 
 // STONITH_OP_RELAY

--- a/daemons/fenced/fenced_ipc.c
+++ b/daemons/fenced/fenced_ipc.c
@@ -137,7 +137,7 @@ fenced_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if (msg == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_NACK, NULL, CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
 

--- a/daemons/fenced/fenced_ipc.c
+++ b/daemons/fenced/fenced_ipc.c
@@ -137,7 +137,7 @@ fenced_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if (msg == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
 

--- a/daemons/pacemakerd/pcmkd_ipc.c
+++ b/daemons/pacemakerd/pcmkd_ipc.c
@@ -149,8 +149,7 @@ pacemakerd_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if (msg == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
         return 0;
 
     } else {

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -34,7 +34,7 @@ handle_node_cache_request(pcmk__request_t *request)
                 pcmk__client_name(request->ipc_client));
 
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_OK);
+                       NULL, CRM_EX_OK);
     return NULL;
 }
 
@@ -55,7 +55,7 @@ handle_ping_request(pcmk__request_t *request)
                 pcmk__s(pcmk__xe_get(msg, PCMK_XA_ORIGIN), ""));
 
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_INDETERMINATE);
+                       NULL, CRM_EX_INDETERMINATE);
 
     ping = pcmk__xe_create(NULL, PCMK__XE_PING_RESPONSE);
     value = pcmk__xe_get(msg, PCMK__XA_CRM_SYS_TO);
@@ -114,7 +114,7 @@ handle_shutdown_request(pcmk__request_t *request)
                                 pcmk__client_privileged);
 
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_INDETERMINATE);
+                       NULL, CRM_EX_INDETERMINATE);
 
     shutdown = pcmk__xe_create(NULL, PCMK__XE_SHUTDOWN);
 
@@ -152,7 +152,7 @@ static xmlNode *
 handle_unknown_request(pcmk__request_t *request)
 {
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
+                       NULL, CRM_EX_PROTOCOL);
 
     pcmk__format_result(&request->result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
                         "Unknown request type '%s' (bug?)",

--- a/daemons/schedulerd/schedulerd_ipc.c
+++ b/daemons/schedulerd/schedulerd_ipc.c
@@ -104,8 +104,7 @@ schedulerd_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if (msg == NULL) {
         pcmk__debug("Unrecognizable IPC data from PID %d", pcmk__client_pid(c));
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_PROTOCOL);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_PROTOCOL);
         return 0;
     }
 
@@ -113,13 +112,11 @@ schedulerd_ipc_dispatch(qb_ipcs_connection_t *c, void *data, size_t size)
 
     if (pcmk__str_eq(pcmk__xe_get(msg, PCMK__XA_SUBT), PCMK__VALUE_RESPONSE,
                      pcmk__str_none)) {
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_INDETERMINATE);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_INDETERMINATE);
         pcmk__info("Ignoring IPC reply from %s", pcmk__client_name(client));
 
     } else if (!pcmk__str_eq(sys_to, CRM_SYSTEM_PENGINE, pcmk__str_none)) {
-        pcmk__ipc_send_ack(client, id, flags, PCMK__XE_ACK, NULL,
-                           CRM_EX_INDETERMINATE);
+        pcmk__ipc_send_ack(client, id, flags, NULL, CRM_EX_INDETERMINATE);
         pcmk__info("Ignoring invalid IPC message: to '%s' not "
                    CRM_SYSTEM_PENGINE, pcmk__s(sys_to, ""));
 

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -79,7 +79,7 @@ handle_pecalc_request(pcmk__request_t *request)
     pcmk_scheduler_t *scheduler = init_scheduler();
 
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_INDETERMINATE);
+                       NULL, CRM_EX_INDETERMINATE);
 
     digest = pcmk__digest_xml(xml_data, false);
     converted = pcmk__xml_copy(NULL, xml_data);
@@ -187,7 +187,7 @@ static xmlNode *
 handle_unknown_request(pcmk__request_t *request)
 {
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_PROTOCOL);
+                       NULL, CRM_EX_PROTOCOL);
 
     pcmk__format_result(&request->result, CRM_EX_PROTOCOL, PCMK_EXEC_INVALID,
                         "Unknown request type '%s' (bug?)",
@@ -199,7 +199,7 @@ static xmlNode *
 handle_hello_request(pcmk__request_t *request)
 {
     pcmk__ipc_send_ack(request->ipc_client, request->ipc_id, request->ipc_flags,
-                       PCMK__XE_ACK, NULL, CRM_EX_INDETERMINATE);
+                       NULL, CRM_EX_INDETERMINATE);
 
     pcmk__trace("Received IPC hello from %s",
                 pcmk__client_name(request->ipc_client));

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -223,7 +223,7 @@ xmlNode *pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
 int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
                           uint32_t request, uint32_t flags, const char *ver,
                           crm_exit_t status);
-#define pcmk__ipc_send_ack(c, req, flags, tag, ver, st) \
+#define pcmk__ipc_send_ack(c, req, flags, ver, st) \
     pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (ver), (st))
 
 int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -216,9 +216,9 @@ void pcmk__drop_all_clients(qb_ipcs_service_t *s);
 void pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax);
 
 xmlNode *pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
-                                 const char *tag, const char *ver, crm_exit_t status);
+                                 const char *ver, crm_exit_t status);
 #define pcmk__ipc_create_ack(flags, tag, ver, st) \
-    pcmk__ipc_create_ack_as(__func__, __LINE__, (flags), (tag), (ver), (st))
+    pcmk__ipc_create_ack_as(__func__, __LINE__, (flags), (ver), (st))
 
 int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
                           uint32_t request, uint32_t flags, const char *tag,

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -217,7 +217,7 @@ void pcmk__set_client_queue_max(pcmk__client_t *client, const char *qmax);
 
 xmlNode *pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
                                  const char *ver, crm_exit_t status);
-#define pcmk__ipc_create_ack(flags, tag, ver, st) \
+#define pcmk__ipc_create_ack(flags, ver, st) \
     pcmk__ipc_create_ack_as(__func__, __LINE__, (flags), (ver), (st))
 
 int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -221,10 +221,10 @@ xmlNode *pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
     pcmk__ipc_create_ack_as(__func__, __LINE__, (flags), (ver), (st))
 
 int pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
-                          uint32_t request, uint32_t flags, const char *tag,
-                          const char *ver, crm_exit_t status);
+                          uint32_t request, uint32_t flags, const char *ver,
+                          crm_exit_t status);
 #define pcmk__ipc_send_ack(c, req, flags, tag, ver, st) \
-    pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (tag), (ver), (st))
+    pcmk__ipc_send_ack_as(__func__, __LINE__, (c), (req), (flags), (ver), (st))
 
 int pcmk__ipc_prepare_iov(uint32_t request, const GString *message,
                           uint16_t index, struct iovec **result, ssize_t *bytes);

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -34,13 +34,18 @@ typedef struct {
     mainloop_io_t *source;
 } cib_native_opaque_t;
 
-static void
-handle_nack(const xmlNode *reply)
+static bool
+ack_is_failure(const xmlNode *reply)
 {
     int status = 0;
 
     pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
-    pcmk__err("Received error response from based: %s", crm_exit_str(status));
+    if (status != CRM_EX_OK) {
+        pcmk__err("Received error response from based: %s", crm_exit_str(status));
+        return true;
+    }
+
+    return false;
 }
 
 static int
@@ -99,8 +104,11 @@ cib_native_perform_op_delegate(cib_t *cib, const char *op, const char *host,
         goto done;
     }
 
-    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
-        handle_nack(op_reply);
+    /* The only reason we can receive an ACK here is if dispatch_common ->
+     * pcmk__client_data2xml processed something that's not valid XML.
+     * dispatch_common does not return ACK, unlike other daemons.
+     */
+    if (pcmk__xe_is(op_reply, PCMK__XE_ACK) && ack_is_failure(op_reply)) {
         rc = -EPROTO;
         goto done;
     }
@@ -336,8 +344,11 @@ cib_native_signon(cib_t *cib, const char *name, enum cib_conn_type type)
             goto done;
         }
 
-        if (pcmk__xe_is(reply, PCMK__XE_NACK)) {
-            handle_nack(reply);
+        /* The only reason we can receive an ACK here is if dispatch_common ->
+         * pcmk__client_data2xml processed something that's not valid XML.
+         * dispatch_common does not return ACK, unlike other daemons.
+         */
+        if (pcmk__xe_is(reply, PCMK__XE_ACK) && ack_is_failure(reply)) {
             rc = -EPROTO;
             goto done;
         }
@@ -409,7 +420,7 @@ cib_native_register_notification(cib_t *cib, const char *callback, int enabled)
         pcmk__xe_set_int(notify_msg, PCMK__XA_CIB_NOTIFY_ACTIVATE, enabled);
 
         /* We don't care about the reply here, so there's no need to check
-         * if we got a NACK in response.
+         * if we got an ACK in response.
          */
         rc = crm_ipc_send(native->ipc, notify_msg, crm_ipc_client_response,
                           1000 * cib->call_timeout, NULL);

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -34,6 +34,15 @@ typedef struct {
     mainloop_io_t *source;
 } cib_native_opaque_t;
 
+static void
+handle_nack(const xmlNode *reply)
+{
+    int status = 0;
+
+    pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
+    pcmk__err("Received error response from based: %s", crm_exit_str(status));
+}
+
 static int
 cib_native_perform_op_delegate(cib_t *cib, const char *op, const char *host,
                                const char *section, xmlNode *data,
@@ -87,6 +96,12 @@ cib_native_perform_op_delegate(cib_t *cib, const char *op, const char *host,
         pcmk__err("Couldn't perform %s operation (timeout=%ds): %s (%d)", op,
                   cib->call_timeout, pcmk_strerror(rc), rc);
         rc = -ECOMM;
+        goto done;
+    }
+
+    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
+        handle_nack(op_reply);
+        rc = -EPROTO;
         goto done;
     }
 
@@ -321,6 +336,12 @@ cib_native_signon(cib_t *cib, const char *name, enum cib_conn_type type)
             goto done;
         }
 
+        if (pcmk__xe_is(reply, PCMK__XE_NACK)) {
+            handle_nack(reply);
+            rc = -EPROTO;
+            goto done;
+        }
+
         msg_type = pcmk__xe_get(reply, PCMK__XA_CIB_OP);
 
         pcmk__log_xml_trace(reply, "reg-reply");
@@ -386,6 +407,10 @@ cib_native_register_notification(cib_t *cib, const char *callback, int enabled)
         pcmk__xe_set(notify_msg, PCMK__XA_CIB_OP, PCMK__VALUE_CIB_NOTIFY);
         pcmk__xe_set(notify_msg, PCMK__XA_CIB_NOTIFY_TYPE, callback);
         pcmk__xe_set_int(notify_msg, PCMK__XA_CIB_NOTIFY_ACTIVATE, enabled);
+
+        /* We don't care about the reply here, so there's no need to check
+         * if we got a NACK in response.
+         */
         rc = crm_ipc_send(native->ipc, notify_msg, crm_ipc_client_response,
                           1000 * cib->call_timeout, NULL);
         if (rc <= 0) {

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -48,13 +48,18 @@ typedef struct {
     int timeout_sec;
 } cib_remote_opaque_t;
 
-static void
-handle_nack(const xmlNode *reply)
+static bool
+ack_is_failure(const xmlNode *reply)
 {
     int status = 0;
 
     pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
-    pcmk__err("Received error response from based: %s", crm_exit_str(status));
+    if (status != CRM_EX_OK) {
+        pcmk__err("Received error response from based: %s", crm_exit_str(status));
+        return true;
+    }
+
+    return false;
 }
 
 static int
@@ -167,8 +172,11 @@ cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
         return -ENOMSG;
     }
 
-    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
-        handle_nack(op_reply);
+    /* The only reason we can receive an ACK here is if dispatch_common ->
+     * pcmk__client_data2xml processed something that's not valid XML.
+     * dispatch_common does not return ACK, unlike other daemons.
+     */
+    if (pcmk__xe_is(op_reply, PCMK__XE_ACK) && ack_is_failure(op_reply)) {
         pcmk__xml_free(op_reply);
         return -EPROTO;
     }
@@ -449,8 +457,11 @@ cib_tls_signon(cib_t *cib, pcmk__remote_t *connection, gboolean event_channel)
         goto done;
     }
 
-    if (pcmk__xe_is(answer, PCMK__XE_NACK)) {
-        handle_nack(answer);
+    /* The only reason we can receive an ACK here is if dispatch_common ->
+     * pcmk__client_data2xml processed something that's not valid XML.
+     * dispatch_common does not return ACK, unlike other daemons.
+     */
+    if (pcmk__xe_is(answer, PCMK__XE_ACK) && ack_is_failure(answer)) {
         rc = -EPROTO;
         goto done;
     }

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -48,6 +48,15 @@ typedef struct {
     int timeout_sec;
 } cib_remote_opaque_t;
 
+static void
+handle_nack(const xmlNode *reply)
+{
+    int status = 0;
+
+    pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
+    pcmk__err("Received error response from based: %s", crm_exit_str(status));
+}
+
 static int
 cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
                       const char *section, xmlNode *data,
@@ -151,9 +160,17 @@ cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
     if (rc == ENOTCONN) {
         pcmk__err("Disconnected while waiting for reply");
         return -ENOTCONN;
-    } else if (op_reply == NULL) {
+    }
+
+    if (op_reply == NULL) {
         pcmk__err("No reply message - empty");
         return -ENOMSG;
+    }
+
+    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
+        handle_nack(op_reply);
+        pcmk__xml_free(op_reply);
+        return -EPROTO;
     }
 
     pcmk__trace("Synchronous reply received");
@@ -428,6 +445,12 @@ cib_tls_signon(cib_t *cib, pcmk__remote_t *connection, gboolean event_channel)
     answer = pcmk__remote_message_xml(connection);
 
     if (answer == NULL) {
+        rc = -EPROTO;
+        goto done;
+    }
+
+    if (pcmk__xe_is(answer, PCMK__XE_NACK)) {
+        handle_nack(answer);
         rc = -EPROTO;
         goto done;
     }

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -957,7 +957,6 @@ done:
  * \param[in] function  Calling function
  * \param[in] line      Source file line within calling function
  * \param[in] flags     IPC flags to use when sending
- * \param[in] tag       Element name to use for acknowledgement
  * \param[in] ver       IPC protocol version (can be NULL)
  * \param[in] status    Exit status code to add to ack
  *
@@ -968,17 +967,19 @@ done:
  */
 xmlNode *
 pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
-                        const char *tag, const char *ver, crm_exit_t status)
+                        const char *ver, crm_exit_t status)
 {
     xmlNode *ack = NULL;
 
-    if (pcmk__is_set(flags, crm_ipc_client_response)) {
-        ack = pcmk__xe_create(NULL, tag);
-        pcmk__xe_set(ack, PCMK_XA_FUNCTION, function);
-        pcmk__xe_set_int(ack, PCMK__XA_LINE, line);
-        pcmk__xe_set_int(ack, PCMK_XA_STATUS, (int) status);
-        pcmk__xe_set(ack, PCMK__XA_IPC_PROTO_VERSION, ver);
+    if (!pcmk__is_set(flags, crm_ipc_client_response)) {
+        return NULL;
     }
+
+    ack = pcmk__xe_create(NULL, PCMK__XE_ACK);
+    pcmk__xe_set(ack, PCMK_XA_FUNCTION, function);
+    pcmk__xe_set_int(ack, PCMK__XA_LINE, line);
+    pcmk__xe_set_int(ack, PCMK_XA_STATUS, (int) status);
+    pcmk__xe_set(ack, PCMK__XA_IPC_PROTO_VERSION, ver);
     return ack;
 }
 
@@ -1003,7 +1004,7 @@ pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
                       const char *ver, crm_exit_t status)
 {
     int rc = pcmk_rc_ok;
-    xmlNode *ack = pcmk__ipc_create_ack_as(function, line, flags, tag, ver, status);
+    xmlNode *ack = pcmk__ipc_create_ack_as(function, line, flags, ver, status);
 
     if (ack != NULL) {
         pcmk__trace("Ack'ing IPC message from client %s as <%s status=%d>",

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -992,7 +992,6 @@ pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
  * \param[in] c         Client to send ack to
  * \param[in] request   Request ID being replied to
  * \param[in] flags     IPC flags to use when sending
- * \param[in] tag       Element name to use for acknowledgement
  * \param[in] ver       IPC protocol version (can be NULL)
  * \param[in] status    Status code to send with acknowledgement
  *
@@ -1000,20 +999,23 @@ pcmk__ipc_create_ack_as(const char *function, int line, uint32_t flags,
  */
 int
 pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
-                      uint32_t request, uint32_t flags, const char *tag,
-                      const char *ver, crm_exit_t status)
+                      uint32_t request, uint32_t flags, const char *ver,
+                      crm_exit_t status)
 {
     int rc = pcmk_rc_ok;
     xmlNode *ack = pcmk__ipc_create_ack_as(function, line, flags, ver, status);
 
-    if (ack != NULL) {
-        pcmk__trace("Ack'ing IPC message from client %s as <%s status=%d>",
-                    pcmk__client_name(c), tag, status);
-        pcmk__log_xml_trace(ack, "sent-ack");
-        c->request_id = 0;
-        rc = pcmk__ipc_send_xml(c, request, ack, flags);
-        pcmk__xml_free(ack);
+    if (ack == NULL) {
+        return pcmk_rc_ok;
     }
+
+    pcmk__trace("Ack'ing IPC message from client %s as <" PCMK__XE_ACK
+                " status=%d>",
+                pcmk__client_name(c), status);
+    pcmk__log_xml_trace(ack, "sent-ack");
+    c->request_id = 0;
+    rc = pcmk__ipc_send_xml(c, request, ack, flags);
+    pcmk__xml_free(ack);
     return rc;
 }
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1119,13 +1119,18 @@ stonith_dispatch_internal(const char *buffer, ssize_t length, gpointer userdata)
     return 1;
 }
 
-static void
-handle_nack(const xmlNode *reply)
+static bool
+ack_is_failure(const xmlNode *reply)
 {
     int status = 0;
 
     pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
-    pcmk__err("Received error response from fenced: %s", crm_exit_str(status));
+    if (status != CRM_EX_OK) {
+        pcmk__err("Received error response from fenced: %s", crm_exit_str(status));
+        return true;
+    }
+
+    return false;
 }
 
 static int
@@ -1204,13 +1209,12 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
         goto done;
     }
 
-    /* The only reason we can receive a NACK here is if fenced_ipc_dispatch ->
+    /* The only reason we can receive an ACK here is if fenced_ipc_dispatch ->
      * pcmk__client_data2xml processed something that's not valid XML.
      * fenced_ipc_disaptch does not return ACK from handle_unknown_request,
      * unlike other daemons.
      */
-    if (pcmk__xe_is(reply, PCMK__XE_NACK)) {
-        handle_nack(reply);
+    if (pcmk__xe_is(reply, PCMK__XE_ACK) && ack_is_failure(reply)) {
         rc = -EPROTO;
         goto done;
     }
@@ -1268,7 +1272,7 @@ stonith_set_notification(stonith_t * stonith, const char *callback, int enabled)
         }
 
         /* We don't care about the reply here, so there's no need to check
-         * if we got a NACK in response.
+         * if we got an ACK in response.
          */
         rc = crm_ipc_send(native->ipc, notify_msg, crm_ipc_client_response, -1, NULL);
         if (rc < 0) {
@@ -1654,8 +1658,7 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
         goto done;
     }
 
-    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
-        handle_nack(op_reply);
+    if (pcmk__xe_is(op_reply, PCMK__XE_ACK) && ack_is_failure(op_reply)) {
         rc = -EPROTO;
         goto done;
     }

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1119,6 +1119,15 @@ stonith_dispatch_internal(const char *buffer, ssize_t length, gpointer userdata)
     return 1;
 }
 
+static void
+handle_nack(const xmlNode *reply)
+{
+    int status = 0;
+
+    pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
+    pcmk__err("Received error response from fenced: %s", crm_exit_str(status));
+}
+
 static int
 stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
 {
@@ -1195,6 +1204,17 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
         goto done;
     }
 
+    /* The only reason we can receive a NACK here is if fenced_ipc_dispatch ->
+     * pcmk__client_data2xml processed something that's not valid XML.
+     * fenced_ipc_disaptch does not return ACK from handle_unknown_request,
+     * unlike other daemons.
+     */
+    if (pcmk__xe_is(reply, PCMK__XE_NACK)) {
+        handle_nack(reply);
+        rc = -EPROTO;
+        goto done;
+    }
+
     msg_type = pcmk__xe_get(reply, PCMK__XA_ST_OP);
 
     native->token = pcmk__xe_get_copy(reply, PCMK__XA_ST_CLIENTID);
@@ -1247,6 +1267,9 @@ stonith_set_notification(stonith_t * stonith, const char *callback, int enabled)
             pcmk__xe_set(notify_msg, PCMK__XA_ST_NOTIFY_DEACTIVATE, callback);
         }
 
+        /* We don't care about the reply here, so there's no need to check
+         * if we got a NACK in response.
+         */
         rc = crm_ipc_send(native->ipc, notify_msg, crm_ipc_client_response, -1, NULL);
         if (rc < 0) {
             pcmk__debug("Couldn't register for fencing notifications: %s",
@@ -1628,6 +1651,12 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
         pcmk__err("Couldn't perform %s operation (timeout=%ds): %s", op,
                   timeout, pcmk_strerror(rc));
         rc = -ECOMM;
+        goto done;
+    }
+
+    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
+        handle_nack(op_reply);
+        rc = -EPROTO;
         goto done;
     }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -866,6 +866,17 @@ lrmd_api_is_connected(lrmd_t * lrmd)
     }
 }
 
+static void
+handle_nack(const xmlNode *reply)
+{
+    int status = 0;
+
+    pcmk__log_xml_err(reply, "Bad reply");
+
+    pcmk__xe_get_int(reply, PCMK_XA_STATUS, &status);
+    pcmk__err("Received error response from executor: %s", crm_exit_str(status));
+}
+
 /*!
  * \internal
  * \brief Send a prepared API command to the executor
@@ -929,14 +940,23 @@ lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
         goto done;
     }
 
-    rc = pcmk_ok;
+    /* The only reason we can receive a NACK here is because we sent a request
+     * that execd didn't recognize and it responded via handle_unknown_request.
+     */
+    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
+        handle_nack(op_reply);
+        rc = -EPROTO;
+        goto done;
+    }
+
     pcmk__trace("%s op reply received", op);
+    pcmk__log_xml_trace(op_reply, "Reply");
+
+    rc = pcmk_ok;
     if (pcmk__xe_get_int(op_reply, PCMK__XA_LRMD_RC, &rc) != pcmk_rc_ok) {
         rc = -ENOMSG;
         goto done;
     }
-
-    pcmk__log_xml_trace(op_reply, "Reply");
 
     if (output_data) {
         *output_data = op_reply;
@@ -1017,6 +1037,14 @@ process_lrmd_handshake_reply(xmlNode *reply, lrmd_private_t *native)
     const char *msg_type = pcmk__xe_get(reply, PCMK__XA_LRMD_OP);
     const char *tmp_ticket = pcmk__xe_get(reply, PCMK__XA_LRMD_CLIENTID);
     const char *start_state = pcmk__xe_get(reply, PCMK__XA_NODE_START_STATE);
+
+    /* The only reason we can receive a NACK here is because execd didn't
+     * understand the CRM_OP_REGISTER message we sent in lrmd_handshake.
+     */
+    if (pcmk__xe_is(reply, PCMK__XE_NACK)) {
+        handle_nack(reply);
+        return EPROTO;
+    }
 
     pcmk__xe_get_int(reply, PCMK__XA_LRMD_RC, &rc);
     rc = pcmk_legacy2rc(rc);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -867,7 +867,7 @@ lrmd_api_is_connected(lrmd_t * lrmd)
 }
 
 static void
-handle_nack(const xmlNode *reply)
+handle_ack(const xmlNode *reply)
 {
     int status = 0;
 
@@ -940,11 +940,12 @@ lrmd_send_command(lrmd_t *lrmd, const char *op, xmlNode *data,
         goto done;
     }
 
-    /* The only reason we can receive a NACK here is because we sent a request
-     * that execd didn't recognize and it responded via handle_unknown_request.
+    /* The only reason we can receive an ACK here is because we sent a request
+     * that execd didn't recognize and it responded via handle_unknown_request,
+     * and the status code will always indicate some sort of error.
      */
-    if (pcmk__xe_is(op_reply, PCMK__XE_NACK)) {
-        handle_nack(op_reply);
+    if (pcmk__xe_is(op_reply, PCMK__XE_ACK)) {
+        handle_ack(op_reply);
         rc = -EPROTO;
         goto done;
     }
@@ -1038,11 +1039,12 @@ process_lrmd_handshake_reply(xmlNode *reply, lrmd_private_t *native)
     const char *tmp_ticket = pcmk__xe_get(reply, PCMK__XA_LRMD_CLIENTID);
     const char *start_state = pcmk__xe_get(reply, PCMK__XA_NODE_START_STATE);
 
-    /* The only reason we can receive a NACK here is because execd didn't
-     * understand the CRM_OP_REGISTER message we sent in lrmd_handshake.
+    /* The only reason we can receive an ACK here is because execd didn't
+     * understand the CRM_OP_REGISTER message we sent in lrmd_handshake{,_async},
+     * and the status code will always indicate some sort of error.
      */
-    if (pcmk__xe_is(reply, PCMK__XE_NACK)) {
-        handle_nack(reply);
+    if (pcmk__xe_is(reply, PCMK__XE_ACK)) {
+        handle_ack(reply);
         return EPROTO;
     }
 

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -690,6 +690,9 @@ purge_node_from_fencer(const char *node_name, long node_id)
     }
     pcmk__xe_set(cmd, PCMK_XA_UNAME, node_name);
 
+    /* We don't care about the reply here, so there's no need to check if we
+     * got an ACK in response.
+     */
     rc = crm_ipc_send(conn, cmd, 0, 0, NULL);
     if (rc >= 0) {
         rc = pcmk_rc_ok;


### PR DESCRIPTION
This is an update of #4041.  The problem with that PR is that it only modified the clients to deal with NACKs during connection to the server, and not during the rest of the IPC communication.  This corrects that and also rebases on main to pick up the prep PR.