### PR TITLE
Fix some memory leaks found by valgrind in cts-cli tests

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -675,9 +675,7 @@ done:
         the_cib->cmds->set_user(the_cib, NULL);
     }
 
-    if (alert_attribute_value != NULL) {
-        g_hash_table_destroy(alert_attribute_value);
-    }
+    g_clear_pointer(&alert_attribute_value, g_hash_table_destroy);
 }
 
 /*!

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -270,8 +270,7 @@ attrd_cib_callback(xmlNode *msg, int call_id, int rc, xmlNode *output, void *use
             last_cib_op_done = call_id;
             if (a->timer && !a->timeout_ms) {
                 // Remove temporary dampening for failed writes
-                mainloop_timer_del(a->timer);
-                a->timer = NULL;
+                g_clear_pointer(&a->timer, mainloop_timer_del);
             }
             break;
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -56,9 +56,7 @@ static GHashTable *removed_peers = NULL;
 void
 attrd_free_removed_peers(void)
 {
-    if (removed_peers != NULL) {
-        g_hash_table_destroy(removed_peers);
-    }
+    g_clear_pointer(&removed_peers, g_hash_table_destroy);
 }
 
 static xmlNode *

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the Pacemaker project contributors
+ * Copyright 2013-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -74,8 +74,7 @@ attrd_handle_election_op(const pcmk__node_status_t *peer, xmlNode *xml)
         case election_start:
             pcmk__debug("Unsetting writer (was %s) and starting new election",
                         pcmk__s(peer_writer, "unset"));
-            free(peer_writer);
-            peer_writer = NULL;
+            g_clear_pointer(&peer_writer, free);
             election_vote(attrd_cluster);
             break;
 
@@ -147,8 +146,7 @@ attrd_remove_voter(const pcmk__node_status_t *peer)
     if ((peer_writer != NULL)
         && pcmk__str_eq(peer->name, peer_writer, pcmk__str_casei)) {
 
-        free(peer_writer);
-        peer_writer = NULL;
+        g_clear_pointer(&peer_writer, free);
         pcmk__notice("Lost attribute writer %s", peer->name);
 
         /* Clear any election dampening in effect. Otherwise, if the lost writer

--- a/daemons/attrd/attrd_messages.c
+++ b/daemons/attrd/attrd_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -259,10 +259,7 @@ attrd_register_handlers(void)
 void
 attrd_unregister_handlers(void)
 {
-    if (attrd_handlers != NULL) {
-        g_hash_table_destroy(attrd_handlers);
-        attrd_handlers = NULL;
-    }
+    g_clear_pointer(&attrd_handlers, g_hash_table_destroy);
 }
 
 void

--- a/daemons/attrd/attrd_nodes.c
+++ b/daemons/attrd/attrd_nodes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -75,8 +75,5 @@ attrd_forget_node_xml_id(const char *node_name)
 void
 attrd_cleanup_xml_ids(void)
 {
-    if (node_xml_ids != NULL) {
-        g_hash_table_destroy(node_xml_ids);
-        node_xml_ids = NULL;
-    }
+    g_clear_pointer(&node_xml_ids, g_hash_table_destroy);
 }

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -182,12 +182,7 @@ attrd_add_client_to_waitlist(pcmk__request_t *request)
 void
 attrd_free_waitlist(void)
 {
-    if (waitlist == NULL) {
-        return;
-    }
-
-    g_hash_table_destroy(waitlist);
-    waitlist = NULL;
+    g_clear_pointer(&waitlist, g_hash_table_destroy);
 }
 
 /*!
@@ -530,10 +525,7 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
 void
 attrd_free_confirmations(void)
 {
-    if (expected_confirmations != NULL) {
-        g_hash_table_destroy(expected_confirmations);
-        expected_confirmations = NULL;
-    }
+    g_clear_pointer(&expected_confirmations, g_hash_table_destroy);
 }
 
 /*!

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -68,10 +68,7 @@ attrd_shutdown(int nsig)
     attrd_free_waitlist();
     attrd_free_confirmations();
 
-    if (peer_protocol_vers != NULL) {
-        g_hash_table_destroy(peer_protocol_vers);
-        peer_protocol_vers = NULL;
-    }
+    g_clear_pointer(&peer_protocol_vers, g_hash_table_destroy);
 
     if ((mloop == NULL) || !g_main_loop_is_running(mloop)) {
         /* If there's no main loop active, just exit. This should be possible

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -527,8 +527,8 @@ based_remote_client_destroy(gpointer user_data)
                                  pcmk__client_tls_handshake_complete)) {
                     gnutls_bye(client->remote->tls_session, GNUTLS_SHUT_WR);
                 }
-                gnutls_deinit(client->remote->tls_session);
-                client->remote->tls_session = NULL;
+
+                g_clear_pointer(&client->remote->tls_session, gnutls_deinit);
             }
             break;
         default:

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -234,11 +234,10 @@ main(int argc, char **argv)
         pcmk__crit("Aborting start-up because another CIB manager instance is "
                    "already active");
         goto done;
-    } else {
-        /* not up or not authentic, we'll proceed either way */
-        crm_ipc_destroy(old_instance);
-        old_instance = NULL;
     }
+
+    // Not up or not authentic; we'll proceed either way
+    g_clear_pointer(&old_instance, crm_ipc_destroy);
 
     if (stand_alone) {
         rc = setup_stand_alone(&error);

--- a/daemons/controld/controld_attrd.c
+++ b/daemons/controld/controld_attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2025 the Pacemaker project contributors
+ * Copyright 2006-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,12 +22,13 @@ static pcmk_ipc_api_t *attrd_api = NULL;
 void
 controld_close_attrd_ipc(void)
 {
-    if (attrd_api != NULL) {
-        pcmk__trace("Closing connection to " PCMK__SERVER_ATTRD);
-        pcmk_disconnect_ipc(attrd_api);
-        pcmk_free_ipc_api(attrd_api);
-        attrd_api = NULL;
+    if (attrd_api == NULL) {
+        return;
     }
+
+    pcmk__trace("Closing connection to " PCMK__SERVER_ATTRD);
+    pcmk_disconnect_ipc(attrd_api);
+    g_clear_pointer(&attrd_api, pcmk_free_ipc_api);
 }
 
 static inline const char *

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -224,8 +224,7 @@ crmd_exit(crm_exit_t exit_code)
     controld_clear_fsa_input_flags(R_LRM_CONNECTED);
     lrm_state_destroy_all();
 
-    mainloop_destroy_trigger(config_read_trigger);
-    config_read_trigger = NULL;
+    g_clear_pointer(&config_read_trigger, mainloop_destroy_trigger);
 
     controld_destroy_fsa_trigger();
     controld_destroy_transition_trigger();

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -237,20 +237,11 @@ crmd_exit(crm_exit_t exit_code)
     controld_cleanup_fencing_history_sync(NULL, true);
     controld_free_sched_timer();
 
-    free(controld_globals.our_uuid);
-    controld_globals.our_uuid = NULL;
-
-    free(controld_globals.dc_name);
-    controld_globals.dc_name = NULL;
-
-    free(controld_globals.dc_version);
-    controld_globals.dc_version = NULL;
-
-    free(controld_globals.cluster_name);
-    controld_globals.cluster_name = NULL;
-
-    free(controld_globals.te_uuid);
-    controld_globals.te_uuid = NULL;
+    g_clear_pointer(&controld_globals.our_uuid, free);
+    g_clear_pointer(&controld_globals.dc_name, free);
+    g_clear_pointer(&controld_globals.dc_version, free);
+    g_clear_pointer(&controld_globals.cluster_name, free);
+    g_clear_pointer(&controld_globals.te_uuid, free);
 
     free_max_generation();
     controld_destroy_failed_sync_table();

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -289,8 +289,7 @@ crmd_exit(crm_exit_t exit_code)
 
     throttle_fini();
 
-    pcmk_cluster_free(controld_globals.cluster);
-    controld_globals.cluster = NULL;
+    g_clear_pointer(&controld_globals.cluster, pcmk_cluster_free);
 
     /* Graceful */
     pcmk__trace("Done preparing for exit with status %d (%s)", exit_code,

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -117,13 +117,13 @@ history_remove_recurring_op(rsc_history_t *history, const lrmd_event_data_t *op)
 static void
 history_free_recurring_ops(rsc_history_t *history)
 {
-    GList *iter;
+    for (GList *iter = history->recurring_op_list; iter != NULL;
+         iter = iter->next) {
 
-    for (iter = history->recurring_op_list; iter != NULL; iter = iter->next) {
         lrmd_free_event(iter->data);
     }
-    g_list_free(history->recurring_op_list);
-    history->recurring_op_list = NULL;
+
+    g_clear_pointer(&history->recurring_op_list, g_list_free);
 }
 
 /*!
@@ -1794,7 +1794,7 @@ verify_stopped(enum crmd_fsa_state cur_state, int log_level)
     }
 
     controld_set_fsa_input_flags(R_SENT_RSC_STOP);
-    g_list_free(lrm_state_list); lrm_state_list = NULL;
+    g_clear_pointer(&lrm_state_list, g_list_free);
     return res;
 }
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -137,9 +137,7 @@ history_free(gpointer data)
 {
     rsc_history_t *history = (rsc_history_t*)data;
 
-    if (history->stop_params) {
-        g_hash_table_destroy(history->stop_params);
-    }
+    g_clear_pointer(&history->stop_params, g_hash_table_destroy);
 
     /* Don't need to free history->rsc.id because it's set to history->id */
     free(history->rsc.type);
@@ -224,9 +222,8 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
                                                PCMK_ACTION_RELOAD,
                                                PCMK_ACTION_RELOAD_AGENT,
                                                PCMK_ACTION_MONITOR, NULL)) {
-            if (entry->stop_params) {
-                g_hash_table_destroy(entry->stop_params);
-            }
+
+            g_clear_pointer(&entry->stop_params, g_hash_table_destroy);
             entry->stop_params = pcmk__strkey_table(free, free);
 
             g_hash_table_foreach(op->params, copy_instance_keys, entry->stop_params);
@@ -1680,8 +1677,7 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
 
             g_hash_table_foreach(params, copy_meta_keys, op->params);
             g_hash_table_foreach(entry->stop_params, copy_instance_keys, op->params);
-            g_hash_table_destroy(params);
-            params = NULL;
+            g_clear_pointer(&params, g_hash_table_destroy);
         }
     }
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -207,15 +207,11 @@ update_history_cache(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, lrmd_event_
         /* Store failed monitors here, otherwise the block below will cause them
          * to be forgotten when a stop happens.
          */
-        if (entry->failed) {
-            lrmd_free_event(entry->failed);
-        }
+        lrmd_free_event(entry->failed);
         entry->failed = lrmd_copy_event(op);
 
     } else if (op->interval_ms == 0) {
-        if (entry->last) {
-            lrmd_free_event(entry->last);
-        }
+        lrmd_free_event(entry->last);
         entry->last = lrmd_copy_event(op);
 
         if (op->params && pcmk__strcase_any_of(op->op_type, PCMK_ACTION_START,
@@ -788,8 +784,7 @@ lrm_clear_last_failure(const char *rsc_id, const char *node_name,
                                                    rsc_id);
 
         if (last_failed_matches_op(entry, operation, interval_ms)) {
-            lrmd_free_event(entry->failed);
-            entry->failed = NULL;
+            g_clear_pointer(&entry->failed, lrmd_free_event);
         }
     }
 }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1183,8 +1183,7 @@ fail_lrm_resource(xmlNode *xml, lrm_state_t *lrm_state, const char *user_name,
      */
     op = construct_op(lrm_state, xml, pcmk__xe_id(xml_rsc), "asyncmon");
 
-    free((char*) op->user_data);
-    op->user_data = NULL;
+    g_clear_pointer(&op->user_data, free);
     op->interval_ms = 0;
 
     if (user_name && !pcmk__is_privileged(user_name)) {

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -253,26 +253,15 @@ lrm_state_reset_tables(lrm_state_t * lrm_state, gboolean reset_metadata)
     }
 }
 
-gboolean
+void
 lrm_state_init_local(void)
 {
-    if (lrm_state_table) {
-        return TRUE;
+    if (lrm_state_table != NULL) {
+        return;
     }
 
     lrm_state_table = pcmk__strikey_table(NULL, internal_lrm_state_destroy);
-    if (!lrm_state_table) {
-        return FALSE;
-    }
-
     proxy_table = pcmk__strikey_table(NULL, remote_proxy_free);
-    if (!proxy_table) {
-        g_hash_table_destroy(lrm_state_table);
-        lrm_state_table = NULL;
-        return FALSE;
-    }
-
-    return TRUE;
 }
 
 void

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -52,9 +52,7 @@ free_recurring_op(gpointer value)
     free(op->rsc_id);
     free(op->op_type);
     free(op->op_key);
-    if (op->params) {
-        g_hash_table_destroy(op->params);
-    }
+    g_clear_pointer(&op->params, g_hash_table_destroy);
     free(op);
 }
 
@@ -199,26 +197,11 @@ internal_lrm_state_destroy(gpointer data)
     remote_ra_cleanup(lrm_state);
     lrmd_api_delete(lrm_state->conn);
 
-    if (lrm_state->rsc_info_cache) {
-        pcmk__trace("Destroying rsc info cache with %u members",
-                    g_hash_table_size(lrm_state->rsc_info_cache));
-        g_hash_table_destroy(lrm_state->rsc_info_cache);
-    }
-    if (lrm_state->resource_history) {
-        pcmk__trace("Destroying history op cache with %u members",
-                    g_hash_table_size(lrm_state->resource_history));
-        g_hash_table_destroy(lrm_state->resource_history);
-    }
-    if (lrm_state->deletion_ops) {
-        pcmk__trace("Destroying deletion op cache with %u members",
-                    g_hash_table_size(lrm_state->deletion_ops));
-        g_hash_table_destroy(lrm_state->deletion_ops);
-    }
-    if (lrm_state->active_ops != NULL) {
-        pcmk__trace("Destroying pending op cache with %u members",
-                    g_hash_table_size(lrm_state->active_ops));
-        g_hash_table_destroy(lrm_state->active_ops);
-    }
+    g_clear_pointer(&lrm_state->rsc_info_cache, g_hash_table_destroy);
+    g_clear_pointer(&lrm_state->resource_history, g_hash_table_destroy);
+    g_clear_pointer(&lrm_state->deletion_ops, g_hash_table_destroy);
+    g_clear_pointer(&lrm_state->active_ops, g_hash_table_destroy);
+
     metadata_cache_free(lrm_state->metadata_cache);
 
     free((char *)lrm_state->node_name);
@@ -267,16 +250,8 @@ lrm_state_init_local(void)
 void
 lrm_state_destroy_all(void)
 {
-    if (lrm_state_table) {
-        pcmk__trace("Destroying state table with %u members",
-                    g_hash_table_size(lrm_state_table));
-        g_hash_table_destroy(lrm_state_table); lrm_state_table = NULL;
-    }
-    if(proxy_table) {
-        pcmk__trace("Destroying proxy table with %u members",
-                    g_hash_table_size(proxy_table));
-        g_hash_table_destroy(proxy_table); proxy_table = NULL;
-    }
+    g_clear_pointer(&lrm_state_table, g_hash_table_destroy);
+    g_clear_pointer(&proxy_table, g_hash_table_destroy);
 }
 
 /*!

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -737,17 +737,14 @@ controld_disconnect_fencer(bool destroy)
     }
     if (destroy) {
         if (fencer_api != NULL) {
-            fencer_api->cmds->free(fencer_api);
-            fencer_api = NULL;
+            g_clear_pointer(&fencer_api, fencer_api->cmds->free);
         }
         if (controld_fencer_connect_timer) {
             mainloop_timer_del(controld_fencer_connect_timer);
             controld_fencer_connect_timer = NULL;
         }
-        if (te_client_id) {
-            free(te_client_id);
-            te_client_id = NULL;
-        }
+
+        g_clear_pointer(&te_client_id, free);
     }
 }
 

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -351,8 +351,8 @@ controld_purge_fencing_cleanup(void)
         pcmk__info("Purging %s from fencing cleanup list", target);
         free(target);
     }
-    g_list_free(fencing_cleanup_list);
-    fencing_cleanup_list = NULL;
+
+    g_clear_pointer(&fencing_cleanup_list, g_list_free);
 }
 
 /*!
@@ -373,8 +373,8 @@ controld_execute_fencing_cleanup(void)
         update_node_state_after_fencing(target, uuid);
         free(target);
     }
-    g_list_free(fencing_cleanup_list);
-    fencing_cleanup_list = NULL;
+
+    g_clear_pointer(&fencing_cleanup_list, g_list_free);
 }
 
 /* end fencing cleanup list functions */

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -739,11 +739,8 @@ controld_disconnect_fencer(bool destroy)
         if (fencer_api != NULL) {
             g_clear_pointer(&fencer_api, fencer_api->cmds->free);
         }
-        if (controld_fencer_connect_timer) {
-            mainloop_timer_del(controld_fencer_connect_timer);
-            controld_fencer_connect_timer = NULL;
-        }
 
+        g_clear_pointer(&controld_fencer_connect_timer, mainloop_timer_del);
         g_clear_pointer(&te_client_id, free);
     }
 }
