### PR TITLE
Static analysis / memory fixes

### DIFF
--- a/cts/valgrind-pcmk.suppressions
+++ b/cts/valgrind-pcmk.suppressions
@@ -348,3 +348,17 @@
    fun:call_init
    fun:_dl_init
 }
+
+{
+   glib - iconv
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   ...
+   fun:g_convert_with_iconv
+   fun:g_convert
+   ...
+   fun:g_option_context_parse
+   fun:g_option_context_parse_strv
+   fun:main
+}

--- a/cts/valgrind-pcmk.suppressions
+++ b/cts/valgrind-pcmk.suppressions
@@ -23,7 +23,6 @@
    Bash reader_loop leaks
    Memcheck:Leak
    fun:malloc
-   fun:xmalloc
    ...
    fun:reader_loop
    fun:main

--- a/daemons/based/based_ipc.c
+++ b/daemons/based/based_ipc.c
@@ -151,7 +151,7 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
                    "cib_transaction flag set outside of any transaction",
                    client->name);
         pcmk__log_xml_info(msg, "no-transaction");
-        return 0;
+        goto cleanup;
     }
 
     if (pcmk__is_set(call_options, cib_sync_call)) {
@@ -178,7 +178,7 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
         xmlNode *reply = NULL;
 
         if (!pcmk__is_set(flags, crm_ipc_client_response)) {
-            return 0;
+            goto cleanup;
         }
 
         reply = pcmk__xe_create(NULL, __func__);
@@ -188,7 +188,7 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
 
         client->request_id = 0;
         pcmk__xml_free(reply);
-        return 0;
+        goto cleanup;
     }
 
     if (pcmk__str_eq(op, PCMK__VALUE_CIB_NOTIFY, pcmk__str_none)) {
@@ -200,10 +200,12 @@ dispatch_common(qb_ipcs_connection_t *c, void *data, bool privileged)
         }
 
         pcmk__ipc_send_ack(client, id, flags, NULL, status);
-        return 0;
+        goto cleanup;
     }
 
     based_process_request(msg, privileged, client);
