### PR TITLE
Fix memory leaks found by valgrind in cts-cli tests

### DIFF
--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -572,7 +572,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
     config_hash = pcmk__strkey_table(free, free);
     pcmk__unpack_nvpair_blocks(crmconfig, PCMK_XE_CLUSTER_PROPERTY_SET,
                                PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
-                               config_hash, NULL);
+                               config_hash, NULL, crmconfig->doc);
 
     // Validate all options, and use defaults if not already present in hash
     pcmk__validate_cluster_options(config_hash);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -570,9 +570,9 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 
     pcmk__debug("Call %d : Parsing CIB options", call_id);
     config_hash = pcmk__strkey_table(free, free);
-    pcmk_unpack_nvpair_blocks(crmconfig, PCMK_XE_CLUSTER_PROPERTY_SET,
-                              PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
-                              config_hash, NULL);
+    pcmk__unpack_nvpair_blocks(crmconfig, PCMK_XE_CLUSTER_PROPERTY_SET,
+                               PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
+                               config_hash, NULL);
 
     // Validate all options, and use defaults if not already present in hash
     pcmk__validate_cluster_options(config_hash);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -426,35 +426,39 @@ crmd_proxy_dispatch(const char *session, xmlNode *msg)
 }
 
 static void
-remote_config_check(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data)
+remote_config_check(xmlNode *msg, int call_id, int rc, xmlNode *output,
+                    void *user_data)
 {
+    lrmd_t *lrmd = user_data;
+    GHashTable *config_hash = NULL;
+    crm_time_t *now = NULL;
+    pcmk_rule_input_t rule_input = { NULL, };
+
     if (rc != pcmk_ok) {
         pcmk__err("Query resulted in an error: %s", pcmk_strerror(rc));
 
-        if (rc == -EACCES || rc == -pcmk_err_schema_validation) {
-            pcmk__err("The cluster is mis-configured - shutting down and "
+        if ((rc == -EACCES) || (rc == -pcmk_err_schema_validation)) {
+            pcmk__err("The cluster is misconfigured - shutting down and "
                       "staying down");
         }
 
-    } else {
-        lrmd_t * lrmd = (lrmd_t *)user_data;
-        crm_time_t *now = crm_time_new(NULL);
-        GHashTable *config_hash = pcmk__strkey_table(free, free);
-        pcmk_rule_input_t rule_input = {
-            .now = now,
-        };
-
-        pcmk__debug("Call %d : Parsing CIB options", call_id);
-        pcmk__unpack_nvpair_blocks(output, PCMK_XE_CLUSTER_PROPERTY_SET,
-                                   PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS,
-                                   &rule_input, config_hash, NULL);
-
-        /* Now send it to the remote peer */
-        lrmd__validate_remote_settings(lrmd, config_hash);
-
-        g_hash_table_destroy(config_hash);
-        crm_time_free(now);
+        return;
     }
+
+    config_hash = pcmk__strkey_table(free, free);
+    now = crm_time_new(NULL);
+    rule_input.now = now;
+
+    pcmk__debug("Call %d : Parsing CIB options", call_id);
+    pcmk__unpack_nvpair_blocks(output, PCMK_XE_CLUSTER_PROPERTY_SET,
+                               PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
+                               config_hash, NULL);
+
+    // Now send it to the remote peer
+    lrmd__validate_remote_settings(lrmd, config_hash);
+
+    g_hash_table_destroy(config_hash);
+    crm_time_free(now);
 }
 
 static void

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -445,9 +445,9 @@ remote_config_check(xmlNode * msg, int call_id, int rc, xmlNode * output, void *
         };
 
         pcmk__debug("Call %d : Parsing CIB options", call_id);
-        pcmk_unpack_nvpair_blocks(output, PCMK_XE_CLUSTER_PROPERTY_SET,
-                                  PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
-                                  config_hash, NULL);
+        pcmk__unpack_nvpair_blocks(output, PCMK_XE_CLUSTER_PROPERTY_SET,
+                                   PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS,
+                                   &rule_input, config_hash, NULL);
 
         /* Now send it to the remote peer */
         lrmd__validate_remote_settings(lrmd, config_hash);

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -450,9 +450,11 @@ remote_config_check(xmlNode *msg, int call_id, int rc, xmlNode *output,
     rule_input.now = now;
 
     pcmk__debug("Call %d : Parsing CIB options", call_id);
-    pcmk__unpack_nvpair_blocks(output, PCMK_XE_CLUSTER_PROPERTY_SET,
-                               PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
-                               config_hash, NULL);
+    if (output != NULL) {
+        pcmk__unpack_nvpair_blocks(output, PCMK_XE_CLUSTER_PROPERTY_SET,
+                                   PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS,
+                                   &rule_input, config_hash, NULL, output->doc);
+    }
 
     // Now send it to the remote peer
     lrmd__validate_remote_settings(lrmd, config_hash);

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -444,7 +444,6 @@ generate_params(void)
     xmlNode *cib_xml_copy = NULL;
     pcmk_resource_t *rsc = NULL;
     GHashTable *params = NULL;
-    GHashTable *meta = NULL;
     GHashTableIter iter;
     char *key = NULL;
     char *value = NULL;
@@ -496,9 +495,7 @@ generate_params(void)
     }
 
     // Add resource meta-attributes to options.params
-    meta = pcmk__strkey_table(free, free);
-    get_meta_attributes(meta, rsc, NULL, scheduler);
-    g_hash_table_iter_init(&iter, meta);
+    g_hash_table_iter_init(&iter, rsc->priv->meta);
     while (g_hash_table_iter_next(&iter, (gpointer *) &key,
                                   (gpointer *) &value)) {
         char *crm_name = crm_meta_name(key);
@@ -506,7 +503,6 @@ generate_params(void)
         options.params = lrmd_key_value_add(options.params, crm_name, value);
         free(crm_name);
     }
-    g_hash_table_destroy(meta);
 
     pcmk_free_scheduler(scheduler);
     return rc;

--- a/daemons/fenced/fenced_scheduler.c
+++ b/daemons/fenced/fenced_scheduler.c
@@ -214,7 +214,6 @@ register_if_fencing_device(gpointer data, gpointer user_data)
 
     agent = pcmk__xe_get(rsc->priv->xml, PCMK_XA_TYPE);
 
-    get_meta_attributes(rsc->priv->meta, rsc, NULL, scheduler);
     rsc_provides = g_hash_table_lookup(rsc->priv->meta,
                                        PCMK_FENCING_PROVIDES);
 

--- a/include/crm/common/nodes_internal.h
+++ b/include/crm/common/nodes_internal.h
@@ -106,7 +106,7 @@ struct pcmk__node_private {
     /* Node's XML ID in the CIB (the cluster layer ID for cluster nodes,
      * the node name for Pacemaker Remote nodes)
      */
-    const char *id;
+    char *id;
 
     /*
      * Sum of priorities of all resources active on node and on any guest nodes
@@ -115,7 +115,7 @@ struct pcmk__node_private {
      */
     int priority;
 
-    const char *name;                   // Node name in cluster
+    char *name;                         // Node name in cluster
     enum pcmk__node_variant variant;    // Node variant
     uint32_t flags;                     // Group of enum pcmk__node_flags
     GHashTable *attrs;                  // Node attributes

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -10,13 +10,8 @@
 #ifndef PCMK__CRM_COMMON_NVPAIR__H
 #define PCMK__CRM_COMMON_NVPAIR__H
 
-#include <glib.h>         // gpointer, GHashTable
+#include <glib.h>         // GHashTable, gpointer, GSList
 #include <libxml/tree.h>  // xmlNode
-
-#include <crm/crm.h>
-#include <crm/common/iso8601.h> // crm_time_t
-#include <crm/common/rules.h>   // pcmk_rule_input_t
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,11 +38,6 @@ void hash2field(gpointer key, gpointer value, gpointer user_data);
 void hash2metafield(gpointer key, gpointer value, gpointer user_data);
 void hash2smartfield(gpointer key, gpointer value, gpointer user_data);
 GHashTable *xml2list(const xmlNode *parent);
-
-void pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
-                               const char *first_id,
-                               const pcmk_rule_input_t *rule_input,
-                               GHashTable *values, crm_time_t *next_change);
 
 char *crm_meta_name(const char *field);
 const char *crm_meta_value(GHashTable *hash, const char *field);

--- a/include/crm/common/nvpair_compat.h
+++ b/include/crm/common/nvpair_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -10,8 +10,11 @@
 #ifndef PCMK__CRM_COMMON_NVPAIR_COMPAT__H
 #define PCMK__CRM_COMMON_NVPAIR_COMPAT__H
 
-#include <glib.h>               // GSList, gpointer
+#include <glib.h>               // GHashTable, gpointer, GSList
 #include <libxml/tree.h>        // xmlNode
+
+#include <crm/common/iso8601.h> // crm_time_t
+#include <crm/common/rules.h>   // pcmk_rule_input_t
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,6 +40,12 @@ void pcmk_nvpairs2xml_attrs(GSList *list, xmlNode *xml);
 
 //! \deprecated Do not use
 void hash2nvpair(gpointer key, gpointer value, gpointer user_data);
+
+//! \deprecated Do not use
+void pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
+                               const char *first_id,
+                               const pcmk_rule_input_t *rule_input,
+                               GHashTable *values, crm_time_t *next_change);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -30,6 +30,7 @@ extern "C" {
 typedef struct {
     GHashTable *values;             // Where to put name/value pairs
     const char *first_id;           // Block with this XML ID should sort first
+    xmlDoc *doc;                    // XML document to use for resolving IDREFs
     pcmk_rule_input_t rule_input;   // Data used to evaluate rules
 
     /* Whether each block's values should overwrite any existing ones

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -52,7 +52,8 @@ void pcmk__unpack_nvpair_block(gpointer data, gpointer user_data);
 void pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                                 const char *first_id,
                                 const pcmk_rule_input_t *rule_input,
-                                GHashTable *values, crm_time_t *next_change);
+                                GHashTable *values, crm_time_t *next_change,
+                                xmlDoc *doc);
 
 int pcmk__scan_nvpair(const gchar *input, gchar **name, gchar **value);
 char *pcmk__format_nvpair(const char *name, const char *value,

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -49,6 +49,11 @@ gint pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b,
 
 void pcmk__unpack_nvpair_block(gpointer data, gpointer user_data);
 
+void pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
+                                const char *first_id,
+                                const pcmk_rule_input_t *rule_input,
+                                GHashTable *values, crm_time_t *next_change);
+
 int pcmk__scan_nvpair(const gchar *input, gchar **name, gchar **value);
 char *pcmk__format_nvpair(const char *name, const char *value,
                           const char *units);

--- a/include/crm/common/resources_internal.h
+++ b/include/crm/common/resources_internal.h
@@ -340,13 +340,24 @@ struct pcmk__resource_private {
     pcmk_resource_t *parent;        // Resource's parent resource, if any
     pcmk_scheduler_t *scheduler;    // Scheduler data containing resource
 
-    // Resource configuration (possibly expanded from template)
+    /* Effective resource configuration (possibly expanded from template).
+     *
+     * This is not part of scheduler->input but may have been copied from it.
+     */
     xmlNode *xml;
 
-    // Original resource configuration, if using template
+    /* Original resource configuration. In the common case (without template
+     * expansion), this is equal to xml. In that case, do not free this
+     * directly.
+     *
+     * This is not part of scheduler->input but may have been copied from it.
+     */
     xmlNode *orig_xml;
 
-    // Configuration of resource operations (possibly expanded from template)
+    /* Configuration of resource operations (possibly expanded from template)
+     *
+     * This is part of scheduler->input.
+     */
     xmlNode *ops_xml;
 
     /*

--- a/include/crm/common/xml_idref_internal.h
+++ b/include/crm/common/xml_idref_internal.h
@@ -27,6 +27,6 @@ void pcmk__add_idref(GHashTable *table, const char *id, const char *referrer);
 void pcmk__free_idref(gpointer data);
 xmlNode *pcmk__xe_resolve_idref(xmlNode *xml, xmlDoc *doc);
 GList *pcmk__xe_dereference_children(const xmlNode *xml,
-                                     const char *element_name);
+                                     const char *element_name, xmlDoc *doc);
 
 #endif // PCMK__CRM_COMMON_XML_IDREF_INTERNAL__H

--- a/include/crm/common/xml_idref_internal.h
+++ b/include/crm/common/xml_idref_internal.h
@@ -25,7 +25,7 @@ typedef struct {
 
 void pcmk__add_idref(GHashTable *table, const char *id, const char *referrer);
 void pcmk__free_idref(gpointer data);
-xmlNode *pcmk__xe_resolve_idref(xmlNode *xml, xmlNode *search);
+xmlNode *pcmk__xe_resolve_idref(xmlNode *xml, xmlDoc *doc);
 GList *pcmk__xe_dereference_children(const xmlNode *xml,
                                      const char *element_name);
 

--- a/include/crm/pengine/complex.h
+++ b/include/crm/pengine/complex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -20,7 +20,7 @@ extern "C" {
 
 GHashTable *pe_rsc_params(pcmk_resource_t *rsc, const pcmk_node_t *node,
                           pcmk_scheduler_t *scheduler);
-void get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t *rsc,
+void get_meta_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
                          pcmk_node_t *node, pcmk_scheduler_t *scheduler);
 void get_rsc_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
                         const pcmk_node_t *node, pcmk_scheduler_t *scheduler);

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -293,8 +293,9 @@ int pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, unsigned int opt
 void pe_fence_node(pcmk_scheduler_t *scheduler, pcmk_node_t *node,
                    const char *reason, bool priority_delay);
 
-pcmk_node_t *pe_create_node(const char *id, const char *uname, const char *type,
-                            int score, pcmk_scheduler_t *scheduler);
+pcmk_node_t *pe__create_node(const char *id, const char *uname,
+                             const char *type, int score,
+                             pcmk_scheduler_t *scheduler);
 
 int pe__common_output_text(pcmk__output_t *out, const pcmk_resource_t *rsc,
                            const char *name, const pcmk_node_t *node,

--- a/include/crm/pengine/rules_compat.h
+++ b/include/crm/pengine/rules_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -34,14 +34,14 @@ extern "C" {
 gboolean test_rule(xmlNode *rule, GHashTable *node_hash, enum rsc_role_e role,
                    crm_time_t *now);
 
-//! \deprecated Use pcmk_unpack_nvpair_blocks() instead
+//! \deprecated Do not use
 void pe_unpack_nvpairs(xmlNode *top, const xmlNode *xml_obj,
                        const char *set_name, GHashTable *node_hash,
                        GHashTable *hash, const char *always_first,
                        gboolean overwrite, crm_time_t *now,
                        crm_time_t *next_change);
 
-//! \deprecated Use pcmk_unpack_nvpair_blocks() instead
+//! \deprecated Do not use
 void pe_eval_nvpairs(xmlNode *top, const xmlNode *xml_obj, const char *set_name,
                      const pe_rule_eval_data_t *rule_data, GHashTable *hash,
                      const char *always_first, gboolean overwrite,

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -145,7 +145,7 @@ read_config(GHashTable *options, xmlNode *current_cib)
 
     pcmk__unpack_nvpair_blocks(config, PCMK_XE_CLUSTER_PROPERTY_SET,
                                PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
-                               options, NULL);
+                               options, NULL, config->doc);
     crm_time_free(now);
 }
 

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -143,9 +143,9 @@ read_config(GHashTable *options, xmlNode *current_cib)
     now = crm_time_new(NULL);
     rule_input.now = now;
 
-    pcmk_unpack_nvpair_blocks(config, PCMK_XE_CLUSTER_PROPERTY_SET,
-                              PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
-                              options, NULL);
+    pcmk__unpack_nvpair_blocks(config, PCMK_XE_CLUSTER_PROPERTY_SET,
+                               PCMK_VALUE_CIB_BOOTSTRAP_OPTIONS, &rule_input,
+                               options, NULL);
     crm_time_free(now);
 }
 

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -153,8 +153,8 @@ unpack_alert_options(xmlNode *xml, pcmk__alert_t *entry, guint *max_timeout)
         .now = now,
     };
 
-    pcmk_unpack_nvpair_blocks(xml, PCMK_XE_META_ATTRIBUTES, NULL, &rule_input,
-                              config_hash, NULL);
+    pcmk__unpack_nvpair_blocks(xml, PCMK_XE_META_ATTRIBUTES, NULL, &rule_input,
+                               config_hash, NULL);
     crm_time_free(now);
 
     value = g_hash_table_lookup(config_hash, PCMK_META_ENABLED);

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -154,7 +154,7 @@ unpack_alert_options(xmlNode *xml, pcmk__alert_t *entry, guint *max_timeout)
     };
 
     pcmk__unpack_nvpair_blocks(xml, PCMK_XE_META_ATTRIBUTES, NULL, &rule_input,
-                               config_hash, NULL);
+                               config_hash, NULL, xml->doc);
     crm_time_free(now);
 
     value = g_hash_table_lookup(config_hash, PCMK_META_ENABLED);

--- a/lib/common/nodes.c
+++ b/lib/common/nodes.c
@@ -30,10 +30,6 @@ pcmk__free_node(gpointer user_data)
     if (node == NULL) {
         return;
     }
-    if (node->details == NULL) {
-        free(node);
-        return;
-    }
 
     /* This may be called after freeing resources, which means that we can't
      * use node->private->name for Pacemaker Remote nodes.
@@ -41,13 +37,19 @@ pcmk__free_node(gpointer user_data)
     pcmk__trace("Freeing node %s",
                 (is_remote? "(guest or remote)" : pcmk__node_name(node)));
 
-    g_clear_pointer(&node->priv->attrs, g_hash_table_destroy);
-    g_clear_pointer(&node->priv->utilization, g_hash_table_destroy);
-    g_clear_pointer(&node->priv->digest_cache, g_hash_table_destroy);
-    g_list_free(node->details->running_rsc);
-    g_list_free(node->priv->assigned_resources);
-    free(node->priv);
-    free(node->details);
+    if (node->details != NULL) {
+        g_list_free(node->details->running_rsc);
+        free(node->details);
+    }
+
+    if (node->priv != NULL) {
+        g_clear_pointer(&node->priv->attrs, g_hash_table_destroy);
+        g_clear_pointer(&node->priv->utilization, g_hash_table_destroy);
+        g_clear_pointer(&node->priv->digest_cache, g_hash_table_destroy);
+        g_list_free(node->priv->assigned_resources);
+        free(node->priv);
+    }
+
     free(node->assign);
     free(node);
 }

--- a/lib/common/nodes.c
+++ b/lib/common/nodes.c
@@ -25,7 +25,6 @@ void
 pcmk__free_node(gpointer user_data)
 {
     pcmk_node_t *node = user_data;
-    const bool is_remote = pcmk__is_pacemaker_remote_node(node);
 
     if (node == NULL) {
         return;
@@ -34,8 +33,7 @@ pcmk__free_node(gpointer user_data)
     /* This may be called after freeing resources, which means that we can't
      * use node->private->name for Pacemaker Remote nodes.
      */
-    pcmk__trace("Freeing node %s",
-                (is_remote? "(guest or remote)" : pcmk__node_name(node)));
+    pcmk__trace("Freeing node %s", pcmk__node_name(node));
 
     if (node->details != NULL) {
         g_list_free(node->details->running_rsc);
@@ -43,6 +41,8 @@ pcmk__free_node(gpointer user_data)
     }
 
     if (node->priv != NULL) {
+        free(node->priv->id);
+        free(node->priv->name);
         g_clear_pointer(&node->priv->attrs, g_hash_table_destroy);
         g_clear_pointer(&node->priv->utilization, g_hash_table_destroy);
         g_clear_pointer(&node->priv->digest_cache, g_hash_table_destroy);

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -504,6 +504,7 @@ pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
         return;
     }
 
+    data.doc = xml->doc;
     if (rule_input != NULL) {
         data.rule_input = *rule_input;
     }

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -397,7 +397,8 @@ unpack_nvpair(xmlNode *nvpair, void *userdata)
     const char *name = NULL;
     const char *value = NULL;
     const char *old_value = NULL;
-    const xmlNode *ref_nvpair = pcmk__xe_resolve_idref(nvpair, nvpair->doc);
+    const xmlNode *ref_nvpair = pcmk__xe_resolve_idref(nvpair,
+                                                       unpack_data->doc);
 
     if (ref_nvpair == NULL) {
         /* Not possible with schema validation enabled (error already

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -397,7 +397,7 @@ unpack_nvpair(xmlNode *nvpair, void *userdata)
     const char *name = NULL;
     const char *value = NULL;
     const char *old_value = NULL;
-    const xmlNode *ref_nvpair = pcmk__xe_resolve_idref(nvpair, NULL);
+    const xmlNode *ref_nvpair = pcmk__xe_resolve_idref(nvpair, nvpair->doc);
 
     if (ref_nvpair == NULL) {
         /* Not possible with schema validation enabled (error already

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -487,8 +487,13 @@ pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                           const pcmk_rule_input_t *rule_input,
                           GHashTable *values, crm_time_t *next_change)
 {
-    GList *blocks = pcmk__xe_dereference_children(xml, element_name);
+    GList *blocks = NULL;
 
+    if (xml == NULL) {
+        return;
+    }
+
+    blocks = pcmk__xe_dereference_children(xml, element_name, xml->doc);
     if (blocks != NULL) {
         pcmk__nvpair_unpack_t data = {
             .values = values,

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -471,6 +471,7 @@ pcmk__unpack_nvpair_block(gpointer data, gpointer user_data)
 }
 
 /*!
+ * \internal
  * \brief Unpack nvpair blocks contained by an XML element into a hash table,
  *        evaluated for any rules
  *
@@ -483,10 +484,10 @@ pcmk__unpack_nvpair_block(gpointer data, gpointer user_data)
  *                           change, if sooner than its current value
  */
 void
-pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
-                          const char *first_id,
-                          const pcmk_rule_input_t *rule_input,
-                          GHashTable *values, crm_time_t *next_change)
+pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
+                           const char *first_id,
+                           const pcmk_rule_input_t *rule_input,
+                           GHashTable *values, crm_time_t *next_change)
 {
     GList *blocks = NULL;
     pcmk__nvpair_unpack_t data = {
@@ -515,6 +516,27 @@ pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
     g_list_free(blocks);
 }
 
+/*!
+ * \brief Unpack nvpair blocks contained by an XML element into a hash table,
+ *        evaluated for any rules
+ *
+ * \param[in]  xml           XML element containing blocks of nvpair elements
+ * \param[in]  element_name  If not NULL, only unpack blocks of this element
+ * \param[in]  first_id      If not NULL, process block with this ID first
+ * \param[in]  rule_input    Values used to evaluate rule criteria
+ * \param[out] values        Where to store extracted name/value pairs
+ * \param[out] next_change   If not NULL, set to when evaluation will next
+ *                           change, if sooner than its current value
+ */
+void
+pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
+                          const char *first_id,
+                          const pcmk_rule_input_t *rule_input,
+                          GHashTable *values, crm_time_t *next_change)
+{
+    pcmk__unpack_nvpair_blocks(xml, element_name, first_id, rule_input, values,
+                               next_change);
+}
 
 // Meta-attribute handling
 

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -488,30 +488,29 @@ pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                           GHashTable *values, crm_time_t *next_change)
 {
     GList *blocks = NULL;
+    pcmk__nvpair_unpack_t data = {
+        .values = values,
+        .first_id = first_id,
+        .overwrite = false,
+        .next_change = next_change,
+    };
 
     if (xml == NULL) {
         return;
     }
 
     blocks = pcmk__xe_dereference_children(xml, element_name, xml->doc);
-    if (blocks != NULL) {
-        pcmk__nvpair_unpack_t data = {
-            .values = values,
-            .first_id = first_id,
-            .rule_input = {
-                .now = NULL,
-            },
-            .overwrite = false,
-            .next_change = next_change,
-        };
-
-        if (rule_input != NULL) {
-            data.rule_input = *rule_input;
-        }
-        blocks = g_list_sort_with_data(blocks, pcmk__cmp_nvpair_blocks, &data);
-        g_list_foreach(blocks, pcmk__unpack_nvpair_block, &data);
-        g_list_free(blocks);
+    if (blocks == NULL) {
+        return;
     }
+
+    if (rule_input != NULL) {
+        data.rule_input = *rule_input;
+    }
+
+    blocks = g_list_sort_with_data(blocks, pcmk__cmp_nvpair_blocks, &data);
+    g_list_foreach(blocks, pcmk__unpack_nvpair_block, &data);
+    g_list_free(blocks);
 }
 
 

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -482,12 +482,14 @@ pcmk__unpack_nvpair_block(gpointer data, gpointer user_data)
  * \param[out] values        Where to store extracted name/value pairs
  * \param[out] next_change   If not NULL, set to when evaluation will next
  *                           change, if sooner than its current value
+ * \param[in]  doc           XML document to use for resolving IDREFs
  */
 void
 pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                            const char *first_id,
                            const pcmk_rule_input_t *rule_input,
-                           GHashTable *values, crm_time_t *next_change)
+                           GHashTable *values, crm_time_t *next_change,
+                           xmlDoc *doc)
 {
     GList *blocks = NULL;
     pcmk__nvpair_unpack_t data = {
@@ -506,7 +508,7 @@ pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
         return;
     }
 
-    data.doc = xml->doc;
+    data.doc = doc;
     if (rule_input != NULL) {
         data.rule_input = *rule_input;
     }
@@ -736,8 +738,12 @@ pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                           const pcmk_rule_input_t *rule_input,
                           GHashTable *values, crm_time_t *next_change)
 {
+    if (xml == NULL) {
+        return;
+    }
+
     pcmk__unpack_nvpair_blocks(xml, element_name, first_id, rule_input, values,
-                               next_change);
+                               next_change, xml->doc);
 }
 
 // LCOV_EXCL_STOP

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -516,28 +516,6 @@ pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
     g_list_free(blocks);
 }
 