@@ -1026,10 +1023,9 @@ void
 controld_cleanup_fencing_history_sync(stonith_t *st, bool free_timers)
 {
     if (free_timers) {
-        mainloop_timer_del(fencing_history_sync_timer_short);
-        fencing_history_sync_timer_short = NULL;
-        mainloop_timer_del(fencing_history_sync_timer_long);
-        fencing_history_sync_timer_long = NULL;
+        g_clear_pointer(&fencing_history_sync_timer_short, mainloop_timer_del);
+        g_clear_pointer(&fencing_history_sync_timer_long, mainloop_timer_del);
+
     } else {
         mainloop_timer_stop(fencing_history_sync_timer_short);
         mainloop_timer_stop(fencing_history_sync_timer_long);

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -96,8 +96,7 @@ void
 controld_destroy_fsa_trigger(void)
 {
     // This basically will not work, since mainloop has a reference to it
-    mainloop_destroy_trigger(fsa_trigger);
-    fsa_trigger = NULL;
+    g_clear_pointer(&fsa_trigger, mainloop_destroy_trigger);
 }
 
 /*!

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -674,9 +674,7 @@ do_dc_join_finalize(long long action, enum crmd_fsa_cause cause,
 void
 free_max_generation(void)
 {
-    free(max_generation_from);
-    max_generation_from = NULL;
-
+    g_clear_pointer(&max_generation_from, free);
     g_clear_pointer(&max_generation_xml, pcmk__xml_free);
 }
 

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -84,10 +84,7 @@ join_phase_text(enum controld_join_phase phase)
 void
 controld_destroy_failed_sync_table(void)
 {
-    if (failed_sync_nodes != NULL) {
-        g_hash_table_destroy(failed_sync_nodes);
-        failed_sync_nodes = NULL;
-    }
+    g_clear_pointer(&failed_sync_nodes, g_hash_table_destroy);
 }
 
 /*!

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -677,8 +677,7 @@ free_max_generation(void)
     free(max_generation_from);
     max_generation_from = NULL;
 
-    pcmk__xml_free(max_generation_xml);
-    max_generation_xml = NULL;
+    g_clear_pointer(&max_generation_xml, pcmk__xml_free);
 }
 
 void

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -109,7 +109,7 @@ GList *lrm_state_get_list(void);
 /*!
  * \brief Initiate internal state tables
  */
-gboolean lrm_state_init_local(void);
+void lrm_state_init_local(void);
 
 /*!
  * \brief Destroy all state entries and internal state tables

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -768,12 +768,7 @@ handle_remote_state(const xmlNode *msg)
                             0);
 
     conn_host = pcmk__xe_get(msg, PCMK__XA_CONNECTION_HOST);
-    if (conn_host) {
-        pcmk__str_update(&remote_peer->conn_host, conn_host);
-    } else if (remote_peer->conn_host) {
-        free(remote_peer->conn_host);
-        remote_peer->conn_host = NULL;
-    }
+    pcmk__str_update(&remote_peer->conn_host, conn_host);
 
     return I_NULL;
 }

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the Pacemaker project contributors
+ * Copyright 2013-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -449,9 +449,7 @@ report_remote_ra_result(remote_ra_cmd_t * cmd)
 
     lrm_op_callback(&op);
 
-    if (op.params) {
-        g_hash_table_destroy(op.params);
-    }
+    g_clear_pointer(&op.params, g_hash_table_destroy);
     lrmd__reset_result(&op);
 }
 

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -770,12 +770,9 @@ remote_lrm_op_callback(lrmd_event_data_t * op)
 static void
 handle_remote_ra_stop(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd)
 {
-    remote_ra_data_t *ra_data = NULL;
-
     pcmk__assert(lrm_state != NULL);
-    ra_data = lrm_state->remote_ra_data;
 
-    if (!pcmk__is_set(ra_data->status, takeover_complete)) {
+    if (!pcmk__is_set(lrm_state->remote_ra_data->status, takeover_complete)) {
         /* delete pending ops when ever the remote connection is intentionally stopped */
         g_hash_table_remove_all(lrm_state->active_ops);
     } else {
@@ -787,15 +784,13 @@ handle_remote_ra_stop(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd)
     lrm_remote_clear_flags(lrm_state, remote_active);
     lrm_state_disconnect(lrm_state);
 
-    if (ra_data->cmds) {
-        g_list_free_full(ra_data->cmds, free_cmd);
-    }
-    if (ra_data->recurring_cmds) {
-        g_list_free_full(ra_data->recurring_cmds, free_cmd);
-    }
-    ra_data->cmds = NULL;
-    ra_data->recurring_cmds = NULL;
-    ra_data->cur_cmd = NULL;
+    g_list_free_full(lrm_state->remote_ra_data->cmds, free_cmd);
+    lrm_state->remote_ra_data->cmds = NULL;
+
+    g_list_free_full(lrm_state->remote_ra_data->recurring_cmds, free_cmd);
+    lrm_state->remote_ra_data->recurring_cmds = NULL;
+
+    lrm_state->remote_ra_data->cur_cmd = NULL;
 
     if (cmd) {
         pcmk__set_result(&(cmd->result), PCMK_OCF_OK, PCMK_EXEC_DONE, NULL);

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -966,22 +966,14 @@ remote_ra_data_init(lrm_state_t * lrm_state)
 void
 remote_ra_cleanup(lrm_state_t * lrm_state)
 {
-    remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
-
-    if (!ra_data) {
+    if (lrm_state->remote_ra_data == NULL) {
         return;
     }
 
-    if (ra_data->cmds) {
-        g_list_free_full(ra_data->cmds, free_cmd);
-    }
-
-    if (ra_data->recurring_cmds) {
-        g_list_free_full(ra_data->recurring_cmds, free_cmd);
-    }
-    mainloop_destroy_trigger(ra_data->work);
-    free(ra_data);
-    lrm_state->remote_ra_data = NULL;
+    g_list_free_full(lrm_state->remote_ra_data->cmds, free_cmd);
+    g_list_free_full(lrm_state->remote_ra_data->recurring_cmds, free_cmd);
+    mainloop_destroy_trigger(lrm_state->remote_ra_data->work);
+    g_clear_pointer(&lrm_state->remote_ra_data, free);
 }
 
 gboolean

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -312,10 +312,7 @@ controld_expect_sched_reply(char *ref)
 void
 controld_free_sched_timer(void)
 {
-    if (controld_sched_timer != NULL) {
-        mainloop_timer_del(controld_sched_timer);
-        controld_sched_timer = NULL;
-    }
+    g_clear_pointer(&controld_sched_timer, mainloop_timer_del);
 }
 
 // A_PE_INVOKE
@@ -454,8 +451,7 @@ sleep_timer(gpointer data)
 {
     controld_set_fsa_action_flags(A_PE_INVOKE);
     controld_trigger_fsa();
-    mainloop_timer_del(controld_cib_retry_timer);
-    controld_cib_retry_timer = NULL;
+    g_clear_pointer(&controld_cib_retry_timer, mainloop_timer_del);
     return G_SOURCE_REMOVE;
 }
 

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -202,9 +202,7 @@ controld_shutdown_schedulerd_ipc(void)
     controld_clear_fsa_input_flags(R_PE_REQUIRED);
     pcmk_disconnect_ipc(schedulerd_api);
     handle_disconnect();
-
-    pcmk_free_ipc_api(schedulerd_api);
-    schedulerd_api = NULL;
+    g_clear_pointer(&schedulerd_api, pcmk_free_ipc_api);
 }
 
 static void do_pe_invoke_callback(xmlNode *msg, int call_id, int rc,

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -51,10 +51,7 @@ controld_remove_all_outside_events(void)
 void
 controld_destroy_outside_events_table(void)
 {
-    if (outside_events != NULL) {
-        g_hash_table_destroy(outside_events);
-        outside_events = NULL;
-    }
+    g_clear_pointer(&outside_events, g_hash_table_destroy);
 }
 
 /*!

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -291,12 +291,7 @@ controld_node_pending_timer(const pcmk__node_status_t *node)
 void
 controld_free_node_pending_timers(void)
 {
-    if (node_pending_timers == NULL) {
-        return;
-    }
-
-    g_hash_table_destroy(node_pending_timers);
-    node_pending_timers = NULL;
+    g_clear_pointer(&node_pending_timers, g_hash_table_destroy);
 }
 
 static const char *

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -112,8 +112,7 @@ controld_init_transition_trigger(void)
 void
 controld_destroy_transition_trigger(void)
 {
-    mainloop_destroy_trigger(transition_trigger);
-    transition_trigger = NULL;
+    g_clear_pointer(&transition_trigger, mainloop_destroy_trigger);
 }
 
 void

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -291,11 +291,7 @@ controld_configure_throttle(GHashTable *options)
 void
 throttle_fini(void)
 {
-    if (throttle_timer != NULL) {
-        mainloop_timer_del(throttle_timer);
-        throttle_timer = NULL;
-    }
-
+    g_clear_pointer(&throttle_timer, mainloop_timer_del);
     g_clear_pointer(&throttle_records, g_hash_table_destroy);
 }
 

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the Pacemaker project contributors
+ * Copyright 2013-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -295,10 +295,8 @@ throttle_fini(void)
         mainloop_timer_del(throttle_timer);
         throttle_timer = NULL;
     }
-    if (throttle_records != NULL) {
-        g_hash_table_destroy(throttle_records);
-        throttle_records = NULL;
-    }
+
+    g_clear_pointer(&throttle_records, g_hash_table_destroy);
 }
 
 int

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -370,13 +370,13 @@ controld_free_fsa_timers(void)
     controld_stop_timer(wait_timer);
     controld_stop_timer(recheck_timer);
 
-    free(transition_timer); transition_timer = NULL;
-    free(integration_timer); integration_timer = NULL;
-    free(finalization_timer); finalization_timer = NULL;
-    free(election_timer); election_timer = NULL;
-    free(shutdown_escalation_timer); shutdown_escalation_timer = NULL;
-    free(wait_timer); wait_timer = NULL;
-    free(recheck_timer); recheck_timer = NULL;
+    g_clear_pointer(&transition_timer, free);
+    g_clear_pointer(&integration_timer, free);
+    g_clear_pointer(&finalization_timer, free);
+    g_clear_pointer(&election_timer, free);
+    g_clear_pointer(&shutdown_escalation_timer, free);
+    g_clear_pointer(&wait_timer, free);
+    g_clear_pointer(&recheck_timer, free);
 }
 
 /*!

--- a/daemons/controld/controld_transition.c
+++ b/daemons/controld/controld_transition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -36,8 +36,7 @@ do_te_control(long long action, enum crmd_fsa_cause cause,
     cib_t *cib_conn = controld_globals.cib_conn;
 
     if (pcmk__is_set(action, A_TE_STOP)) {
-        pcmk__free_graph(controld_globals.transition_graph);
-        controld_globals.transition_graph = NULL;
+        g_clear_pointer(&controld_globals.transition_graph, pcmk__free_graph);
 
         if (cib_conn != NULL) {
             cib_conn->cmds->del_notify_callback(cib_conn,

--- a/daemons/controld/pacemaker-controld.c
+++ b/daemons/controld/pacemaker-controld.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -139,12 +139,10 @@ main(int argc, char **argv)
                    "already active");
         initialize = false;
         goto done;
-
-    } else {
-        /* not up or not authentic, we'll proceed either way */
-        crm_ipc_destroy(old_instance);
-        old_instance = NULL;
     }
+
+    // Not up or not authentic; we'll proceed either way
+    g_clear_pointer(&old_instance, crm_ipc_destroy);
 
     if (pcmk__daemon_can_write(PCMK_SCHEDULER_INPUT_DIR, NULL) == FALSE) {
         exit_code = CRM_EX_FATAL;

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -95,8 +95,7 @@ alert_complete(svc_action_t *action)
     }
 
     free(cb_data->client_id);
-    free(action->cb_data);
-    action->cb_data = NULL;
+    g_clear_pointer(&action->cb_data, free);
 }
 
 int

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 the Pacemaker project contributors
+ * Copyright 2016-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -191,7 +191,6 @@ lrmd_drain_alerts(GMainLoop *mloop)
                     (timer_ms / 1000.0));
         draining_alerts = TRUE;
         pcmk_drain_main_loop(mloop, timer_ms, drain_check);
-        g_hash_table_destroy(inflight_alerts);
-        inflight_alerts = NULL;
+        g_clear_pointer(&inflight_alerts, g_hash_table_destroy);
     }
 }

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -495,8 +495,7 @@ merge_recurring_duplicate(lrmd_rsc_t * rsc, lrmd_cmd_t * cmd)
     dup->userdata_str = cmd->userdata_str;
     cmd->userdata_str = NULL;
     dup->call_id = cmd->call_id;
-    free_lrmd_cmd(cmd);
-    cmd = NULL;
+    g_clear_pointer(&cmd, free_lrmd_cmd);
 
     /* If dup is not pending, that means it has already executed at least once
      * and is waiting in the interval. In that case, stop waiting and initiate

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -364,9 +364,9 @@ free_lrmd_cmd(lrmd_cmd_t * cmd)
     if (cmd->delay_id) {
         g_source_remove(cmd->delay_id);
     }
-    if (cmd->params) {
-        g_hash_table_destroy(cmd->params);
-    }
+
+    g_clear_pointer(&cmd->params, g_hash_table_destroy);
+
     pcmk__reset_result(&(cmd->result));
     free(cmd->origin);
     free(cmd->action);

--- a/daemons/execd/execd_messages.c
+++ b/daemons/execd/execd_messages.c
@@ -427,10 +427,7 @@ execd_register_handlers(void)
 void
 execd_unregister_handlers(void)
 {
-    if (execd_handlers != NULL) {
-        g_hash_table_destroy(execd_handlers);
-        execd_handlers = NULL;
-    }
+    g_clear_pointer(&execd_handlers, g_hash_table_destroy);
 }
 
 bool

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -69,8 +69,7 @@ stonith_t *
 execd_get_fencer_connection(void)
 {
     if ((fencer_api != NULL) && (fencer_api->state == stonith_disconnected)) {
-        stonith__api_free(fencer_api);
-        fencer_api = NULL;
+        g_clear_pointer(&fencer_api, stonith__api_free);
     }
 
     if (fencer_api == NULL) {
@@ -88,8 +87,7 @@ execd_get_fencer_connection(void)
             pcmk__err("Could not connect to fencer in 10 attempts: %s "
                       QB_XS " rc=%d",
                       pcmk_rc_str(rc), rc);
-            stonith__api_free(fencer_api);
-            fencer_api = NULL;
+            g_clear_pointer(&fencer_api, stonith__api_free);
 
         } else {
             stonith_api_operations_t *cmds = fencer_api->cmds;

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -180,8 +180,7 @@ lrmd_remote_client_destroy(gpointer user_data)
         int csock = pcmk__tls_get_client_sock(client->remote);
 
         gnutls_bye(client->remote->tls_session, GNUTLS_SHUT_RDWR);
-        gnutls_deinit(client->remote->tls_session);
-        client->remote->tls_session = NULL;
+        g_clear_pointer(&client->remote->tls_session, gnutls_deinit);
         close(csock);
     }
 

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -456,10 +456,7 @@ lrmd_init_remote_tls_server(void)
 void
 execd_stop_tls_server(void)
 {
-    if (tls != NULL) {
-        pcmk__free_tls(tls);
-        tls = NULL;
-    }
+    g_clear_pointer(&tls, pcmk__free_tls);
 
     if (ssock >= 0) {
         close(ssock);

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -540,14 +540,13 @@ update_cib_cache_cb(const char *event, xmlNode * msg)
             case -pcmk_err_diff_failed:
                 pcmk__notice("[%s] Patch aborted: %s (%d)", event,
                              pcmk_strerror(rc), rc);
-                pcmk__xml_free(local_cib);
-                local_cib = NULL;
+                g_clear_pointer(&local_cib, pcmk__xml_free);
                 break;
             default:
                 pcmk__warn("[%s] ABORTED: %s (%d)", event, pcmk_strerror(rc),
                            rc);
-                pcmk__xml_free(local_cib);
-                local_cib = NULL;
+                g_clear_pointer(&local_cib, pcmk__xml_free);
+                break;
         }
     }
 
@@ -619,8 +618,8 @@ fenced_cib_cleanup(void)
                                            update_cib_cache_cb);
         cib__clean_up_connection(&cib_api);
     }
-    pcmk__xml_free(local_cib);
-    local_cib = NULL;
+
+    g_clear_pointer(&local_cib, pcmk__xml_free);
 }
 
 void

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -1639,9 +1639,7 @@ free_topology_entry(gpointer data)
     stonith_topology_t *tp = data;
 
     for (int i = 0; i < ST__LEVEL_COUNT; i++) {
-        if (tp->levels[i] != NULL) {
-            g_list_free_full(tp->levels[i], free);
-        }
+        g_list_free_full(tp->levels[i], free);
     }
 
     free(tp->target);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -939,12 +939,7 @@ fenced_init_device_table(void)
 void
 fenced_free_device_table(void)
 {
-    if (device_table == NULL) {
-        return;
-    }
-
-    g_hash_table_destroy(device_table);
-    device_table = NULL;
+    g_clear_pointer(&device_table, g_hash_table_destroy);
 }
 
 static GHashTable *
@@ -994,12 +989,7 @@ GHashTable *metadata_cache = NULL;
 void
 free_metadata_cache(void)
 {
-    if (metadata_cache == NULL) {
-        return;
-    }
-
-    g_hash_table_destroy(metadata_cache);
-    metadata_cache = NULL;
+    g_clear_pointer(&metadata_cache, g_hash_table_destroy);
 }
 
 static void
@@ -1664,12 +1654,7 @@ free_topology_entry(gpointer data)
 void
 free_topology_list(void)
 {
-    if (topology == NULL) {
-        return;
-    }
-
-    g_hash_table_destroy(topology);
-    topology = NULL;
+    g_clear_pointer(&topology, g_hash_table_destroy);
 }
 
 void
@@ -3686,10 +3671,7 @@ fenced_register_handlers(void)
 void
 fenced_unregister_handlers(void)
 {
-    if (fenced_handlers != NULL) {
-        g_hash_table_destroy(fenced_handlers);
-        fenced_handlers = NULL;
-    }
+    g_clear_pointer(&fenced_handlers, g_hash_table_destroy);
 }
 
 void

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -260,17 +260,9 @@ free_remote_op(gpointer data)
     free(op->client_name);
     free(op->originator);
 
-    if (op->query_results) {
-        g_list_free_full(op->query_results, free_remote_query);
-    }
-    if (op->request) {
-        pcmk__xml_free(op->request);
-        op->request = NULL;
-    }
-    if (op->devices_list) {
-        g_list_free_full(op->devices_list, free);
-        op->devices_list = NULL;
-    }
+    g_list_free_full(op->query_results, free_remote_query);
+    g_clear_pointer(&op->request, pcmk__xml_free);
+    g_list_free_full(op->devices_list, free);
     g_list_free_full(op->automatic_list, free);
     g_list_free(op->duplicates);
 
@@ -637,11 +629,8 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
         g_list_free_full(op->query_results, free_remote_query);
         op->query_results = NULL;
     }
-    if (op->request) {
-        pcmk__xml_free(op->request);
-        op->request = NULL;
-    }
 
+    g_clear_pointer(&op->request, pcmk__xml_free);
     pcmk__xml_free(local_data);
 }
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -625,10 +625,8 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
     /* Free non-essential parts of the record
      * Keep the record around so we can query the history
      */