+
+cleanup:
     pcmk__xml_free(msg);
     return 0;
 }

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -703,7 +703,7 @@ controld_register_graph_functions(void)
 void
 notify_crmd(pcmk__graph_t *graph)
 {
-    const char *type = "unknown";
+    const char *type = NULL;
     enum crmd_fsa_input event = I_NULL;
 
     pcmk__debug("Processing transition completion in state %s",

--- a/daemons/execd/remoted_pidone.c
+++ b/daemons/execd/remoted_pidone.c
@@ -196,10 +196,18 @@ load_env_vars(void)
         return;
     }
 
-    while (getline(&line, &buf_size, fp) != -1) {
-        load_env_var_line(line);
+    do {
+        ssize_t rc = 0;
+
         errno = 0;
-    }
+        rc = getline(&line, &buf_size, fp);
+
+        if (rc == -1) {
+            break;
+        }
+
+        load_env_var_line(line);
+    } while (true);
 
     // getline() returns -1 on EOF (expected) or error
     if (errno != 0) {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -371,7 +371,7 @@ main(int argc, char **argv)
     }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
-    if (rc != pcmk_rc_ok) {
+    if ((rc != pcmk_rc_ok) || (out == NULL)) {
         exit_code = CRM_EX_ERROR;
         g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                     "Error creating output format %s: %s",

--- a/devel/Makefile.am
+++ b/devel/Makefile.am
@@ -124,6 +124,7 @@ cppcheck:
 		--include=/usr/include/qb/qblog.h 		\
 		--output-file=$(CPPCHECK_OUT)			\
 		--max-configs=30 --inline-suppr -q		\
+		-j $(shell nproc --ignore=1) 			\
 		--library=posix --library=gnu --library=gtk	\
 		$(GLIB_INCL_DEF_CFLAGS) -D__GNUC__ 		\
 		$(foreach dir,$(CPPCHECK_DIRS),$(top_srcdir)/$(dir))

--- a/devel/Makefile.am
+++ b/devel/Makefile.am
@@ -27,6 +27,7 @@ clang:
 	OUT=$$(cd $(top_builddir)					\
 		&& scan-build $(CLANG_checkers:%=-enable-checker %)	\
 		$(MAKE) $(AM_MAKEFLAGS) CFLAGS="-std=c99 $(CFLAGS)"	\
+		-j $(shell nproc --ignore=1) 				\
 		clean all 2>&1);					\
 	REPORT=$$(echo "$$OUT"						\
 		| sed -n -e "s/.*'scan-view \(.*\)'.*/\1/p");		\

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -350,6 +350,7 @@ cib_native_signon(cib_t *cib, const char *name, enum cib_conn_type type)
          */
         if (pcmk__xe_is(reply, PCMK__XE_ACK) && ack_is_failure(reply)) {
             rc = -EPROTO;
+            pcmk__xml_free(reply);
             goto done;
         }
 
@@ -369,6 +370,8 @@ cib_native_signon(cib_t *cib, const char *name, enum cib_conn_type type)
                 rc = -EPROTO;
             }
         }
+
+        pcmk__xml_free(reply);
     }
 
 done:

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1085,17 +1085,16 @@ update_peer_uname(pcmk__node_status_t *node, const char *uname)
 static inline const char *
 proc2text(enum crm_proc_flag proc)
 {
-    const char *text = "unknown";
-
     switch (proc) {
         case crm_proc_none:
-            text = "none";
-            break;
+            return "none";
+
         case crm_proc_cpg:
-            text = "corosync-cpg";
-            break;
+            return "corosync-cpg";
+
+        default:
+            return "unknown";
     }
-    return text;
 }
 
 /*!

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -94,7 +94,15 @@ pcmk__bare_output_new(pcmk__output_t **out, const char *fmt_name,
         return ENOMEM;
     }
 
-    if (pcmk__str_eq(filename, "-", pcmk__str_null_matches)) {
+    /* Static analysis can't figure out that passing pcmk__str_null_matches
+     * to pcmk__str_eq means filename can't be NULL in the else block, so
+     * we'll just take care of that here.
+     */
+    if (filename == NULL) {
+        filename = "-";
+    }
+
+    if (pcmk__str_eq(filename, "-", pcmk__str_none)) {
         (*out)->dest = stdout;
     } else {
         (*out)->dest = fopen(filename, "w");

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -107,8 +107,10 @@ pcmk__bare_output_new(pcmk__output_t **out, const char *fmt_name,
     } else {
         (*out)->dest = fopen(filename, "w");
         if ((*out)->dest == NULL) {
+            int rc = errno;
+
             g_clear_pointer(out, pcmk__output_free);
-            return errno;
+            return rc;
         }
     }
 

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -1067,6 +1067,7 @@ apply_upgrade(const xmlNode *input_xml, int schema_index, gboolean to_logs)
     }
 
     // Final result document from upgrade pipeline needs private data
+    pcmk__assert(new_xml != NULL);
     pcmk__xml_new_private_data((xmlNode *) new_xml->doc);
 
     // Ensure result validates with its new schema

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -407,7 +407,10 @@ load_transforms_from_dir(const char *dir)
                 g_hash_table_insert(transforms, version_s, list);
 
             } else {
-                list = g_list_append(list, namelist[i]);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+                g_list_append(list, namelist[i]);
+#pragma GCC diagnostic pop
                 free(version_s);
             }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -773,6 +773,8 @@ free_xml_with_position(xmlNode *node, int position)
         return pcmk_rc_ok;
     }
 