-/*!
- * \brief Unpack nvpair blocks contained by an XML element into a hash table,
- *        evaluated for any rules
- *
- * \param[in]  xml           XML element containing blocks of nvpair elements
- * \param[in]  element_name  If not NULL, only unpack blocks of this element
- * \param[in]  first_id      If not NULL, process block with this ID first
- * \param[in]  rule_input    Values used to evaluate rule criteria
- * \param[out] values        Where to store extracted name/value pairs
- * \param[out] next_change   If not NULL, set to when evaluation will next
- *                           change, if sooner than its current value
- */
-void
-pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
-                          const char *first_id,
-                          const pcmk_rule_input_t *rule_input,
-                          GHashTable *values, crm_time_t *next_change)
-{
-    pcmk__unpack_nvpair_blocks(xml, element_name, first_id, rule_input, values,
-                               next_change);
-}
-
 // Meta-attribute handling
 
 /*!
@@ -750,6 +728,16 @@ hash2nvpair(gpointer key, gpointer value, gpointer user_data)
 
     crm_create_nvpair_xml(xml_node, name, name, s_value);
     pcmk__trace("dumped: name=%s value=%s", name, s_value);
+}
+
+void
+pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
+                          const char *first_id,
+                          const pcmk_rule_input_t *rule_input,
+                          GHashTable *values, crm_time_t *next_change)
+{
+    pcmk__unpack_nvpair_blocks(xml, element_name, first_id, rule_input, values,
+                               next_change);
 }
 
 // LCOV_EXCL_STOP

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -1313,7 +1313,7 @@ pcmk_evaluate_rule(xmlNode *rule, const pcmk_rule_input_t *rule_input,
         return EINVAL;
     }
 
-    rule = pcmk__xe_resolve_idref(rule, NULL);
+    rule = pcmk__xe_resolve_idref(rule, rule->doc);
     if (rule == NULL) {
         // Not possible with schema validation enabled; message already logged
         return pcmk_rc_unpack_error;

--- a/lib/common/tests/nodes/pcmk__find_node_in_list_test.c
+++ b/lib/common/tests/nodes/pcmk__find_node_in_list_test.c
@@ -22,8 +22,12 @@ empty_list(void **state)
 static void
 non_null_list(void **state)
 {
-    struct pcmk__node_private node1_priv = { .name = "cluster1" };
-    struct pcmk__node_private node2_priv = { .name = "cluster2" };
+    struct pcmk__node_private node1_priv = {
+        .name = pcmk__str_copy("cluster1"),
+    };
+    struct pcmk__node_private node2_priv = {
+        .name = pcmk__str_copy("cluster2"),
+    };
     pcmk_node_t node1 = { .priv = &node1_priv };
     pcmk_node_t node2 = { .priv = &node2_priv };
     GList *nodes = NULL;
@@ -37,6 +41,8 @@ non_null_list(void **state)
     assert_ptr_equal(&node2, pcmk__find_node_in_list(nodes, "CLUSTER2"));
     assert_null(pcmk__find_node_in_list(nodes, "xyz"));
 
+    free(node1_priv.name);
+    free(node2_priv.name);
     g_list_free(nodes);
 }
 

--- a/lib/common/tests/nodes/pcmk__find_node_in_list_test.c
+++ b/lib/common/tests/nodes/pcmk__find_node_in_list_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,30 +22,21 @@ empty_list(void **state)
 static void
 non_null_list(void **state)
 {
+    struct pcmk__node_private node1_priv = { .name = "cluster1" };
+    struct pcmk__node_private node2_priv = { .name = "cluster2" };
+    pcmk_node_t node1 = { .priv = &node1_priv };
+    pcmk_node_t node2 = { .priv = &node2_priv };
     GList *nodes = NULL;
 
-    pcmk_node_t *a = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
-    pcmk_node_t *b = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    nodes = g_list_prepend(nodes, &node1);
+    nodes = g_list_prepend(nodes, &node2);
 
-    a->priv = pcmk__assert_alloc(1, sizeof(struct pcmk__node_private));
-    b->priv = pcmk__assert_alloc(1, sizeof(struct pcmk__node_private));
-
-    a->priv->name = "cluster1";
-    b->priv->name = "cluster2";
-
-    nodes = g_list_append(nodes, a);
-    nodes = g_list_append(nodes, b);
-
-    assert_ptr_equal(a, pcmk__find_node_in_list(nodes, "cluster1"));
+    assert_ptr_equal(&node1, pcmk__find_node_in_list(nodes, "cluster1"));
     assert_null(pcmk__find_node_in_list(nodes, "cluster10"));
     assert_null(pcmk__find_node_in_list(nodes, "nodecluster1"));
-    assert_ptr_equal(b, pcmk__find_node_in_list(nodes, "CLUSTER2"));
+    assert_ptr_equal(&node2, pcmk__find_node_in_list(nodes, "CLUSTER2"));
     assert_null(pcmk__find_node_in_list(nodes, "xyz"));
 
-    free(a->priv);
-    free(a);
-    free(b->priv);
-    free(b);
     g_list_free(nodes);
 }
 

--- a/lib/common/tests/nvpair/Makefile.am
+++ b/lib/common/tests/nvpair/Makefile.am
@@ -17,6 +17,6 @@ check_PROGRAMS += crm_meta_value_test
 check_PROGRAMS += pcmk__cmp_nvpair_blocks_test
 check_PROGRAMS += pcmk__scan_nvpair_test
 check_PROGRAMS += pcmk__unpack_nvpair_block_test
-check_PROGRAMS += pcmk_unpack_nvpair_blocks_test
+check_PROGRAMS += pcmk__unpack_nvpair_blocks_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
+++ b/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
@@ -41,6 +41,10 @@
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp2-3' "          \
         PCMK_XA_NAME "='name3' " PCMK_XA_VALUE "='2' />"
 
+#define XML_NVPAIRS_IDREF                                   \
+    "<" PCMK_XE_NVPAIR " " PCMK_XA_ID_REF "='nvp1-1' />"    \
+    "<" PCMK_XE_NVPAIR " " PCMK_XA_ID_REF "='nvp2-2' />"
+
 #define assert_unpack_nvpair_block(xml_str, unpack_data, size, value1,      \
                                    value2, value3)                          \
     do {                                                                    \
@@ -48,7 +52,10 @@
         xmlNode *xml = pcmk__xml_parse(xml_str);                            \
                                                                             \
         assert_non_null(xml);                                               \
-        (unpack_data)->doc = xml->doc;                                      \
+                                                                            \
+        if ((unpack_data)->doc == NULL) {                                   \
+            (unpack_data)->doc = xml->doc;                                  \
+        }                                                                   \
                                                                             \
         pcmk__unpack_nvpair_block(xml, unpack_data);                        \
         assert_int_equal(g_hash_table_size((unpack_data)->values), size);   \
@@ -105,7 +112,8 @@ invalid_args(void **state)
 }
 
 static void
-with_rules(void **state) {
+with_rules(void **state)
+{
     crm_time_t *now = crm_time_new("2024-01-01 15:00:00");
     pcmk__nvpair_unpack_t unpack_data = {
         .values = pcmk__strkey_table(free, free),
@@ -172,9 +180,30 @@ attributes_child(void **state)
     g_hash_table_destroy(unpack_data.values);
 }
 
+static void
+with_idref(void **state)
+{
+    pcmk__nvpair_unpack_t unpack_data = {
+        .values = pcmk__strkey_table(free, free),
+    };
+
+    xmlNode *ref_source = pcmk__xml_parse("<xml>"
+                                              XML_NVPAIRS_1 XML_NVPAIRS_2
+                                          "</xml>");
+
+    assert_non_null(ref_source);
+    unpack_data.doc = ref_source->doc;
+
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_IDREF "</xml>", &unpack_data,
+                               2, "1", "2", NULL);
+
+    pcmk__xml_free(ref_source);
+}
+
 PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
                 cmocka_unit_test(invalid_args),
                 cmocka_unit_test(with_rules),
                 cmocka_unit_test(without_overwrite),
                 cmocka_unit_test(with_overwrite),
-                cmocka_unit_test(attributes_child))
+                cmocka_unit_test(attributes_child),
+                cmocka_unit_test(with_idref))

--- a/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
+++ b/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
@@ -14,32 +14,32 @@
 #include <crm/common/unittest_internal.h>
 
 #define XML_PASSING_RULE                                    \
-    "<" PCMK_XE_RULE " " PCMK_XA_ID "='rp' >\n"             \
+    "<" PCMK_XE_RULE " " PCMK_XA_ID "='rp' >"               \
       "<" PCMK_XE_DATE_EXPRESSION " " PCMK_XA_ID "='ep' "   \
           PCMK_XA_OPERATION "='" PCMK_VALUE_GT "' "         \
-          PCMK_XA_START "='1950-01-01 00:00:00' />\n"       \
-    "</" PCMK_XE_RULE ">\n"
+          PCMK_XA_START "='1950-01-01 00:00:00' />"         \
+    "</" PCMK_XE_RULE ">"
 
 #define XML_FAILING_RULE                                    \
-    "<" PCMK_XE_RULE " " PCMK_XA_ID "='rf' >\n"             \
+    "<" PCMK_XE_RULE " " PCMK_XA_ID "='rf' >"               \
       "<" PCMK_XE_DATE_EXPRESSION " " PCMK_XA_ID "='ef' "   \
           PCMK_XA_OPERATION "='" PCMK_VALUE_LT "' "         \
-          PCMK_XA_END "='1950-01-01 00:00:00' />\n"         \
-    "</" PCMK_XE_RULE ">\n"
+          PCMK_XA_END "='1950-01-01 00:00:00' />"           \
+    "</" PCMK_XE_RULE ">"
 
 #define XML_NVPAIRS_1                                       \
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp1-1' "          \
-        PCMK_XA_NAME "='name1' " PCMK_XA_VALUE "='1' />\n"  \
+        PCMK_XA_NAME "='name1' " PCMK_XA_VALUE "='1' />"    \
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp1-2' "          \
-        PCMK_XA_NAME "='name2' " PCMK_XA_VALUE "='1' />\n"
+        PCMK_XA_NAME "='name2' " PCMK_XA_VALUE "='1' />"
 
 #define XML_NVPAIRS_2                                       \
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp2-1' "          \
-        PCMK_XA_NAME "='name1' " PCMK_XA_VALUE "='2' />\n"  \
+        PCMK_XA_NAME "='name1' " PCMK_XA_VALUE "='2' />"    \
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp2-2' "          \
-        PCMK_XA_NAME "='name2' " PCMK_XA_VALUE "='2' />\n"  \
+        PCMK_XA_NAME "='name2' " PCMK_XA_VALUE "='2' />"    \
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp2-3' "          \
-        PCMK_XA_NAME "='name3' " PCMK_XA_VALUE "='2' />\n"
+        PCMK_XA_NAME "='name3' " PCMK_XA_VALUE "='2' />"
 
 static void
 invalid_args(void **state)
@@ -80,7 +80,7 @@ with_rules(void **state) {
 
     xmlNode *xml = NULL;
 
-    xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_1 XML_PASSING_RULE "</xml>\n");
+    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_1 XML_PASSING_RULE "</xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;
@@ -91,7 +91,7 @@ with_rules(void **state) {
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
     pcmk__xml_free(xml);
 
-    xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_2 XML_FAILING_RULE "</xml>\n");
+    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_2 XML_FAILING_RULE "</xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;
@@ -100,7 +100,6 @@ with_rules(void **state) {
     assert_int_equal(g_hash_table_size(unpack_data.values), 2);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-    assert_null(g_hash_table_lookup(unpack_data.values, "name3"));
 
     pcmk__xml_free(xml);
     crm_time_free(now);
@@ -117,7 +116,7 @@ without_overwrite(void **state)
 
     xmlNode *xml = NULL;
 
-    xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_1 "</xml>\n");
+    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_1 "</xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;
@@ -128,7 +127,7 @@ without_overwrite(void **state)
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
     pcmk__xml_free(xml);
 
-    xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_2 "</xml>\n");
+    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_2 "</xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;
@@ -153,7 +152,7 @@ with_overwrite(void **state)
 
     xmlNode *xml = NULL;
 
-    xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_1 "</xml>\n");
+    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_1 "</xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;
@@ -164,7 +163,7 @@ with_overwrite(void **state)
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
     pcmk__xml_free(xml);
 
-    xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_2 "</xml>\n");
+    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_2 "</xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;
@@ -186,9 +185,9 @@ attributes_child(void **state)
         .values = pcmk__strkey_table(free, free),
     };
 
-    xmlNode *xml = pcmk__xml_parse("<xml>\n<" PCMK__XE_ATTRIBUTES ">\n"
+    xmlNode *xml = pcmk__xml_parse("<xml><" PCMK__XE_ATTRIBUTES ">"
                                    XML_NVPAIRS_1
-                                   "</" PCMK__XE_ATTRIBUTES ">\n</xml>\n");
+                                   "</" PCMK__XE_ATTRIBUTES "></xml>");
 
     assert_non_null(xml);
     unpack_data.doc = xml->doc;

--- a/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
+++ b/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
@@ -41,6 +41,42 @@
     "<" PCMK_XE_NVPAIR " " PCMK_XA_ID "='nvp2-3' "          \
         PCMK_XA_NAME "='name3' " PCMK_XA_VALUE "='2' />"
 
+#define assert_unpack_nvpair_block(xml_str, unpack_data, size, value1,      \
+                                   value2, value3)                          \
+    do {                                                                    \
+        const char *found = NULL;                                           \
+        xmlNode *xml = pcmk__xml_parse(xml_str);                            \
+                                                                            \
+        assert_non_null(xml);                                               \
+        (unpack_data)->doc = xml->doc;                                      \
+                                                                            \
+        pcmk__unpack_nvpair_block(xml, unpack_data);                        \
+        assert_int_equal(g_hash_table_size((unpack_data)->values), size);   \
+                                                                            \
+        found = g_hash_table_lookup((unpack_data)->values, "name1");        \
+        if ((value1) == NULL) {                                             \
+            assert_null(found);                                             \
+        } else {                                                            \
+            assert_string_equal(found, value1);                             \
+        }                                                                   \
+                                                                            \
+        found = g_hash_table_lookup((unpack_data)->values, "name2");        \
+        if ((value2) == NULL) {                                             \
+            assert_null(found);                                             \
+        } else {                                                            \
+            assert_string_equal(found, value2);                             \
+        }                                                                   \
+                                                                            \
+        found = g_hash_table_lookup((unpack_data)->values, "name3");        \
+        if ((value3) == NULL) {                                             \
+            assert_null(found);                                             \
+        } else {                                                            \
+            assert_string_equal(found, value3);                             \
+        }                                                                   \
+                                                                            \
+        pcmk__xml_free(xml);                                                \
+    } while (0)
+
 static void
 invalid_args(void **state)
 {
@@ -78,30 +114,11 @@ with_rules(void **state) {
         },
     };
 
-    xmlNode *xml = NULL;
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_1 XML_PASSING_RULE "</xml>",
+                               &unpack_data, 2, "1", "1", NULL);
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_2 XML_FAILING_RULE "</xml>",
+                               &unpack_data, 2, "1", "1", NULL);
 
-    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_1 XML_PASSING_RULE "</xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 2);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-    pcmk__xml_free(xml);
-
-    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_2 XML_FAILING_RULE "</xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 2);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-
-    pcmk__xml_free(xml);
     crm_time_free(now);
     g_hash_table_destroy(unpack_data.values);
 }
@@ -114,30 +131,10 @@ without_overwrite(void **state)
         .overwrite = false,
     };
 
-    xmlNode *xml = NULL;
-
-    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_1 "</xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 2);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-    pcmk__xml_free(xml);
-
-    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_2 "</xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 3);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name3"), "2");
-    pcmk__xml_free(xml);
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_1 "</xml>", &unpack_data, 2,
+                               "1", "1", NULL);
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_2 "</xml>", &unpack_data, 3,
+                               "1", "1", "2");
 
     g_hash_table_destroy(unpack_data.values);
 }
@@ -150,30 +147,10 @@ with_overwrite(void **state)
         .overwrite = true,
     };
 
-    xmlNode *xml = NULL;
-
-    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_1 "</xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 2);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-    pcmk__xml_free(xml);
-
-    xml = pcmk__xml_parse("<xml>" XML_NVPAIRS_2 "</xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 3);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "2");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "2");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name3"), "2");
-    pcmk__xml_free(xml);
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_1 "</xml>", &unpack_data, 2,
+                               "1", "1", NULL);
+    assert_unpack_nvpair_block("<xml>" XML_NVPAIRS_2 "</xml>", &unpack_data, 3,
+                               "2", "2", "2");
 
     g_hash_table_destroy(unpack_data.values);
 }
@@ -185,18 +162,12 @@ attributes_child(void **state)
         .values = pcmk__strkey_table(free, free),
     };
 
-    xmlNode *xml = pcmk__xml_parse("<xml><" PCMK__XE_ATTRIBUTES ">"
-                                   XML_NVPAIRS_1
-                                   "</" PCMK__XE_ATTRIBUTES "></xml>");
-
-    assert_non_null(xml);
-    unpack_data.doc = xml->doc;
-
-    pcmk__unpack_nvpair_block(xml, &unpack_data);
-    assert_int_equal(g_hash_table_size(unpack_data.values), 2);
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
-    assert_string_equal(g_hash_table_lookup(unpack_data.values, "name2"), "1");
-    pcmk__xml_free(xml);
+    assert_unpack_nvpair_block("<xml>"
+                                   "<" PCMK__XE_ATTRIBUTES ">"
+                                       XML_NVPAIRS_1
+                                   "</" PCMK__XE_ATTRIBUTES ">"
+                               "</xml>",
+                               &unpack_data, 2, "1", "1", NULL);
 
     g_hash_table_destroy(unpack_data.values);
 }

--- a/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
+++ b/lib/common/tests/nvpair/pcmk__unpack_nvpair_block_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -54,6 +54,7 @@ invalid_args(void **state)
     xmlNode *xml = pcmk__xml_parse("<xml/>");
 
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
 
     pcmk__assert_asserts(pcmk__unpack_nvpair_block(NULL, NULL));
     pcmk__assert_asserts(pcmk__unpack_nvpair_block(NULL, &unpack_data));
@@ -80,7 +81,10 @@ with_rules(void **state) {
     xmlNode *xml = NULL;
 
     xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_1 XML_PASSING_RULE "</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 2);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
@@ -88,7 +92,10 @@ with_rules(void **state) {
     pcmk__xml_free(xml);
 
     xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_2 XML_FAILING_RULE "</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 2);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
@@ -111,7 +118,10 @@ without_overwrite(void **state)
     xmlNode *xml = NULL;
 
     xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_1 "</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 2);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
@@ -119,7 +129,10 @@ without_overwrite(void **state)
     pcmk__xml_free(xml);
 
     xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_2 "</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 3);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
@@ -141,7 +154,10 @@ with_overwrite(void **state)
     xmlNode *xml = NULL;
 
     xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_1 "</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 2);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");
@@ -149,7 +165,10 @@ with_overwrite(void **state)
     pcmk__xml_free(xml);
 
     xml = pcmk__xml_parse("<xml>\n" XML_NVPAIRS_2 "</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 3);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "2");
@@ -170,7 +189,10 @@ attributes_child(void **state)
     xmlNode *xml = pcmk__xml_parse("<xml>\n<" PCMK__XE_ATTRIBUTES ">\n"
                                    XML_NVPAIRS_1
                                    "</" PCMK__XE_ATTRIBUTES ">\n</xml>\n");
+
     assert_non_null(xml);
+    unpack_data.doc = xml->doc;
+
     pcmk__unpack_nvpair_block(xml, &unpack_data);
     assert_int_equal(g_hash_table_size(unpack_data.values), 2);
     assert_string_equal(g_hash_table_lookup(unpack_data.values, "name1"), "1");

--- a/lib/common/tests/nvpair/pcmk__unpack_nvpair_blocks_test.c
+++ b/lib/common/tests/nvpair/pcmk__unpack_nvpair_blocks_test.c
@@ -71,7 +71,7 @@ null_xml(void **state)
 
     // This mainly tests that it doesn't crash
     pcmk__unpack_nvpair_blocks(NULL, PCMK_XE_INSTANCE_ATTRIBUTES, "id1",
-                               &rule_input, values, next_change);
+                               &rule_input, values, next_change, NULL);
     assert_int_equal(g_hash_table_size(values), 0);
     g_hash_table_destroy(values);
     crm_time_free(now);
@@ -92,7 +92,7 @@ null_table(void **state)
     pcmk__assert_asserts(pcmk__unpack_nvpair_blocks(xml,
                                                     PCMK_XE_INSTANCE_ATTRIBUTES,
                                                     "id1", &rule_input, NULL,
-                                                    next_change));
+                                                    next_change, xml->doc));
     pcmk__xml_free(xml);
     crm_time_free(next_change);
     crm_time_free(now);
@@ -111,7 +111,7 @@ rule_passes(void **state)
 
     assert_non_null(xml);
     pcmk__unpack_nvpair_blocks(xml, NULL, "id1", &rule_input, values,
-                               next_change);
+                               next_change, xml->doc);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "1");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "1");
@@ -139,7 +139,7 @@ rule_fails(void **state)
 
     assert_non_null(xml);
     pcmk__unpack_nvpair_blocks(xml, NULL, "id1", &rule_input, values,
-                               next_change);
+                               next_change, xml->doc);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "3");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "3");
@@ -170,7 +170,7 @@ element_name(void **state)
      */
 
     pcmk__unpack_nvpair_blocks(xml, PCMK_XE_META_ATTRIBUTES, NULL, &rule_input,
-                               values, NULL);
+                               values, NULL, xml->doc);
     assert_int_equal(g_hash_table_size(values), 2);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "1");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "1");