-    if (op->query_results) {
-        g_list_free_full(op->query_results, free_remote_query);
-        op->query_results = NULL;
-    }
+    g_list_free_full(op->query_results, free_remote_query);
+    op->query_results = NULL;
 
     g_clear_pointer(&op->request, pcmk__xml_free);
     pcmk__xml_free(local_data);
@@ -832,10 +830,9 @@ set_op_device_list(remote_fencing_op_t * op, GList *devices)
 {
     GList *lpc = NULL;
 
-    if (op->devices_list) {
-        g_list_free_full(op->devices_list, free);
-        op->devices_list = NULL;
-    }
+    g_list_free_full(op->devices_list, free);
+    op->devices_list = NULL;
+
     for (lpc = devices; lpc != NULL; lpc = lpc->next) {
         const char *device = lpc->data;
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -109,10 +109,7 @@ free_remote_query(gpointer data)
 void
 free_stonith_remote_op_list(void)
 {
-    if (stonith_remote_op_list != NULL) {
-        g_hash_table_destroy(stonith_remote_op_list);
-        stonith_remote_op_list = NULL;
-    }
+    g_clear_pointer(&stonith_remote_op_list, g_hash_table_destroy);
 }
 
 struct peer_count_data {

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 the Pacemaker project contributors
+ * Copyright 2010-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -96,8 +96,7 @@ static gboolean
 cluster_reconnect_cb(gpointer data)
 {
     if (cluster_connect_cfg()) {
-        mainloop_timer_del(reconnect_timer);
-        reconnect_timer = NULL;
+        g_clear_pointer(&reconnect_timer, mainloop_timer_del);
         pcmk__notice("Cluster reconnect succeeded");
         pacemakerd_read_config();
         restart_cluster_subdaemons();
@@ -129,13 +128,11 @@ void
 cluster_disconnect_cfg(void)
 {
     close_cfg();
-    if (reconnect_timer != NULL) {
-        /* The mainloop should be gone by this point, so this isn't necessary,
-         * but cleaning up memory should make valgrind happier.
-         */
-        mainloop_timer_del(reconnect_timer);
-        reconnect_timer = NULL;
-    }
+
+    /* The mainloop should be gone by this point, so this isn't necessary, but
+     * cleaning up memory should make valgrind happier.
+     */
+    g_clear_pointer(&reconnect_timer, mainloop_timer_del);
 }
 
 #define cs_repeat(counter, max, code) do {		\

--- a/daemons/pacemakerd/pcmkd_messages.c
+++ b/daemons/pacemakerd/pcmkd_messages.c
@@ -176,10 +176,7 @@ pacemakerd_register_handlers(void)
 void
 pacemakerd_unregister_handlers(void)
 {
-    if (pacemakerd_handlers != NULL) {
-        g_hash_table_destroy(pacemakerd_handlers);
-        pacemakerd_handlers = NULL;
-    }
+    g_clear_pointer(&pacemakerd_handlers, g_hash_table_destroy);
 }
 
 void

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -223,10 +223,7 @@ schedulerd_register_handlers(void)
 void
 schedulerd_unregister_handlers(void)
 {
-    if (schedulerd_handlers != NULL) {
-        g_hash_table_destroy(schedulerd_handlers);
-        schedulerd_handlers = NULL;
-    }
+    g_clear_pointer(&schedulerd_handlers, g_hash_table_destroy);
 }
 
 void

--- a/daemons/schedulerd/schedulerd_messages.c
+++ b/daemons/schedulerd/schedulerd_messages.c
@@ -147,8 +147,7 @@ handle_pecalc_request(pcmk__request_t *request)
     }
 
     if (series_wrap == 0) { // Don't save any inputs of this kind
-        free(filename);
-        filename = NULL;
+        g_clear_pointer(&filename, free);
 
     } else if (!is_repoke) { // Input changed, save to disk
         free(filename);

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -435,10 +435,7 @@ cib_destroy_op_callback(gpointer data)
 static void
 destroy_op_callback_table(void)
 {
-    if (cib_op_callback_table != NULL) {
-        g_hash_table_destroy(cib_op_callback_table);
-        cib_op_callback_table = NULL;
-    }
+    g_clear_pointer(&cib_op_callback_table, g_hash_table_destroy);
 }
 
 char *

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -389,8 +389,8 @@ cib_client_end_transaction(cib_t *cib, bool commit, int call_options)
             pcmk__trace("No transaction found for CIB client %s", client_id);
         }
     }
-    pcmk__xml_free(cib->transaction);
-    cib->transaction = NULL;
+
+    g_clear_pointer(&cib->transaction, pcmk__xml_free);
     return rc;
 }
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -691,8 +691,7 @@ file_signoff(cib_t *cib)
     }
 
     /* Free the in-memory CIB */
-    pcmk__xml_free(private->cib_xml);
-    private->cib_xml = NULL;
+    g_clear_pointer(&private->cib_xml, pcmk__xml_free);
     return rc;
 }
 

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -113,8 +113,7 @@ unregister_client(const cib_t *cib)
      * instead of destroying the client table when there are no more clients.
      */
     if (g_hash_table_size(client_table) == 0) {
-        g_hash_table_destroy(client_table);
-        client_table = NULL;
+        g_clear_pointer(&client_table, g_hash_table_destroy);
     }
 }
 

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -262,8 +262,7 @@ cib_native_signoff(cib_t *cib)
 
     if (native->source != NULL) {
         /* Attached to mainloop */
-        mainloop_del_ipc_client(native->source);
-        native->source = NULL;
+        g_clear_pointer(&native->source, mainloop_del_ipc_client);
         native->ipc = NULL;
 
     } else if (native->ipc) {

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -918,20 +918,24 @@ cib__process_upgrade(const char *op, int options, const char *section,
 {
     int rc = pcmk_rc_ok;
     const char *max_schema = pcmk__xe_get(req, PCMK__XA_CIB_SCHEMA_MAX);
-    const char *original_schema = NULL;
+    char *original_schema = NULL;
     const char *new_schema = NULL;
 
-    original_schema = pcmk__xe_get(*cib, PCMK_XA_VALIDATE_WITH);
+    // pcmk__update_schema() may free the original validate-with string
+    original_schema = pcmk__xe_get_copy(*cib, PCMK_XA_VALIDATE_WITH);
+
     rc = pcmk__update_schema(cib, max_schema, true,
                              !pcmk__is_set(options, cib_verbose));
     new_schema = pcmk__xe_get(*cib, PCMK_XA_VALIDATE_WITH);
 
     if (pcmk__cmp_schemas_by_name(new_schema, original_schema) > 0) {
+        free(original_schema);
         update_counter(*cib, PCMK_XA_ADMIN_EPOCH, false);
         update_counter(*cib, PCMK_XA_EPOCH, true);
         update_counter(*cib, PCMK_XA_NUM_UPDATES, true);
         return pcmk_rc_ok;
     }
 
+    free(original_schema);
     return rc;
 }

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -157,8 +157,7 @@ cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
                       msg_id);
         }
 
-        pcmk__xml_free(op_reply);
-        op_reply = NULL;
+        g_clear_pointer(&op_reply, pcmk__xml_free);
 
         /* wasn't the right reply, try and read some more */
         remaining_time = time(NULL) - start_time;

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -340,8 +340,7 @@ cib_tls_close(cib_t *cib)
 
         private->command.tls_session = NULL;
         private->callback.tls_session = NULL;
-        pcmk__free_tls(tls);
-        tls = NULL;
+        g_clear_pointer(&tls, pcmk__free_tls);
     }
 
     if (private->command.tcp_socket >= 0) {

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -309,8 +309,7 @@ cib_remote_command_dispatch(gpointer user_data)
         return 0;
     }
 
-    free(private->command.buffer);
-    private->command.buffer = NULL;
+    g_clear_pointer(&private->command.buffer, free);
     pcmk__err("Received late reply for remote cib connection, discarding");
 
     if (rc != pcmk_rc_ok) {
@@ -356,10 +355,8 @@ cib_tls_close(cib_t *cib)
     private->command.tcp_socket = -1;
     private->callback.tcp_socket = -1;
 
-    free(private->command.buffer);
-    free(private->callback.buffer);
-    private->command.buffer = NULL;
-    private->callback.buffer = NULL;
+    g_clear_pointer(&private->command.buffer, free);
+    g_clear_pointer(&private->callback.buffer, free);
 
     return 0;
 }

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -192,9 +192,9 @@ pcmk__corosync_name(uint64_t /*cmap_handle_t */ cmap_handle, uint32_t nodeid)
                 pcmk__trace("%s = %s", key, pcmk__s(name, "<null>"));
 
                 if (!node_name_is_valid(key, name)) {
-                    free(name);
-                    name = NULL;
+                    g_clear_pointer(&name, free);
                 }
+
                 free(key);
             }
             break;

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -664,8 +664,8 @@ pcmk__cpg_confchg_cb(cpg_handle_t handle,
         node_left(group_name->value, counter, local_nodeid, &left_list[i],
                   sorted, member_list_entries);
     }
-    free(sorted);
-    sorted = NULL;
+
+    g_clear_pointer(&sorted, free);
 
     for (int i = 0; i < joined_list_entries; i++) {
         pcmk__info("Group %s event %d: node %u pid %u joined%s",

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -157,8 +157,7 @@ election_fini(pcmk_cluster_t *cluster)
         election_reset(cluster);
         pcmk__trace("Destroying election");
         mainloop_timer_del(cluster->priv->election->timeout);
-        free(cluster->priv->election);
-        cluster->priv->election = NULL;
+        g_clear_pointer(&cluster->priv->election, free);
     }
 }
 

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -137,10 +137,7 @@ election_reset(pcmk_cluster_t *cluster)
     if ((cluster != NULL) && (cluster->priv->election != NULL)) {
         pcmk__trace("Resetting election");
         mainloop_timer_stop(cluster->priv->election->timeout);
-        if (cluster->priv->election->voted != NULL) {
-            g_hash_table_destroy(cluster->priv->election->voted);
-            cluster->priv->election->voted = NULL;
-        }
+        g_clear_pointer(&cluster->priv->election->voted, g_hash_table_destroy);
     }
 }
 

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -587,26 +587,9 @@ pcmk__cluster_init_node_caches(void)
 void
 pcmk__cluster_destroy_node_caches(void)
 {
-    if (pcmk__peer_cache != NULL) {
-        pcmk__trace("Destroying peer cache with %u members",
-                    g_hash_table_size(pcmk__peer_cache));
-        g_hash_table_destroy(pcmk__peer_cache);
-        pcmk__peer_cache = NULL;
-    }
-
-    if (pcmk__remote_peer_cache != NULL) {
-        pcmk__trace("Destroying remote peer cache with %u members",
-                    pcmk__cluster_num_remote_nodes());
-        g_hash_table_destroy(pcmk__remote_peer_cache);
-        pcmk__remote_peer_cache = NULL;
-    }
-
-    if (cluster_node_cib_cache != NULL) {
-        pcmk__trace("Destroying configured cluster node cache with %u members",
-                    g_hash_table_size(cluster_node_cib_cache));
-        g_hash_table_destroy(cluster_node_cib_cache);
-        cluster_node_cib_cache = NULL;
-    }
+    g_clear_pointer(&pcmk__peer_cache, g_hash_table_destroy);
+    g_clear_pointer(&pcmk__remote_peer_cache, g_hash_table_destroy);
+    g_clear_pointer(&cluster_node_cib_cache, g_hash_table_destroy);
 }
 
 static void (*peer_status_callback)(enum pcmk__node_update,

--- a/lib/common/actions.c
+++ b/lib/common/actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -193,14 +193,12 @@ pcmk__free_action(gpointer user_data)
     if (action == NULL) {
         return;
     }
+
     g_list_free_full(action->actions_before, free);
     g_list_free_full(action->actions_after, free);
-    if (action->extra != NULL) {
-        g_hash_table_destroy(action->extra);
-    }
-    if (action->meta != NULL) {
-        g_hash_table_destroy(action->meta);
-    }
+    g_clear_pointer(&action->extra, g_hash_table_destroy);
+    g_clear_pointer(&action->meta, g_hash_table_destroy);
+
     pcmk__free_node_copy(action->node);
     free(action->cancel_task);
     free(action->reason);

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -448,7 +448,5 @@ pcmk__unpack_alerts(const xmlNode *alerts)
 void
 pcmk__free_alerts(GList *alert_list)
 {
-    if (alert_list != NULL) {
-        g_list_free_full(alert_list, (GDestroyNotify) pcmk__free_alert);
-    }
+    g_list_free_full(alert_list, (GDestroyNotify) pcmk__free_alert);
 }

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the Pacemaker project contributors
+ * Copyright 2015-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -71,9 +71,8 @@ pcmk__free_alert(pcmk__alert_t *entry)
         free(entry->recipient);
 
         g_strfreev(entry->select_attribute_name);
-        if (entry->envvars) {
-            g_hash_table_destroy(entry->envvars);
-        }
+        g_clear_pointer(&entry->envvars, g_hash_table_destroy);
+
         free(entry);
     }
 }

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -38,8 +38,7 @@ pcmk__new_common_args(const char *summary)
     args->summary = strdup(summary);
     // cppcheck-suppress nullPointerOutOfMemory
     if (args->summary == NULL) {
-        free(args);
-        args = NULL;
+        g_clear_pointer(&args, free);
         crm_exit(CRM_EX_OSERR);
     }
 

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -336,8 +336,9 @@ pcmk__filter_op_for_digest(xmlNode *param_set)
      */
     key = crm_meta_name(PCMK_META_INTERVAL);
     pcmk__xe_get_guint(param_set, key, &interval_ms);
-    free(key);
-    key = NULL;
+
+    g_clear_pointer(&key, free);
+
     if (interval_ms != 0) {
         key = crm_meta_name(PCMK_META_TIMEOUT);
         timeout = pcmk__xe_get_copy(param_set, key);

--- a/lib/common/io.c
+++ b/lib/common/io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -332,8 +332,7 @@ pcmk__daemon_can_write(const char *dir, const char *file)
         s_res = stat(full_file, &buf);
         if (s_res < 0) {
             pcmk__notice("%s not found: %s", target, pcmk_rc_str(errno));
-            free(full_file);
-            full_file = NULL;
+            g_clear_pointer(&full_file, &free);
             target = NULL;
 
         } else if (!S_ISREG(buf.st_mode)) {
@@ -460,8 +459,7 @@ pcmk__file_contents(const char *filename, char **contents)
 
         read_len = fread(*contents, 1, length, fp);
         if (read_len != length) {
-            free(*contents);
-            *contents = NULL;
+            g_clear_pointer(contents, &free);
             rc = EIO;
         } else {
             /* Coverity thinks *contents isn't null-terminated. It doesn't

--- a/lib/common/ipc_attrd.c
+++ b/lib/common/ipc_attrd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the Pacemaker project contributors
+ * Copyright 2011-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -105,10 +105,7 @@ done:
     pcmk__call_ipc_callback(api, pcmk_ipc_event_reply, status, &reply_data);
 
     /* Free any reply data that was allocated */
-    if (reply_data.data.pairs) {
-        g_list_free_full(reply_data.data.pairs, free);
-    }
-
+    g_list_free_full(reply_data.data.pairs, free);
     return false;
 }
 

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -56,8 +56,7 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
 
     (*api)->server = server;
     if (pcmk_ipc_name(*api, false) == NULL) {
-        pcmk_free_ipc_api(*api);
-        *api = NULL;
+        g_clear_pointer(api, pcmk_free_ipc_api);
         return EOPNOTSUPP;
     }
 
@@ -89,31 +88,28 @@ pcmk_new_ipc_api(pcmk_ipc_api_t **api, enum pcmk_ipc_server server)
             break;
 
         default: // pcmk_ipc_unknown
-            pcmk_free_ipc_api(*api);
-            *api = NULL;
+            g_clear_pointer(api, pcmk_free_ipc_api);
             return EINVAL;
     }
     if ((*api)->cmds == NULL) {
-        pcmk_free_ipc_api(*api);
-        *api = NULL;
+        g_clear_pointer(api, pcmk_free_ipc_api);
         return ENOMEM;
     }
 
     (*api)->ipc = crm_ipc_new(pcmk_ipc_name(*api, false), 0);
     if ((*api)->ipc == NULL) {
-        pcmk_free_ipc_api(*api);
-        *api = NULL;
+        g_clear_pointer(api, pcmk_free_ipc_api);
         return ENOMEM;
     }
 
     // If daemon API has its own data to track, allocate it
-    if ((*api)->cmds->new_data != NULL) {
-        if ((*api)->cmds->new_data(*api) != pcmk_rc_ok) {
-            pcmk_free_ipc_api(*api);
-            *api = NULL;
-            return ENOMEM;
-        }
+    if (((*api)->cmds->new_data != NULL)
+        && ((*api)->cmds->new_data(*api) != pcmk_rc_ok)) {
+
+        g_clear_pointer(api, pcmk_free_ipc_api);
+        return ENOMEM;
     }
+
     pcmk__trace("Created %s API IPC object", pcmk_ipc_name(*api, true));
     return pcmk_rc_ok;
 }

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -119,8 +119,7 @@ free_daemon_specific_data(pcmk_ipc_api_t *api)
 {
     if ((api != NULL) && (api->cmds != NULL)) {
         if ((api->cmds->free_data != NULL) && (api->api_data != NULL)) {
-            api->cmds->free_data(api->api_data);
-            api->api_data = NULL;
+            g_clear_pointer(&api->api_data, api->cmds->free_data);
         }
 
         g_clear_pointer(&api->cmds, free);
@@ -1475,8 +1474,7 @@ crm_ipc_send(crm_ipc_t *client, const xmlNode *message,
             index++;
         }
 
-        pcmk_free_ipc_event(iov);
-        iov = NULL;
+        g_clear_pointer(&iov, pcmk_free_ipc_event);
     } while (true);
 
     /* If we should not wait for a response, bail now */

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -126,8 +126,8 @@ free_daemon_specific_data(pcmk_ipc_api_t *api)
             api->cmds->free_data(api->api_data);
             api->api_data = NULL;
         }
-        free(api->cmds);
-        api->cmds = NULL;
+
+        g_clear_pointer(&api->cmds, free);
     }
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -121,8 +121,7 @@ pcmk__client_cleanup(void)
             pcmk__warn("Exiting with %d active IPC client%s", active,
                        pcmk__plural_s(active));
         }