+    pcmk__assert(doc != NULL);
+
     docpriv = doc->_private;
     xpath = pcmk__element_xpath(node);
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -734,6 +734,8 @@ free_xml_with_position(xmlNode *node, int position)
 {
     xmlDoc *doc = NULL;
     xml_node_private_t *nodepriv = NULL;
+    xml_doc_private_t *docpriv = NULL;
+    GString *xpath = NULL;
 
     if (node == NULL) {
         return pcmk_rc_ok;
@@ -765,37 +767,39 @@ free_xml_with_position(xmlNode *node, int position)
         return EACCES;
     }
 
-    if (pcmk__xml_doc_all_flags_set(node->doc, pcmk__xf_tracking)
-        && !pcmk__is_set(nodepriv->flags, pcmk__xf_created)) {
-
-        xml_doc_private_t *docpriv = doc->_private;
-        GString *xpath = pcmk__element_xpath(node);
-
-        if (xpath != NULL) {
-            pcmk__deleted_xml_t *deleted_obj = NULL;
-
-            pcmk__trace("Deleting %s %p from %p", xpath->str, node, doc);
-
-            deleted_obj = pcmk__assert_alloc(1, sizeof(pcmk__deleted_xml_t));
-            deleted_obj->path = g_string_free(xpath, FALSE);
-            deleted_obj->position = -1;
-
-            // Record the position only for XML comments for now
-            if (node->type == XML_COMMENT_NODE) {
-                if (position >= 0) {
-                    deleted_obj->position = position;
-
-                } else {
-                    deleted_obj->position = pcmk__xml_position(node,
-                                                               pcmk__xf_skip);
-                }
-            }
-
-            docpriv->deleted_objs = g_list_append(docpriv->deleted_objs,
-                                                  deleted_obj);
-            pcmk__xml_doc_set_flags(node->doc, pcmk__xf_dirty);
-        }
+    if (!pcmk__xml_doc_all_flags_set(node->doc, pcmk__xf_tracking)
+        || pcmk__is_set(nodepriv->flags, pcmk__xf_created)) {
+        pcmk__xml_free_node(node);
+        return pcmk_rc_ok;
     }
+
+    docpriv = doc->_private;
+    xpath = pcmk__element_xpath(node);
+
+    if (xpath != NULL) {
+        pcmk__deleted_xml_t *deleted_obj = NULL;
+
+        pcmk__trace("Deleting %s %p from %p", xpath->str, node, doc);
+
+        deleted_obj = pcmk__assert_alloc(1, sizeof(pcmk__deleted_xml_t));
+        deleted_obj->path = g_string_free(xpath, FALSE);
+        deleted_obj->position = -1;
+
+        // Record the position only for XML comments for now
+        if (node->type == XML_COMMENT_NODE) {
+            if (position >= 0) {
+                deleted_obj->position = position;
+
+            } else {
+                deleted_obj->position = pcmk__xml_position(node, pcmk__xf_skip);
+            }
+        }
+
+        docpriv->deleted_objs = g_list_append(docpriv->deleted_objs,
+                                              deleted_obj);
+        pcmk__xml_doc_set_flags(node->doc, pcmk__xf_dirty);
+    }
+
     pcmk__xml_free_node(node);
     return pcmk_rc_ok;
 }

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -634,6 +634,7 @@ inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
     pcmk__assert(rc == pcmk_ok);
 
 done:
+    free(resource);
     free(task);
     free(node);
     free(key);

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1824,6 +1824,7 @@ process_rsc_history(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
 
     sorted_op_list = rsc_history_as_list(rsc_entry, &start_index, &stop_index);
     if (start_index < stop_index) {
+        g_list_free(sorted_op_list);
         return; // Resource is stopped
     }
 

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -565,6 +565,8 @@ probe_anonymous_clone(pcmk_resource_t *clone, pcmk_node_t *node)
 
         pcmk_resource_t *instance = (pcmk_resource_t *) iter->data;
         const pcmk_node_t *instance_node = NULL;
+
+        pcmk__assert(instance != NULL);
 
         instance_node = instance->priv->fns->location(instance, NULL,
                                                       pcmk__rsc_node_assigned);

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1271,10 +1271,9 @@ order_resource_actions_after(pcmk_action_t *first_action,
 
         } else {
             pcmk__clear_action_flags(then_action_iter, pcmk__action_runnable);
-            // coverity[null_field] order->rsc1 can't be NULL here
-            pcmk__warn("%s of %s is unrunnable because there is no %s of %s "
+            pcmk__warn("%s of %s is unrunnable because there is no %s "
                        "to order it after", then_action_iter->task, rsc->id,
-                       order->task1, order->rsc1->id);
+                       order->task1);
         }
     }
 

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -590,7 +590,7 @@ promotion_score_applies(const pcmk_resource_t *rsc, const pcmk_node_t *node)
     char *id = clone_strip(rsc->id);
     const pcmk_resource_t *parent = pe__const_top_resource(rsc, false);
     pcmk_resource_t *active = NULL;
-    const char *reason = "allowed";
+    const char *reason = NULL;
 
     // Some checks apply only to anonymous clone instances
     if (!pcmk__is_set(rsc->flags, pcmk__rsc_unique)) {
@@ -641,7 +641,8 @@ promotion_score_applies(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 check_allowed:
     if (is_allowed(rsc, node)) {
         pcmk__rsc_trace(rsc, "Counting %s promotion score (for %s) on %s: %s",
-                        rsc->id, id, pcmk__node_name(node), reason);
+                        rsc->id, id, pcmk__node_name(node),
+                        pcmk__s(reason, "allowed"));
         free(id);
         return true;
     }

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -28,8 +28,7 @@ enum loss_ticket_policy {
 
 typedef struct {
     const char *id;
-    pcmk_resource_t *rsc;
-    pcmk__ticket_t *ticket;
+    const pcmk__ticket_t *ticket;
     enum loss_ticket_policy loss_policy;
     int role;
 } rsc_ticket_t;
@@ -171,7 +170,6 @@ rsc_ticket_new(const char *id, pcmk_resource_t *rsc, pcmk__ticket_t *ticket,
     new_rsc_ticket = pcmk__assert_alloc(1, sizeof(rsc_ticket_t));
     new_rsc_ticket->id = id;
     new_rsc_ticket->ticket = ticket;
-    new_rsc_ticket->rsc = rsc;
     new_rsc_ticket->role = role;
 
     if (pcmk__str_eq(loss_policy, PCMK_VALUE_FENCE, pcmk__str_casei)) {
@@ -188,37 +186,37 @@ rsc_ticket_new(const char *id, pcmk_resource_t *rsc, pcmk__ticket_t *ticket,
 
     if (new_rsc_ticket->loss_policy == loss_ticket_fence) {
         pcmk__debug("On loss of ticket '%s': Fence the nodes running %s (%s)",
-                    new_rsc_ticket->ticket->id, new_rsc_ticket->rsc->id,
+                    new_rsc_ticket->ticket->id, rsc->id,
                     pcmk_role_text(new_rsc_ticket->role));
 
     } else if (pcmk__str_eq(loss_policy, PCMK_VALUE_FREEZE, pcmk__str_casei)) {
         pcmk__debug("On loss of ticket '%s': Freeze %s (%s)",
-                    new_rsc_ticket->ticket->id, new_rsc_ticket->rsc->id,
+                    new_rsc_ticket->ticket->id, rsc->id,
                     pcmk_role_text(new_rsc_ticket->role));
         new_rsc_ticket->loss_policy = loss_ticket_freeze;
 
     } else if (pcmk__str_eq(loss_policy, PCMK_VALUE_DEMOTE, pcmk__str_casei)) {
         pcmk__debug("On loss of ticket '%s': Demote %s (%s)",
-                    new_rsc_ticket->ticket->id, new_rsc_ticket->rsc->id,
+                    new_rsc_ticket->ticket->id, rsc->id,
                     pcmk_role_text(new_rsc_ticket->role));
         new_rsc_ticket->loss_policy = loss_ticket_demote;
 
     } else if (pcmk__str_eq(loss_policy, PCMK_VALUE_STOP, pcmk__str_casei)) {
         pcmk__debug("On loss of ticket '%s': Stop %s (%s)",
-                    new_rsc_ticket->ticket->id, new_rsc_ticket->rsc->id,
+                    new_rsc_ticket->ticket->id, rsc->id,
                     pcmk_role_text(new_rsc_ticket->role));
         new_rsc_ticket->loss_policy = loss_ticket_stop;
 
     } else {
         if (new_rsc_ticket->role == pcmk_role_promoted) {
             pcmk__debug("On loss of ticket '%s': Default to demote %s (%s)",
-                        new_rsc_ticket->ticket->id, new_rsc_ticket->rsc->id,
+                        new_rsc_ticket->ticket->id, rsc->id,
                         pcmk_role_text(new_rsc_ticket->role));
             new_rsc_ticket->loss_policy = loss_ticket_demote;
 
         } else {
             pcmk__debug("On loss of ticket '%s': Default to stop %s (%s)",
-                        new_rsc_ticket->ticket->id, new_rsc_ticket->rsc->id,
+                        new_rsc_ticket->ticket->id, rsc->id,
                         pcmk_role_text(new_rsc_ticket->role));
             new_rsc_ticket->loss_policy = loss_ticket_stop;
         }

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -753,6 +753,9 @@ pe__clone_default(pcmk__output_t *out, va_list args)
 
     if (pcmk__is_set(show_opts, pcmk_show_clone_detail)) {
         PCMK__OUTPUT_LIST_FOOTER(out, rc);
+
+        g_list_free(promoted_list);
+        g_list_free(started_list);
         return pcmk_rc_ok;
     }
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -1088,7 +1088,7 @@ common_free(pcmk_resource_t * rsc)
     g_list_free(rsc->priv->with_this_colocations);
     g_list_free(rsc->priv->this_with_colocations);
     g_list_free(rsc->priv->location_constraints);
-    g_list_free(rsc->priv->ticket_constraints);
+    g_list_free_full(rsc->priv->ticket_constraints, free);
 
     if (rsc->priv->meta != NULL) {
         g_hash_table_destroy(rsc->priv->meta);

--- a/lib/services/services_lsb.c
+++ b/lib/services/services_lsb.c
@@ -203,7 +203,11 @@ services__get_lsb_metadata(const char *type, char **output)
             long_desc = pcmk__xml_escape(desc->str, pcmk__xml_escape_text);
             g_string_free(desc, TRUE);
 
-            if (processed_line) {
+            if (ferror(fp) || feof(fp)) {
+                // We hit a problem or EOF in the fgets loop on the long
+                // description
+                break;
+            } else if (processed_line) {
                 // We grabbed the line into the long description
                 continue;
             }

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -796,7 +796,7 @@ main(int argc, char **argv)
     pcmk__cli_init_logging("crm_node", args->verbosity);
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
-    if (rc != pcmk_rc_ok) {
+    if ((rc != pcmk_rc_ok) || (out == NULL)) {
         exit_code = pcmk_rc2exitc(rc);
         g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                     "Error creating output format %s: %s", args->output_ty,

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -104,6 +104,7 @@ cli_resource_print_operations(const char *rsc_id, const char *host_uname,
     }
 
     out->end_list(out);
+    g_list_free_full(ops, (GDestroyNotify) pcmk__xml_free);
     return rc;
 }
 

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -370,7 +370,7 @@ main(int argc, char **argv)
     pcmk__cli_init_logging("crm_ticket", args->verbosity);
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
-    if (rc != pcmk_rc_ok) {
+    if ((rc != pcmk_rc_ok) || (out == NULL)) {
         exit_code = pcmk_rc2exitc(rc);
         g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
                     "Error creating output format %s: %s", args->output_ty,

--- a/tools/crm_verify.c
+++ b/tools/crm_verify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -132,6 +132,8 @@ output_config_error(void *ctx, const char *msg, ...)
     if (options.verbosity > 0) {
         out->err(out, "error: %s", buf);
     }
+
+    free(buf);
     va_end(ap);
 }
 
@@ -156,6 +158,8 @@ output_config_warning(void *ctx, const char *msg, ...)
     if (options.verbosity > 0) {
         out->err(out, "warning: %s", buf);
     }
+
+    free(buf);
     va_end(ap);
 }
 


### PR DESCRIPTION
These are fixes for issues found by static analysis.  There are still three outstanding results from clang that I haven't decided what to do about (if anything):

* pcmk__is_anonymous_clone - It thinks `rsc->flags` is a NULL pointer dereference, which is impossible.
* tools/crm_resource.c:2086 - It thinks `args->verbosity` is a NULL pointer dereference, which is impossible.  `pcmk__new_common_args` exits on error.
* get_capable_devices - It thinks we're leaking `search`, which is pretty hard to decide if that's the case or not.