@@ -178,7 +178,7 @@ element_name(void **state)
     g_hash_table_remove_all(values);
 
     pcmk__unpack_nvpair_blocks(xml, PCMK_XE_INSTANCE_ATTRIBUTES, NULL,
-                               &rule_input, values, NULL);
+                               &rule_input, values, NULL, xml->doc);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "3");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "3");
@@ -199,7 +199,7 @@ first_id(void **state)
 
     // This also tests that NULL rule_input is handled without problems
 
-    pcmk__unpack_nvpair_blocks(xml, NULL, "ia2", NULL, values, NULL);
+    pcmk__unpack_nvpair_blocks(xml, NULL, "ia2", NULL, values, NULL, xml->doc);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "2");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "2");

--- a/lib/common/tests/nvpair/pcmk__unpack_nvpair_blocks_test.c
+++ b/lib/common/tests/nvpair/pcmk__unpack_nvpair_blocks_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -70,8 +70,8 @@ null_xml(void **state)
     };
 
     // This mainly tests that it doesn't crash
-    pcmk_unpack_nvpair_blocks(NULL, PCMK_XE_INSTANCE_ATTRIBUTES, "id1",
-                              &rule_input, values, next_change);
+    pcmk__unpack_nvpair_blocks(NULL, PCMK_XE_INSTANCE_ATTRIBUTES, "id1",
+                               &rule_input, values, next_change);
     assert_int_equal(g_hash_table_size(values), 0);
     g_hash_table_destroy(values);
     crm_time_free(now);
@@ -89,10 +89,10 @@ null_table(void **state)
     };
 
     assert_non_null(xml);
-    pcmk__assert_asserts(pcmk_unpack_nvpair_blocks(xml,
-                                                   PCMK_XE_INSTANCE_ATTRIBUTES,
-                                                   "id1", &rule_input, NULL,
-                                                   next_change));
+    pcmk__assert_asserts(pcmk__unpack_nvpair_blocks(xml,
+                                                    PCMK_XE_INSTANCE_ATTRIBUTES,
+                                                    "id1", &rule_input, NULL,
+                                                    next_change));
     pcmk__xml_free(xml);
     crm_time_free(next_change);
     crm_time_free(now);
@@ -110,8 +110,8 @@ rule_passes(void **state)
     };
 
     assert_non_null(xml);
-    pcmk_unpack_nvpair_blocks(xml, NULL, "id1", &rule_input, values,
-                              next_change);
+    pcmk__unpack_nvpair_blocks(xml, NULL, "id1", &rule_input, values,
+                               next_change);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "1");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "1");
@@ -138,8 +138,8 @@ rule_fails(void **state)
     // This also tests that next_change is set when appropriate
 
     assert_non_null(xml);
-    pcmk_unpack_nvpair_blocks(xml, NULL, "id1", &rule_input, values,
-                              next_change);
+    pcmk__unpack_nvpair_blocks(xml, NULL, "id1", &rule_input, values,
+                               next_change);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "3");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "3");
@@ -169,16 +169,16 @@ element_name(void **state)
      * problems
      */
 
-    pcmk_unpack_nvpair_blocks(xml, PCMK_XE_META_ATTRIBUTES, NULL, &rule_input,
-                              values, NULL);
+    pcmk__unpack_nvpair_blocks(xml, PCMK_XE_META_ATTRIBUTES, NULL, &rule_input,
+                               values, NULL);
     assert_int_equal(g_hash_table_size(values), 2);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "1");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "1");
     assert_null(g_hash_table_lookup(values, "name3"));
     g_hash_table_remove_all(values);
 
-    pcmk_unpack_nvpair_blocks(xml, PCMK_XE_INSTANCE_ATTRIBUTES, NULL,
-                              &rule_input, values, NULL);
+    pcmk__unpack_nvpair_blocks(xml, PCMK_XE_INSTANCE_ATTRIBUTES, NULL,
+                               &rule_input, values, NULL);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "3");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "3");
@@ -199,7 +199,7 @@ first_id(void **state)
 
     // This also tests that NULL rule_input is handled without problems
 
-    pcmk_unpack_nvpair_blocks(xml, NULL, "ia2", NULL, values, NULL);
+    pcmk__unpack_nvpair_blocks(xml, NULL, "ia2", NULL, values, NULL);
     assert_int_equal(g_hash_table_size(values), 3);
     assert_string_equal(g_hash_table_lookup(values, "name1"), "2");
     assert_string_equal(g_hash_table_lookup(values, "name2"), "2");

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -13,6 +13,39 @@
 
 #include <crm/common/unittest_internal.h>
 