-        g_hash_table_destroy(client_connections);
-        client_connections = NULL;
+        g_clear_pointer(&client_connections, g_hash_table_destroy);
     }
 }
 

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -401,12 +401,9 @@ mainloop_destroy_signal(int sig)
 static qb_array_t *gio_map = NULL;
 
 void
-mainloop_cleanup(void) 
+mainloop_cleanup(void)
 {
-    if (gio_map != NULL) {
-        qb_array_free(gio_map);
-        gio_map = NULL;
-    }
+    g_clear_pointer(&gio_map, qb_array_free);
 
     for (int sig = 0; sig < NSIG; ++sig) {
         mainloop_destroy_signal_entry(sig);

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -830,7 +830,7 @@ mainloop_gio_destroy(gpointer c)
 
     pcmk__trace("Destroyed client %s[%p]", c_name, c);
 
-    free(client->name); client->name = NULL;
+    free(client->name);
     free(client);
 
     free(c_name);

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -241,8 +241,6 @@ pcmk__process_request(pcmk__request_t *request, GHashTable *handlers)
 void
 pcmk__reset_request(pcmk__request_t *request)
 {
-    free(request->op);
-    request->op = NULL;
-
+    g_clear_pointer(&request->op, free);
     pcmk__reset_result(&(request->result));
 }

--- a/lib/common/nodes.c
+++ b/lib/common/nodes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -41,15 +41,9 @@ pcmk__free_node(gpointer user_data)
     pcmk__trace("Freeing node %s",
                 (is_remote? "(guest or remote)" : pcmk__node_name(node)));
 
-    if (node->priv->attrs != NULL) {
-        g_hash_table_destroy(node->priv->attrs);
-    }
-    if (node->priv->utilization != NULL) {
-        g_hash_table_destroy(node->priv->utilization);
-    }
-    if (node->priv->digest_cache != NULL) {
-        g_hash_table_destroy(node->priv->digest_cache);
-    }
+    g_clear_pointer(&node->priv->attrs, g_hash_table_destroy);
+    g_clear_pointer(&node->priv->utilization, g_hash_table_destroy);
+    g_clear_pointer(&node->priv->digest_cache, g_hash_table_destroy);
     g_list_free(node->details->running_rsc);
     g_list_free(node->priv->assigned_resources);
     free(node->priv);

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -43,10 +43,7 @@ pcmk__output_free(pcmk__output_t *out) {
 
     out->free_priv(out);
 
-    if (out->messages != NULL) {
-        g_hash_table_destroy(out->messages);
-    }
-
+    g_clear_pointer(&out->messages, g_hash_table_destroy);
     g_free(out->request);
     free(out);
 }
@@ -183,11 +180,9 @@ pcmk__register_formats(GOptionGroup *group,
 }
 
 void
-pcmk__unregister_formats(void) {
-    if (formatters != NULL) {
-        g_hash_table_destroy(formatters);
-        formatters = NULL;
-    }
+pcmk__unregister_formats(void)
+{
+    g_clear_pointer(&formatters, g_hash_table_destroy);
 }
 
 int

--- a/lib/common/output.c
+++ b/lib/common/output.c
@@ -266,10 +266,7 @@ pcmk__xml_output_new(pcmk__output_t **out, xmlNodePtr *xml) {
         return EINVAL;
     }
 
-    if (*xml != NULL) {
-        pcmk__xml_free(*xml);
-        *xml = NULL;
-    }
+    g_clear_pointer(xml, pcmk__xml_free);
     pcmk__register_formats(NULL, xml_format);
     return pcmk__output_new(out, "xml", NULL, NULL);
 }

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -94,8 +94,7 @@ html_free_priv(pcmk__output_t *out) {
      */
     g_queue_free(priv->parent_q);
     g_slist_free_full(priv->errors, free);
-    free(priv);
-    out->priv = NULL;
+    g_clear_pointer(&out->priv, free);
 }
 
 static bool

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -74,8 +74,7 @@ log_free_priv(pcmk__output_t *out) {
     priv = out->priv;
 
     g_queue_free(priv->prefixes);
-    free(priv);
-    out->priv = NULL;
+    g_clear_pointer(&out->priv, free);
 }
 
 static bool

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -48,8 +48,7 @@ text_free_priv(pcmk__output_t *out) {
     priv = out->priv;
 
     g_queue_free_full(priv->parent_q, free_list_data);
-    free(priv);
-    out->priv = NULL;
+    g_clear_pointer(&out->priv, free);
 }
 
 static bool
@@ -473,10 +472,7 @@ pcmk__text_prompt(const char *prompt, bool echo, char **dest)
     if (rc == 0) {
         fprintf(stderr, "%s: ", prompt);
 
-        if (*dest != NULL) {
-            free(*dest);
-            *dest = NULL;
-        }
+        g_clear_pointer(dest, free);
 
 #if HAVE_SSCANF_M
         rc = scanf("%ms", dest);
@@ -488,8 +484,7 @@ pcmk__text_prompt(const char *prompt, bool echo, char **dest)
     }
 
     if (rc < 1) {
-        free(*dest);
-        *dest = NULL;
+        g_clear_pointer(dest, free);
     }
 
     if (orig_c_lflag != 0) {

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -146,8 +146,7 @@ xml_free_priv(pcmk__output_t *out) {
     }
 
     g_slist_free_full(priv->errors, free);
-    free(priv);
-    out->priv = NULL;
+    g_clear_pointer(&out->priv, free);
 }
 
 static bool

--- a/lib/common/procfs.c
+++ b/lib/common/procfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the Pacemaker project contributors
+ * Copyright 2015-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -396,8 +396,7 @@ pcmk__throttle_cib_load(const char *server, float *load)
         int rc = errno;
 
         pcmk__warn("Couldn't read %s: %s (%d)", loadfile, pcmk_rc_str(rc), rc);
-        free(loadfile);
-        loadfile = NULL;
+        g_clear_pointer(&loadfile, free);
         return false;
     }
 

--- a/lib/common/results.c
+++ b/lib/common/results.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1295,14 +1295,9 @@ pcmk__reset_result(pcmk__action_result_t *result)
         return;
     }
 
-    free(result->exit_reason);
-    result->exit_reason = NULL;
-
-    free(result->action_stdout);
-    result->action_stdout = NULL;
-
-    free(result->action_stderr);
-    result->action_stderr = NULL;
+    g_clear_pointer(&result->exit_reason, free);
+    g_clear_pointer(&result->action_stdout, free);
+    g_clear_pointer(&result->action_stderr, free);
 }
 
 /*!

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -220,8 +220,7 @@ pcmk__evaluate_date_spec(const xmlNode *date_spec, const crm_time_t *now)
                              parent_id, id,                                 \
                              pcmk__time_component_attr(component),          \
                              pcmk_rc_str(rc));                              \
-            crm_time_free(*end);                                            \
-            *end = NULL;                                                    \
+            g_clear_pointer(end, crm_time_free);                            \
             return rc;                                                      \
         }                                                                   \
     } while (0)

--- a/lib/common/scheduler.c
+++ b/lib/common/scheduler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -105,13 +105,8 @@ pcmk_reset_scheduler(pcmk_scheduler_t *scheduler)
 
     // Do not reset local_node_name or out
 
-    crm_time_free(scheduler->priv->now);
-    scheduler->priv->now = NULL;
-
-    if (scheduler->priv->options != NULL) {
-        g_hash_table_destroy(scheduler->priv->options);
-        scheduler->priv->options = NULL;
-    }
+    g_clear_pointer(&scheduler->priv->now, crm_time_free);
+    g_clear_pointer(&scheduler->priv->options, g_hash_table_destroy);
 
     scheduler->priv->fence_action = NULL;
     scheduler->priv->fence_timeout_ms = 0U;
@@ -125,30 +120,18 @@ pcmk_reset_scheduler(pcmk_scheduler_t *scheduler)
     g_list_free_full(scheduler->priv->resources, pcmk__free_resource);
     scheduler->priv->resources = NULL;
 
-    if (scheduler->priv->templates != NULL) {
-        g_hash_table_destroy(scheduler->priv->templates);
-        scheduler->priv->templates = NULL;
-    }
-    if (scheduler->priv->tags != NULL) {
-        g_hash_table_destroy(scheduler->priv->tags);
-        scheduler->priv->tags = NULL;
-    }
+    g_clear_pointer(&scheduler->priv->templates, g_hash_table_destroy);
+    g_clear_pointer(&scheduler->priv->tags, g_hash_table_destroy);
 
     g_list_free_full(scheduler->priv->actions, pcmk__free_action);
     scheduler->priv->actions = NULL;
 
-    if (scheduler->priv->singletons != NULL) {
-        g_hash_table_destroy(scheduler->priv->singletons);
-        scheduler->priv->singletons = NULL;
-    }
-
-    pcmk__xml_free(scheduler->priv->failed);
-    scheduler->priv->failed = NULL;
+    g_clear_pointer(&scheduler->priv->singletons, g_hash_table_destroy);
+    g_clear_pointer(&scheduler->priv->failed, pcmk__xml_free);
 
     pcmk__free_param_checks(scheduler);
 
-    g_list_free(scheduler->priv->stop_needed);
-    scheduler->priv->stop_needed = NULL;
+    g_clear_pointer(&scheduler->priv->stop_needed, g_list_free);
 
     g_list_free_full(scheduler->priv->location_constraints,
                      pcmk__free_location);
@@ -161,23 +144,18 @@ pcmk_reset_scheduler(pcmk_scheduler_t *scheduler)
                      pcmk__free_action_relation);
     scheduler->priv->ordering_constraints = NULL;
 
-    if (scheduler->priv->ticket_constraints != NULL) {
-        g_hash_table_destroy(scheduler->priv->ticket_constraints);
-        scheduler->priv->ticket_constraints = NULL;
-    }
+    g_clear_pointer(&scheduler->priv->ticket_constraints, g_hash_table_destroy);
 
     scheduler->priv->ninstances = 0;
     scheduler->priv->blocked_resources = 0;
     scheduler->priv->disabled_resources = 0;
     scheduler->priv->recheck_by = 0;
 
-    pcmk__xml_free(scheduler->priv->graph);
-    scheduler->priv->graph = NULL;
+    g_clear_pointer(&scheduler->priv->graph, pcmk__xml_free);
 
     scheduler->priv->synapse_count = 0;
 
-    pcmk__xml_free(scheduler->input);
-    scheduler->input = NULL;
+    g_clear_pointer(&scheduler->input, pcmk__xml_free);
 
     pcmk__set_scheduler_defaults(scheduler);
 

--- a/lib/common/scheduler.c
+++ b/lib/common/scheduler.c
@@ -389,8 +389,10 @@ pcmk__foreach_param_check(pcmk_scheduler_t *scheduler,
 void
 pcmk__free_param_checks(pcmk_scheduler_t *scheduler)
 {
-    if ((scheduler != NULL) && (scheduler->priv->param_check != NULL)) {
-        g_list_free_full(scheduler->priv->param_check, free);
-        scheduler->priv->param_check = NULL;
+    if (scheduler == NULL) {
+        return;
     }
+
+    g_list_free_full(scheduler->priv->param_check, free);
+    scheduler->priv->param_check = NULL;
 }

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -685,10 +685,8 @@ free_schema(gpointer data)
 void
 pcmk__schema_cleanup(void)
 {
-    if (known_schemas != NULL) {
-        g_list_free_full(known_schemas, free_schema);
-        known_schemas = NULL;
-    }
+    g_list_free_full(known_schemas, free_schema);
+    known_schemas = NULL;
     initialized = false;
 
     wrap_libxslt(true);

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -479,9 +479,7 @@ pcmk__load_schemas_from_dir(const char *dir)
 
 done:
     free(namelist);
-    if (transforms != NULL) {
-        g_hash_table_destroy(transforms);
-    }
+    g_clear_pointer(&transforms, g_hash_table_destroy);
 }
 
 static gint

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -1300,8 +1300,7 @@ pcmk__update_configured_schema(xmlNode **xml, bool to_logs)
                 }
             }
 
-            pcmk__xml_free(converted);
-            converted = NULL;
+            g_clear_pointer(&converted, pcmk__xml_free);
             return pcmk_rc_transform_failed;
 
         } else {

--- a/lib/common/tests/rules/pcmk__evaluate_condition_test.c
+++ b/lib/common/tests/rules/pcmk__evaluate_condition_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -88,8 +88,7 @@ attribute_expression(void **state)
     assert_int_equal(pcmk__evaluate_condition(xml, &rule_input, NULL),
                      pcmk_rc_ok);
 
-    g_hash_table_destroy(rule_input.node_attrs);
-    rule_input.node_attrs = NULL;
+    g_clear_pointer(&rule_input.node_attrs, g_hash_table_destroy);
     pcmk__xml_free(xml);
 }
 
@@ -110,8 +109,7 @@ location_expression(void **state)
     assert_int_equal(pcmk__evaluate_condition(xml, &rule_input, NULL),
                      pcmk_rc_ok);
 
-    g_hash_table_destroy(rule_input.node_attrs);
-    rule_input.node_attrs = NULL;
+    g_clear_pointer(&rule_input.node_attrs, g_hash_table_destroy);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
+++ b/lib/common/tests/xml_idref/pcmk__xe_dereference_children_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -68,9 +68,7 @@ assert_deref(const char *xml_string, const char *element_name, ...)
     }
 
     g_list_free(list);
-    if (table != NULL) {
-        g_hash_table_destroy(table);
-    }
+    g_clear_pointer(&table, g_hash_table_destroy);
     pcmk__xml_free(xml);
 }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -255,10 +255,8 @@ reset_xml_private_data(xml_doc_private_t *docpriv)
         g_clear_pointer(&docpriv->acl_user, free);
         g_clear_pointer(&docpriv->acls, pcmk__free_acls);
 
-        if(docpriv->deleted_objs) {
-            g_list_free_full(docpriv->deleted_objs, free_deleted_object);
-            docpriv->deleted_objs = NULL;
-        }
+        g_list_free_full(docpriv->deleted_objs, free_deleted_object);
+        docpriv->deleted_objs = NULL;
     }
 }
 

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -368,8 +368,8 @@ free_private_data(xmlNode *node, void *user_data)
             free_private_data((xmlNode *) iter, user_data);
         }
     }
-    free(node->_private);
-    node->_private = NULL;
+
+    g_clear_pointer(&node->_private, free);
     return true;
 }
 

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -77,8 +77,8 @@ decompress_file(const char *filename)
         rc = pcmk__bzlib2rc(rc);
         pcmk__err("Could not read compressed %s: %s " QB_XS " rc=%d", filename,
                   pcmk_rc_str(rc), rc);
-        free(buffer);
-        buffer = NULL;
+        g_clear_pointer(&buffer, free);
+
     } else {
         buffer[length] = '\0';
     }

--- a/lib/common/xml_io.c
+++ b/lib/common/xml_io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -149,8 +149,7 @@ pcmk__xml_read(const char *filename)
     last_error = xmlCtxtGetLastError(ctxt);
     if ((last_error != NULL) && (xml != NULL)) {
         pcmk__log_xml_debug(xml, "partial");
-        pcmk__xml_free(xml);
-        xml = NULL;
+        g_clear_pointer(&xml, pcmk__xml_free);
     }
 
     xmlFreeParserCtxt(ctxt);
@@ -195,8 +194,7 @@ pcmk__xml_parse(const char *input)
     last_error = xmlCtxtGetLastError(ctxt);
     if ((last_error != NULL) && (xml != NULL)) {
         pcmk__log_xml_debug(xml, "partial");
-        pcmk__xml_free(xml);
-        xml = NULL;
+        g_clear_pointer(&xml, pcmk__xml_free);
     }
 
     xmlFreeParserCtxt(ctxt);

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -209,13 +209,9 @@ stonith__destroy_action(stonith_action_t *action)
 {
     if (action) {
         free(action->agent);
-        if (action->args) {
-            g_hash_table_destroy(action->args);
-        }
         free(action->action);
-        if (action->svc_action) {
-            services_action_free(action->svc_action);
-        }
+        g_clear_pointer(&action->args, g_hash_table_destroy);
+        g_clear_pointer(&action->svc_action, services_action_free);
         pcmk__reset_result(&(action->result));
         free(action);
     }

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -1168,8 +1168,7 @@ stonith_api_signon(stonith_t * stonith, const char *name, int *stonith_fd)
             }
             if (rc != pcmk_rc_ok) {
                 crm_ipc_close(native->ipc);
-                crm_ipc_destroy(native->ipc);
-                native->ipc = NULL;
+                g_clear_pointer(&native->ipc, crm_ipc_destroy);
             }
         }
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -290,7 +290,7 @@ stonith_connection_destroy(gpointer user_data)
     native->ipc = NULL;
     native->source = NULL;
 
-    free(native->token); native->token = NULL;
+    g_clear_pointer(&native->token, free);
     stonith->state = stonith_disconnected;
     pcmk__xe_set(blob.xml, PCMK__XA_T, PCMK__VALUE_ST_NOTIFY);
     pcmk__xe_set(blob.xml, PCMK__XA_SUBT, PCMK__VALUE_ST_NOTIFY_DISCONNECT);
@@ -886,7 +886,7 @@ stonith_api_signoff(stonith_t * stonith)
         crm_ipc_destroy(ipc);
     }
 
-    free(native->token); native->token = NULL;
+    g_clear_pointer(&native->token, free);
     stonith->state = stonith_disconnected;
     return pcmk_ok;
 }
@@ -1706,7 +1706,7 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
   done:
     if (!crm_ipc_connected(native->ipc)) {
         pcmk__err("Fencer disconnected");
-        free(native->token); native->token = NULL;
+        g_clear_pointer(&native->token, free);
         stonith->state = stonith_disconnected;
     }
 

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -873,8 +873,7 @@ stonith_api_signoff(stonith_t * stonith)
 
     if (native->source != NULL) {
         /* Attached to mainloop */
