### PR TITLE
Low: libcrmcommon: Don't log on error in pcmk__ipc_send_iov.

### DIFF
--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -808,11 +808,6 @@ pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags)
             if (qb_rc < 0) {
                 rc = (int) -qb_rc;
             }
-
-            pcmk__notice("Response %" PRId32 "%sto pid %u failed: %s "
-                         QB_XS " bytes=%" PRId32 " rc=%zd ipcs=%p",
-                         header->qb.id, part_text, c->pid, pcmk_rc_str(rc),
-                         header->qb.size, qb_rc, c->ipcs);
 
         } else {
             pcmk__trace("Response %" PRId32 "%ssent, %zd bytes to %p[%u]",


### PR DESCRIPTION
If pcmk__ipc_send_iov gets an error, we'll log a notice message.  This includes if it gets an EAGAIN, which could happen repeatedly and doesn't really indicate an error.  Regardless, we'll log for all non-EAGAIN error conditions in every place where pcmk__ipc_send_iov is called. This makes the notice logging redundant.

We could potentially get rid of the rest of the trace level logging in this function, but I've found it helpful for debugging IPC problems.

Fixes RHEL-153850