+static void
+assert_deref_one(const xmlNode *xml, const char *element_name,
+                 GList *expected_ids)
+{
+    GList *resolved_nodes = pcmk__xe_dereference_children(xml, element_name);
+    GList *resolved_ids = NULL;
+
+    for (const GList *iter = resolved_nodes; iter != NULL; iter = iter->next) {
+        const xmlNode *data = iter->data;
+        const char *value = pcmk__xe_get(data, "testattr");
+
+        resolved_ids = g_list_prepend(resolved_ids, (void *) value);
+    }
+
+    // Ensure returned list has exactly the expected child IDs
+    resolved_ids = g_list_sort(resolved_ids, (GCompareFunc) g_strcmp0);
+
+    assert_int_equal(g_list_length(expected_ids), g_list_length(resolved_ids));
+
+    for (const GList *e_iter = expected_ids, *r_iter = resolved_ids;
+         (e_iter != NULL) && (r_iter != NULL);
+         e_iter = e_iter->next, r_iter = r_iter->next) {
+
+        const char *e_value = e_iter->data;
+        const char *r_value = r_iter->data;
+
+        assert_string_equal(e_value, r_value);
+    }
+
+    g_list_free(resolved_nodes);
+    g_list_free(resolved_ids);
+}
+
 /*!
  * \internal
  * \brief Test an invocation of pcmk__xe_dereference_children()
@@ -29,8 +62,6 @@ assert_deref(const char *xml_string, const char *element_name, ...)
     xmlNode *xml = NULL;
     const xmlNode *child = NULL;
     GList *expected_ids = NULL;
-    GList *resolved_nodes = NULL;
-    GList *resolved_ids = NULL;
     va_list ap;
 
     // Parse given XML
@@ -48,36 +79,14 @@ assert_deref(const char *xml_string, const char *element_name, ...)
     }
     va_end(ap);
 
+    expected_ids = g_list_sort(expected_ids, (GCompareFunc) g_strcmp0);
+
     // Call tested function on "test" child
     child = pcmk__xe_first_child(xml, "test", NULL, NULL);
-    resolved_nodes = pcmk__xe_dereference_children(child, element_name);
 
-    for (const GList *iter = resolved_nodes; iter != NULL; iter = iter->next) {
-        const xmlNode *data = iter->data;
-        const char *value = pcmk__xe_get(data, "testattr");
-
-        resolved_ids = g_list_prepend(resolved_ids, (void *) value);
-    }
-
-    // Ensure returned list has exactly the expected child IDs
-    expected_ids = g_list_sort(expected_ids, (GCompareFunc) g_strcmp0);
-    resolved_ids = g_list_sort(resolved_ids, (GCompareFunc) g_strcmp0);
-
-    assert_int_equal(g_list_length(expected_ids), g_list_length(resolved_ids));
-
-    for (const GList *e_iter = expected_ids, *r_iter = resolved_ids;
-         (e_iter != NULL) && (r_iter != NULL);
-         e_iter = e_iter->next, r_iter = r_iter->next) {
-
-        const char *e_value = e_iter->data;
-        const char *r_value = r_iter->data;
-
-        assert_string_equal(e_value, r_value);
-    }
+    assert_deref_one(child, element_name, expected_ids);
 
     g_list_free(expected_ids);
-    g_list_free(resolved_nodes);
-    g_list_free(resolved_ids);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -59,11 +59,11 @@ assert_deref(const char *xml_string, const char *element_name, ...)
         goto done;
     }
 
-    while (list != NULL) {
-        const char *value = pcmk__xe_get((xmlNode *) list->data, "testattr");
+    for (const GList *iter = list; iter != NULL; iter = iter->next) {
+        xmlNode *data = iter->data;
+        const char *value = pcmk__xe_get(data, "testattr");
 
         assert_true(g_hash_table_remove(table, value));
-        list = list->next;
     }
 
     assert_int_equal(g_hash_table_size(table), 0);

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -14,10 +14,11 @@
 #include <crm/common/unittest_internal.h>
 
 static void
-assert_deref_one(const xmlNode *xml, const char *element_name,
+assert_deref_one(const xmlNode *xml, xmlDoc *doc, const char *element_name,
                  GList *expected_ids)
 {
-    GList *resolved_nodes = pcmk__xe_dereference_children(xml, element_name);
+    GList *resolved_nodes = pcmk__xe_dereference_children(xml, element_name,
+                                                          doc);
     GList *resolved_ids = NULL;
 
     for (const GList *iter = resolved_nodes; iter != NULL; iter = iter->next) {
@@ -60,7 +61,8 @@ static void
 assert_deref(const char *xml_string, const char *element_name, ...)
 {
     xmlNode *xml = NULL;
-    const xmlNode *child = NULL;
+    xmlNode *child = NULL;
+    xmlDoc *doc = NULL;
     GList *expected_ids = NULL;
     va_list ap;
 
@@ -68,6 +70,7 @@ assert_deref(const char *xml_string, const char *element_name, ...)
     if (xml_string != NULL) {
         xml = pcmk__xml_parse(xml_string);
         assert_non_null(xml);
+        doc = xml->doc;
     }
 
     // Create a list of all expected child IDs
@@ -83,10 +86,16 @@ assert_deref(const char *xml_string, const char *element_name, ...)
 
     // Call tested function on "test" child
     child = pcmk__xe_first_child(xml, "test", NULL, NULL);
+    assert_deref_one(child, doc, element_name, expected_ids);
 
-    assert_deref_one(child, element_name, expected_ids);
+    /* Call tested function on a copy of child in a different document,
+     * searching in the original document
+     */
+    child = pcmk__xml_copy(NULL, child);
+    assert_deref_one(child, doc, element_name, expected_ids);
 
     g_list_free(expected_ids);
+    pcmk__xml_free(child);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -27,8 +27,10 @@ static void
 assert_deref(const char *xml_string, const char *element_name, ...)
 {
     xmlNode *xml = NULL;
-    GList *list = NULL;
-    GHashTable *table = NULL;
+    const xmlNode *child = NULL;
+    GList *expected_ids = NULL;
+    GList *resolved_nodes = NULL;
+    GList *resolved_ids = NULL;
     va_list ap;
 
     // Parse given XML
@@ -37,40 +39,45 @@ assert_deref(const char *xml_string, const char *element_name, ...)
         assert_non_null(xml);
     }
 
-    // Create a hash table with all expected child IDs
+    // Create a list of all expected child IDs
     va_start(ap, element_name);
     for (const char *value = va_arg(ap, const char *);
          value != NULL; value = va_arg(ap, const char *)) {
-        if (table == NULL) {
-            table = pcmk__strkey_table(NULL, NULL);
-        }
-        g_hash_table_add(table, (gpointer) value);
+
+        expected_ids = g_list_prepend(expected_ids, (void *) value);
     }
     va_end(ap);
 
     // Call tested function on "test" child
-    list = pcmk__xe_dereference_children(pcmk__xe_first_child(xml, "test",
-                                                              NULL, NULL),
-                                         element_name);
+    child = pcmk__xe_first_child(xml, "test", NULL, NULL);
+    resolved_nodes = pcmk__xe_dereference_children(child, element_name);
 
-    // Ensure returned list has exactly the expected child IDs
-    if (table == NULL) {
-        assert_null(list);
-        goto done;
-    }
-
-    for (const GList *iter = list; iter != NULL; iter = iter->next) {
-        xmlNode *data = iter->data;
+    for (const GList *iter = resolved_nodes; iter != NULL; iter = iter->next) {
+        const xmlNode *data = iter->data;
         const char *value = pcmk__xe_get(data, "testattr");
 
-        assert_true(g_hash_table_remove(table, value));
+        resolved_ids = g_list_prepend(resolved_ids, (void *) value);
     }
 
-    assert_int_equal(g_hash_table_size(table), 0);
+    // Ensure returned list has exactly the expected child IDs
+    expected_ids = g_list_sort(expected_ids, (GCompareFunc) g_strcmp0);
+    resolved_ids = g_list_sort(resolved_ids, (GCompareFunc) g_strcmp0);
 
-done:
-    g_list_free(list);
-    g_clear_pointer(&table, g_hash_table_destroy);
+    assert_int_equal(g_list_length(expected_ids), g_list_length(resolved_ids));
+
+    for (const GList *e_iter = expected_ids, *r_iter = resolved_ids;
+         (e_iter != NULL) && (r_iter != NULL);
+         e_iter = e_iter->next, r_iter = r_iter->next) {
+
+        const char *e_value = e_iter->data;
+        const char *r_value = r_iter->data;
+
+        assert_string_equal(e_value, r_value);
+    }
+
+    g_list_free(expected_ids);
+    g_list_free(resolved_nodes);
+    g_list_free(resolved_ids);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -56,17 +56,19 @@ assert_deref(const char *xml_string, const char *element_name, ...)
     // Ensure returned list has exactly the expected child IDs
     if (table == NULL) {
         assert_null(list);
-    } else {
-        while (list != NULL) {
-            const char *value = pcmk__xe_get((xmlNode *) list->data,
-                                             "testattr");
-
-            assert_true(g_hash_table_remove(table, value));
-            list = list->next;
-        }
-        assert_int_equal(g_hash_table_size(table), 0);
+        goto done;
     }
 
+    while (list != NULL) {
+        const char *value = pcmk__xe_get((xmlNode *) list->data, "testattr");
+
+        assert_true(g_hash_table_remove(table, value));
+        list = list->next;
+    }
+
+    assert_int_equal(g_hash_table_size(table), 0);
+
+done:
     g_list_free(list);
     g_clear_pointer(&table, g_hash_table_destroy);
     pcmk__xml_free(xml);

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -160,6 +160,40 @@ with_idref(void **state)
     assert_deref(XML_WITH_IDREF, "nonexistent", NULL);
 }
 
+// There may be no valid use case for this, but it should work
+#define XML_WITH_DUPLICATE_IDREF                            \
+    "<xml>\n"                                               \
+    "  <other id='other1' testattr='othervalue1' />\n"      \
+    "  <child id='child2' testattr='childvalue2' />\n"      \
+    "  <test>\n"                                            \
+    "    <!-- comment -->\n"                                \
+    "    <other id-ref='other1'/>\n"                        \
+    "    <child id='child1' testattr='childvalue1' />\n"    \
+    "    <other id-ref='other1'/>\n"                        \
+    "    <other id='other2' testattr='othervalue2' />\n"    \
+    "    <child id-ref='child2' />\n"                       \
+    "    <child id='child3' testattr='childvalue3' />\n"    \
+    "    <other id='other3' testattr='othervalue3' />\n"    \
+    "  </test>\n"                                           \
+    "</xml>\n"
+
+static void
+with_duplicate_idref(void **state)
+{
+    assert_deref(XML_WITH_DUPLICATE_IDREF, NULL,
+                 "othervalue1", "othervalue1", "othervalue2", "othervalue3",
+                 "childvalue1", "childvalue2", "childvalue3", NULL);
+
+    assert_deref(XML_WITH_DUPLICATE_IDREF, "other",
+                 "othervalue1", "othervalue1", "othervalue2", "othervalue3",
+                 NULL);
+
+    assert_deref(XML_WITH_DUPLICATE_IDREF, "child",
+                 "childvalue1", "childvalue2", "childvalue3", NULL);
+
+    assert_deref(XML_WITH_DUPLICATE_IDREF, "nonexistent", NULL);
+}
+
 #define XML_WITH_BROKEN_IDREF                               \
     "<xml>\n"                                               \
     "  <test>\n"                                            \
@@ -194,4 +228,5 @@ PCMK__UNIT_TEST(pcmk__xml_test_setup_group, pcmk__xml_test_teardown_group,
                 cmocka_unit_test(null_for_no_children),
                 cmocka_unit_test(without_idref),
                 cmocka_unit_test(with_idref),
+                cmocka_unit_test(with_duplicate_idref),
                 cmocka_unit_test(with_broken_idref))

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1553,7 +1553,7 @@ pcmk__xe_attr_is_true(const xmlNode *node, const char *name)
 xmlNode *
 expand_idref(xmlNode *input, xmlNode *top)
 {
-    return pcmk__xe_resolve_idref(input, top);
+    return pcmk__xe_resolve_idref(input, ((top != NULL)? top->doc : NULL));
 }
 
 const char *

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1553,7 +1553,8 @@ pcmk__xe_attr_is_true(const xmlNode *node, const char *name)
 xmlNode *
 expand_idref(xmlNode *input, xmlNode *top)
 {
-    return pcmk__xe_resolve_idref(input, ((top != NULL)? top->doc : NULL));
+    return pcmk__xe_resolve_idref(input,
+                                  ((top != NULL)? top->doc : input->doc));
 }
 
 const char *

--- a/lib/common/xml_idref.c
+++ b/lib/common/xml_idref.c
@@ -114,12 +114,14 @@ pcmk__xe_resolve_idref(xmlNode *xml, xmlDoc *doc)
  *
  * \param[in] xml           XML element to get list for
  * \param[in] element_name  If not NULL, list only children of this element type
+ * \param[in] doc           XML document to use for resolving references
  *
  * \return Unordered list of XML elements corresponding to child elements of
  *         \p xml with any ID references resolved to the referenced elements
  */
 GList *