-        mainloop_del_ipc_client(native->source);
-        native->source = NULL;
+        g_clear_pointer(&native->source, mainloop_del_ipc_client);
         native->ipc = NULL;
 
     } else if (native->ipc) {

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -649,10 +649,7 @@ stonith_api_list(stonith_t * stonith, int call_options, const char *id, char **l
         }
     }
 
-    if (output) {
-        pcmk__xml_free(output);
-    }
-
+    pcmk__xml_free(output);
     return rc;
 }
 
@@ -1693,16 +1690,16 @@ stonith_send_command(stonith_t * stonith, const char *op, xmlNode * data, xmlNod
     } else if (reply_id <= 0) {
         pcmk__err("Received bad reply: No id set");
         pcmk__log_xml_err(op_reply, "Bad reply");
-        pcmk__xml_free(op_reply);
-        op_reply = NULL;
+
+        g_clear_pointer(&op_reply, pcmk__xml_free);
         rc = -ENOMSG;
 
     } else {
         pcmk__err("Received bad reply: %d (wanted %d)", reply_id,
                   stonith->call_id);
         pcmk__log_xml_err(op_reply, "Old reply");
-        pcmk__xml_free(op_reply);
-        op_reply = NULL;
+
+        g_clear_pointer(&op_reply, pcmk__xml_free);
         rc = -ENOMSG;
     }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -616,20 +616,17 @@ lrmd_tls_connection_destroy(gpointer userdata)
         mainloop_destroy_trigger(native->process_notify);
         native->process_notify = NULL;
     }
-    if (native->pending_notify) {
-        g_list_free_full(native->pending_notify,
-                         (GDestroyNotify) pcmk__xml_free);
-        native->pending_notify = NULL;
-    }
+
+    g_list_free_full(native->pending_notify, (GDestroyNotify) pcmk__xml_free);
+    native->pending_notify = NULL;
+
     if (native->handshake_trigger != NULL) {
         mainloop_destroy_trigger(native->handshake_trigger);
         native->handshake_trigger = NULL;
     }
 
-    free(native->remote->buffer);
-    free(native->remote->start_state);
-    native->remote->buffer = NULL;
-    native->remote->start_state = NULL;
+    g_clear_pointer(&native->remote->buffer, free);
+    g_clear_pointer(&native->remote->start_state, free);
     native->source = 0;
     native->sock = -1;
 
@@ -1658,11 +1655,8 @@ lrmd_tls_disconnect(lrmd_t * lrmd)
         native->sock = -1;
     }
 
-    if (native->pending_notify) {
-        g_list_free_full(native->pending_notify,
-                         (GDestroyNotify) pcmk__xml_free);
-        native->pending_notify = NULL;
-    }
+    g_list_free_full(native->pending_notify, (GDestroyNotify) pcmk__xml_free);
+    native->pending_notify = NULL;
 }
 
 static int
@@ -1687,11 +1681,8 @@ lrmd_api_disconnect(lrmd_t * lrmd)
             rc = -EPROTONOSUPPORT;
     }
 
-    free(native->token);
-    native->token = NULL;
-
-    free(native->peer_version);
-    native->peer_version = NULL;
+    g_clear_pointer(&native->token, free);
+    g_clear_pointer(&native->peer_version, free);
     return rc;
 }
 
@@ -2515,11 +2506,8 @@ lrmd__reset_result(lrmd_event_data_t *event)
         return;
     }
 
-    free((void *) event->exit_reason);
-    event->exit_reason = NULL;
-
-    free((void *) event->output);
-    event->output = NULL;
+    g_clear_pointer(&event->exit_reason, free);
+    g_clear_pointer(&event->output, free);
 }
 
 /*!

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -352,12 +352,6 @@ lrmd_ipc_dispatch(const char *buffer, ssize_t length, gpointer userdata)
     return 0;
 }
 
-static void
-lrmd_free_xml(gpointer userdata)
-{
-    pcmk__xml_free((xmlNode *) userdata);
-}
-
 static bool
 remote_executor_connected(lrmd_t * lrmd)
 {
@@ -419,7 +413,7 @@ process_pending_notifies(gpointer userdata)
 
     pcmk__trace("Processing pending notifies");
     g_list_foreach(native->pending_notify, lrmd_dispatch_internal, lrmd);
-    g_list_free_full(native->pending_notify, lrmd_free_xml);
+    g_list_free_full(native->pending_notify, (GDestroyNotify) pcmk__xml_free);
     native->pending_notify = NULL;
     return G_SOURCE_CONTINUE;
 }
@@ -623,7 +617,8 @@ lrmd_tls_connection_destroy(gpointer userdata)
         native->process_notify = NULL;
     }
     if (native->pending_notify) {
-        g_list_free_full(native->pending_notify, lrmd_free_xml);
+        g_list_free_full(native->pending_notify,
+                         (GDestroyNotify) pcmk__xml_free);
         native->pending_notify = NULL;
     }
     if (native->handshake_trigger != NULL) {
@@ -704,8 +699,8 @@ read_remote_reply(lrmd_t *lrmd, int total_timeout, int expected_reply_id,
 
         if (!msg_type) {
             pcmk__err("Empty msg type received while waiting for reply");
-            pcmk__xml_free(*reply);
-            *reply = NULL;
+            g_clear_pointer(reply, pcmk__xml_free);
+
         } else if (pcmk__str_eq(msg_type, "notify", pcmk__str_casei)) {
             /* got a notify while waiting for reply, trigger the notify to be processed later */
             pcmk__info("queueing notify");
@@ -718,8 +713,8 @@ read_remote_reply(lrmd_t *lrmd, int total_timeout, int expected_reply_id,
         } else if (!pcmk__str_eq(msg_type, "reply", pcmk__str_casei)) {
             /* msg isn't a reply, make some noise */
             pcmk__err("Expected a reply, got %s", msg_type);
-            pcmk__xml_free(*reply);
-            *reply = NULL;
+            g_clear_pointer(reply, pcmk__xml_free);
+
         } else if (reply_id != expected_reply_id) {
             if (native->expected_late_replies > 0) {
                 native->expected_late_replies--;
@@ -727,8 +722,8 @@ read_remote_reply(lrmd_t *lrmd, int total_timeout, int expected_reply_id,
                 pcmk__err("Got outdated reply, expected id %d got id %d",
                           expected_reply_id, reply_id);
             }
-            pcmk__xml_free(*reply);
-            *reply = NULL;
+
+            g_clear_pointer(reply, pcmk__xml_free);
         }
     }
 
@@ -1664,7 +1659,8 @@ lrmd_tls_disconnect(lrmd_t * lrmd)
     }
 
     if (native->pending_notify) {
-        g_list_free_full(native->pending_notify, lrmd_free_xml);
+        g_list_free_full(native->pending_notify,
+                         (GDestroyNotify) pcmk__xml_free);
         native->pending_notify = NULL;
     }
 }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -605,10 +605,9 @@ lrmd_tls_connection_destroy(gpointer userdata)
         gnutls_deinit(native->remote->tls_session);
         native->remote->tls_session = NULL;
     }
-    if (native->tls) {
-        pcmk__free_tls(native->tls);
-        native->tls = NULL;
-    }
+
+    g_clear_pointer(&native->tls, pcmk__free_tls);
+
     if (native->sock >= 0) {
         close(native->sock);
     }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -611,18 +611,13 @@ lrmd_tls_connection_destroy(gpointer userdata)
     if (native->sock >= 0) {
         close(native->sock);
     }
-    if (native->process_notify) {
-        mainloop_destroy_trigger(native->process_notify);
-        native->process_notify = NULL;
-    }
+
+    g_clear_pointer(&native->process_notify, mainloop_destroy_trigger);
 
     g_list_free_full(native->pending_notify, (GDestroyNotify) pcmk__xml_free);
     native->pending_notify = NULL;
 
-    if (native->handshake_trigger != NULL) {
-        mainloop_destroy_trigger(native->handshake_trigger);
-        native->handshake_trigger = NULL;
-    }
+    g_clear_pointer(&native->handshake_trigger, mainloop_destroy_trigger);
 
     g_clear_pointer(&native->remote->buffer, free);
     g_clear_pointer(&native->remote->start_state, free);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -251,9 +251,7 @@ lrmd_free_event(lrmd_event_data_t *event)
     free((void *) event->user_data);
     free((void *) event->remote_nodename);
     lrmd__reset_result(event);
-    if (event->params != NULL) {
-        g_hash_table_destroy(event->params);
-    }
+    g_clear_pointer(&event->params, g_hash_table_destroy);
     free(event);
 }
 
@@ -334,9 +332,7 @@ lrmd_dispatch_internal(gpointer data, gpointer user_data)
     pcmk__trace("op %s notify event received", type);
     native->callback(&event);
 
-    if (event.params) {
-        g_hash_table_destroy(event.params);
-    }
+    g_clear_pointer(&event.params, g_hash_table_destroy);
     lrmd__reset_result(&event);
 }
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -602,8 +602,7 @@ lrmd_tls_connection_destroy(gpointer userdata)
 
     if (native->remote->tls_session) {
         gnutls_bye(native->remote->tls_session, GNUTLS_SHUT_RDWR);
-        gnutls_deinit(native->remote->tls_session);
-        native->remote->tls_session = NULL;
+        g_clear_pointer(&native->remote->tls_session, gnutls_deinit);
     }
 
     g_clear_pointer(&native->tls, pcmk__free_tls);
@@ -1241,8 +1240,7 @@ tls_handshake_failed(lrmd_t *lrmd, int tls_rc, int rc)
                ((rc == EPROTO)? gnutls_strerror(tls_rc) : pcmk_rc_str(rc)));
     report_async_connection_result(lrmd, pcmk_rc2legacy(rc));
 
-    gnutls_deinit(native->remote->tls_session);
-    native->remote->tls_session = NULL;
+    g_clear_pointer(&native->remote->tls_session, gnutls_deinit);
     lrmd_tls_connection_destroy(lrmd);
 }
 
@@ -1629,8 +1627,7 @@ lrmd_tls_disconnect(lrmd_t * lrmd)
 
     if (native->remote->tls_session) {
         gnutls_bye(native->remote->tls_session, GNUTLS_SHUT_RDWR);
-        gnutls_deinit(native->remote->tls_session);
-        native->remote->tls_session = NULL;
+        g_clear_pointer(&native->remote->tls_session, gnutls_deinit);
     }
 
     if (native->async_timer) {

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1609,8 +1609,7 @@ lrmd_ipc_disconnect(lrmd_t * lrmd)
 
     if (native->source != NULL) {
         /* Attached to mainloop */
-        mainloop_del_ipc_client(native->source);
-        native->source = NULL;
+        g_clear_pointer(&native->source, mainloop_del_ipc_client);
         native->ipc = NULL;
 
     } else if (native->ipc) {
@@ -1641,8 +1640,7 @@ lrmd_tls_disconnect(lrmd_t * lrmd)
 
     if (native->source != NULL) {
         /* Attached to mainloop */
-        mainloop_del_ipc_client(native->source);
-        native->source = NULL;
+        g_clear_pointer(&native->source, mainloop_del_ipc_client);
 
     } else if (native->sock >= 0) {
         close(native->sock);

--- a/lib/pacemaker/pcmk_acl.c
+++ b/lib/pacemaker/pcmk_acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -363,8 +363,7 @@ pcmk__acl_evaled_render(xmlDoc *annotated_doc, enum pcmk__acl_render_how how,
     res = xsltApplyStylesheetUser(xslt, annotated_doc, NULL,
                                   NULL, NULL, xslt_ctxt);
 
-    pcmk__xml_free_doc(annotated_doc);
-    annotated_doc = NULL;
+    g_clear_pointer(&annotated_doc, pcmk__xml_free_doc);
     xsltFreeTransformContext(xslt_ctxt);
     xslt_ctxt = NULL;
 

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -38,9 +38,7 @@ free_graph_action(gpointer user_data)
         pcmk__warn("Cancelling timer for graph action %d", action->id);
         g_source_remove(action->timer);
     }
-    if (action->params != NULL) {
-        g_hash_table_destroy(action->params);
-    }
+    g_clear_pointer(&action->params, g_hash_table_destroy);
     pcmk__xml_free(action->xml);
     free(action);
 }

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -249,6 +249,9 @@ pcmk__inject_action_result(xmlNode *cib_resource, lrmd_event_data_t *op,
  * \param[in]     uuid      UUID of node to inject
  *
  * \return XML of \c PCMK__XE_NODE_STATE entry for new node
+ *
+ * \note The caller is responsible for freeing the return value using
+ *       \c pcmk__xml_free().
  * \note If the global pcmk__simulate_node_config has been set to true, a
  *       node entry in the configuration section will be added, as well as a
  *       node state entry in the status section.
@@ -349,6 +352,9 @@ done:
  * \param[in]     up        If true, change state to online, otherwise offline
  *
  * \return XML of changed (or added) node state entry
+ *
+ * \note The caller is responsible for freeing the return value using
+ *       \c pcmk__xml_free().
  */
 xmlNode *
 pcmk__inject_node_state_change(cib_t *cib_conn, const char *node, bool up)
@@ -638,6 +644,7 @@ done:
     free(task);
     free(node);
     free(key);
+    pcmk__xml_free(cib_node);
 }
 
 /*!

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1422,9 +1422,7 @@ pcmk__apply_coloc_to_scores(pcmk_resource_t *dependent,
                        dependent->id, primary->id);
     }
 
-    if (work != NULL) {
-        g_hash_table_destroy(work);
-    }
+    g_clear_pointer(&work, g_hash_table_destroy);
 }
 
 /*!
@@ -1900,9 +1898,7 @@ pcmk__add_colocated_node_scores(pcmk_resource_t *source_rsc,
         }
     }
 
-    if (*nodes != NULL) {
-       g_hash_table_destroy(*nodes);
-    }
+    g_clear_pointer(nodes, g_hash_table_destroy);
     *nodes = work;
 
     pcmk__clear_rsc_flags(source_rsc, pcmk__rsc_updating_nodes);

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -909,8 +909,8 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
      */
     if (!pcmk__tag_to_set(*expanded_xml, &dependent_set, PCMK_XA_RSC, true,
                           scheduler)) {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
         return pcmk_rc_unpack_error;
     }
 
@@ -930,8 +930,8 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
      */
     if (!pcmk__tag_to_set(*expanded_xml, &primary_set, PCMK_XA_WITH_RSC, true,
                           scheduler)) {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
         return pcmk_rc_unpack_error;
     }
 
@@ -949,8 +949,7 @@ unpack_colocation_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     if (any_sets) {
         pcmk__log_xml_trace(*expanded_xml, "Expanded " PCMK_XE_RSC_COLOCATION);
     } else {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
     }
 
     return pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -329,9 +329,9 @@ pcmk__expand_tags_in_sets(xmlNode *xml_obj, const pcmk_scheduler_t *scheduler)
     }
 
     if (!any_refs) {
-        pcmk__xml_free(new_xml);
-        new_xml = NULL;
+        g_clear_pointer(&new_xml, pcmk__xml_free);
     }
+
     return new_xml;
 }
 

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -513,8 +513,8 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
      */
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set, PCMK_XA_RSC,
                           false, scheduler)) {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
         return pcmk_rc_unpack_error;
     }
 
@@ -530,8 +530,7 @@ unpack_location_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     } else {
         // No sets
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
     }
 
     return pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -935,8 +935,8 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
      */
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_first, PCMK_XA_FIRST, true,
                           scheduler)) {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
         return pcmk_rc_unpack_error;
     }
 
@@ -956,8 +956,8 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
      */
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set_then, PCMK_XA_THEN, true,
                           scheduler)) {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
         return pcmk_rc_unpack_error;
     }
 
@@ -975,8 +975,7 @@ unpack_order_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
     if (any_sets) {
         pcmk__log_xml_trace(*expanded_xml, "Expanded " PCMK_XE_RSC_ORDER);
     } else {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
     }
 
     return pcmk_rc_ok;

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -332,9 +332,8 @@ apply_this_with(pcmk__colocation_t *colocation, pcmk_resource_t *rsc)
         rsc->priv->allowed_nodes = archive;
         archive = NULL;
     }
