### PR TITLE
Low: daemons: Only log a message if we're falling back.

### DIFF
--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -721,8 +721,10 @@ based_remote_init(void)
             goto try_clear_port;
         }
 
-        pcmk__warn("Falling back to anonymous authentication for remote "
-                   "CIB connections");
+        if (!have_psk) {
+            pcmk__warn("Falling back to anonymous authentication for remote "
+                       "CIB connections");
+        }
     }
 
     /* Now that we know whether to fall back to anonymous authentication


### PR DESCRIPTION
This was supposed to have been included in 2a5fddb06, but git ate it somehow.