-pcmk__xe_dereference_children(const xmlNode *xml, const char *element_name)
+pcmk__xe_dereference_children(const xmlNode *xml, const char *element_name,
+                              xmlDoc *doc)
 {
     GList *result = NULL;
 
@@ -129,7 +131,7 @@ pcmk__xe_dereference_children(const xmlNode *xml, const char *element_name)
     for (xmlNode *child = pcmk__xe_first_child(xml, element_name, NULL, NULL);
          child != NULL; child = pcmk__xe_next(child, element_name)) {
 
-        xmlNode *resolved = pcmk__xe_resolve_idref(child, child->doc);
+        xmlNode *resolved = pcmk__xe_resolve_idref(child, doc);
 
         if (resolved == NULL) {
             continue; // Not possible with schema validation enabled

--- a/lib/common/xml_idref.c
+++ b/lib/common/xml_idref.c
@@ -75,7 +75,6 @@ pcmk__free_idref(gpointer data)
  *
  * \param[in] xml  Element whose \c PCMK_XA_ID_REF attribute to check
  * \param[in] doc  Document to search for node with matching \c PCMK_XA_ID
- *                 (\c NULL to use \p xml->doc)
  *
  * \return If \p xml has a \c PCMK_XA_ID_REF attribute, node in \p doc whose
  *         \c PCMK_XA_ID attribute matches; otherwise, \p xml
@@ -87,17 +86,13 @@ pcmk__xe_resolve_idref(xmlNode *xml, xmlDoc *doc)
     const char *ref = NULL;
     xmlNode *result = NULL;
 
-    if (xml == NULL) {
+    if ((xml == NULL) || (doc == NULL)) {
         return NULL;
     }
 
     ref = pcmk__xe_get(xml, PCMK_XA_ID_REF);
     if (ref == NULL) {
         return xml;
-    }
-
-    if (doc == NULL) {
-        doc = xml->doc;
     }
 
     xpath = pcmk__assert_asprintf("//%s[@" PCMK_XA_ID "='%s']", xml->name, ref);
@@ -134,7 +129,7 @@ pcmk__xe_dereference_children(const xmlNode *xml, const char *element_name)
     for (xmlNode *child = pcmk__xe_first_child(xml, element_name, NULL, NULL);
          child != NULL; child = pcmk__xe_next(child, element_name)) {
 
-        xmlNode *resolved = pcmk__xe_resolve_idref(child, NULL);
+        xmlNode *resolved = pcmk__xe_resolve_idref(child, child->doc);
 
         if (resolved == NULL) {
             continue; // Not possible with schema validation enabled

--- a/lib/common/xml_idref.c
+++ b/lib/common/xml_idref.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -73,16 +73,15 @@ pcmk__free_idref(gpointer data)
  * \internal
  * \brief Get the XML element whose \c PCMK_XA_ID matches an \c PCMK_XA_ID_REF
  *
- * \param[in] xml     Element whose \c PCMK_XA_ID_REF attribute to check
- * \param[in] search  Node whose document to search for node with matching
- *                    \c PCMK_XA_ID (\c NULL to use \p xml)
+ * \param[in] xml  Element whose \c PCMK_XA_ID_REF attribute to check
+ * \param[in] doc  Document to search for node with matching \c PCMK_XA_ID
+ *                 (\c NULL to use \p xml->doc)
  *
- * \return If \p xml has a \c PCMK_XA_ID_REF attribute, node in
- *         <tt>search</tt>'s document whose \c PCMK_XA_ID attribute matches;
- *         otherwise, \p xml
+ * \return If \p xml has a \c PCMK_XA_ID_REF attribute, node in \p doc whose
+ *         \c PCMK_XA_ID attribute matches; otherwise, \p xml
  */
 xmlNode *
-pcmk__xe_resolve_idref(xmlNode *xml, xmlNode *search)
+pcmk__xe_resolve_idref(xmlNode *xml, xmlDoc *doc)
 {
     char *xpath = NULL;
     const char *ref = NULL;
@@ -97,12 +96,12 @@ pcmk__xe_resolve_idref(xmlNode *xml, xmlNode *search)
         return xml;
     }
 
-    if (search == NULL) {
-        search = xml;
+    if (doc == NULL) {
+        doc = xml->doc;
     }
 
     xpath = pcmk__assert_asprintf("//%s[@" PCMK_XA_ID "='%s']", xml->name, ref);
-    result = pcmk__xpath_find_one(search->doc, xpath, LOG_DEBUG);
+    result = pcmk__xpath_find_one(doc, xpath, LOG_DEBUG);
     if (result == NULL) {
         // Not possible with schema validation enabled
         pcmk__config_err("Ignoring invalid %s configuration: "

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -1006,7 +1006,7 @@ pcmk__unpack_colocation(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
     for (set = pcmk__xe_first_child(xml_obj, PCMK_XE_RESOURCE_SET, NULL, NULL);
          set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
-        set = pcmk__xe_resolve_idref(set, scheduler->input);
+        set = pcmk__xe_resolve_idref(set, scheduler->input->doc);
         if (set == NULL) { // Configuration error, message already logged
             if (expanded_xml != NULL) {
                 pcmk__xml_free(expanded_xml);

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -205,7 +205,8 @@ generate_location_rule(pcmk_resource_t *rsc, xmlNode *rule_xml,
     enum rsc_role_e role = pcmk_role_unknown;
     enum pcmk__combine combine = pcmk__combine_unknown;
 
-    rule_xml = pcmk__xe_resolve_idref(rule_xml, rsc->priv->scheduler->input);
+    rule_xml = pcmk__xe_resolve_idref(rule_xml,
+                                      rsc->priv->scheduler->input->doc);
     if (rule_xml == NULL) {
         return false; // Error already logged
     }
@@ -601,7 +602,7 @@ pcmk__unpack_location(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
          set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
         any_sets = true;
-        set = pcmk__xe_resolve_idref(set, scheduler->input);
+        set = pcmk__xe_resolve_idref(set, scheduler->input->doc);
         if ((set == NULL) // Configuration error, message already logged
             || (unpack_location_set(xml_obj, set, scheduler) != pcmk_rc_ok)) {
 

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1017,7 +1017,7 @@ pcmk__unpack_ordering(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
     for (set = pcmk__xe_first_child(xml_obj, PCMK_XE_RESOURCE_SET, NULL, NULL);
          set != NULL; set = pcmk__xe_next(set, PCMK_XE_RESOURCE_SET)) {
 
-        set = pcmk__xe_resolve_idref(set, scheduler->input);
+        set = pcmk__xe_resolve_idref(set, scheduler->input->doc);
         if ((set == NULL) // Configuration error, message already logged
             || (unpack_order_set(set, kind, invert, scheduler) != pcmk_rc_ok)) {
 

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -467,7 +467,7 @@ pcmk__unpack_rsc_ticket(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
         const char *loss_policy = NULL;
 
         any_sets = true;
-        set = pcmk__xe_resolve_idref(set, scheduler->input);
+        set = pcmk__xe_resolve_idref(set, scheduler->input->doc);
         loss_policy = pcmk__xe_get(xml_obj, PCMK_XA_LOSS_POLICY);
 
         if ((set == NULL) // Configuration error, message already logged

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -627,6 +627,7 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
 {
     GHashTableIter gIter;
     pcmk_node_t *node = NULL;
+    pcmk_node_t *copy = NULL;
     xmlNode *xml_remote = NULL;
     char *id = NULL;
     char *port_s = NULL;
@@ -728,13 +729,11 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
                         (void *) replica->node->priv->id,
                         pe__copy_node(replica->node));
 
-    {
-        pcmk_node_t *copy = pe__copy_node(replica->node);
+    copy = pe__copy_node(replica->node);
+    copy->assign->score = -PCMK_SCORE_INFINITY;
 
-        copy->assign->score = -PCMK_SCORE_INFINITY;
-        g_hash_table_insert(replica->child->priv->parent->priv->allowed_nodes,
-                            (void *) replica->node->priv->id, copy);
-    }
+    g_hash_table_insert(replica->child->priv->parent->priv->allowed_nodes,
+                        (void *) replica->node->priv->id, copy);
 
     if (pe__unpack_resource(xml_remote, &replica->remote, parent,
                             scheduler) != pcmk_rc_ok) {

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -421,27 +421,20 @@ create_container_resource(pcmk_resource_t *parent,
     char *id = NULL;
     xmlNode *xml_container = NULL;
     xmlNode *xml_obj = NULL;
-
-    // Agent-specific
-    const char *hostname_opt = NULL;
-    const char *env_opt = NULL;
     const char *agent_str = NULL;
-
     GString *buffer = NULL;
     GString *dbuffer = NULL;
 
-    // Where syntax differences are drop-in replacements, set them now
     switch (data->agent_type) {
         case PE__CONTAINER_AGENT_DOCKER:
         case PE__CONTAINER_AGENT_PODMAN:
-            hostname_opt = "-h ";
-            env_opt = "-e ";
             break;
-        default:    // PE__CONTAINER_AGENT_UNKNOWN
+
+        default:
             return pcmk_rc_unpack_error;
     }
-    agent_str = container_agent_str(data->agent_type);
 
+    agent_str = container_agent_str(data->agent_type);
     buffer = g_string_sized_new(4096);
 
     id = pcmk__assert_asprintf("%s-%s-%d", data->prefix, agent_str,
@@ -468,21 +461,22 @@ create_container_resource(pcmk_resource_t *parent,
      * they bind to.
      */
     if (data->ip_range_start != NULL) {
-        g_string_append_printf(buffer, " %s%s-%d", hostname_opt, data->prefix,
+        g_string_append_printf(buffer, " -h %s-%d", data->prefix,
                                replica->offset);
     }
-    pcmk__g_strcat(buffer, " ", env_opt, "PCMK_stderr=1", NULL);
+
+    g_string_append(buffer, " -e PCMK_stderr=1");
 
     if (data->container_network != NULL) {
         pcmk__g_strcat(buffer, " --net=", data->container_network, NULL);
     }
 
     if (data->control_port != NULL) {
-        pcmk__g_strcat(buffer, " ", env_opt, "PCMK_" PCMK__ENV_REMOTE_PORT "=",
+        pcmk__g_strcat(buffer, " -e PCMK_" PCMK__ENV_REMOTE_PORT "=",
                        data->control_port, NULL);
     } else {
-        g_string_append_printf(buffer, " %sPCMK_" PCMK__ENV_REMOTE_PORT "=%d",
-                               env_opt, DEFAULT_REMOTE_PORT);
+        g_string_append_printf(buffer, " -e PCMK_" PCMK__ENV_REMOTE_PORT "=%d",
+                               DEFAULT_REMOTE_PORT);
     }
 
     for (GList *iter = data->mounts; iter != NULL; iter = iter->next) {
@@ -495,44 +489,29 @@ create_container_resource(pcmk_resource_t *parent,
             pcmk__add_separated_word(&dbuffer, 1024, source, ",");
         }
 
-        switch (data->agent_type) {
-            case PE__CONTAINER_AGENT_DOCKER:
-            case PE__CONTAINER_AGENT_PODMAN:
-                pcmk__g_strcat(buffer,
-                               " -v ", pcmk__s(source, mount->source),
-                               ":", mount->target, NULL);
+        pcmk__g_strcat(buffer, " -v ", pcmk__s(source, mount->source), ":",
+                       mount->target, NULL);
 
-                if (mount->options != NULL) {
-                    pcmk__g_strcat(buffer, ":", mount->options, NULL);
-                }
-                break;
-            default:
-                break;
+        if (mount->options != NULL) {
+            pcmk__g_strcat(buffer, ":", mount->options, NULL);
         }
+
         free(source);
     }
 
     for (GList *iter = data->ports; iter != NULL; iter = iter->next) {
         pe__bundle_port_t *port = (pe__bundle_port_t *) iter->data;
 
-        switch (data->agent_type) {
-            case PE__CONTAINER_AGENT_DOCKER:
-            case PE__CONTAINER_AGENT_PODMAN:
-                if (replica->ipaddr != NULL) {
-                    pcmk__g_strcat(buffer,
-                                   " -p ", replica->ipaddr, ":", port->source,
-                                   ":", port->target, NULL);
+        if (replica->ipaddr != NULL) {
+            pcmk__g_strcat(buffer, " -p ", replica->ipaddr, ":", port->source,
+                           ":", port->target, NULL);
 
-                } else if (!pcmk__str_eq(data->container_network,
-                                         PCMK_VALUE_HOST, pcmk__str_none)) {
-                    // No need to do port mapping if net == host
-                    pcmk__g_strcat(buffer,
-                                   " -p ", port->source, ":", port->target,
-                                   NULL);
-                }
-                break;
-            default:
-                break;
+        } else if (!pcmk__str_eq(data->container_network, PCMK_VALUE_HOST,
+                                 pcmk__str_none)) {
+
+            // No need to do port mapping if net == host
+            pcmk__g_strcat(buffer, " -p ", port->source, ":", port->target,
+                           NULL);
         }
     }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -397,6 +397,7 @@ create_ip_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
 
 done:
     free(id);
+    pcmk__xml_free(xml_ip);
     return rc;
 }
 
@@ -423,6 +424,7 @@ create_container_resource(pcmk_resource_t *parent,
     const char *agent_str = NULL;
     GString *buffer = NULL;
     GString *dbuffer = NULL;
+    int rc = pcmk_rc_ok;
 
     switch (data->agent_type) {
         case PE__CONTAINER_AGENT_DOCKER:
@@ -430,7 +432,8 @@ create_container_resource(pcmk_resource_t *parent,
             break;
 
         default:
-            return pcmk_rc_unpack_error;
+            rc = pcmk_rc_unpack_error;
+            goto done;
     }
 
     agent_str = container_agent_str(data->agent_type);
@@ -440,7 +443,6 @@ create_container_resource(pcmk_resource_t *parent,
                                replica->offset);
     pcmk__xml_sanitize_id(id);
     xml_container = create_resource(id, "heartbeat", agent_str);
-    free(id);
 
     xml_obj = pcmk__xe_create(xml_container, PCMK_XE_INSTANCE_ATTRIBUTES);
     pcmk__xe_set_id(xml_obj, "%s-attributes-%d", data->prefix, replica->offset);
@@ -593,13 +595,19 @@ create_container_resource(pcmk_resource_t *parent,
     // TODO: Other ops? Timeouts and intervals from underlying resource?
     if (pe__unpack_resource(xml_container, &replica->container, parent,
                             parent->priv->scheduler) != pcmk_rc_ok) {
-        return pcmk_rc_unpack_error;
+
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
+
     pcmk__set_rsc_flags(replica->container, pcmk__rsc_replica_container);
     parent->priv->children = g_list_append(parent->priv->children,
                                            replica->container);
 
-    return pcmk_rc_ok;
+done:
+    free(id);
+    pcmk__xml_free(xml_container);
+    return rc;
 }
 
 /*!
@@ -630,13 +638,13 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
     pcmk_node_t *copy = NULL;
     xmlNode *xml_remote = NULL;
     char *id = NULL;
-    char *port_s = NULL;
     const char *uname = NULL;
     const char *connect_name = NULL;
     pcmk_scheduler_t *scheduler = parent->priv->scheduler;
+    int rc = pcmk_rc_ok;
 
     if ((replica->child == NULL) || !valid_network(data)) {
-        return pcmk_rc_ok;
+        goto done;
     }
 
     id = pcmk__assert_asprintf("%s-%d", data->prefix, replica->offset);
@@ -658,25 +666,29 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
      */
     connect_name = pcmk__s(replica->ipaddr, "#uname");
 
-    if (data->control_port == NULL) {
-        port_s = pcmk__itoa(DEFAULT_REMOTE_PORT);
-    }
-
     /* This sets replica->container as replica->remote's container, which is
      * similar to what happens with guest nodes. This is how the scheduler knows
      * that the bundle node is fenced by recovering the container, and that
      * remote should be ordered relative to the container.
      */
-    xml_remote = pe_create_remote_xml(NULL, id, replica->container->id, NULL,
-                                      NULL, NULL, connect_name,
-                                      pcmk__s(data->control_port, port_s));
-    free(port_s);
+    if (data->control_port != NULL) {
+        xml_remote = pe_create_remote_xml(NULL, id, replica->container->id,
+                                          NULL, NULL, NULL, connect_name,
+                                          data->control_port);
+
+    } else {
+        char *port_s = pcmk__itoa(DEFAULT_REMOTE_PORT);
+
+        xml_remote = pe_create_remote_xml(NULL, id, replica->container->id,
+                                          NULL, NULL, NULL, connect_name,
+                                          port_s);
+        free(port_s);
+    }
 
     /* Abandon our created ID, and pull the copy from the XML, because we need
      * something that will get freed during scheduler data cleanup to use as the
      * node ID and uname.
      */
-    g_clear_pointer(&id, free);
     uname = pcmk__xe_id(xml_remote);
 
     /* Ensure a node has been created for the guest (it may have already been,
@@ -737,7 +749,9 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
 
     if (pe__unpack_resource(xml_remote, &replica->remote, parent,
                             scheduler) != pcmk_rc_ok) {
-        return pcmk_rc_unpack_error;
+
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     // Make Coverity happy
@@ -773,7 +787,10 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
     parent->priv->children = g_list_append(parent->priv->children,
                                            replica->remote);
 
-    return pcmk_rc_ok;
+done:
+    free(id);
+    pcmk__xml_free(xml_remote);
+    return rc;
 }
 
 static int
@@ -1148,9 +1165,12 @@ pe__unpack_bundle(pcmk_resource_t *rsc)
         GList *childIter = NULL;
         pe__bundle_port_t *port = NULL;
         GString *buffer = NULL;
+        int rc = pe__unpack_resource(xml_resource, &bundle_data->child, rsc,
+                                     rsc->priv->scheduler);
 
-        if (pe__unpack_resource(xml_resource, &(bundle_data->child), rsc,
-                                rsc->priv->scheduler) != pcmk_rc_ok) {
+        pcmk__xml_free(xml_resource);
+
+        if (rc != pcmk_rc_ok) {
             return FALSE;
         }
 
@@ -1831,18 +1851,10 @@ free_bundle_replica(pcmk__bundle_replica_t *replica)
 
     g_clear_pointer(&replica->node, pcmk__free_node_copy);
 
-    if (replica->ip) {
-        g_clear_pointer(&replica->ip->priv->xml, pcmk__xml_free);
-        pcmk__free_resource(replica->ip);
-    }
-    if (replica->container) {
-        g_clear_pointer(&replica->container->priv->xml, pcmk__xml_free);
-        pcmk__free_resource(replica->container);
-    }
-    if (replica->remote) {
-        g_clear_pointer(&replica->remote->priv->xml, pcmk__xml_free);
-        pcmk__free_resource(replica->remote);
-    }
+    pcmk__free_resource(replica->ip);
+    pcmk__free_resource(replica->container);
+    pcmk__free_resource(replica->remote);
+
     free(replica->ipaddr);
     free(replica);
 }
@@ -1873,10 +1885,7 @@ pe__free_bundle(pcmk_resource_t *rsc)
     g_list_free_full(bundle_data->ports, (GDestroyNotify)port_free);
     g_list_free(rsc->priv->children);
 
-    if(bundle_data->child) {
-        g_clear_pointer(&bundle_data->child->priv->xml, pcmk__xml_free);
-        pcmk__free_resource(bundle_data->child);
-    }
+    pcmk__free_resource(bundle_data->child);
 
     common_free(rsc);
 }

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -357,48 +357,47 @@ static int
 create_ip_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
                    pcmk__bundle_replica_t *replica)
 {
-    if(data->ip_range_start) {
-        char *id = NULL;
-        xmlNode *xml_ip = NULL;
-        xmlNode *xml_obj = NULL;
+    char *id = NULL;
+    xmlNode *xml_ip = NULL;
+    xmlNode *xml_obj = NULL;
+    int rc = pcmk_rc_ok;
 
-        id = pcmk__assert_asprintf("%s-ip-%s", data->prefix, replica->ipaddr);
-        pcmk__xml_sanitize_id(id);
-        xml_ip = create_resource(id, "heartbeat", "IPaddr2");
-        free(id);
-
-        xml_obj = pcmk__xe_create(xml_ip, PCMK_XE_INSTANCE_ATTRIBUTES);
-        pcmk__xe_set_id(xml_obj, "%s-attributes-%d",
-                        data->prefix, replica->offset);
-
-        crm_create_nvpair_xml(xml_obj, NULL, "ip", replica->ipaddr);
-        if(data->host_network) {
-            crm_create_nvpair_xml(xml_obj, NULL, "nic", data->host_network);
-        }
-
-        if(data->host_netmask) {
-            crm_create_nvpair_xml(xml_obj, NULL,
-                                  "cidr_netmask", data->host_netmask);
-
-        } else {
-            crm_create_nvpair_xml(xml_obj, NULL, "cidr_netmask", "32");
-        }
-
-        xml_obj = pcmk__xe_create(xml_ip, PCMK_XE_OPERATIONS);
-        crm_create_op_xml(xml_obj, pcmk__xe_id(xml_ip), PCMK_ACTION_MONITOR,
-                          "60s", NULL);
-
-        // TODO: Other ops? Timeouts and intervals from underlying resource?
-
-        if (pe__unpack_resource(xml_ip, &replica->ip, parent,
-                                parent->priv->scheduler) != pcmk_rc_ok) {
-            return pcmk_rc_unpack_error;
-        }
-
-        parent->priv->children = g_list_append(parent->priv->children,
-                                               replica->ip);
+    if (data->ip_range_start == NULL) {
+        goto done;
     }
-    return pcmk_rc_ok;
+
+    id = pcmk__assert_asprintf("%s-ip-%s", data->prefix, replica->ipaddr);
+    pcmk__xml_sanitize_id(id);
+    xml_ip = create_resource(id, "heartbeat", "IPaddr2");
+
+    xml_obj = pcmk__xe_create(xml_ip, PCMK_XE_INSTANCE_ATTRIBUTES);
+    pcmk__xe_set_id(xml_obj, "%s-attributes-%d", data->prefix, replica->offset);
+
+    crm_create_nvpair_xml(xml_obj, NULL, "ip", replica->ipaddr);
+
+    if (data->host_network != NULL) {
+        crm_create_nvpair_xml(xml_obj, NULL, "nic", data->host_network);
+    }
+
+    crm_create_nvpair_xml(xml_obj, NULL, "cidr_netmask",
+                          pcmk__s(data->host_netmask, "32"));
+
+    xml_obj = pcmk__xe_create(xml_ip, PCMK_XE_OPERATIONS);
+    crm_create_op_xml(xml_obj, id, PCMK_ACTION_MONITOR, "60s", NULL);
+
+    // TODO: Other ops? Timeouts and intervals from underlying resource?
+
+    if (pe__unpack_resource(xml_ip, &replica->ip, parent,
+                            parent->priv->scheduler) != pcmk_rc_ok) {
+        rc = pcmk_rc_unpack_error;
+        goto done;
+    }
+
+    parent->priv->children = g_list_append(parent->priv->children, replica->ip);
+
+done:
+    free(id);
+    return rc;
 }
 
 static const char*

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -686,8 +686,8 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
     node = pcmk_find_node(scheduler, uname);
 
     if (node == NULL) {
-        node = pe_create_node(uname, uname, PCMK_VALUE_REMOTE,
-                              -PCMK_SCORE_INFINITY, scheduler);
+        node = pe__create_node(uname, uname, PCMK_VALUE_REMOTE,
+                               -PCMK_SCORE_INFINITY, scheduler);
 
     } else {
         node->assign->score = -PCMK_SCORE_INFINITY;
@@ -757,7 +757,7 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
     replica->remote->priv->launcher = replica->container;
 
     /* A bundle's #kind is closer to "container" (guest node) than the "remote"
-     * set by pe_create_node()
+     * set by pe__create_node()
      */
     pcmk__insert_dup(replica->node->priv->attrs, CRM_ATTR_KIND, "container");
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -625,149 +625,155 @@ static int
 create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
                        pcmk__bundle_replica_t *replica)
 {
-    if (replica->child && valid_network(data)) {
-        GHashTableIter gIter;
-        pcmk_node_t *node = NULL;
-        xmlNode *xml_remote = NULL;
-        char *id = pcmk__assert_asprintf("%s-%d", data->prefix,
-                                         replica->offset);
-        char *port_s = NULL;
-        const char *uname = NULL;
-        const char *connect_name = NULL;
-        pcmk_scheduler_t *scheduler = parent->priv->scheduler;
+    GHashTableIter gIter;
+    pcmk_node_t *node = NULL;
+    xmlNode *xml_remote = NULL;
+    char *id = NULL;
+    char *port_s = NULL;
+    const char *uname = NULL;
+    const char *connect_name = NULL;
+    pcmk_scheduler_t *scheduler = parent->priv->scheduler;
 
-        if (pe_find_resource(scheduler->priv->resources, id) != NULL) {
-            free(id);
-            // The biggest hammer we have
-            id = pcmk__assert_asprintf("pcmk-internal-%s-remote-%d",
-                                       replica->child->id, replica->offset);
-            //@TODO return error instead of asserting?
-            pcmk__assert(pe_find_resource(scheduler->priv->resources,
-                                          id) == NULL);
-        }
+    if ((replica->child == NULL) || !valid_network(data)) {
+        return pcmk_rc_ok;
+    }
 
-        /* REMOTE_CONTAINER_HACK: Using "#uname" as the server name when the
-         * connection does not have its own IP is a magic string that we use to
-         * support nested remotes (i.e. a bundle running on a remote node).
-         */
-        connect_name = (replica->ipaddr? replica->ipaddr : "#uname");
+    id = pcmk__assert_asprintf("%s-%d", data->prefix, replica->offset);
 
-        if (data->control_port == NULL) {
-            port_s = pcmk__itoa(DEFAULT_REMOTE_PORT);
-        }
+    if (pe_find_resource(scheduler->priv->resources, id) != NULL) {
+        free(id);
 
-        /* This sets replica->container as replica->remote's container, which is
-         * similar to what happens with guest nodes. This is how the scheduler
-         * knows that the bundle node is fenced by recovering the container, and
-         * that remote should be ordered relative to the container.
-         */
-        xml_remote = pe_create_remote_xml(NULL, id, replica->container->id,
-                                          NULL, NULL, NULL,
-                                          connect_name, (data->control_port?
-                                          data->control_port : port_s));
-        free(port_s);
+        // The biggest hammer we have
+        id = pcmk__assert_asprintf("pcmk-internal-%s-remote-%d",
+                                   replica->child->id, replica->offset);
 
-        /* Abandon our created ID, and pull the copy from the XML, because we
-         * need something that will get freed during scheduler data cleanup to
-         * use as the node ID and uname.
-         */
-        g_clear_pointer(&id, free);
-        uname = pcmk__xe_id(xml_remote);
+        // @TODO return error instead of asserting?
+        pcmk__assert(pe_find_resource(scheduler->priv->resources, id) == NULL);
+    }
 
-        /* Ensure a node has been created for the guest (it may have already
-         * been, if it has a permanent node attribute), and ensure its weight is
-         * -INFINITY so no other resources can run on it.
-         */
-        node = pcmk_find_node(scheduler, uname);
-        if (node == NULL) {
-            node = pe_create_node(uname, uname, PCMK_VALUE_REMOTE,
-                                  -PCMK_SCORE_INFINITY, scheduler);
-        } else {
+    /* REMOTE_CONTAINER_HACK: Using "#uname" as the server name when the
+     * connection does not have its own IP is a magic string that we use to
+     * support nested remotes (i.e. a bundle running on a remote node).
+     */
+    connect_name = pcmk__s(replica->ipaddr, "#uname");
+
+    if (data->control_port == NULL) {
+        port_s = pcmk__itoa(DEFAULT_REMOTE_PORT);
+    }
+
+    /* This sets replica->container as replica->remote's container, which is
+     * similar to what happens with guest nodes. This is how the scheduler knows
+     * that the bundle node is fenced by recovering the container, and that
+     * remote should be ordered relative to the container.
+     */
+    xml_remote = pe_create_remote_xml(NULL, id, replica->container->id, NULL,
+                                      NULL, NULL, connect_name,
+                                      pcmk__s(data->control_port, port_s));
+    free(port_s);
+
+    /* Abandon our created ID, and pull the copy from the XML, because we need
+     * something that will get freed during scheduler data cleanup to use as the
+     * node ID and uname.
+     */
+    g_clear_pointer(&id, free);
+    uname = pcmk__xe_id(xml_remote);
+
+    /* Ensure a node has been created for the guest (it may have already been,
+     * if it has a permanent node attribute), and ensure its weight is -INFINITY
+     * so no other resources can run on it.
+     */
+    node = pcmk_find_node(scheduler, uname);
+
+    if (node == NULL) {
+        node = pe_create_node(uname, uname, PCMK_VALUE_REMOTE,
+                              -PCMK_SCORE_INFINITY, scheduler);
+
+    } else {
+        node->assign->score = -PCMK_SCORE_INFINITY;
+    }
+
+    node->assign->probe_mode = pcmk__probe_never;
+
+    /* unpack_remote_nodes() ensures that each remote node and guest node has a
+     * pcmk_node_t entry. Ideally, it would do the same for bundle nodes.
+     * Unfortunately, a bundle has to be mostly unpacked before it's obvious
+     * what nodes will be needed, so we do it just above.
+     *
+     * Worse, that means that the node may have been utilized while unpacking
+     * other resources, without our weight correction. The most likely place for
+     * this to happen is when pe__unpack_resource() calls resource_location() to
+     * set a default score in symmetric clusters. This adds a node *copy* to
+     * each resource's allowed nodes, and these copies will have the wrong
+     * weight.
+     *
+     * As a hacky workaround, fix those copies here.
+     *
+     * @TODO Possible alternative: ensure bundles are unpacked before other
+     * resources, so the weight is correct before any copies are made.
+     */
+    g_list_foreach(scheduler->priv->resources, (GFunc) disallow_node,
+                   (void *) uname);
+
+    replica->node = pe__copy_node(node);
+    replica->node->assign->score = 500;
+    replica->node->assign->probe_mode = pcmk__probe_exclusive;
+
+    // Ensure the node shows up as allowed and with the correct discovery set
+    g_clear_pointer(&replica->child->priv->allowed_nodes, g_hash_table_destroy);
+
+    replica->child->priv->allowed_nodes =
+        pcmk__strkey_table(NULL, pcmk__free_node_copy);
+
+    g_hash_table_insert(replica->child->priv->allowed_nodes,
+                        (void *) replica->node->priv->id,
+                        pe__copy_node(replica->node));
+
+    {
+        pcmk_node_t *copy = pe__copy_node(replica->node);
+
+        copy->assign->score = -PCMK_SCORE_INFINITY;
+        g_hash_table_insert(replica->child->priv->parent->priv->allowed_nodes,
+                            (void *) replica->node->priv->id, copy);
+    }
+
+    if (pe__unpack_resource(xml_remote, &replica->remote, parent,
+                            scheduler) != pcmk_rc_ok) {
+        return pcmk_rc_unpack_error;
+    }
+
+    // Make Coverity happy
+    pcmk__assert(replica->remote != NULL);
+
+    g_hash_table_iter_init(&gIter, replica->remote->priv->allowed_nodes);
+    while (g_hash_table_iter_next(&gIter, NULL, (void **)&node)) {
+        if (pcmk__is_pacemaker_remote_node(node)) {
+            // Remote resources can only run on 'normal' cluster node
             node->assign->score = -PCMK_SCORE_INFINITY;
         }
-        node->assign->probe_mode = pcmk__probe_never;
-
-        /* unpack_remote_nodes() ensures that each remote node and guest node
-         * has a pcmk_node_t entry. Ideally, it would do the same for bundle
-         * nodes. Unfortunately, a bundle has to be mostly unpacked before it's
-         * obvious what nodes will be needed, so we do it just above.
-         *
-         * Worse, that means that the node may have been utilized while
-         * unpacking other resources, without our weight correction. The most
-         * likely place for this to happen is when pe__unpack_resource() calls
-         * resource_location() to set a default score in symmetric clusters.
-         * This adds a node *copy* to each resource's allowed nodes, and these
-         * copies will have the wrong weight.
-         *
-         * As a hacky workaround, fix those copies here.
-         *
-         * @TODO Possible alternative: ensure bundles are unpacked before other
-         * resources, so the weight is correct before any copies are made.
-         */
-        g_list_foreach(scheduler->priv->resources,
-                       (GFunc) disallow_node, (gpointer) uname);
-
-        replica->node = pe__copy_node(node);
-        replica->node->assign->score = 500;
-        replica->node->assign->probe_mode = pcmk__probe_exclusive;
-
-        /* Ensure the node shows up as allowed and with the correct discovery set */
-        g_clear_pointer(&replica->child->priv->allowed_nodes,
-                        g_hash_table_destroy);
-        replica->child->priv->allowed_nodes =
-            pcmk__strkey_table(NULL, pcmk__free_node_copy);
-        g_hash_table_insert(replica->child->priv->allowed_nodes,
-                            (gpointer) replica->node->priv->id,
-                            pe__copy_node(replica->node));
-
-        {
-            const pcmk_resource_t *parent = replica->child->priv->parent;
-            pcmk_node_t *copy = pe__copy_node(replica->node);
-
-            copy->assign->score = -PCMK_SCORE_INFINITY;
-            g_hash_table_insert(parent->priv->allowed_nodes,
-                                (gpointer) replica->node->priv->id, copy);
-        }
-        if (pe__unpack_resource(xml_remote, &replica->remote, parent,
-                                scheduler) != pcmk_rc_ok) {
-            return pcmk_rc_unpack_error;
-        }
-
-        // Make Coverity happy
-        pcmk__assert(replica->remote != NULL);
-
-        g_hash_table_iter_init(&gIter, replica->remote->priv->allowed_nodes);
-        while (g_hash_table_iter_next(&gIter, NULL, (void **)&node)) {
-            if (pcmk__is_pacemaker_remote_node(node)) {
-                /* Remote resources can only run on 'normal' cluster node */
-                node->assign->score = -PCMK_SCORE_INFINITY;
-            }
-        }
-
-        replica->node->priv->remote = replica->remote;
-
-        // Ensure pcmk__is_guest_or_bundle_node() functions correctly
-        replica->remote->priv->launcher = replica->container;
-
-        /* A bundle's #kind is closer to "container" (guest node) than the
-         * "remote" set by pe_create_node().
-         */
-        pcmk__insert_dup(replica->node->priv->attrs,
-                         CRM_ATTR_KIND, "container");
-
-        /* One effect of this is that unpack_launcher() will add
-         * replica->remote to replica->container's launched resources, which
-         * will make pe__resource_contains_guest_node() true for
-         * replica->container.
-         *
-         * replica->child does NOT get added to replica->container's launched
-         * resources. The only noticeable effect if it did would be for its
-         * fail count to be taken into account when checking
-         * replica->container's migration threshold.
-         */
-        parent->priv->children = g_list_append(parent->priv->children,
-                                               replica->remote);
     }
+
+    replica->node->priv->remote = replica->remote;
+
+    // Ensure pcmk__is_guest_or_bundle_node() functions correctly
+    replica->remote->priv->launcher = replica->container;
+
+    /* A bundle's #kind is closer to "container" (guest node) than the "remote"
+     * set by pe_create_node()
+     */
+    pcmk__insert_dup(replica->node->priv->attrs, CRM_ATTR_KIND, "container");
+
+    /* One effect of this is that unpack_launcher() will add replica->remote to
+     * replica->container's launched resources, which will make
+     * pe__resource_contains_guest_node() true for replica->container.
+     *
+     * replica->child does NOT get added to replica->container's launched
+     * resources. The only noticeable effect if it did would be for its fail
+     * count to be taken into account when checking replica->container's
+     * migration threshold.
+     */
+    parent->priv->children = g_list_append(parent->priv->children,
+                                           replica->remote);
+
     return pcmk_rc_ok;
 }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -289,23 +289,21 @@ allocate_ip(pe__bundle_variant_data_t *data, pcmk__bundle_replica_t *replica,
     }
 
     data->ip_last = replica->ipaddr;
-    switch (data->agent_type) {
-        case PE__CONTAINER_AGENT_DOCKER:
-        case PE__CONTAINER_AGENT_PODMAN:
-            if (data->add_host) {
-                g_string_append_printf(buffer, " --add-host=%s-%d:%s",
-                                       data->prefix, replica->offset,
-                                       replica->ipaddr);
-            } else {
-                g_string_append_printf(buffer, " --hosts-entry=%s=%s-%d",
-                                       replica->ipaddr, data->prefix,
-                                       replica->offset);
-            }
-            break;
 
-        default: // PE__CONTAINER_AGENT_UNKNOWN
-            break;
+    if ((data->agent_type != PE__CONTAINER_AGENT_DOCKER)
+        && (data->agent_type != PE__CONTAINER_AGENT_PODMAN)) {
+
+        return;
     }
+
+    if (data->add_host) {
+        g_string_append_printf(buffer, " --add-host=%s-%d:%s", data->prefix,
+                               replica->offset, replica->ipaddr);
+        return;
+    }
+
+    g_string_append_printf(buffer, " --hosts-entry=%s=%s-%d", replica->ipaddr,
+                           data->prefix, replica->offset);
 }
 
 static xmlNode *
@@ -426,14 +424,11 @@ create_container_resource(pcmk_resource_t *parent,
     GString *dbuffer = NULL;
     int rc = pcmk_rc_ok;
 
-    switch (data->agent_type) {
-        case PE__CONTAINER_AGENT_DOCKER:
-        case PE__CONTAINER_AGENT_PODMAN:
-            break;
+    if ((data->agent_type != PE__CONTAINER_AGENT_DOCKER)
+        && (data->agent_type != PE__CONTAINER_AGENT_PODMAN)) {
 
-        default:
-            rc = pcmk_rc_unpack_error;
-            goto done;
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     agent_str = container_agent_str(data->agent_type);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -241,8 +241,8 @@ pe__create_clone_child(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
     inc_num = pcmk__itoa(clone_data->total_clones);
     inc_max = pcmk__itoa(clone_data->clone_max);
 
+    // Set PCMK__META_CLONE in a copy, not the original element
     child_copy = pcmk__xml_copy(NULL, clone_data->xml_obj_child);
-
     pcmk__xe_set(child_copy, PCMK__META_CLONE, inc_num);
 
     if (pe__unpack_resource(child_copy, &child_rsc, rsc,
@@ -266,6 +266,7 @@ pe__create_clone_child(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
   bail:
     free(inc_num);
     free(inc_max);
+    pcmk__xml_free(child_copy);
 
     return child_rsc;
 }
@@ -929,24 +930,9 @@ clone_free(pcmk_resource_t * rsc)
 
     get_clone_variant_data(clone_data, rsc);
 
-    pcmk__rsc_trace(rsc, "Freeing %s", rsc->id);
+    pcmk__rsc_trace(rsc, "Freeing clone %s, starting with child list", rsc->id);
 
-    for (GList *gIter = rsc->priv->children;
-         gIter != NULL; gIter = gIter->next) {
-
-        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
-
-        pcmk__assert(child_rsc != NULL);
-        pcmk__rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
-        g_clear_pointer(&child_rsc->priv->xml, pcmk__xml_free);
-
-        /* There could be a saved unexpanded xml */
-        g_clear_pointer(&child_rsc->priv->orig_xml, pcmk__xml_free);
-
-        pcmk__free_resource(child_rsc);
-    }
-
-    g_list_free(rsc->priv->children);
+    g_list_free_full(rsc->priv->children, pcmk__free_resource);
 
     if (clone_data) {
         pcmk__assert((clone_data->demote_notify == NULL)

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -742,12 +742,12 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
     rsc_private->allowed_nodes = pcmk__strkey_table(NULL, pcmk__free_node_copy);
 
     value = pcmk__xe_get(rsc_private->xml, PCMK__META_CLONE);
-    if (value) {
+    if (value != NULL) {
         (*rsc)->id = pcmk__assert_asprintf("%s:%s", id, value);
         pcmk__insert_meta(rsc_private, PCMK__META_CLONE, value);
 
     } else {
-        (*rsc)->id = strdup(id);
+        (*rsc)->id = pcmk__str_copy(id);
     }
 
     rsc_private->fns = &resource_class_functions[rsc_private->variant];

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -730,7 +730,7 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
 
     ops = pcmk__xe_first_child(rsc_private->xml, PCMK_XE_OPERATIONS, NULL,
                                NULL);
-    rsc_private->ops_xml = pcmk__xe_resolve_idref(ops, scheduler->input);
+    rsc_private->ops_xml = pcmk__xe_resolve_idref(ops, scheduler->input->doc);
 
     rsc_private->variant = get_resource_type((const char *)
                                              rsc_private->xml->name);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -123,28 +123,24 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
-expand_parents_fixed_nvpairs(pcmk_resource_t *rsc,
+expand_parents_fixed_nvpairs(const pcmk_resource_t *rsc,
                              const pcmk_rule_input_t *rule_input,
                              GHashTable *meta_hash, pcmk_scheduler_t *scheduler)
 {
     GHashTable *parent_orig_meta = pcmk__strkey_table(free, free);
-    pcmk_resource_t *p = rsc->priv->parent;
-
-    if (p == NULL) {
-        return ;
-    }
 
     /* Search all parent resources, get the fixed value of
      * PCMK_XE_META_ATTRIBUTES set only in the original xml, and stack it in the
      * hash table. The fixed value of the lower parent resource takes precedence
      * and is not overwritten.
      */
-    while(p != NULL) {
+    for (const pcmk_resource_t *parent = rsc->priv->parent; parent != NULL;
+         parent = parent->priv->parent) {
+
         /* A hash table for comparison is generated, including the id-ref. */
-        pe__unpack_dataset_nvpairs(p->priv->xml, PCMK_XE_META_ATTRIBUTES,
+        pe__unpack_dataset_nvpairs(parent->priv->xml, PCMK_XE_META_ATTRIBUTES,
                                    rule_input, parent_orig_meta, NULL,
                                    scheduler);
-        p = p->priv->parent;
     }
 
     // This will not overwrite any values already existing for child

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -111,13 +111,21 @@ dup_attr(gpointer key, gpointer value, gpointer user_data)
     GHashTable *table = user_data;
 
     CRM_CHECK((key != NULL) && (table != NULL), return);
+
+    if (value == NULL) {
+        return;
+    }
+
     if (pcmk__str_eq((const char *) value, "#default", pcmk__str_casei)) {
         // @COMPAT Deprecated since 2.1.8
         pcmk__config_warn("Support for setting meta-attributes (such as %s) to "
                           "the explicit value '#default' is deprecated and "
                           "will be removed in a future release",
                           (const char *) key);
-    } else if ((value != NULL) && (g_hash_table_lookup(table, key) == NULL)) {
+        return;
+    }
+
+    if (!g_hash_table_contains(table, key)) {
         pcmk__insert_dup(table, (const char *) key, (const char *) value);
     }
 }
@@ -157,7 +165,7 @@ expand_parents_fixed_nvpairs(const pcmk_resource_t *rsc,
  * \param[in,out] scheduler  Scheduler data
  */
 void
-get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t * rsc,
+get_meta_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
                     pcmk_node_t *node, pcmk_scheduler_t *scheduler)
 {
     const pcmk_rule_input_t rule_input = {
@@ -167,13 +175,15 @@ get_meta_attributes(GHashTable * meta_hash, pcmk_resource_t * rsc,
         .rsc_agent = pcmk__xe_get(rsc->priv->xml, PCMK_XA_TYPE)
     };
 
-    for (xmlAttrPtr a = pcmk__xe_first_attr(rsc->priv->xml);
-         a != NULL; a = a->next) {
+    for (const xmlAttr *attr = pcmk__xe_first_attr(rsc->priv->xml);
+         attr != NULL; attr = attr->next) {
 
-        if (a->children != NULL) {
-            dup_attr((gpointer) a->name, (gpointer) a->children->content,
-                     meta_hash);
+        if (attr->children == NULL) {
+            continue;
         }
+
+        dup_attr((void *) attr->name, (void *) attr->children->content,
+                 meta_hash);
     }
 
     pe__unpack_dataset_nvpairs(rsc->priv->xml, PCMK_XE_META_ATTRIBUTES,

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -147,10 +147,6 @@ expand_parents_fixed_nvpairs(pcmk_resource_t *rsc,
         p = p->priv->parent;
     }
 
-    if (parent_orig_meta == NULL) {
-        return;
-    }
-
     // This will not overwrite any values already existing for child
     g_hash_table_foreach(parent_orig_meta, dup_attr, meta_hash);
     g_hash_table_destroy(parent_orig_meta);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -265,13 +265,10 @@ template_op_key(const xmlNode *op)
 }
 
 static int
-unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
-                pcmk_scheduler_t *scheduler)
+unpack_template(pcmk_resource_t *rsc, pcmk_scheduler_t *scheduler)
 {
     xmlNode *cib_resources = NULL;
     xmlNode *template = NULL;
-    xmlNode *new_xml = NULL;
-    xmlNode *child_xml = NULL;
     xmlNode *rsc_ops = NULL;
     xmlNode *template_ops = NULL;
     GHashTable *rsc_ops_hash = NULL;
@@ -279,12 +276,12 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     const char *id = NULL;
     int rc = pcmk_rc_ok;
 
-    template_ref = pcmk__xe_get(xml_obj, PCMK_XA_TEMPLATE);
+    template_ref = pcmk__xe_get(rsc->priv->orig_xml, PCMK_XA_TEMPLATE);
     if (template_ref == NULL) {
         goto done;
     }
 
-    id = pcmk__xe_id(xml_obj);
+    id = pcmk__xe_id(rsc->priv->orig_xml);
 
     if (pcmk__str_eq(template_ref, id, pcmk__str_none)) {
         pcmk__config_err("The resource object '%s' should not reference itself",
@@ -308,19 +305,20 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
         goto done;
     }
 
-    new_xml = pcmk__xml_copy(NULL, template);
-    xmlNodeSetName(new_xml, xml_obj->name);
-    pcmk__xe_set(new_xml, PCMK_XA_ID, id);
-    pcmk__xe_set(new_xml, PCMK__META_CLONE,
-                 pcmk__xe_get(xml_obj, PCMK__META_CLONE));
+    rsc->priv->xml = pcmk__xml_copy(NULL, template);
+    xmlNodeSetName(rsc->priv->xml, rsc->priv->orig_xml->name);
+    pcmk__xe_set(rsc->priv->xml, PCMK_XA_ID, id);
+    pcmk__xe_set(rsc->priv->xml, PCMK__META_CLONE,
+                 pcmk__xe_get(rsc->priv->orig_xml, PCMK__META_CLONE));
 
-    template_ops = pcmk__xe_first_child(new_xml, PCMK_XE_OPERATIONS, NULL,
-                                        NULL);
+    template_ops = pcmk__xe_first_child(rsc->priv->xml, PCMK_XE_OPERATIONS,
+                                        NULL, NULL);
 
-    for (child_xml = pcmk__xe_first_child(xml_obj, NULL, NULL, NULL);
+    for (xmlNode *child_xml = pcmk__xe_first_child(rsc->priv->orig_xml, NULL,
+                                                   NULL, NULL);
          child_xml != NULL; child_xml = pcmk__xe_next(child_xml, NULL)) {
 
-        xmlNode *new_child = pcmk__xml_copy(new_xml, child_xml);
+        xmlNode *new_child = pcmk__xml_copy(rsc->priv->xml, child_xml);
 
         if ((rsc_ops == NULL) && pcmk__xe_is(new_child, PCMK_XE_OPERATIONS)) {
             /* Multiple PCMK_XE_OPERATIONS children are not possible with schema
@@ -360,8 +358,11 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     pcmk__xml_free(template_ops);
 
 done:
+    if (rc == pcmk_rc_ok) {
+        pcmk__log_xml_trace(rsc->priv->xml, "[expanded XML]");
+    }
+
     g_clear_pointer(&rsc_ops_hash, g_hash_table_destroy);
-    *expanded_xml = new_xml;
     return rc;
 }
 
@@ -703,25 +704,12 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
 
     rsc_private = (*rsc)->priv;
     rsc_private->scheduler = scheduler;
+    rsc_private->orig_xml = pcmk__xml_copy(NULL, xml_obj);
+    rsc_private->xml = rsc_private->orig_xml;
 
-    rc = unpack_template(xml_obj, &rsc_private->xml, scheduler);
+    rc = unpack_template(*rsc, scheduler);
     if (rc != pcmk_rc_ok) {
         goto done;
-    }
-
-    if (rsc_private->xml != NULL) {
-        /* rsc_private->xml is the effective XML and was expanded from a
-         * template. Save rsc's original XML from the configuration in
-         * rsc_private->orig_xml for later use.
-         */
-        pcmk__log_xml_trace(rsc_private->xml, "[expanded XML]");
-        rsc_private->orig_xml = xml_obj;
-
-    } else {
-        /* rsc_private->xml is both the effective XML and the original XML.
-         * rsc_private->orig_xml remains NULL.
-         */
-        rsc_private->xml = xml_obj;
     }
 
     /* Do not use xml_obj from here on, use (*rsc)->xml in case templates are involved */
@@ -948,8 +936,8 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
                                &rule_input, rsc_private->utilization, NULL,
                                scheduler);
 
-    // ((rsc_private->orig_xml != NULL) means rsc was expanded from a template
-    if ((rsc_private->orig_xml != NULL)
+    // First condition means resource was expanded from a template
+    if ((rsc_private->xml != rsc_private->orig_xml)
         && !add_template_rsc(rsc_private->orig_xml, scheduler)) {
 
         rc = pcmk_rc_unpack_error;
@@ -1033,22 +1021,17 @@ common_free(pcmk_resource_t * rsc)
 
     g_clear_pointer(&rsc->priv->parameter_cache, g_hash_table_destroy);
 
-    if ((rsc->priv->parent == NULL)
-        && pcmk__is_set(rsc->flags, pcmk__rsc_removed)) {
-
-        pcmk__xml_free(rsc->priv->xml);
-        pcmk__xml_free(rsc->priv->orig_xml);
-
-    } else if (rsc->priv->orig_xml != NULL) {
-        // rsc->priv->xml was expanded from a template
-        pcmk__xml_free(rsc->priv->xml);
-    }
     free(rsc->id);
 
     free(rsc->priv->variant_opaque);
     free(rsc->priv->history_id);
     free(rsc->priv->pending_action);
     pcmk__free_node_copy(rsc->priv->assigned_node);
+
+    if (rsc->priv->orig_xml != rsc->priv->xml) {
+        pcmk__xml_free(rsc->priv->orig_xml);
+    }
+    pcmk__xml_free(rsc->priv->xml);
 
     g_list_free(rsc->priv->actions);
     g_list_free(rsc->priv->active_nodes);

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -168,12 +168,10 @@ void
 get_meta_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
                     pcmk_node_t *node, pcmk_scheduler_t *scheduler)
 {
-    const pcmk_rule_input_t rule_input = {
-        .now = scheduler->priv->now,
-        .rsc_standard = pcmk__xe_get(rsc->priv->xml, PCMK_XA_CLASS),
-        .rsc_provider = pcmk__xe_get(rsc->priv->xml, PCMK_XA_PROVIDER),
-        .rsc_agent = pcmk__xe_get(rsc->priv->xml, PCMK_XA_TYPE)
-    };
+    pcmk_rule_input_t rule_input = { NULL, };
+
+    CRM_CHECK((meta_hash != NULL) && (rsc != NULL) && (scheduler != NULL),
+              return);
 
     for (const xmlAttr *attr = pcmk__xe_first_attr(rsc->priv->xml);
          attr != NULL; attr = attr->next) {
@@ -185,6 +183,11 @@ get_meta_attributes(GHashTable *meta_hash, const pcmk_resource_t *rsc,
         dup_attr((void *) attr->name, (void *) attr->children->content,
                  meta_hash);
     }
+
+    rule_input.now = scheduler->priv->now;
+    rule_input.rsc_standard = pcmk__xe_get(rsc->priv->xml, PCMK_XA_CLASS);
+    rule_input.rsc_provider = pcmk__xe_get(rsc->priv->xml, PCMK_XA_PROVIDER);
+    rule_input.rsc_agent = pcmk__xe_get(rsc->priv->xml, PCMK_XA_TYPE);
 
     pe__unpack_dataset_nvpairs(rsc->priv->xml, PCMK_XE_META_ATTRIBUTES,
                                &rule_input, meta_hash, NULL, scheduler);

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -207,7 +207,12 @@ group_unpack(pcmk_resource_t *rsc)
 
         pcmk_resource_t *new_rsc = NULL;
 
+        /* If clone_id is non-NULL, then the group XML (with its children) is a
+         * copy created while unpacking a clone. So setting the PCMK__META_CLONE
+         * attribute here does not affect the original CIB XML.
+         */
         pcmk__xe_set(xml_native_rsc, PCMK__META_CLONE, clone_id);
+
         if (pe__unpack_resource(xml_native_rsc, &new_rsc, rsc,
                                 rsc->priv->scheduler) != pcmk_rc_ok) {
             continue;
@@ -391,21 +396,8 @@ group_free(pcmk_resource_t * rsc)
 {
     CRM_CHECK(rsc != NULL, return);
 
-    pcmk__rsc_trace(rsc, "Freeing %s", rsc->id);
-
-    for (GList *gIter = rsc->priv->children;
-         gIter != NULL; gIter = gIter->next) {
-
-        pcmk_resource_t *child_rsc = (pcmk_resource_t *) gIter->data;
-
-        pcmk__assert(child_rsc != NULL);
-        pcmk__rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
-        pcmk__free_resource(child_rsc);
-    }
-
-    pcmk__rsc_trace(rsc, "Freeing child list");
-    g_list_free(rsc->priv->children);
-
+    pcmk__rsc_trace(rsc, "Freeing group %s, starting with child list", rsc->id);
+    g_list_free_full(rsc->priv->children, pcmk__free_resource);
     common_free(rsc);
 }
 

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -391,17 +391,6 @@ is_mixed_version(pcmk_scheduler_t *scheduler)
         }
     }
     return false;
-}
-
-static void
-formatted_xml_buf(const pcmk_resource_t *rsc, GString *xml_buf, bool raw)
-{
-    if (raw && (rsc->priv->orig_xml != NULL)) {
-        pcmk__xml_string(rsc->priv->orig_xml, pcmk__xml_fmt_pretty, xml_buf,
-                         0);
-    } else {
-        pcmk__xml_string(rsc->priv->xml, pcmk__xml_fmt_pretty, xml_buf, 0);
-    }
 }
 
 #define XPATH_DC_VERSION "//" PCMK_XE_NVPAIR    \
@@ -2949,7 +2938,8 @@ resource_config(pcmk__output_t *out, va_list args) {
     GString *xml_buf = g_string_sized_new(1024);
     bool raw = va_arg(args, int);
 
-    formatted_xml_buf(rsc, xml_buf, raw);
+    pcmk__xml_string((raw? rsc->priv->orig_xml : rsc->priv->xml),
+                     pcmk__xml_fmt_pretty, xml_buf, 0);
 
     out->output_xml(out, PCMK_XE_XML, xml_buf->str);
 

--- a/lib/pengine/rules_compat.c
+++ b/lib/pengine/rules_compat.c
@@ -95,6 +95,7 @@ pe_eval_nvpairs(xmlNode *top, const xmlNode *xml_obj, const char *set_name,
         return;
     }
 
+    data.doc = xml_obj->doc;
     map_rule_input(&(data.rule_input), rule_data);
 
     pairs = g_list_sort_with_data(pairs, pcmk__cmp_nvpair_blocks, &data);

--- a/lib/pengine/rules_compat.c
+++ b/lib/pengine/rules_compat.c
@@ -79,26 +79,27 @@ pe_eval_nvpairs(xmlNode *top, const xmlNode *xml_obj, const char *set_name,
                 crm_time_t *next_change)
 {
     GList *pairs = NULL;
+    pcmk__nvpair_unpack_t data = {
+        .values = hash,
+        .first_id = always_first,
+        .overwrite = overwrite,
+        .next_change = next_change,
+    };
 
     if (xml_obj == NULL) {
         return;
     }
 
     pairs = pcmk__xe_dereference_children(xml_obj, set_name, xml_obj->doc);
-    if (pairs) {
-        pcmk__nvpair_unpack_t data = {
-            .values = hash,
-            .first_id = always_first,
-            .overwrite = overwrite,
-            .next_change = next_change,
-        };
-
-        map_rule_input(&(data.rule_input), rule_data);
-
-        pairs = g_list_sort_with_data(pairs, pcmk__cmp_nvpair_blocks, &data);
-        g_list_foreach(pairs, pcmk__unpack_nvpair_block, &data);
-        g_list_free(pairs);
+    if (pairs == NULL) {
+        return;
     }
+
+    map_rule_input(&(data.rule_input), rule_data);
+
+    pairs = g_list_sort_with_data(pairs, pcmk__cmp_nvpair_blocks, &data);
+    g_list_foreach(pairs, pcmk__unpack_nvpair_block, &data);
+    g_list_free(pairs);
 }
 
 void

--- a/lib/pengine/rules_compat.c
+++ b/lib/pengine/rules_compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -78,8 +78,13 @@ pe_eval_nvpairs(xmlNode *top, const xmlNode *xml_obj, const char *set_name,
                 const char *always_first, gboolean overwrite,
                 crm_time_t *next_change)
 {
-    GList *pairs = pcmk__xe_dereference_children(xml_obj, set_name);
+    GList *pairs = NULL;
 
+    if (xml_obj == NULL) {
+        return;
+    }
+
+    pairs = pcmk__xe_dereference_children(xml_obj, set_name, xml_obj->doc);
     if (pairs) {
         pcmk__nvpair_unpack_t data = {
             .values = hash,

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -178,8 +178,8 @@ cluster_status(pcmk_scheduler_t * scheduler)
                            scheduler->priv->local_node_name) == NULL)) {
         pcmk__info("Creating a fake local node for %s",
                    scheduler->priv->local_node_name);
-        pe_create_node(scheduler->priv->local_node_name,
-                       scheduler->priv->local_node_name, NULL, 0, scheduler);
+        pe__create_node(scheduler->priv->local_node_name,
+                        scheduler->priv->local_node_name, NULL, 0, scheduler);
     }
 
     pcmk__set_scheduler_flags(scheduler, pcmk__sched_have_status);

--- a/lib/pengine/tests/status/pe_find_node_any_test.c
+++ b/lib/pengine/tests/status/pe_find_node_any_test.c
@@ -24,8 +24,14 @@ empty_list(void **state)
 static void
 non_null_list(void **state)
 {
-    struct pcmk__node_private node1_priv = { .id = "id1", .name = "cluster1" };
-    struct pcmk__node_private node2_priv = { .id = "id2", .name = "cluster2" };
+    struct pcmk__node_private node1_priv = {
+        .id = pcmk__str_copy("id1"),
+        .name = pcmk__str_copy("cluster1"),
+    };
+    struct pcmk__node_private node2_priv = {
+        .id = pcmk__str_copy("id2"),
+        .name = pcmk__str_copy("cluster2"),
+    };
     pcmk_node_t node1 = { .priv = &node1_priv };
     pcmk_node_t node2 = { .priv = &node2_priv };
     GList *nodes = NULL;
@@ -46,6 +52,10 @@ non_null_list(void **state)
     assert_null(pe_find_node_any(nodes, "id3", "cluster3"));
     assert_null(pe_find_node_any(nodes, NULL, NULL));
 
+    free(node1_priv.id);
+    free(node1_priv.name);
+    free(node2_priv.id);
+    free(node2_priv.name);
     g_list_free(nodes);
 }
 

--- a/lib/pengine/tests/status/pe_find_node_any_test.c
+++ b/lib/pengine/tests/status/pe_find_node_any_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,7 +13,8 @@
 #include <crm/pengine/internal.h>
 
 static void
-empty_list(void **state) {
+empty_list(void **state)
+{
     assert_null(pe_find_node_any(NULL, NULL, NULL));
     assert_null(pe_find_node_any(NULL, NULL, "cluster1"));
     assert_null(pe_find_node_any(NULL, "id1", NULL));
@@ -21,29 +22,22 @@ empty_list(void **state) {
 }
 
 static void
-non_null_list(void **state) {
+non_null_list(void **state)
+{
+    struct pcmk__node_private node1_priv = { .id = "id1", .name = "cluster1" };
+    struct pcmk__node_private node2_priv = { .id = "id2", .name = "cluster2" };
+    pcmk_node_t node1 = { .priv = &node1_priv };
+    pcmk_node_t node2 = { .priv = &node2_priv };
     GList *nodes = NULL;
 
-    pcmk_node_t *a = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
-    pcmk_node_t *b = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    nodes = g_list_prepend(nodes, &node1);
+    nodes = g_list_prepend(nodes, &node2);
 
-    a->priv = pcmk__assert_alloc(1, sizeof(struct pcmk__node_private));
-    b->priv = pcmk__assert_alloc(1, sizeof(struct pcmk__node_private));
+    assert_ptr_equal(&node1, pe_find_node_any(nodes, "xyz", "cluster1"));
+    assert_ptr_equal(&node1, pe_find_node_any(nodes, NULL, "cluster1"));
 
-    a->priv->name = "cluster1";
-    a->priv->id = "id1";
-
-    b->priv->name = "cluster2";
-    b->priv->id = "id2";
-
-    nodes = g_list_append(nodes, a);
-    nodes = g_list_append(nodes, b);
-
-    assert_ptr_equal(b, pe_find_node_any(nodes, "id2", NULL));
-    assert_ptr_equal(b, pe_find_node_any(nodes, "ID2", NULL));
-
-    assert_ptr_equal(a, pe_find_node_any(nodes, "xyz", "cluster1"));
-    assert_ptr_equal(a, pe_find_node_any(nodes, NULL, "cluster1"));
+    assert_ptr_equal(&node2, pe_find_node_any(nodes, "id2", NULL));
+    assert_ptr_equal(&node2, pe_find_node_any(nodes, "ID2", NULL));
 
     assert_null(pe_find_node_any(nodes, "id10", NULL));
     assert_null(pe_find_node_any(nodes, "nodeid1", NULL));
@@ -52,10 +46,6 @@ non_null_list(void **state) {
     assert_null(pe_find_node_any(nodes, "id3", "cluster3"));
     assert_null(pe_find_node_any(nodes, NULL, NULL));
 
-    free(a->priv);
-    free(a);
-    free(b->priv);
-    free(b);
     g_list_free(nodes);
 }
 

--- a/lib/pengine/tests/status/pe_find_node_id_test.c
+++ b/lib/pengine/tests/status/pe_find_node_id_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,37 +13,30 @@
 #include <crm/pengine/internal.h>
 
 static void
-empty_list(void **state) {
+empty_list(void **state)
+{
     assert_null(pe_find_node_id(NULL, NULL));
     assert_null(pe_find_node_id(NULL, "id1"));
 }
 
 static void
-non_null_list(void **state) {
+non_null_list(void **state)
+{
+    struct pcmk__node_private node1_priv = { .id = "id1" };
+    struct pcmk__node_private node2_priv = { .id = "id2" };
+    pcmk_node_t node1 = { .priv = &node1_priv };
+    pcmk_node_t node2 = { .priv = &node2_priv };
     GList *nodes = NULL;
 
-    pcmk_node_t *a = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
-    pcmk_node_t *b = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    nodes = g_list_prepend(nodes, &node1);
+    nodes = g_list_prepend(nodes, &node2);
 
-    a->priv = pcmk__assert_alloc(1, sizeof(struct pcmk__node_private));
-    b->priv = pcmk__assert_alloc(1, sizeof(struct pcmk__node_private));
-
-    a->priv->id = "id1";
-    b->priv->id = "id2";
-
-    nodes = g_list_append(nodes, a);
-    nodes = g_list_append(nodes, b);
-
-    assert_ptr_equal(a, pe_find_node_id(nodes, "id1"));
+    assert_ptr_equal(&node1, pe_find_node_id(nodes, "id1"));
     assert_null(pe_find_node_id(nodes, "id10"));
     assert_null(pe_find_node_id(nodes, "nodeid1"));
-    assert_ptr_equal(b, pe_find_node_id(nodes, "ID2"));
+    assert_ptr_equal(&node2, pe_find_node_id(nodes, "ID2"));
     assert_null(pe_find_node_id(nodes, "xyz"));
 
-    free(a->priv);
-    free(a);
-    free(b->priv);
-    free(b);
     g_list_free(nodes);
 }
 

--- a/lib/pengine/tests/status/pe_find_node_id_test.c
+++ b/lib/pengine/tests/status/pe_find_node_id_test.c
@@ -22,8 +22,8 @@ empty_list(void **state)
 static void
 non_null_list(void **state)
 {
-    struct pcmk__node_private node1_priv = { .id = "id1" };
-    struct pcmk__node_private node2_priv = { .id = "id2" };
+    struct pcmk__node_private node1_priv = { .id = pcmk__str_copy("id1") };
+    struct pcmk__node_private node2_priv = { .id = pcmk__str_copy("id2") };
     pcmk_node_t node1 = { .priv = &node1_priv };
     pcmk_node_t node2 = { .priv = &node2_priv };
     GList *nodes = NULL;
@@ -37,6 +37,8 @@ non_null_list(void **state)
     assert_ptr_equal(&node2, pe_find_node_id(nodes, "ID2"));
     assert_null(pe_find_node_id(nodes, "xyz"));
 
+    free(node1_priv.id);
+    free(node2_priv.id);
     g_list_free(nodes);
 }
 

--- a/lib/pengine/tests/utils/pe__cmp_node_name_test.c
+++ b/lib/pengine/tests/utils/pe__cmp_node_name_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,9 +23,13 @@ nodes_equal(void **state)
 {
     assert_int_equal(pe__cmp_node_name(NULL, NULL), 0);
 
-    node1.priv->name = "node10";
-    node2.priv->name = "node10";
+    node1.priv->name = pcmk__str_copy("node10");
+    node2.priv->name = pcmk__str_copy("node10");
+
     assert_int_equal(pe__cmp_node_name(&node1, &node2), 0);
+
+    free(node1.priv->name);
+    free(node2.priv->name);
 }
 
 static void
@@ -34,9 +38,13 @@ node1_first(void **state)
     assert_int_equal(pe__cmp_node_name(NULL, &node2), -1);
 
     // The heavy testing is done in pcmk__numeric_strcasecmp()'s unit tests
-    node1.priv->name = "node9";
-    node2.priv->name = "node10";
+    node1.priv->name = pcmk__str_copy("node9");
+    node2.priv->name = pcmk__str_copy("node10");
+
     assert_int_equal(pe__cmp_node_name(&node1, &node2), -1);
+
+    free(node1.priv->name);
+    free(node2.priv->name);
 }
 
 static void
@@ -44,9 +52,13 @@ node2_first(void **state)
 {
     assert_int_equal(pe__cmp_node_name(&node1, NULL), 1);
 
-    node1.priv->name = "node10";
-    node2.priv->name = "node9";
+    node1.priv->name = pcmk__str_copy("node10");
+    node2.priv->name = pcmk__str_copy("node9");
+
     assert_int_equal(pe__cmp_node_name(&node1, &node2), 1);
+
+    free(node1.priv->name);
+    free(node2.priv->name);
 }
 
 PCMK__UNIT_TEST(NULL, NULL,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -501,8 +501,8 @@ pe__create_node(const char *id, const char *uname, const char *type, int score,
 
     pcmk__trace("Creating node for entry %s/%s", uname, id);
     new_node->assign->score = score;
-    new_node->priv->id = id;
-    new_node->priv->name = uname;
+    new_node->priv->id = pcmk__str_copy(id);
+    new_node->priv->name = pcmk__str_copy(uname);
     new_node->priv->flags = pcmk__node_probes_allowed;
     new_node->details->online = false;
     new_node->details->shutdown = false;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -492,34 +492,20 @@ pe__create_node(const char *id, const char *uname, const char *type, int score,
         return NULL;
     }
 
-    new_node = calloc(1, sizeof(pcmk_node_t));
-    if (new_node == NULL) {
-        pcmk__sched_err(scheduler, "Could not allocate memory for node %s",
-                        uname);
-        return NULL;
-    }
-
-    new_node->assign = calloc(1, sizeof(struct pcmk__node_assignment));
-    new_node->details = calloc(1, sizeof(struct pcmk__node_details));
-    new_node->priv = calloc(1, sizeof(pcmk__node_private_t));
-    if ((new_node->assign == NULL) || (new_node->details == NULL)
-        || (new_node->priv == NULL)) {
-        free(new_node->assign);
-        free(new_node->details);
-        free(new_node->priv);
-        free(new_node);
-        pcmk__sched_err(scheduler, "Could not allocate memory for node %s",
-                        uname);
-        return NULL;
-    }
+    new_node = pcmk__assert_alloc(1, sizeof(pcmk_node_t));
+    new_node->assign = pcmk__assert_alloc(1,
+                                          sizeof(struct pcmk__node_assignment));
+    new_node->details = pcmk__assert_alloc(1,
+                                           sizeof(struct pcmk__node_details));
+    new_node->priv = pcmk__assert_alloc(1, sizeof(pcmk__node_private_t));
 
     pcmk__trace("Creating node for entry %s/%s", uname, id);
     new_node->assign->score = score;
     new_node->priv->id = id;
     new_node->priv->name = uname;
     new_node->priv->flags = pcmk__node_probes_allowed;
-    new_node->details->online = FALSE;
-    new_node->details->shutdown = FALSE;
+    new_node->details->online = false;
+    new_node->details->shutdown = false;
     new_node->details->running_rsc = NULL;
     new_node->priv->scheduler = scheduler;
     new_node->priv->variant = variant;
@@ -530,6 +516,7 @@ pe__create_node(const char *id, const char *uname, const char *type, int score,
     if (pcmk__is_pacemaker_remote_node(new_node)) {
         pcmk__insert_dup(new_node->priv->attrs, CRM_ATTR_KIND, "remote");
         pcmk__set_scheduler_flags(scheduler, pcmk__sched_have_remote_nodes);
+
     } else {
         pcmk__insert_dup(new_node->priv->attrs, CRM_ATTR_KIND, "cluster");
     }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -469,8 +469,8 @@ unpack_config(xmlNode *config, pcmk_scheduler_t *scheduler)
  *       freed separately.
  */
 pcmk_node_t *
-pe_create_node(const char *id, const char *uname, const char *type,
-               int score, pcmk_scheduler_t *scheduler)
+pe__create_node(const char *id, const char *uname, const char *type, int score,
+                pcmk_scheduler_t *scheduler)
 {
     enum pcmk__node_variant variant = pcmk__node_variant_cluster;
     pcmk_node_t *new_node = NULL;
@@ -661,7 +661,7 @@ unpack_nodes(xmlNode *xml_nodes, pcmk_scheduler_t *scheduler)
                               pcmk__xe_get(xml_obj, PCMK_XA_SCORE),
                               pcmk_rc_str(rc));
         }
-        new_node = pe_create_node(id, uname, type, score, scheduler);
+        new_node = pe__create_node(id, uname, type, score, scheduler);
 
         if (new_node == NULL) {
             return FALSE;
@@ -732,8 +732,8 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
                 && (pcmk_find_node(scheduler, new_node_id) == NULL)) {
                 pcmk__trace("Found remote node %s defined by resource %s",
                             new_node_id, pcmk__xe_id(xml_obj));
-                pe_create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
-                               0, scheduler);
+                pe__create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE, 0,
+                                scheduler);
             }
             continue;
         }
@@ -752,8 +752,8 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
                 && (pcmk_find_node(scheduler, new_node_id) == NULL)) {
                 pcmk__trace("Found guest node %s in resource %s",
                             new_node_id, pcmk__xe_id(xml_obj));
-                pe_create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
-                               0, scheduler);
+                pe__create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE, 0,
+                                scheduler);
             }
             continue;
         }
@@ -775,8 +775,8 @@ unpack_remote_nodes(xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
                                 "group %s",
                                 new_node_id, pcmk__xe_id(xml_obj2),
                                 pcmk__xe_id(xml_obj));
-                    pe_create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
-                                   0, scheduler);
+                    pe__create_node(new_node_id, new_node_id, PCMK_VALUE_REMOTE,
+                                    0, scheduler);
                 }
             }
         }
@@ -820,7 +820,7 @@ link_rsc2remotenode(pcmk_scheduler_t *scheduler, pcmk_resource_t *new_rsc)
         handle_startup_fencing(scheduler, remote_node);
 
     } else {
-        /* pe_create_node() marks the new node as "remote" or "cluster"; now
+        /* pe__create_node() marks the new node as "remote" or "cluster"; now
          * that we know the node is a guest node, update it correctly.
          */
         pcmk__insert_dup(remote_node->priv->attrs,
@@ -2050,8 +2050,8 @@ create_fake_resource(const char *rsc_id, const xmlNode *rsc_entry,
         pcmk__debug("Detected removed remote node %s", rsc_id);
         node = pcmk_find_node(scheduler, rsc_id);
         if (node == NULL) {
-            node = pe_create_node(rsc_id, rsc_id, PCMK_VALUE_REMOTE, 0,
-                                  scheduler);
+            node = pe__create_node(rsc_id, rsc_id, PCMK_VALUE_REMOTE, 0,
+                                   scheduler);
         }
         link_rsc2remotenode(scheduler, rsc);
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -711,7 +711,7 @@ pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
 
     next_change = crm_time_new_undefined();
     pcmk__unpack_nvpair_blocks(xml_obj, set_name, always_first, rule_input,
-                               hash, next_change);
+                               hash, next_change, xml_obj->doc);
 
     if (crm_time_is_defined(next_change)) {
         time_t recheck = (time_t) crm_time_get_seconds_since_epoch(next_change);

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -710,8 +710,9 @@ pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
     }
 
     next_change = crm_time_new_undefined();
-    pcmk_unpack_nvpair_blocks(xml_obj, set_name, always_first, rule_input, hash,
-                              next_change);
+    pcmk__unpack_nvpair_blocks(xml_obj, set_name, always_first, rule_input,
+                               hash, next_change);
+
     if (crm_time_is_defined(next_change)) {
         time_t recheck = (time_t) crm_time_get_seconds_since_epoch(next_change);
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -711,7 +711,7 @@ pe__unpack_dataset_nvpairs(const xmlNode *xml_obj, const char *set_name,
 
     next_change = crm_time_new_undefined();
     pcmk__unpack_nvpair_blocks(xml_obj, set_name, always_first, rule_input,
-                               hash, next_change, xml_obj->doc);
+                               hash, next_change, scheduler->input->doc);
 
     if (crm_time_is_defined(next_change)) {
         time_t recheck = (time_t) crm_time_get_seconds_since_epoch(next_change);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1439,10 +1439,8 @@ handle_get_param(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
 
     } else if (pcmk__str_eq(options.attr_set_type, PCMK_XE_META_ATTRIBUTES,
                             pcmk__str_none)) {
-        params = pcmk__strkey_table(free, free);
-        get_meta_attributes(params, rsc, NULL, scheduler);
-
-        value = g_hash_table_lookup(params, options.prop_name);
+        value = g_hash_table_lookup(rsc->priv->meta, options.prop_name);
+        free_params = false;
 
     } else if (pcmk__str_eq(options.attr_set_type, ATTR_SET_ELEMENT,
                             pcmk__str_none)) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1414,9 +1414,7 @@ handle_get_param(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
                  xmlNode *cib_xml_orig)
 {
     unsigned int count = 0;
-    GHashTable *params = NULL;
     pcmk_node_t *current = rsc->priv->fns->active_node(rsc, &count, NULL);
-    bool free_params = true;
     const char *value = NULL;
     int rc = pcmk_rc_ok;
 
@@ -1432,38 +1430,35 @@ handle_get_param(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
 
     if (pcmk__str_eq(options.attr_set_type, PCMK_XE_INSTANCE_ATTRIBUTES,
                      pcmk__str_none)) {
-        params = pe_rsc_params(rsc, current, scheduler);
-        free_params = false;
 
-        value = g_hash_table_lookup(params, options.prop_name);
+        value = g_hash_table_lookup(pe_rsc_params(rsc, current, scheduler),
+                                    options.prop_name);
 
     } else if (pcmk__str_eq(options.attr_set_type, PCMK_XE_META_ATTRIBUTES,
                             pcmk__str_none)) {
+
         value = g_hash_table_lookup(rsc->priv->meta, options.prop_name);
-        free_params = false;
 
     } else if (pcmk__str_eq(options.attr_set_type, ATTR_SET_ELEMENT,
                             pcmk__str_none)) {
+
         value = pcmk__xe_get(rsc->priv->xml, options.prop_name);
-        free_params = false;
 
     } else {
         const pcmk_rule_input_t rule_input = {
             .now = scheduler->priv->now,
         };
 
-        params = pcmk__strkey_table(free, free);
+        GHashTable *params = pcmk__strkey_table(free, free);
+
         pe__unpack_dataset_nvpairs(rsc->priv->xml, PCMK_XE_UTILIZATION,
                                    &rule_input, params, NULL, scheduler);
 
         value = g_hash_table_lookup(params, options.prop_name);
-    }
-
-    rc = out->message(out, "attribute-list", rsc, options.prop_name, value);
-    if (free_params) {
         g_hash_table_destroy(params);
     }
 
+    rc = out->message(out, "attribute-list", rsc, options.prop_name, value);
     return pcmk_rc2exitc(rc);
 }
 

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -40,7 +40,7 @@
 #include <crm/common/strings.h>             // pcmk_parse_interval_spec
 #include <crm/common/xml.h>                 // PCMK_XA_ID, PCMK_XE_*
 #include <crm/crm.h>                        // CRM_FEATURE_SET, crm_system_name
-#include <crm/pengine/complex.h>            // get_meta_attributes, uber_parent
+#include <crm/pengine/complex.h>            // uber_parent
 #include <crm/pengine/internal.h>           // clone_strip, pe__const_top_resource
 #include <crm/pengine/status.h>             // cluster_status, pe_find_resource
 #include <crm/services.h>                   // resources_find_service_class
@@ -1309,7 +1309,6 @@ static GHashTable *
 generate_resource_params(pcmk_resource_t *rsc)
 {
     GHashTable *params = NULL;
-    GHashTable *meta = NULL;
     GHashTable *combined = NULL;
     GHashTableIter iter;
     char *key = NULL;
@@ -1325,16 +1324,11 @@ generate_resource_params(pcmk_resource_t *rsc)
         }
     }
 
-    meta = pcmk__strkey_table(free, free);
-    get_meta_attributes(meta, rsc, NULL, rsc->priv->scheduler);
-    if (meta != NULL) {
-        g_hash_table_iter_init(&iter, meta);
-        while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & value)) {
-            char *crm_name = crm_meta_name(key);
+    g_hash_table_iter_init(&iter, rsc->priv->meta);
+    while (g_hash_table_iter_next(&iter, (void *) &key, (void *) &value)) {
+        char *crm_name = crm_meta_name(key);
 
-            g_hash_table_insert(combined, crm_name, strdup(value));
-        }
-        g_hash_table_destroy(meta);
+        g_hash_table_insert(combined, crm_name, strdup(value));
     }
 
     return combined;

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1328,7 +1328,7 @@ generate_resource_params(pcmk_resource_t *rsc)
     while (g_hash_table_iter_next(&iter, (void *) &key, (void *) &value)) {
         char *crm_name = crm_meta_name(key);
 
-        g_hash_table_insert(combined, crm_name, strdup(value));
+        g_hash_table_insert(combined, crm_name, pcmk__str_copy(value));
     }
 
     return combined;


### PR DESCRIPTION
Valgrind found leaks in the `crm_resource`, `crm_simulate`, `crm_verify`, and `upgrade` tests.

If you don't mind, indulge me on the refactor commits. They came up while working on the fix commits. Taking them out of this PR makes conflict resolution a pain in the fix commits. I could do a separate PR first for the refactors though, if you want. Just trying to get the fixes in ASAP.