-    if (archive != NULL) {
-        g_hash_table_destroy(archive);
-    }
+
+    g_clear_pointer(&archive, g_hash_table_destroy);
 }
 
 /*!

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the Pacemaker project contributors
+ * Copyright 2014-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -774,12 +774,9 @@ done:
                 ((r2_node == NULL)? "" : " on "),
                 ((r2_node == NULL)? "" : r2_node->priv->id),
                 reason);
-    if (r1_nodes != NULL) {
-        g_hash_table_destroy(r1_nodes);
-    }
-    if (r2_nodes != NULL) {
-        g_hash_table_destroy(r2_nodes);
-    }
+
+    g_clear_pointer(&r1_nodes, g_hash_table_destroy);
+    g_clear_pointer(&r2_nodes, g_hash_table_destroy);
     return rc;
 }
 

--- a/lib/pacemaker/pcmk_sched_tickets.c
+++ b/lib/pacemaker/pcmk_sched_tickets.c
@@ -387,8 +387,8 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
      */
     if (!pcmk__tag_to_set(*expanded_xml, &rsc_set, PCMK_XA_RSC, false,
                           scheduler)) {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
         return pcmk_rc_unpack_error;
     }
 
@@ -402,8 +402,7 @@ unpack_rsc_ticket_tags(xmlNode *xml_obj, xmlNode **expanded_xml,
         }
 
     } else {
-        pcmk__xml_free(*expanded_xml);
-        *expanded_xml = NULL;
+        g_clear_pointer(expanded_xml, pcmk__xml_free);
     }
 
     return pcmk_rc_ok;

--- a/lib/pacemaker/tests/pcmk_resource/pcmk_resource_delete_test.c
+++ b/lib/pacemaker/tests/pcmk_resource/pcmk_resource_delete_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -60,8 +60,7 @@ bad_input(void **state)
      */
     assert_int_equal(pcmk_resource_delete(&xml, "Fencing", NULL), EINVAL);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     assert_int_equal(pcmk_resource_delete(&xml, NULL, "primitive"), EINVAL);
     pcmk__assert_validates(xml);

--- a/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_delete_test.c
+++ b/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_delete_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -71,8 +71,7 @@ unknown_ticket(void **state)
 
     assert_int_equal(pcmk_ticket_delete(&xml, "XYZ", false), ENXIO);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     assert_int_equal(pcmk_ticket_delete(&xml, "XYZ", true), pcmk_rc_ok);
     pcmk__assert_validates(xml);

--- a/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_get_attr_test.c
+++ b/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_get_attr_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -48,8 +48,7 @@ bad_arguments(void **state)
 
     assert_int_equal(pcmk_ticket_get_attr(&xml, NULL, "attrA", NULL), EINVAL);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     assert_int_equal(pcmk_ticket_get_attr(&xml, "ticketA", NULL, NULL), EINVAL);
     pcmk__assert_validates(xml);
@@ -67,8 +66,7 @@ unknown_ticket(void **state)
      */
     assert_int_equal(pcmk_ticket_get_attr(&xml, "XYZ", "attrA", NULL), ENXIO);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     assert_int_equal(pcmk_ticket_get_attr(&xml, "ticketA", "XYZ", NULL), ENXIO);
     pcmk__assert_validates(xml);

--- a/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_remove_attr_test.c
+++ b/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_remove_attr_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -77,8 +77,7 @@ no_attrs(void **state)
     /* Deleting no attributes on a ticket that doesn't exist is a no-op */
     assert_int_equal(pcmk_ticket_remove_attr(&xml, "XYZ", NULL, false), pcmk_rc_ok);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     cib->cmds->query(cib, "//" PCMK__XE_TICKET_STATE "[@" PCMK_XA_ID "=\"XYZ\"]",
                      &xml_search, cib_xpath);
@@ -87,8 +86,7 @@ no_attrs(void **state)
     /* Deleting no attributes on a ticket that exists is also a no-op */
     assert_int_equal(pcmk_ticket_remove_attr(&xml, "ticketA", NULL, false), pcmk_rc_ok);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     cib->cmds->query(cib, "//" PCMK__XE_TICKET_STATE "[@" PCMK_XA_ID "=\"ticketA\"]",
                      &xml_search, cib_xpath);

--- a/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_set_attr_test.c
+++ b/lib/pacemaker/tests/pcmk_ticket/pcmk_ticket_set_attr_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -77,8 +77,7 @@ unknown_ticket_no_attrs(void **state)
     /* Setting no attributes on a ticket that doesn't exist is a no-op */
     assert_int_equal(pcmk_ticket_set_attr(&xml, "XYZ", NULL, false), pcmk_rc_ok);
     pcmk__assert_validates(xml);
-    pcmk__xml_free(xml);
-    xml = NULL;
+    g_clear_pointer(&xml, pcmk__xml_free);
 
     cib->cmds->query(cib, "//" PCMK__XE_TICKET_STATE "[@" PCMK_XA_ID "=\"XYZ\"]",
                      &xml_search, cib_xpath);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -693,8 +693,7 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
          * need something that will get freed during scheduler data cleanup to
          * use as the node ID and uname.
          */
-        free(id);
-        id = NULL;
+        g_clear_pointer(&id, free);
         uname = pcmk__xe_id(xml_remote);
 
         /* Ensure a node has been created for the guest (it may have already

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1851,18 +1851,15 @@ free_bundle_replica(pcmk__bundle_replica_t *replica)
     replica->node = NULL;
 
     if (replica->ip) {
-        pcmk__xml_free(replica->ip->priv->xml);
-        replica->ip->priv->xml = NULL;
+        g_clear_pointer(&replica->ip->priv->xml, pcmk__xml_free);
         pcmk__free_resource(replica->ip);
     }
     if (replica->container) {
-        pcmk__xml_free(replica->container->priv->xml);
-        replica->container->priv->xml = NULL;
+        g_clear_pointer(&replica->container->priv->xml, pcmk__xml_free);
         pcmk__free_resource(replica->container);
     }
     if (replica->remote) {
-        pcmk__xml_free(replica->remote->priv->xml);
-        replica->remote->priv->xml = NULL;
+        g_clear_pointer(&replica->remote->priv->xml, pcmk__xml_free);
         pcmk__free_resource(replica->remote);
     }
     free(replica->ipaddr);
@@ -1896,10 +1893,10 @@ pe__free_bundle(pcmk_resource_t *rsc)
     g_list_free(rsc->priv->children);
 
     if(bundle_data->child) {
-        pcmk__xml_free(bundle_data->child->priv->xml);
-        bundle_data->child->priv->xml = NULL;
+        g_clear_pointer(&bundle_data->child->priv->xml, pcmk__xml_free);
         pcmk__free_resource(bundle_data->child);
     }
+
     common_free(rsc);
 }
 

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -1846,8 +1846,7 @@ free_bundle_replica(pcmk__bundle_replica_t *replica)
         return;
     }
 
-    pcmk__free_node_copy(replica->node);
-    replica->node = NULL;
+    g_clear_pointer(&replica->node, pcmk__free_node_copy);
 
     if (replica->ip) {
         g_clear_pointer(&replica->ip->priv->xml, pcmk__xml_free);

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -735,9 +735,8 @@ create_remote_resource(pcmk_resource_t *parent, pe__bundle_variant_data_t *data,
         replica->node->assign->probe_mode = pcmk__probe_exclusive;
 
         /* Ensure the node shows up as allowed and with the correct discovery set */
-        if (replica->child->priv->allowed_nodes != NULL) {
-            g_hash_table_destroy(replica->child->priv->allowed_nodes);
-        }
+        g_clear_pointer(&replica->child->priv->allowed_nodes,
+                        g_hash_table_destroy);
         replica->child->priv->allowed_nodes =
             pcmk__strkey_table(NULL, pcmk__free_node_copy);
         g_hash_table_insert(replica->child->priv->allowed_nodes,

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -1199,17 +1199,14 @@ pe__free_clone_notification_data(pcmk_resource_t *clone)
 
     get_clone_variant_data(clone_data, clone);
 
-    pe__free_action_notification_data(clone_data->demote_notify);
-    clone_data->demote_notify = NULL;
-
-    pe__free_action_notification_data(clone_data->stop_notify);
-    clone_data->stop_notify = NULL;
-
-    pe__free_action_notification_data(clone_data->start_notify);
-    clone_data->start_notify = NULL;
-
-    pe__free_action_notification_data(clone_data->promote_notify);
-    clone_data->promote_notify = NULL;
+    g_clear_pointer(&clone_data->demote_notify,
+                    pe__free_action_notification_data);
+    g_clear_pointer(&clone_data->stop_notify,
+                    pe__free_action_notification_data);
+    g_clear_pointer(&clone_data->start_notify,
+                    pe__free_action_notification_data);
+    g_clear_pointer(&clone_data->promote_notify,
+                    pe__free_action_notification_data);
 }
 
 /*!

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -831,10 +831,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             GList *list = g_hash_table_get_values(rsc->priv->allowed_nodes);
 
             /* Custom stopped table for non-unique clones */
-            if (stopped != NULL) {
-                g_hash_table_destroy(stopped);
-                stopped = NULL;
-            }
+            g_clear_pointer(&stopped, g_hash_table_destroy);
 
             if (list == NULL) {
                 /* Clusters with PCMK_OPT_SYMMETRIC_CLUSTER=false haven't

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -938,11 +938,11 @@ clone_free(pcmk_resource_t * rsc)
 
         pcmk__assert(child_rsc != NULL);
         pcmk__rsc_trace(child_rsc, "Freeing child %s", child_rsc->id);
-        pcmk__xml_free(child_rsc->priv->xml);
-        child_rsc->priv->xml = NULL;
+        g_clear_pointer(&child_rsc->priv->xml, pcmk__xml_free);
+
         /* There could be a saved unexpanded xml */
-        pcmk__xml_free(child_rsc->priv->orig_xml);
-        child_rsc->priv->orig_xml = NULL;
+        g_clear_pointer(&child_rsc->priv->orig_xml, pcmk__xml_free);
+
         pcmk__free_resource(child_rsc);
     }
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -288,8 +288,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
         goto done;
     }
 
-    cib_resources = pcmk__xpath_find_one(scheduler->input->doc,
-                                         "//" PCMK_XE_RESOURCES, LOG_TRACE);
+    cib_resources = pcmk_find_cib_element(scheduler->input, PCMK_XE_RESOURCES);
     if (cib_resources == NULL) {
         pcmk__config_err("No " PCMK_XE_RESOURCES " section");
         rc = pcmk_rc_unpack_error;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -291,7 +291,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     cib_resources = pcmk__xpath_find_one(scheduler->input->doc,
                                          "//" PCMK_XE_RESOURCES, LOG_TRACE);
     if (cib_resources == NULL) {
-        pcmk__config_err("No resources configured");
+        pcmk__config_err("No " PCMK_XE_RESOURCES " section");
         rc = pcmk_rc_unpack_error;
         goto done;
     }

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -263,7 +263,7 @@ template_op_key(xmlNode * op)
     return key;
 }
 
-static gboolean
+static int
 unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
                 pcmk_scheduler_t *scheduler)
 {
@@ -278,38 +278,38 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
 
     if (xml_obj == NULL) {
         pcmk__config_err("No resource object for template unpacking");
-        return FALSE;
+        return pcmk_rc_unpack_error;
     }
 
     template_ref = pcmk__xe_get(xml_obj, PCMK_XA_TEMPLATE);
     if (template_ref == NULL) {
-        return TRUE;
+        return pcmk_rc_ok;
     }
 
     id = pcmk__xe_id(xml_obj);
     if (id == NULL) {
         pcmk__config_err("'%s' object must have a id", xml_obj->name);
-        return FALSE;
+        return pcmk_rc_unpack_error;
     }
 
     if (pcmk__str_eq(template_ref, id, pcmk__str_none)) {
         pcmk__config_err("The resource object '%s' should not reference itself",
                          id);
-        return FALSE;
+        return pcmk_rc_unpack_error;
     }
 
     cib_resources = pcmk__xpath_find_one(scheduler->input->doc,
                                          "//" PCMK_XE_RESOURCES, LOG_TRACE);
     if (cib_resources == NULL) {
         pcmk__config_err("No resources configured");
-        return FALSE;
+        return pcmk_rc_unpack_error;
     }
 
     template = pcmk__xe_first_child(cib_resources, PCMK_XE_TEMPLATE,
                                     PCMK_XA_ID, template_ref);
     if (template == NULL) {
         pcmk__config_err("No template named '%s'", template_ref);
-        return FALSE;
+        return pcmk_rc_unpack_error;
     }
 
     new_xml = pcmk__xml_copy(NULL, template);
@@ -363,7 +363,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     }
 
     *expanded_xml = new_xml;
-    return TRUE;
+    return pcmk_rc_ok;
 }
 
 static bool
@@ -708,8 +708,8 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
         goto done;
     }
 
-    if (unpack_template(xml_obj, &expanded_xml, scheduler) == FALSE) {
-        rc = pcmk_rc_unpack_error;
+    rc = unpack_template(xml_obj, &expanded_xml, scheduler);
+    if (rc != pcmk_rc_ok) {
         goto done;
     }
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -280,11 +280,6 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     }
 
     id = pcmk__xe_id(xml_obj);
-    if (id == NULL) {
-        pcmk__config_err("'%s' object must have a id", xml_obj->name);
-        rc = pcmk_rc_unpack_error;
-        goto done;
-    }
 
     if (pcmk__str_eq(template_ref, id, pcmk__str_none)) {
         pcmk__config_err("The resource object '%s' should not reference itself",

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -676,7 +676,6 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
                     pcmk_resource_t *parent, pcmk_scheduler_t *scheduler)
 {
     int rc = pcmk_rc_ok;
-    xmlNode *expanded_xml = NULL;
     xmlNode *ops = NULL;
     const char *value = NULL;
     const char *id = NULL;
@@ -705,25 +704,30 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
         goto done;
     }
 
-    rc = unpack_template(xml_obj, &expanded_xml, scheduler);
-    if (rc != pcmk_rc_ok) {
-        goto done;
-    }
-
     *rsc = pcmk__assert_alloc(1, sizeof(pcmk_resource_t));
     (*rsc)->priv = pcmk__assert_alloc(1, sizeof(pcmk__resource_private_t));
 
     rsc_private = (*rsc)->priv;
     rsc_private->scheduler = scheduler;
 
-    if (expanded_xml) {
-        pcmk__log_xml_trace(expanded_xml, "[expanded XML]");
-        rsc_private->xml = expanded_xml;
+    rc = unpack_template(xml_obj, &rsc_private->xml, scheduler);
+    if (rc != pcmk_rc_ok) {
+        goto done;
+    }
+
+    if (rsc_private->xml != NULL) {
+        /* rsc_private->xml is the effective XML and was expanded from a
+         * template. Save rsc's original XML from the configuration in
+         * rsc_private->orig_xml for later use.
+         */
+        pcmk__log_xml_trace(rsc_private->xml, "[expanded XML]");
         rsc_private->orig_xml = xml_obj;
 
     } else {
+        /* rsc_private->xml is both the effective XML and the original XML.
+         * rsc_private->orig_xml remains NULL.
+         */
         rsc_private->xml = xml_obj;
-        rsc_private->orig_xml = NULL;
     }
 
     /* Do not use xml_obj from here on, use (*rsc)->xml in case templates are involved */

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -147,17 +147,13 @@ expand_parents_fixed_nvpairs(pcmk_resource_t *rsc,
         p = p->priv->parent;
     }
 
-    if (parent_orig_meta != NULL) {
-        // This will not overwrite any values already existing for child
-        g_hash_table_foreach(parent_orig_meta, dup_attr, meta_hash);
+    if (parent_orig_meta == NULL) {
+        return;
     }
 
-    if (parent_orig_meta != NULL) {
-        g_hash_table_destroy(parent_orig_meta);
-    }
-    
-    return ;
-
+    // This will not overwrite any values already existing for child
+    g_hash_table_foreach(parent_orig_meta, dup_attr, meta_hash);
+    g_hash_table_destroy(parent_orig_meta);
 }
 
 /*
@@ -367,10 +363,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     pcmk__xml_free(template_ops);
 
 done:
-    if (rsc_ops_hash != NULL) {
-        g_hash_table_destroy(rsc_ops_hash);
-    }
-
+    g_clear_pointer(&rsc_ops_hash, g_hash_table_destroy);
     *expanded_xml = new_xml;
     return rc;
 }
@@ -442,7 +435,7 @@ detect_unique(const pcmk_resource_t *rsc)
 static void
 free_params_table(gpointer data)
 {
-    g_hash_table_destroy((GHashTable *) data);
+    g_clear_pointer(&data, g_hash_table_destroy);
 }
 
 /*!
@@ -1045,9 +1038,7 @@ common_free(pcmk_resource_t * rsc)
 
     pcmk__rsc_trace(rsc, "Freeing %s", rsc->id);
 
-    if (rsc->priv->parameter_cache != NULL) {
-        g_hash_table_destroy(rsc->priv->parameter_cache);
-    }
+    g_clear_pointer(&rsc->priv->parameter_cache, g_hash_table_destroy);
 
     if ((rsc->priv->parent == NULL)
         && pcmk__is_set(rsc->flags, pcmk__rsc_removed)) {
@@ -1075,21 +1066,12 @@ common_free(pcmk_resource_t * rsc)
     g_list_free(rsc->priv->location_constraints);
     g_list_free_full(rsc->priv->ticket_constraints, free);
 
-    if (rsc->priv->meta != NULL) {
-        g_hash_table_destroy(rsc->priv->meta);
-    }
-    if (rsc->priv->utilization != NULL) {
-        g_hash_table_destroy(rsc->priv->utilization);
-    }
-    if (rsc->priv->probed_nodes != NULL) {
-        g_hash_table_destroy(rsc->priv->probed_nodes);
-    }
-    if (rsc->priv->allowed_nodes != NULL) {
-        g_hash_table_destroy(rsc->priv->allowed_nodes);
-    }
+    g_clear_pointer(&rsc->priv->meta, g_hash_table_destroy);
+    g_clear_pointer(&rsc->priv->utilization, g_hash_table_destroy);
+    g_clear_pointer(&rsc->priv->probed_nodes, g_hash_table_destroy);
+    g_clear_pointer(&rsc->priv->allowed_nodes, g_hash_table_destroy);
 
     free(rsc->priv);
-
     free(rsc);
 }
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1065,14 +1065,11 @@ common_free(pcmk_resource_t * rsc)
         && pcmk__is_set(rsc->flags, pcmk__rsc_removed)) {
 
         pcmk__xml_free(rsc->priv->xml);
-        rsc->priv->xml = NULL;
         pcmk__xml_free(rsc->priv->orig_xml);
-        rsc->priv->orig_xml = NULL;
 
     } else if (rsc->priv->orig_xml != NULL) {
-        // rsc->private->xml was expanded from a template
+        // rsc->priv->xml was expanded from a template
         pcmk__xml_free(rsc->priv->xml);
-        rsc->priv->xml = NULL;
     }
     free(rsc->id);
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -247,7 +247,7 @@ get_rsc_attributes(GHashTable *instance_attrs, const pcmk_resource_t *rsc,
 }
 
 static char *
-template_op_key(xmlNode * op)
+template_op_key(const xmlNode *op)
 {
     const char *name = pcmk__xe_get(op, PCMK_XA_NAME);
     const char *role = pcmk__xe_get(op, PCMK_XA_ROLE);
@@ -273,43 +273,50 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     xmlNode *child_xml = NULL;
     xmlNode *rsc_ops = NULL;
     xmlNode *template_ops = NULL;
+    GHashTable *rsc_ops_hash = NULL;
     const char *template_ref = NULL;
     const char *id = NULL;
+    int rc = pcmk_rc_ok;
 
     if (xml_obj == NULL) {
         pcmk__config_err("No resource object for template unpacking");
-        return pcmk_rc_unpack_error;
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     template_ref = pcmk__xe_get(xml_obj, PCMK_XA_TEMPLATE);
     if (template_ref == NULL) {
-        return pcmk_rc_ok;
+        goto done;
     }
 
     id = pcmk__xe_id(xml_obj);
     if (id == NULL) {
         pcmk__config_err("'%s' object must have a id", xml_obj->name);
-        return pcmk_rc_unpack_error;
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     if (pcmk__str_eq(template_ref, id, pcmk__str_none)) {
         pcmk__config_err("The resource object '%s' should not reference itself",
                          id);
-        return pcmk_rc_unpack_error;
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     cib_resources = pcmk__xpath_find_one(scheduler->input->doc,
                                          "//" PCMK_XE_RESOURCES, LOG_TRACE);
     if (cib_resources == NULL) {
         pcmk__config_err("No resources configured");
-        return pcmk_rc_unpack_error;
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     template = pcmk__xe_first_child(cib_resources, PCMK_XE_TEMPLATE,
                                     PCMK_XA_ID, template_ref);
     if (template == NULL) {
         pcmk__config_err("No template named '%s'", template_ref);
-        return pcmk_rc_unpack_error;
+        rc = pcmk_rc_unpack_error;
+        goto done;
     }
 
     new_xml = pcmk__xml_copy(NULL, template);
@@ -331,39 +338,41 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
         }
     }
 
-    if (template_ops && rsc_ops) {
-        xmlNode *op = NULL;
-        GHashTable *rsc_ops_hash = pcmk__strkey_table(free, NULL);
+    if ((template_ops == NULL) || (rsc_ops == NULL)) {
+        goto done;
+    }
 
-        for (op = pcmk__xe_first_child(rsc_ops, NULL, NULL, NULL); op != NULL;
-             op = pcmk__xe_next(op, NULL)) {
+    // Operations configured in the resource override those in the template
+    rsc_ops_hash = pcmk__strkey_table(free, NULL);
 
-            char *key = template_op_key(op);
+    for (const xmlNode *op = pcmk__xe_first_child(rsc_ops, NULL, NULL, NULL);
+         op != NULL; op = pcmk__xe_next(op, NULL)) {
 
-            g_hash_table_insert(rsc_ops_hash, key, op);
+        g_hash_table_insert(rsc_ops_hash, template_op_key(op), (void *) op);
+    }
+
+    for (xmlNode *op = pcmk__xe_first_child(template_ops, NULL, NULL, NULL);
+         op != NULL; op = pcmk__xe_next(op, NULL)) {
+
+        char *key = template_op_key(op);
+
+        if (g_hash_table_lookup(rsc_ops_hash, key) == NULL) {
+            pcmk__xml_copy(rsc_ops, op);
         }
 
-        for (op = pcmk__xe_first_child(template_ops, NULL, NULL, NULL);
-             op != NULL; op = pcmk__xe_next(op, NULL)) {
+        free(key);
+    }
 
-            char *key = template_op_key(op);
+    // template_ops has been replaced by rsc_ops
+    pcmk__xml_free(template_ops);
 
-            if (g_hash_table_lookup(rsc_ops_hash, key) == NULL) {
-                pcmk__xml_copy(rsc_ops, op);
-            }
-
-            free(key);
-        }
-
-        if (rsc_ops_hash) {
-            g_hash_table_destroy(rsc_ops_hash);
-        }
-
-        pcmk__xml_free(template_ops);
+done:
+    if (rsc_ops_hash != NULL) {
+        g_hash_table_destroy(rsc_ops_hash);
     }
 
     *expanded_xml = new_xml;
-    return pcmk_rc_ok;
+    return rc;
 }
 
 static bool

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -317,7 +317,11 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
 
         xmlNode *new_child = pcmk__xml_copy(new_xml, child_xml);
 
-        if (pcmk__xe_is(new_child, PCMK_XE_OPERATIONS)) {
+        if ((rsc_ops == NULL) && pcmk__xe_is(new_child, PCMK_XE_OPERATIONS)) {
+            /* Multiple PCMK_XE_OPERATIONS children are not possible with schema
+             * validation enabled. However, in pe__unpack_resource(), we use
+             * only the first in case of multiple. Do the same here.
+             */
             rsc_ops = new_child;
         }
     }

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -362,17 +362,7 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
         pcmk__xml_free(template_ops);
     }
 
-    /*pcmk__xml_free(*expanded_xml); */
     *expanded_xml = new_xml;
-
-#if 0 /* Disable multi-level templates for now */
-    if (!unpack_template(new_xml, expanded_xml, scheduler)) {
-       pcmk__xml_free(*expanded_xml);
-       *expanded_xml = NULL;
-       return FALSE;
-    }
-#endif
-
     return TRUE;
 }
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -376,8 +376,8 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     return TRUE;
 }
 
-static gboolean
-add_template_rsc(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
+static bool
+add_template_rsc(const xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
 {
     const char *template_ref = NULL;
     const char *id = NULL;
@@ -385,28 +385,28 @@ add_template_rsc(xmlNode *xml_obj, pcmk_scheduler_t *scheduler)
     if (xml_obj == NULL) {
         pcmk__config_err("No resource object for processing resource list "
                          "of template");
-        return FALSE;
+        return false;
     }
 
     template_ref = pcmk__xe_get(xml_obj, PCMK_XA_TEMPLATE);
     if (template_ref == NULL) {
-        return TRUE;
+        return true;
     }
 
     id = pcmk__xe_id(xml_obj);
     if (id == NULL) {
         pcmk__config_err("'%s' object must have a id", xml_obj->name);
-        return FALSE;
+        return false;
     }
 
     if (pcmk__str_eq(template_ref, id, pcmk__str_none)) {
         pcmk__config_err("The resource object '%s' should not reference itself",
                          id);
-        return FALSE;
+        return false;
     }
 
     pcmk__add_idref(scheduler->priv->templates, template_ref, id);
-    return TRUE;
+    return true;
 }
 
 /*!

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -723,23 +723,10 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
         goto done;
     }
 
-    *rsc = calloc(1, sizeof(pcmk_resource_t));
-    if (*rsc == NULL) {
-        pcmk__sched_err(scheduler,
-                        "Unable to allocate memory for resource '%s'", id);
-        rc = ENOMEM;
-        goto done;
-    }
+    *rsc = pcmk__assert_alloc(1, sizeof(pcmk_resource_t));
+    (*rsc)->priv = pcmk__assert_alloc(1, sizeof(pcmk__resource_private_t));
 
-    (*rsc)->priv = calloc(1, sizeof(pcmk__resource_private_t));
-    if ((*rsc)->priv == NULL) {
-        pcmk__sched_err(scheduler,
-                        "Unable to allocate memory for resource '%s'", id);
-        rc = ENOMEM;
-        goto done;
-    }
     rsc_private = (*rsc)->priv;
-
     rsc_private->scheduler = scheduler;
 
     if (expanded_xml) {

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -985,8 +985,7 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
 
 done:
     if (rc != pcmk_rc_ok) {
-        pcmk__free_resource(*rsc);
-        *rsc = NULL;
+        g_clear_pointer(rsc, pcmk__free_resource);
     }
     return rc;
 }

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -976,7 +976,10 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
                                &rule_input, rsc_private->utilization, NULL,
                                scheduler);
 
-    if ((expanded_xml != NULL) && !add_template_rsc(xml_obj, scheduler)) {
+    // ((rsc_private->orig_xml != NULL) means rsc was expanded from a template
+    if ((rsc_private->orig_xml != NULL)
+        && !add_template_rsc(rsc_private->orig_xml, scheduler)) {
+
         rc = pcmk_rc_unpack_error;
     }
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -274,12 +274,6 @@ unpack_template(xmlNode *xml_obj, xmlNode **expanded_xml,
     const char *id = NULL;
     int rc = pcmk_rc_ok;
 
-    if (xml_obj == NULL) {
-        pcmk__config_err("No resource object for template unpacking");
-        rc = pcmk_rc_unpack_error;
-        goto done;
-    }
-
     template_ref = pcmk__xe_get(xml_obj, PCMK_XA_TEMPLATE);
     if (template_ref == NULL) {
         goto done;
@@ -687,10 +681,7 @@ pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,
         .now = NULL,
     };
 
-    CRM_CHECK(rsc != NULL, return EINVAL);
-    CRM_CHECK((xml_obj != NULL) && (scheduler != NULL),
-              rc = EINVAL;
-              goto done);
+    pcmk__assert((xml_obj != NULL) && (rsc != NULL) && (scheduler != NULL));
 
     rule_input.now = scheduler->priv->now;
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -432,12 +432,6 @@ detect_unique(const pcmk_resource_t *rsc)
     return pcmk__is_true(value);
 }
 
-static void
-free_params_table(gpointer data)
-{
-    g_clear_pointer(&data, g_hash_table_destroy);
-}
-
 /*!
  * \brief Get a table of resource parameters
  *
@@ -472,8 +466,9 @@ pe_rsc_params(pcmk_resource_t *rsc, const pcmk_node_t *node,
 
     // Find the parameter table for given node
     if (rsc->priv->parameter_cache == NULL) {
-        rsc->priv->parameter_cache = pcmk__strikey_table(free,
-                                                         free_params_table);
+        rsc->priv->parameter_cache =
+            pcmk__strikey_table(free, (GDestroyNotify) g_hash_table_destroy);
+
     } else {
         params_on_node = g_hash_table_lookup(rsc->priv->parameter_cache,
                                              node_name);

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -220,8 +220,7 @@ group_unpack(pcmk_resource_t *rsc)
 
     if (rsc->priv->children == NULL) {
         // Not possible with schema validation enabled
-        free(group_data);
-        rsc->priv->variant_opaque = NULL;
+        g_clear_pointer(&rsc->priv->variant_opaque, free);
         pcmk__config_err("Group %s has no members", rsc->id);
         return FALSE;
     }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1114,9 +1114,7 @@ pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, uint32_t show_opts)
             rc = pcmk_rc_ok;
         }
 
-        if (sorted_nodes) {
-            g_list_free(sorted_nodes);
-        }
+        g_list_free(sorted_nodes);
     }
 
     g_clear_pointer(&rsc_table, g_hash_table_destroy);

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -141,9 +141,8 @@ native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
                     pcmk_node_t *local_node = NULL;
 
                     /* make sure it doesn't come up again */
-                    if (rsc->priv->allowed_nodes != NULL) {
-                        g_hash_table_destroy(rsc->priv->allowed_nodes);
-                    }
+                    g_clear_pointer(&rsc->priv->allowed_nodes,
+                                    g_hash_table_destroy);
                     rsc->priv->allowed_nodes =
                         pe__node_list2table(scheduler->nodes);
                     g_hash_table_iter_init(&gIter, rsc->priv->allowed_nodes);
@@ -1037,11 +1036,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
 static void
 destroy_node_table(gpointer data)
 {
-    GHashTable *node_table = data;
-
-    if (node_table) {
-        g_hash_table_destroy(node_table);
-    }
+    g_clear_pointer(&data, g_hash_table_destroy);
 }
 
 int
@@ -1124,18 +1119,9 @@ pe__rscs_brief_output(pcmk__output_t *out, GList *rsc_list, uint32_t show_opts)
         }
     }
 
-    if (rsc_table) {
-        g_hash_table_destroy(rsc_table);
-        rsc_table = NULL;
-    }
-    if (active_table) {
-        g_hash_table_destroy(active_table);
-        active_table = NULL;
-    }
-    if (sorted_rscs) {
-        g_list_free(sorted_rscs);
-    }
-
+    g_clear_pointer(&rsc_table, g_hash_table_destroy);
+    g_clear_pointer(&active_table, g_hash_table_destroy);
+    g_clear_pointer(&sorted_rscs, g_list_free);
     return rc;
 }
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1110,9 +1110,7 @@ custom_action(pcmk_resource_t *rsc, char *key, const char *task,
 
             GHashTable *attrs = action->node->priv->attrs;
 
-            if (action->extra != NULL) {
-                g_hash_table_destroy(action->extra);
-            }
+            g_clear_pointer(&action->extra, g_hash_table_destroy);
             action->extra = pcmk__unpack_action_rsc_params(action->op_entry,
                                                            attrs, scheduler);
             pcmk__set_action_flags(action, pcmk__action_attrs_evaluated);

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -138,8 +138,8 @@ cluster_status(pcmk_scheduler_t * scheduler)
                                    LOG_TRACE);
     unpack_nodes(section, scheduler);
 
-    section = pcmk__xpath_find_one(scheduler->input->doc,
-                                   "//" PCMK_XE_RESOURCES, LOG_TRACE);
+    section = pcmk_find_cib_element(scheduler->input, PCMK_XE_RESOURCES);
+
     if (!pcmk__is_set(scheduler->flags, pcmk__sched_location_only)) {
         unpack_remote_nodes(section, scheduler);
     }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -3641,9 +3641,7 @@ ban_from_all_nodes(pcmk_resource_t *rsc)
 
     // Ban the resource from all nodes
     pcmk__notice("%s will not be started under current conditions", rsc->id);
-    if (rsc->priv->allowed_nodes != NULL) {
-        g_hash_table_destroy(rsc->priv->allowed_nodes);
-    }
+    g_clear_pointer(&rsc->priv->allowed_nodes, g_hash_table_destroy);
     rsc->priv->allowed_nodes = pe__node_list2table(scheduler->nodes);
     g_hash_table_foreach(rsc->priv->allowed_nodes, set_node_score, &score);
 }

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -1476,8 +1476,8 @@ unpack_status(xmlNode *status, pcmk_scheduler_t *scheduler)
                 stop_action(container, node, FALSE);
             }
         }
-        g_list_free(scheduler->priv->stop_needed);
-        scheduler->priv->stop_needed = NULL;
+
+        g_clear_pointer(&scheduler->priv->stop_needed, g_list_free);
     }
 
     /* Now that we know status of all Pacemaker Remote connections and nodes,

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -870,17 +870,18 @@ unpack_resources(const xmlNode *xml_resources, pcmk_scheduler_t *scheduler)
         }
 
         pcmk__trace("Unpacking <%s " PCMK_XA_ID "='%s'>", xml_obj->name, id);
-        if (pe__unpack_resource(xml_obj, &new_rsc, NULL,
-                                scheduler) == pcmk_rc_ok) {
-            scheduler->priv->resources =
-                g_list_append(scheduler->priv->resources, new_rsc);
-            pcmk__rsc_trace(new_rsc, "Added resource %s", new_rsc->id);
 
-        } else {
-            pcmk__config_err("Ignoring <%s> resource '%s' "
-                             "because configuration is invalid",
-                             xml_obj->name, id);
+        if (pe__unpack_resource(xml_obj, &new_rsc, NULL,
+                                scheduler) != pcmk_rc_ok) {
+
+            pcmk__config_err("Ignoring <%s> resource '%s' because "
+                             "configuration is invalid", xml_obj->name, id);
+            continue;
         }
+
+        scheduler->priv->resources = g_list_append(scheduler->priv->resources,
+                                                   new_rsc);
+        pcmk__rsc_trace(new_rsc, "Added resource %s", new_rsc->id);
     }
 
     for (gIter = scheduler->priv->resources;

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2602,8 +2602,7 @@ process_rsc_state(pcmk_resource_t *rsc, pcmk_node_t *node,
          */
         pcmk__rsc_trace(rsc, "Clearing history ID %s for %s (stopped)",
                         rsc->priv->history_id, rsc->id);
-        free(rsc->priv->history_id);
-        rsc->priv->history_id = NULL;
+        g_clear_pointer(&rsc->priv->history_id, free);
 
     } else {
         GList *possible_matches = pe__resource_actions(rsc, node,

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -425,8 +425,7 @@ resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
         // @TODO Should this be more like pcmk__unassign_resource()?
         pcmk__info("Unassigning %s from %s", rsc->id,
                    pcmk__node_name(rsc->priv->assigned_node));
-        pcmk__free_node_copy(rsc->priv->assigned_node);
-        rsc->priv->assigned_node = NULL;
+        g_clear_pointer(&rsc->priv->assigned_node, pcmk__free_node_copy);
     }
 }
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -531,9 +531,7 @@ destroy_ticket(gpointer data)
 {
     pcmk__ticket_t *ticket = data;
 
-    if (ticket->state) {
-        g_hash_table_destroy(ticket->state);
-    }
+    g_clear_pointer(&ticket->state, g_hash_table_destroy);
     free(ticket->id);
     free(ticket);
 }

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the Pacemaker project contributors
+ * Copyright 2014-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -66,8 +66,8 @@ dispatch_messages(void)
             dbus_connection_dispatch(connection);
         }
     }
-    g_list_free(conn_dispatches);
-    conn_dispatches = NULL;
+
+    g_clear_pointer(&conn_dispatches, g_list_free);
 }
 
 

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -764,8 +764,7 @@ pcmk_dbus_get_property(DBusConnection *connection, const char *target,
                                        query_data, timeout);
         if (local_pending == NULL) {
             // async_query_result_cb() was not called in this case
-            free_property_query(query_data);
-            query_data = NULL;
+            g_clear_pointer(&query_data, free_property_query);
         }
 
         if (pending) {

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 the Pacemaker project contributors
+ * Copyright 2010-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -267,9 +267,7 @@ services__create_resource_action(const char *name, const char *standard,
     op = new_action();
     if (op == NULL) {
         pcmk__crit("Cannot prepare action: %s", strerror(ENOMEM));
-        if (params != NULL) {
-            g_hash_table_destroy(params);
-        }
+        g_clear_pointer(&params, g_hash_table_destroy);
         return NULL;
     }
 
@@ -281,9 +279,9 @@ services__create_resource_action(const char *name, const char *standard,
     // Take ownership of params
     if (pcmk__is_set(ra_caps, pcmk_ra_cap_params)) {
         op->params = params;
-    } else if (params != NULL) {
-        g_hash_table_destroy(params);
-        params = NULL;
+
+    } else {
+        g_clear_pointer(&params, g_hash_table_destroy);
     }
 
     if (required_argument_missing(ra_caps, name, standard, provider, agent,
@@ -622,11 +620,7 @@ services_action_free(svc_action_t * op)
     free(op->stdout_data);
     free(op->stderr_data);
 
-    if (op->params) {
-        g_hash_table_destroy(op->params);
-        op->params = NULL;
-    }
-
+    g_clear_pointer(&op->params, g_hash_table_destroy);
     free(op);
 }
 

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -1294,11 +1294,12 @@ services__format_result(svc_action_t *action, int agent_status,
 void
 services__set_cancelled(svc_action_t *action)
 {
-    if (action != NULL) {
-        action->status = PCMK_EXEC_CANCELLED;
-        free(action->opaque->exit_reason);
-        action->opaque->exit_reason = NULL;
+    if (action == NULL) {
+        return;
     }
+
+    action->status = PCMK_EXEC_CANCELLED;
+    g_clear_pointer(&action->opaque->exit_reason, free);
 }
 
 /*!

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -555,10 +555,8 @@ recurring_action_timer(gpointer data)
     pcmk__debug("Scheduling another invocation of %s", op->id);
 
     /* Clean out the old result */
-    free(op->stdout_data);
-    op->stdout_data = NULL;
-    free(op->stderr_data);
-    op->stderr_data = NULL;
+    g_clear_pointer(&op->stdout_data, free);
+    g_clear_pointer(&op->stderr_data, free);
     op->opaque->repeat_timer = 0;
 
     services_action_async(op, NULL);

--- a/tools/cibsecret.c
+++ b/tools/cibsecret.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the Pacemaker project contributors
+ * Copyright 2025-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -406,10 +406,7 @@ done:
 
     free(nd.local_node);
     free(xml_node);
-
-    if (nd.all_nodes != NULL) {
-        g_list_free_full(nd.all_nodes, g_free);
-    }
+    g_list_free_full(nd.all_nodes, g_free);
 
     return reachable;
 }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -886,8 +886,7 @@ setup_fencer_connection(void)
                                             crm_mon_fencer_display_cb);
         }
     } else {
-        stonith__api_free(st);
-        st = NULL;
+        g_clear_pointer(&st, stonith__api_free);
     }
 
     return rc;
@@ -937,8 +936,7 @@ setup_cib_connection(void)
 
             out->err(out, "Cannot monitor CIB changes; exiting");
             cib__clean_up_connection(&cib);
-            stonith__api_free(st);
-            st = NULL;
+            g_clear_pointer(&st, stonith__api_free);
         }
     }
     return rc;

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -1951,7 +1951,7 @@ crm_diff_update(const char *event, xmlNode * msg)
             case -pcmk_err_diff_failed:
                 pcmk__notice("[%s] Patch aborted: %s (%d)", event,
                              pcmk_strerror(rc), rc);
-                pcmk__xml_free(current_cib); current_cib = NULL;
+                g_clear_pointer(&current_cib, pcmk__xml_free);
                 break;
             case pcmk_ok:
                 cib_updated = TRUE;
@@ -1959,7 +1959,7 @@ crm_diff_update(const char *event, xmlNode * msg)
             default:
                 pcmk__notice("[%s] ABORTED: %s (%d)", event, pcmk_strerror(rc),
                              rc);
-                pcmk__xml_free(current_cib); current_cib = NULL;
+                g_clear_pointer(&current_cib, pcmk__xml_free);
                 break;
         }
     }

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -343,10 +343,7 @@ apply_include(const gchar *includes, GError **error) {
             show = all_includes(output_format);
         } else if (g_str_has_prefix(*s, "bans")) {
             show |= pcmk_section_bans;
-            if (options.neg_location_prefix != NULL) {
-                free(options.neg_location_prefix);
-                options.neg_location_prefix = NULL;
-            }
+            g_clear_pointer(&options.neg_location_prefix, free);
 
             if (strlen(*s) > 4 && (*s)[4] == ':') {
                 options.neg_location_prefix = strdup(*s+5);

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -56,8 +56,7 @@ curses_free_priv(pcmk__output_t *out) {
     priv = out->priv;
 
     g_queue_free_full(priv->parent_q, free_list_data);
-    free(priv);
-    out->priv = NULL;
+    g_clear_pointer(&out->priv, free);
 }
 
 static bool
@@ -328,8 +327,7 @@ curses_prompt(const char *prompt, bool do_echo, char **dest)
     }
 
     if (rc < 1) {
-        free(*dest);
-        *dest = NULL;
+        g_clear_pointer(dest, free);
     }
 
     if (do_echo) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -2375,9 +2375,7 @@ done:
     g_free(options.agent);
     g_free(options.class);
     g_free(options.provider);
-    if (options.override_params != NULL) {
-        g_hash_table_destroy(options.override_params);
-    }
+    g_clear_pointer(&options.override_params, g_hash_table_destroy);
     g_strfreev(options.remainder);
 
     // Don't destroy options.cmdline_params here. See comment in option_cb().

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1244,7 +1244,6 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
     GList *after = NULL;
     GList *remaining = NULL;
     int rc = pcmk_rc_ok;
-    xmlNode *cib_xml = NULL;
 
     if (!out->is_quiet(out)) {
         before = build_constraint_list(scheduler->input);
@@ -1268,19 +1267,18 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
         return pcmk_rc2exitc(rc);
     }
 
-    rc = cib_conn->cmds->query(cib_conn, NULL, &cib_xml, cib_sync_call);
-    rc = pcmk_legacy2rc(rc);
+    pcmk_reset_scheduler(scheduler);
 
+    rc = cib_conn->cmds->query(cib_conn, NULL, &scheduler->input,
+                               cib_sync_call);
+    rc = pcmk_legacy2rc(rc);
     if (rc != pcmk_rc_ok) {
         g_set_error(&error, PCMK__RC_ERROR, rc,
                     _("Could not get modified CIB: %s"), pcmk_rc_str(rc));
         g_list_free_full(before, free);
-        pcmk__xml_free(cib_xml);
         return pcmk_rc2exitc(rc);
     }
 
-    pcmk_reset_scheduler(scheduler);
-    scheduler->input = cib_xml;
     cluster_status(scheduler);
 
     after = build_constraint_list(scheduler->input);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -298,7 +298,9 @@ build_constraint_list(xmlNode *root)
         xmlNode *match = pcmk__xpath_result(xpathObj, ndx);
 
         if (match != NULL) {
-            retval = g_list_insert_sorted(retval, (gpointer) pcmk__xe_id(match),
+            // Insert a copy in case root is freed
+            retval = g_list_insert_sorted(retval,
+                                          pcmk__str_copy(pcmk__xe_id(match)),
                                           (GCompareFunc) g_strcmp0);
         }
     }
@@ -1270,11 +1272,12 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
         if (rc != pcmk_rc_ok) {
             g_set_error(&error, PCMK__RC_ERROR, rc,
                         _("Could not get modified CIB: %s"), pcmk_rc_str(rc));
-            g_list_free(before);
+            g_list_free_full(before, free);
             pcmk__xml_free(cib_xml);
             return pcmk_rc2exitc(rc);
         }
 
+        pcmk_reset_scheduler(scheduler);
         scheduler->input = cib_xml;
         cluster_status(scheduler);
 
@@ -1287,8 +1290,8 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
             out->info(out, "Removing constraint: %s", constraint);
         }
 
-        g_list_free(before);
-        g_list_free(after);
+        g_list_free_full(before, free);
+        g_list_free_full(after, free);
         g_list_free(remaining);
     }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1264,7 +1264,7 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
     }
 
     if (out->is_quiet(out)) {
-        return pcmk_rc2exitc(rc);
+        goto done;
     }
 
     pcmk_reset_scheduler(scheduler);
@@ -1275,8 +1275,7 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
     if (rc != pcmk_rc_ok) {
         g_set_error(&error, PCMK__RC_ERROR, rc,
                     _("Could not get modified CIB: %s"), pcmk_rc_str(rc));
-        g_list_free_full(before, free);
-        return pcmk_rc2exitc(rc);
+        goto done;
     }
 
     cluster_status(scheduler);
@@ -1290,6 +1289,7 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
         out->info(out, "Removing constraint: %s", constraint);
     }
 
+done:
     g_list_free_full(before, free);
     g_list_free_full(after, free);
     g_list_free(remaining);

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -1244,6 +1244,7 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
     GList *after = NULL;
     GList *remaining = NULL;
     int rc = pcmk_rc_ok;
+    xmlNode *cib_xml = NULL;
 
     if (!out->is_quiet(out)) {
         before = build_constraint_list(scheduler->input);
@@ -1263,37 +1264,37 @@ handle_clear(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
                                 cib_conn, true, options.force);
     }
 
-    if (!out->is_quiet(out)) {
-        xmlNode *cib_xml = NULL;
-
-        rc = cib_conn->cmds->query(cib_conn, NULL, &cib_xml, cib_sync_call);
-        rc = pcmk_legacy2rc(rc);
-
-        if (rc != pcmk_rc_ok) {
-            g_set_error(&error, PCMK__RC_ERROR, rc,
-                        _("Could not get modified CIB: %s"), pcmk_rc_str(rc));
-            g_list_free_full(before, free);
-            pcmk__xml_free(cib_xml);
-            return pcmk_rc2exitc(rc);
-        }
-
-        pcmk_reset_scheduler(scheduler);
-        scheduler->input = cib_xml;
-        cluster_status(scheduler);
-
-        after = build_constraint_list(scheduler->input);
-        remaining = pcmk__subtract_lists(before, after, (GCompareFunc) strcmp);
-
-        for (const GList *iter = remaining; iter != NULL; iter = iter->next) {
-            const char *constraint = iter->data;
-
-            out->info(out, "Removing constraint: %s", constraint);
-        }
-
-        g_list_free_full(before, free);
-        g_list_free_full(after, free);
-        g_list_free(remaining);
+    if (out->is_quiet(out)) {
+        return pcmk_rc2exitc(rc);
     }
+
+    rc = cib_conn->cmds->query(cib_conn, NULL, &cib_xml, cib_sync_call);
+    rc = pcmk_legacy2rc(rc);
+
+    if (rc != pcmk_rc_ok) {
+        g_set_error(&error, PCMK__RC_ERROR, rc,
+                    _("Could not get modified CIB: %s"), pcmk_rc_str(rc));
+        g_list_free_full(before, free);
+        pcmk__xml_free(cib_xml);
+        return pcmk_rc2exitc(rc);
+    }
+
+    pcmk_reset_scheduler(scheduler);
+    scheduler->input = cib_xml;
+    cluster_status(scheduler);
+
+    after = build_constraint_list(scheduler->input);
+    remaining = pcmk__subtract_lists(before, after, (GCompareFunc) strcmp);
+
+    for (const GList *iter = remaining; iter != NULL; iter = iter->next) {
+        const char *constraint = iter->data;
+
+        out->info(out, "Removing constraint: %s", constraint);
+    }
+
+    g_list_free_full(before, free);
+    g_list_free_full(after, free);
+    g_list_free(remaining);
 
     return pcmk_rc2exitc(rc);
 }

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -675,8 +675,7 @@ resource_reasons_list_default(pcmk__output_t *out, va_list args)
             }
 
             cli_resource_check(out, rsc, NULL);
-            g_list_free(hosts);
-            hosts = NULL;
+            g_clear_pointer(&hosts, g_list_free);
         }
 
     } else if ((rsc != NULL) && (host_uname != NULL)) {
@@ -763,8 +762,7 @@ resource_reasons_list_xml(pcmk__output_t *out, va_list args)
 
             cli_resource_check(out, rsc, NULL);
             pcmk__output_xml_pop_parent(out);
-            g_list_free(hosts);
-            hosts = NULL;
+            g_clear_pointer(&hosts, g_list_free);
         }
 
         pcmk__output_xml_pop_parent(out);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1932,8 +1932,8 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                                            PCMK_META_TARGET_ROLE,
                                            orig_target_role, false, cib,
                                            cib_xml_orig, force);
-        free(orig_target_role);
-        orig_target_role = NULL;
+        g_clear_pointer(&orig_target_role, free);
+
     } else {
         rc = cli_resource_delete_attribute(rsc, rsc_id, NULL,
                                            PCMK_XE_META_ATTRIBUTES, NULL,
@@ -1948,9 +1948,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
         goto done;
     }
 
-    if (target_active != NULL) {
-        g_list_free_full(target_active, free);
-    }
+    g_list_free_full(target_active, free);
     target_active = restart_target_active;
 
     list_delta = pcmk__subtract_lists(target_active, current_active, (GCompareFunc) strcmp);

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -1851,14 +1851,12 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
     if(rc != pcmk_rc_ok) {
         out->err(out, "Could not set " PCMK_META_TARGET_ROLE " for %s: %s (%d)",
                  rsc_id, pcmk_rc_str(rc), rc);
-        if (current_active != NULL) {
-            g_list_free_full(current_active, free);
-            current_active = NULL;
-        }
-        if (restart_target_active != NULL) {
-            g_list_free_full(restart_target_active, free);
-            restart_target_active = NULL;
-        }
+
+        g_list_free_full(current_active, free);
+        current_active = NULL;
+
+        g_list_free_full(restart_target_active, free);
+        restart_target_active = NULL;
         goto done;
     }
 
@@ -1897,9 +1895,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                 goto failure;
             }
 
-            if (current_active != NULL) {
-                g_list_free_full(current_active, free);
-            }
+            g_list_free_full(current_active, free);
             current_active = get_active_resources(host,
                                                   scheduler->priv->resources);
 
@@ -1984,9 +1980,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
             /* It's OK if dependent resources moved to a different node,
              * so we check active resources on all nodes.
              */
-            if (current_active != NULL) {
-                g_list_free_full(current_active, free);
-            }
+            g_list_free_full(current_active, free);
             current_active = get_active_resources(NULL,
                                                   scheduler->priv->resources);
 
@@ -2026,18 +2020,15 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
     }
 
 done:
-    if (list_delta != NULL) {
-        g_list_free(list_delta);
-    }
-    if (current_active != NULL) {
-        g_list_free_full(current_active, free);
-    }
+    g_list_free(list_delta);
+    g_list_free_full(current_active, free);
+
     if (target_active != NULL && (target_active != restart_target_active)) {
         g_list_free_full(target_active, free);
     }
-    if (restart_target_active != NULL) {
-        g_list_free_full(restart_target_active, free);
-    }
+
+    g_list_free_full(restart_target_active, free);
+
     free(rsc_id);
     free(lookup_id);
     pcmk_free_scheduler(scheduler);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -621,9 +621,7 @@ main(int argc, char **argv)
  done:
     g_clear_pointer(&attr_set, g_hash_table_destroy);
 
-    if (attr_delete) {
-        g_list_free_full(attr_delete, free);
-    }
+    g_list_free_full(attr_delete, free);
     attr_delete = NULL;
 
     g_clear_pointer(&scheduler, pcmk_free_scheduler);

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -619,10 +619,7 @@ main(int argc, char **argv)
     }
 
  done:
-    if (attr_set) {
-        g_hash_table_destroy(attr_set);
-    }
-    attr_set = NULL;
+    g_clear_pointer(&attr_set, g_hash_table_destroy);
 
     if (attr_delete) {
         g_list_free_full(attr_delete, free);

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -374,8 +374,7 @@ request_fencing(stonith_t *st, const char *target, const char *command,
 
         // If reason is identical to return code string, don't display it twice
         if (pcmk__str_eq(rc_str, reason, pcmk__str_none)) {
-            free(reason);
-            reason = NULL;
+            g_clear_pointer(&reason, free);
         }
 
         g_set_error(error, PCMK__RC_ERROR, rc,

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -716,9 +716,7 @@ main(int argc, char **argv)
     free(name);
     g_list_free_full(options.devices, free);
 
-    if (options.params != NULL) {
-        g_hash_table_destroy(options.params);
-    }
+    g_clear_pointer(&options.params, g_hash_table_destroy);
 
     if (st != NULL) {
         st->cmds->disconnect(st);


### PR DESCRIPTION
This is #4083, minus the "Avoid leaking a pcmk_resource_t's xml/orig_xml" commit. That leaves one known leak to fix. To reproduce that, run `sudo /usr/share/pacemaker/tests/cts-cli -v -r crm_verify` from outside the source tree.