### PR TITLE
Replace some GLib type aliases with native C types

### DIFF
--- a/daemons/attrd/attrd_alerts.c
+++ b/daemons/attrd/attrd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the Pacemaker project contributors
+ * Copyright 2015-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -103,7 +103,7 @@ config_query_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void
 }
 
 gboolean
-attrd_read_options(gpointer user_data)
+attrd_read_options(void *user_data)
 {
     int call_id;
 

--- a/daemons/attrd/attrd_attributes.c
+++ b/daemons/attrd/attrd_attributes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the Pacemaker project contributors
+ * Copyright 2013-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -172,9 +172,9 @@ attrd_clear_value_seen(void)
     attribute_value_t *v = NULL;
 
     g_hash_table_iter_init(&aIter, attributes);
-    while (g_hash_table_iter_next(&aIter, NULL, (gpointer *) & a)) {
+    while (g_hash_table_iter_next(&aIter, NULL, (void **) &a)) {
         g_hash_table_iter_init(&vIter, a->values);
-        while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & v)) {
+        while (g_hash_table_iter_next(&vIter, NULL, (void **) &v)) {
             attrd_clear_value_flags(v, attrd_value_from_peer);
         }
     }

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -27,7 +27,7 @@ static int last_cib_op_done = 0;
 static void write_attribute(attribute_t *a, bool ignore_delay);
 
 static void
-attrd_cib_destroy_cb(gpointer user_data)
+attrd_cib_destroy_cb(void *user_data)
 {
     cib_t *cib = user_data;
 
@@ -235,7 +235,7 @@ attrd_cib_init(void)
 }
 
 static gboolean
-attribute_timer_cb(gpointer data)
+attribute_timer_cb(void *data)
 {
     attribute_t *a = data;
     pcmk__trace("Dampen interval expired for %s", a->id);
@@ -287,7 +287,7 @@ attrd_cib_callback(xmlNode *msg, int call_id, int rc, xmlNode *output, void *use
                call_id, a->id, pcmk_strerror(rc), rc);
 
     g_hash_table_iter_init(&iter, a->values);
-    while (g_hash_table_iter_next(&iter, (gpointer *) & peer, (gpointer *) & v)) {
+    while (g_hash_table_iter_next(&iter, (void **) &peer, (void **) &v)) {
         if (rc == pcmk_ok) {
             pcmk__info("* Wrote %s[%s]=%s", a->id, peer,
                        pcmk__s(v->requested, "(unset)"));
@@ -447,7 +447,7 @@ send_alert_attributes_value(attribute_t *a, GHashTable *t)
 
     g_hash_table_iter_init(&vIter, t);
 
-    while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & at)) {
+    while (g_hash_table_iter_next(&vIter, NULL, (void **) &at)) {
         const char *node_xml_id = attrd_get_node_xml_id(at->nodename);
         const char *failed_s = NULL;
 
@@ -572,7 +572,7 @@ write_attribute(attribute_t *a, bool ignore_delay)
 
     /* Iterate over each peer value of this attribute */
     g_hash_table_iter_init(&iter, a->values);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &v)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &v)) {
         const char *node_xml_id = NULL;
         const char *prev_xml_id = NULL;
 
@@ -692,7 +692,7 @@ attrd_write_attributes(uint32_t options)
     pcmk__debug("Writing out %s attributes",
                 pcmk__is_set(options, attrd_write_all)? "all" : "changed");
     g_hash_table_iter_init(&iter, attributes);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & a)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &a)) {
         if (!pcmk__is_set(options, attrd_write_all)
             && pcmk__is_set(a->flags, attrd_attr_node_unknown)) {
             // Try writing this attribute again, in case peer ID was learned

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -527,7 +527,7 @@ attrd_peer_clear_failure(pcmk__request_t *request)
     const char *host = pcmk__xe_get(xml, PCMK__XA_ATTR_HOST);
     const char *op = pcmk__xe_get(xml, PCMK__XA_ATTR_CLEAR_OPERATION);
     const char *interval_spec = pcmk__xe_get(xml, PCMK__XA_ATTR_CLEAR_INTERVAL);
-    guint interval_ms = 0U;
+    unsigned int interval_ms = 0;
     char *attr = NULL;
     GHashTableIter iter;
     regex_t regex;

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -177,7 +177,7 @@ attrd_cpg_dispatch(cpg_handle_t handle, const struct cpg_name *group_name,
  * \param[in] unused Unused
  */
 static void
-attrd_cpg_destroy(gpointer unused)
+attrd_cpg_destroy(void *unused)
 {
     if (attrd_shutting_down()) {
         pcmk__info("Disconnected from Corosync process group");
@@ -433,7 +433,7 @@ attrd_peer_update_one(const pcmk__node_status_t *peer, xmlNode *xml,
         pcmk__xe_remove_attr(xml, PCMK__XA_ATTR_HOST_ID);
         g_hash_table_iter_init(&vIter, a->values);
 
-        while (g_hash_table_iter_next(&vIter, (gpointer *) & host, NULL)) {
+        while (g_hash_table_iter_next(&vIter, (void **) &host, NULL)) {
             update_attr_on_host(a, peer, xml, attr, value, host, filter);
         }
 
@@ -460,10 +460,10 @@ broadcast_unseen_local_values(void)
     xmlNode *sync = NULL;
 
     g_hash_table_iter_init(&aIter, attributes);
-    while (g_hash_table_iter_next(&aIter, NULL, (gpointer *) & a)) {
+    while (g_hash_table_iter_next(&aIter, NULL, (void **) &a)) {
 
         g_hash_table_iter_init(&vIter, a->values);
-        while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & v)) {
+        while (g_hash_table_iter_next(&vIter, NULL, (void **) &v)) {
 
             if (!pcmk__is_set(v->flags, attrd_value_from_peer)
                 && pcmk__str_eq(v->nodename, attrd_cluster->priv->node_name,
@@ -550,7 +550,7 @@ attrd_peer_clear_failure(pcmk__request_t *request)
     pcmk__xe_remove_attr(xml, PCMK__XA_ATTR_VALUE);
 
     g_hash_table_iter_init(&iter, attributes);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &attr, NULL)) {
+    while (g_hash_table_iter_next(&iter, (void **) &attr, NULL)) {
         if (regexec(&regex, attr, 0, NULL, 0) == 0) {
             pcmk__trace("Matched %s when clearing %s", attr,
                         pcmk__s(rsc, "all resources"));
@@ -616,7 +616,7 @@ attrd_erase_removed_peer_attributes(void)
     }
 
     g_hash_table_iter_init(&iter, removed_peers);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &host, NULL)) {
+    while (g_hash_table_iter_next(&iter, (void **) &host, NULL)) {
         attrd_cib_erase_transient_attrs(host);
         g_hash_table_iter_remove(&iter);
     }
@@ -642,7 +642,7 @@ attrd_peer_remove(const char *host, bool uncache, const char *source)
                  host, source, (uncache? "and" : "without"));
 
     g_hash_table_iter_init(&aIter, attributes);
-    while (g_hash_table_iter_next(&aIter, NULL, (gpointer *) & a)) {
+    while (g_hash_table_iter_next(&aIter, NULL, (void **) &a)) {
         if(g_hash_table_remove(a->values, host)) {
             pcmk__debug("Removed %s[%s] for peer %s", a->id, host, source);
         }
@@ -702,9 +702,9 @@ attrd_peer_sync(pcmk__node_status_t *peer)
     pcmk__xe_set(sync, PCMK_XA_TASK, PCMK__ATTRD_CMD_SYNC_RESPONSE);
 
     g_hash_table_iter_init(&aIter, attributes);
-    while (g_hash_table_iter_next(&aIter, NULL, (gpointer *) & a)) {
+    while (g_hash_table_iter_next(&aIter, NULL, (void **) &a)) {
         g_hash_table_iter_init(&vIter, a->values);
-        while (g_hash_table_iter_next(&vIter, NULL, (gpointer *) & v)) {
+        while (g_hash_table_iter_next(&vIter, NULL, (void **) &v)) {
             pcmk__debug("Syncing %s[%s]='%s' to %s", a->id, v->nodename,
                         readable_value(v), readable_peer(peer));
             attrd_add_value_xml(sync, a, v, false);

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -114,7 +114,7 @@ attrd_client_clear_failure(pcmk__request_t *request)
             pattern = pcmk__assert_asprintf(ATTRD_RE_CLEAR_ONE, rsc);
 
         } else {
-            guint interval_ms = 0U;
+            unsigned int interval_ms = 0;
 
             pcmk_parse_interval_spec(interval_spec, &interval_ms);
             pattern = pcmk__assert_asprintf(ATTRD_RE_CLEAR_OP, rsc, op,

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -73,7 +73,7 @@ static xmlNode *build_query_reply(const char *attr, const char *host)
             GHashTableIter iter;
 
             g_hash_table_iter_init(&iter, a->values);
-            while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &v)) {
+            while (g_hash_table_iter_next(&iter, NULL, (void **) &v)) {
                 host_value = pcmk__xe_create(reply, PCMK_XE_NODE);
                 pcmk__xe_set(host_value, PCMK__XA_ATTR_HOST, v->nodename);
                 pcmk__xe_set(host_value, PCMK__XA_ATTR_VALUE, v->current);
@@ -257,7 +257,7 @@ expand_regexes(xmlNode *xml, const char *attr, const char *value, const char *re
         }
 
         g_hash_table_iter_init(&aIter, attributes);
-        while (g_hash_table_iter_next(&aIter, (gpointer *) & attr, NULL)) {
+        while (g_hash_table_iter_next(&aIter, (void **) &attr, NULL)) {
             int status = regexec(&r_patt, attr, 0, NULL, 0);
 
             if (status == 0) {

--- a/daemons/attrd/attrd_sync.c
+++ b/daemons/attrd/attrd_sync.c
@@ -98,7 +98,7 @@ next_key(void)
 }
 
 static void
-free_waitlist_node(gpointer data)
+free_waitlist_node(void *data)
 {
     struct waitlist_node *wl = (struct waitlist_node *) data;
 
@@ -196,7 +196,7 @@ void
 attrd_remove_client_from_waitlist(pcmk__client_t *client)
 {
     GHashTableIter iter;
-    gpointer value;
+    void *value = NULL;
 
     if (waitlist == NULL) {
         return;
@@ -231,7 +231,7 @@ void
 attrd_ack_waitlist_clients(enum attrd_sync_point sync_point, const xmlNode *xml)
 {
     int callid;
-    gpointer value;
+    void *value = NULL;
 
     if (waitlist == NULL) {
         return;
@@ -337,7 +337,7 @@ attrd_request_has_sync_point(xmlNode *xml)
 }
 
 static void
-free_action(gpointer data)
+free_action(void *data)
 {
     struct confirmation_action *action = (struct confirmation_action *) data;
     g_list_free_full(action->respondents, free);
@@ -353,12 +353,12 @@ free_action(gpointer data)
  * cleared of things that didn't complete.
  */
 static gboolean
-confirmation_timeout_cb(gpointer data)
+confirmation_timeout_cb(void *data)
 {
     struct confirmation_action *action = (struct confirmation_action *) data;
 
     GHashTableIter iter;
-    gpointer value;
+    void *value = NULL;
 
     if (expected_confirmations == NULL) {
         return G_SOURCE_REMOVE;
@@ -431,7 +431,7 @@ void
 attrd_do_not_wait_for_client(pcmk__client_t *client)
 {
     GHashTableIter iter;
-    gpointer value;
+    void *value = NULL;
 
     if (expected_confirmations == NULL) {
         return;
@@ -476,7 +476,8 @@ attrd_expect_confirmations(pcmk__request_t *request, attrd_confirmation_action_f
 {
     struct confirmation_action *action = NULL;
     GHashTableIter iter;
-    gpointer host, ver;
+    void *host = NULL;
+    void *ver = NULL;
     GList *respondents = NULL;
     int callid;
 

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -168,7 +168,7 @@ attrd_expand_value(const char *value, const char *old_value)
  */
 int
 attrd_failure_regex(regex_t *regex, const char *rsc, const char *op,
-                    guint interval_ms)
+                    unsigned int interval_ms)
 {
     char *pattern = NULL;
     int rc;

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -193,7 +193,7 @@ attrd_failure_regex(regex_t *regex, const char *rsc, const char *op,
 }
 
 void
-attrd_free_attribute_value(gpointer data)
+attrd_free_attribute_value(void *data)
 {
     attribute_value_t *v = data;
 
@@ -204,7 +204,7 @@ attrd_free_attribute_value(gpointer data)
 }
 
 void
-attrd_free_attribute(gpointer data)
+attrd_free_attribute(void *data)
 {
     attribute_t *a = data;
     if(a) {

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -89,7 +89,7 @@ int attrd_expand_value(const char *value, const char *old_value);
 #define ATTRD_RE_CLEAR_OP ATTRD_RE_CLEAR_ALL "%s#%s_%u$"
 
 int attrd_failure_regex(regex_t *regex, const char *rsc, const char *op,
-                        guint interval_ms);
+                        unsigned int interval_ms);
 
 extern cib_t *the_cib;
 extern crm_exit_t attrd_exit_status;

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -100,7 +100,7 @@ extern lrmd_t *the_lrmd;
 extern crm_trigger_t *attrd_config_read;
 
 void attrd_lrmd_disconnect(void);
-gboolean attrd_read_options(gpointer user_data);
+gboolean attrd_read_options(void *user_data);
 int attrd_send_attribute_alert(const char *node, const char *node_xml_id,
                                const char *attr, const char *value);
 
@@ -216,8 +216,8 @@ gboolean attrd_send_message(const pcmk__node_status_t *node, xmlNode *data,
 xmlNode *attrd_add_value_xml(xmlNode *parent, const attribute_t *a,
                              const attribute_value_t *v, bool force_write);
 void attrd_clear_value_seen(void);
-void attrd_free_attribute(gpointer data);
-void attrd_free_attribute_value(gpointer data);
+void attrd_free_attribute(void *data);
+void attrd_free_attribute_value(void *data);
 attribute_t *attrd_populate_attribute(xmlNode *xml, const char *attr);
 char *attrd_set_id(const attribute_t *attr, const char *node_state_id);
 char *attrd_nvpair_id(const attribute_t *attr, const char *node_state_id);

--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -18,7 +18,7 @@
 #include <time.h>                   // time_t
 #include <unistd.h>                 // close
 
-#include <glib.h>                   // gboolean, gpointer, g_*, etc.
+#include <glib.h>                   // gboolean, g_*, etc.
 #include <libxml/tree.h>            // xmlNode
 #include <qb/qbipcs.h>              // qb_ipcs_connection_t
 #include <qb/qblog.h>               // LOG_TRACE
@@ -178,7 +178,7 @@ do_local_notify(const xmlNode *xml, const char *client_id, bool sync_reply,
  *       is received.
  */
 static gboolean
-digest_timer_cb(gpointer data)
+digest_timer_cb(void *data)
 {
     xmlNode *ping = NULL;
 
@@ -892,7 +892,7 @@ based_peer_callback(xmlNode *msg, void *private_data)
 }
 
 static gboolean
-cib_force_exit(gpointer data)
+cib_force_exit(void *data)
 {
     pcmk__notice("Exiting immediately after %s without shutdown acknowledgment",
                  pcmk__readable_interval(EXIT_ESCALATION_MS));

--- a/daemons/based/based_io.c
+++ b/daemons/based/based_io.c
@@ -87,7 +87,7 @@ write_cib_cb(mainloop_child_t *child, int core, int signo, int exit_code)
  * \param[in] user_data  Ignored
  */
 static int
-write_cib_async(gpointer user_data)
+write_cib_async(void *user_data)
 {
     int rc = pcmk_rc_ok;
     pid_t pid = 0;

--- a/daemons/based/based_notify.c
+++ b/daemons/based/based_notify.c
@@ -16,7 +16,7 @@
 #include <stdint.h>                 // int32_t, uint16_t, UINT64_C
 #include <sys/types.h>              // ssize_t
 
-#include <glib.h>                   // gpointer, g_string_free
+#include <glib.h>                   // g_*, etc.
 #include <libxml/tree.h>            // xmlNode
 #include <qb/qblog.h>               // QB_XS
 
@@ -107,7 +107,7 @@ based_update_notify_flags(const xmlNode *xml, pcmk__client_t *client)
 }
 
 static void
-cib_notify_send_one(gpointer key, gpointer value, gpointer user_data)
+cib_notify_send_one(void *key, void *value, void *user_data)
 {
     const char *type = NULL;
     int rc = pcmk_rc_ok;

--- a/daemons/based/based_remote.c
+++ b/daemons/based/based_remote.c
@@ -21,7 +21,7 @@
 #include <sys/socket.h>             // sockaddr{,_storage}, AF_INET, etc.
 #include <unistd.h>                 // close
 
-#include <glib.h>                   // gboolean, gpointer, g_source_remove, etc.
+#include <glib.h>                   // gboolean, g_source_remove, etc.
 #include <gnutls/gnutls.h>          // gnutls_bye, gnutls_deinit
 #include <libxml/tree.h>            // xmlNode
 #include <qb/qblog.h>               // QB_XS
@@ -70,7 +70,7 @@ int remote_tls_fd = 0;
  * \return \c G_SOURCE_REMOVE (to destroy the timeout)
  */
 static gboolean
-remote_auth_timeout_cb(gpointer data)
+remote_auth_timeout_cb(void *data)
 {
     pcmk__client_t *client = data;
 
@@ -397,7 +397,7 @@ cib_handle_remote_msg(pcmk__client_t *client, xmlNode *command)
 }
 
 static int
-cib_remote_msg(gpointer data)
+cib_remote_msg(void *data)
 {
     xmlNode *command = NULL;
     pcmk__client_t *client = data;
@@ -503,7 +503,7 @@ cib_remote_msg(gpointer data)
 }
 
 static void
-based_remote_client_destroy(gpointer user_data)
+based_remote_client_destroy(void *user_data)
 {
     pcmk__client_t *client = user_data;
     int csock = -1;
@@ -547,7 +547,7 @@ based_remote_client_destroy(gpointer user_data)
 }
 
 static int
-cib_remote_listen(gpointer data)
+cib_remote_listen(void *data)
 {
     int csock = -1;
     unsigned laddr;
@@ -621,7 +621,7 @@ cib_remote_listen(gpointer data)
 }
 
 static void
-based_remote_listener_destroy(gpointer user_data)
+based_remote_listener_destroy(void *user_data)
 {
     pcmk__info("No longer listening for remote connections");
 }
@@ -774,7 +774,7 @@ try_clear_port:
  * \param[in]     user_data  Ignored
  */
 static void
-drop_client_if_remote(gpointer key, gpointer value, gpointer user_data)
+drop_client_if_remote(void *key, void *value, void *user_data)
 {
     pcmk__client_t *client = value;
 

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -121,7 +121,7 @@ based_metadata(pcmk__output_t *out)
 }
 
 static gboolean
-disk_writes_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+disk_writes_cb(const gchar *option_name, const gchar *optarg, void *data,
                GError **error)
 {
     based_enable_writes(0);
@@ -324,7 +324,7 @@ cib_cs_dispatch(cpg_handle_t handle,
 }
 
 static void
-cib_cs_destroy(gpointer user_data)
+cib_cs_destroy(void *user_data)
 {
     if (cib_shutdown_flag) {
         pcmk__info("Corosync disconnection complete");

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -121,7 +121,7 @@ based_metadata(pcmk__output_t *out)
 }
 
 static gboolean
-disk_writes_cb(const gchar *option_name, const gchar *optarg, void *data,
+disk_writes_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     based_enable_writes(0);

--- a/daemons/controld/controld_callbacks.c
+++ b/daemons/controld/controld_callbacks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -380,7 +380,7 @@ peer_update_callback(enum pcmk__node_update type, pcmk__node_status_t *node,
 }
 
 gboolean
-crm_fsa_trigger(gpointer user_data)
+crm_fsa_trigger(void *user_data)
 {
     pcmk__trace("Invoking FSA (queue len: %u)",
                 controld_fsa_message_queue_length());

--- a/daemons/controld/controld_callbacks.h
+++ b/daemons/controld/controld_callbacks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
 
 extern void crmd_ha_msg_filter(xmlNode * msg);
 
-extern gboolean crm_fsa_trigger(gpointer user_data);
+gboolean crm_fsa_trigger(void *user_data);
 
 void peer_update_callback(enum pcmk__node_update type,
                           pcmk__node_status_t *node, const void *data);

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -28,7 +28,7 @@ static int pending_rsc_update = 0;
  * \param[in] user_data  CIB connection that dropped
  */
 static void
-handle_cib_disconnect(gpointer user_data)
+handle_cib_disconnect(void *user_data)
 {
     CRM_LOG_ASSERT(user_data == controld_globals.cib_conn);
 
@@ -126,7 +126,7 @@ do_cib_control(long long action, enum crmd_fsa_cause cause,
 
     cib_t *cib_conn = controld_globals.cib_conn;
 
-    void (*dnotify_fn)(gpointer user_data) = handle_cib_disconnect;
+    void (*dnotify_fn)(void *user_data) = handle_cib_disconnect;
     void (*update_cb)(const char *event, xmlNodePtr msg) = do_cib_updated;
 
     int rc = pcmk_ok;

--- a/daemons/controld/controld_cib.c
+++ b/daemons/controld/controld_cib.c
@@ -974,7 +974,7 @@ controld_delete_action_history(const lrmd_event_data_t *op)
  */
 void
 controld_cib_delete_last_failure(const char *rsc_id, const char *node,
-                                 const char *action, guint interval_ms)
+                                 const char *action, unsigned int interval_ms)
 {
     char *xpath = NULL;
     char *last_failure_key = NULL;

--- a/daemons/controld/controld_cib.h
+++ b/daemons/controld/controld_cib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -86,7 +86,8 @@ void controld_update_resource_history(const char *node_name,
 void controld_delete_action_history(const lrmd_event_data_t *op);
 
 void controld_cib_delete_last_failure(const char *rsc_id, const char *node,
-                                      const char *action, guint interval_ms);
+                                      const char *action,
+                                      unsigned int interval_ms);
 
 void controld_delete_action_history_by_key(const char *rsc_id, const char *node,
                                            const char *key, int call_id);

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -677,7 +677,7 @@ static void
 crm_shutdown(int nsig)
 {
     const char *value = NULL;
-    guint default_period_ms = 0;
+    unsigned int default_period_ms = 0;
 
     if ((controld_globals.mainloop == NULL)
         || !g_main_loop_is_running(controld_globals.mainloop)) {

--- a/daemons/controld/controld_control.c
+++ b/daemons/controld/controld_control.c
@@ -30,7 +30,7 @@ extern gboolean crm_connect_corosync(pcmk_cluster_t *cluster);
 #endif
 
 static void crm_shutdown(int nsig);
-static gboolean crm_read_options(gpointer user_data);
+static gboolean crm_read_options(void *user_data);
 
 // A_HA_CONNECT
 void
@@ -650,7 +650,7 @@ controld_trigger_config_as(const char *fn, int line)
 }
 
 gboolean
-crm_read_options(gpointer user_data)
+crm_read_options(void *user_data)
 {
     cib_t *cib_conn = controld_globals.cib_conn;
     int call_id = cib_conn->cmds->query(cib_conn,

--- a/daemons/controld/controld_corosync.c
+++ b/daemons/controld/controld_corosync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -76,7 +76,7 @@ crmd_quorum_callback(unsigned long long seq, gboolean quorate)
 }
 
 static void
-crmd_cs_destroy(gpointer user_data)
+crmd_cs_destroy(void *user_data)
 {
     if (!pcmk__is_set(controld_globals.fsa_input_register, R_HA_DISCONNECTED)) {
         pcmk__crit("Lost connection to cluster layer, shutting down");

--- a/daemons/controld/controld_election.c
+++ b/daemons/controld/controld_election.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -42,7 +42,7 @@ void
 controld_configure_election(GHashTable *options)
 {
     const char *value = g_hash_table_lookup(options, PCMK_OPT_ELECTION_TIMEOUT);
-    guint interval_ms = 0U;
+    unsigned int interval_ms = 0;
 
     pcmk_parse_interval_spec(value, &interval_ms);
     election_timeout_set_period(controld_globals.cluster, interval_ms);

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1257,7 +1257,7 @@ static bool do_lrm_cancel(ha_msg_input_t *input, lrm_state_t *lrm_state,
     CRM_CHECK(op_task != NULL, return FALSE);
 
     meta_key = crm_meta_name(PCMK_META_INTERVAL);
-    if (pcmk__xe_get_guint(params, meta_key, &interval_ms) != pcmk_rc_ok) {
+    if (pcmk__xe_get_uint(params, meta_key, &interval_ms) != pcmk_rc_ok) {
         free(meta_key);
         return FALSE;
     }

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -35,7 +35,7 @@ struct delete_event_s {
 
 static gboolean is_rsc_active(lrm_state_t * lrm_state, const char *rsc_id);
 static gboolean build_active_RAs(lrm_state_t * lrm_state, xmlNode * rsc_list);
-static gboolean stop_recurring_actions(gpointer key, gpointer value, gpointer user_data);
+static gboolean stop_recurring_actions(void *key, void *value, void *user_data);
 
 static lrmd_event_data_t *construct_op(const lrm_state_t *lrm_state,
                                        const xmlNode *rsc_op,
@@ -64,7 +64,7 @@ make_stop_id(const char *rsc, int call_id)
 }
 
 static void
-copy_instance_keys(gpointer key, gpointer value, gpointer user_data)
+copy_instance_keys(void *key, void *value, void *user_data)
 {
     if (!g_str_has_prefix(key, CRM_META "_")) {
         pcmk__insert_dup(user_data, (const char *) key, (const char *) value);
@@ -72,7 +72,7 @@ copy_instance_keys(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
-copy_meta_keys(gpointer key, gpointer value, gpointer user_data)
+copy_meta_keys(void *key, void *value, void *user_data)
 {
     if (g_str_has_prefix(key, CRM_META "_")) {
         pcmk__insert_dup(user_data, (const char *) key, (const char *) value);
@@ -133,7 +133,7 @@ history_free_recurring_ops(rsc_history_t *history)
  * \param[in,out] history  Resource history to free
  */
 void
-history_free(gpointer data)
+history_free(void *data)
 {
     rsc_history_t *history = (rsc_history_t*)data;
 
@@ -438,7 +438,8 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
             || !pcmk__is_set(controld_globals.fsa_input_register,
                              R_SENT_RSC_STOP)) {
             g_hash_table_iter_init(&gIter, lrm_state->active_ops);
-            while (g_hash_table_iter_next(&gIter, (gpointer*)&key, (gpointer*)&pending)) {
+            while (g_hash_table_iter_next(&gIter, (void **) &key,
+                                          (void **) &pending)) {
                 do_crm_log(log_level, "Pending action: %s (%s)", key, pending->op_key);
             }
 
@@ -459,7 +460,7 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
 
     counter = 0;
     g_hash_table_iter_init(&gIter, lrm_state->resource_history);
-    while (g_hash_table_iter_next(&gIter, NULL, (gpointer*)&entry)) {
+    while (g_hash_table_iter_next(&gIter, NULL, (void **) &entry)) {
         if (is_rsc_active(lrm_state, entry->id) == FALSE) {
             continue;
         }
@@ -474,7 +475,8 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
             GHashTableIter hIter;
 
             g_hash_table_iter_init(&hIter, lrm_state->active_ops);
-            while (g_hash_table_iter_next(&hIter, (gpointer*)&key, (gpointer*)&pending)) {
+            while (g_hash_table_iter_next(&hIter, (void **) &key,
+                                          (void **) &pending)) {
                 if (pcmk__str_eq(entry->id, pending->rsc_id, pcmk__str_none)) {
                     const bool recurring = (pending->interval_ms != 0);
 
@@ -681,7 +683,7 @@ notify_deleted(lrm_state_t * lrm_state, ha_msg_input_t * input, const char *rsc_
 }
 
 static gboolean
-lrm_remove_deleted_rsc(gpointer key, gpointer value, gpointer user_data)
+lrm_remove_deleted_rsc(void *key, void *value, void *user_data)
 {
     struct delete_event_s *event = user_data;
     struct pending_deletion_op_s *op = value;
@@ -694,7 +696,7 @@ lrm_remove_deleted_rsc(gpointer key, gpointer value, gpointer user_data)
 }
 
 static gboolean
-lrm_remove_deleted_op(gpointer key, gpointer value, gpointer user_data)
+lrm_remove_deleted_op(void *key, void *value, void *user_data)
 {
     const char *rsc = user_data;
     active_op_t *pending = value;
@@ -857,7 +859,7 @@ struct cancel_data {
 };
 
 static gboolean
-cancel_action_by_key(gpointer key, gpointer value, gpointer user_data)
+cancel_action_by_key(void *key, void *value, void *user_data)
 {
     gboolean remove = FALSE;
     struct cancel_data *data = user_data;
@@ -1799,7 +1801,7 @@ struct stop_recurring_action_s {
 };
 
 static gboolean
-stop_recurring_action_by_rsc(gpointer key, gpointer value, gpointer user_data)
+stop_recurring_action_by_rsc(void *key, void *value, void *user_data)
 {
     gboolean remove = FALSE;
     struct stop_recurring_action_s *event = user_data;
@@ -1817,7 +1819,7 @@ stop_recurring_action_by_rsc(gpointer key, gpointer value, gpointer user_data)
 }
 
 static gboolean
-stop_recurring_actions(gpointer key, gpointer value, gpointer user_data)
+stop_recurring_actions(void *key, void *value, void *user_data)
 {
     gboolean remove = FALSE;
     lrm_state_t *lrm_state = user_data;

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -408,10 +408,10 @@ lrm_state_verify_stopped(lrm_state_t * lrm_state, enum crmd_fsa_state cur_state,
     }
 
     if ((lrm_state->active_ops != NULL) && lrm_state_is_connected(lrm_state)) {
-        guint removed = g_hash_table_foreach_remove(lrm_state->active_ops,
-                                                    stop_recurring_actions,
-                                                    lrm_state);
-        guint nremaining = g_hash_table_size(lrm_state->active_ops);
+        unsigned int removed =
+            g_hash_table_foreach_remove(lrm_state->active_ops,
+                                        stop_recurring_actions, lrm_state);
+        unsigned int nremaining = g_hash_table_size(lrm_state->active_ops);
 
         if (removed || nremaining) {
             pcmk__notice("Stopped %u recurring operation%s at %s (%u "
@@ -745,7 +745,8 @@ delete_rsc_entry(lrm_state_t *lrm_state, ha_msg_input_t *input,
 }
 
 static inline gboolean
-last_failed_matches_op(rsc_history_t *entry, const char *op, guint interval_ms)
+last_failed_matches_op(rsc_history_t *entry, const char *op,
+                       unsigned int interval_ms)
 {
     if (entry == NULL) {
         return FALSE;
@@ -772,7 +773,7 @@ last_failed_matches_op(rsc_history_t *entry, const char *op, guint interval_ms)
  */
 void
 lrm_clear_last_failure(const char *rsc_id, const char *node_name,
-                       const char *operation, guint interval_ms)
+                       const char *operation, unsigned int interval_ms)
 {
     lrm_state_t *lrm_state = controld_get_executor_state(node_name, false);
 
@@ -872,7 +873,7 @@ cancel_action_by_key(gpointer key, gpointer value, gpointer user_data)
 static gboolean
 cancel_op_key(lrm_state_t * lrm_state, lrmd_rsc_info_t * rsc, const char *key, gboolean remove)
 {
-    guint removed = 0;
+    unsigned int removed = 0;
     struct cancel_data data;
 
     CRM_CHECK(rsc != NULL, return FALSE);
@@ -1243,7 +1244,7 @@ static bool do_lrm_cancel(ha_msg_input_t *input, lrm_state_t *lrm_state,
     int call = 0;
     const char *call_id = NULL;
     const char *op_task = NULL;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
     gboolean in_progress = FALSE;
     xmlNode *params = pcmk__xe_first_child(input->xml, PCMK__XE_ATTRIBUTES,
                                            NULL, NULL);
@@ -1842,7 +1843,8 @@ stop_recurring_actions(gpointer key, gpointer value, gpointer user_data)
  * \return true if recurring actions should be cancelled, otherwise false
  */
 static bool
-should_cancel_recurring(const char *rsc_id, const char *action, guint interval_ms)
+should_cancel_recurring(const char *rsc_id, const char *action,
+                        unsigned int interval_ms)
 {
     if (is_remote_lrmd_ra(NULL, NULL, rsc_id) && (interval_ms == 0)
         && (strcmp(action, PCMK_ACTION_MIGRATE_TO) == 0)) {
@@ -1944,7 +1946,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
     CRM_CHECK(op != NULL, return);
 
     if (should_cancel_recurring(rsc->id, operation, op->interval_ms)) {
-        guint removed = 0;
+        unsigned int removed = 0;
         struct stop_recurring_action_s data;
 
         data.rsc = rsc;
@@ -2056,7 +2058,7 @@ do_lrm_rsc_op(lrm_state_t *lrm_state, lrmd_rsc_info_t *rsc, xmlNode *msg,
 
 static bool
 did_lrm_rsc_op_fail(lrm_state_t *lrm_state, const char * rsc_id,
-                    const char * op_type, guint interval_ms)
+                    const char * op_type, unsigned int interval_ms)
 {
     rsc_history_t *entry = NULL;
 

--- a/daemons/controld/controld_execd.c
+++ b/daemons/controld/controld_execd.c
@@ -1624,8 +1624,8 @@ construct_op(const lrm_state_t *lrm_state, const xmlNode *rsc_op,
     op_timeout = crm_meta_value(params, PCMK_META_TIMEOUT);
     pcmk__scan_min_int(op_timeout, &op->timeout, 0);
 
-    if (pcmk__guint_from_hash(params, CRM_META "_" PCMK_META_INTERVAL, 0,
-                              &(op->interval_ms)) != pcmk_rc_ok) {
+    if (pcmk__uint_from_hash(params, CRM_META "_" PCMK_META_INTERVAL, 0,
+                             &(op->interval_ms)) != pcmk_rc_ok) {
         op->interval_ms = 0;
     }
 

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -237,7 +237,7 @@ lrm_state_get_list(void)
 void
 lrm_state_disconnect_only(lrm_state_t * lrm_state)
 {
-    guint removed = 0;
+    unsigned int removed = 0;
 
     if (!lrm_state->conn) {
         return;
@@ -368,7 +368,7 @@ lrm_state_get_metadata(lrm_state_t * lrm_state,
 
 int
 lrm_state_cancel(lrm_state_t *lrm_state, const char *rsc_id, const char *action,
-                 guint interval_ms)
+                 unsigned int interval_ms)
 {
     if (!lrm_state->conn) {
         return -ENOTCONN;
@@ -432,7 +432,7 @@ lrm_state_get_rsc_info(lrm_state_t * lrm_state, const char *rsc_id, enum lrmd_ca
 int
 controld_execute_resource_agent(lrm_state_t *lrm_state, const char *rsc_id,
                                 const char *action, const char *userdata,
-                                guint interval_ms, int timeout_ms,
+                                unsigned int interval_ms, int timeout_ms,
                                 int start_delay_ms, GHashTable *parameters,
                                 int *call_id)
 {

--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -22,7 +22,7 @@
 static GHashTable *lrm_state_table = NULL;
 
 static void
-free_rsc_info(gpointer value)
+free_rsc_info(void *value)
 {
     lrmd_rsc_info_t *rsc_info = value;
 
@@ -30,7 +30,7 @@ free_rsc_info(gpointer value)
 }
 
 static void
-free_deletion_op(gpointer value)
+free_deletion_op(void *value)
 {
     struct pending_deletion_op_s *op = value;
 
@@ -40,7 +40,7 @@ free_deletion_op(gpointer value)
 }
 
 static void
-free_recurring_op(gpointer value)
+free_recurring_op(void *value)
 {
     active_op_t *op = value;
 
@@ -53,7 +53,7 @@ free_recurring_op(gpointer value)
 }
 
 static gboolean
-fail_pending_op(gpointer key, gpointer value, gpointer user_data)
+fail_pending_op(void *key, void *value, void *user_data)
 {
     lrmd_event_data_t event = { 0, };
     lrm_state_t *lrm_state = user_data;
@@ -121,7 +121,7 @@ lrm_state_create(const char *node_name)
 }
 
 static void
-internal_lrm_state_destroy(gpointer data)
+internal_lrm_state_destroy(void *data)
 {
     lrm_state_t *lrm_state = data;
 
@@ -450,8 +450,8 @@ controld_execute_resource_agent(lrm_state_t *lrm_state, const char *rsc_id,
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, parameters);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &key,
-                                      (gpointer *) &value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &key,
+                                      (void **) &value)) {
             params = lrmd_key_value_add(params, key, value);
         }
     }

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -100,7 +100,7 @@ static bool
 too_many_fencing_failures(const char *target)
 {
     GHashTableIter iter;
-    gpointer value = NULL;
+    void *value = NULL;
 
     if (fencing_fail_counts == NULL) {
         return false;
@@ -108,7 +108,7 @@ too_many_fencing_failures(const char *target)
 
     if (target == NULL) {
         g_hash_table_iter_init(&iter, fencing_fail_counts);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &target, &value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &target, &value)) {
             if (GPOINTER_TO_INT(value) >= fencing_max_attempts) {
                 goto too_many;
             }
@@ -151,8 +151,8 @@ controld_reset_fencing_fail_count(const char *target)
 static void
 increment_fencing_fail_count(const char *target)
 {
-    gpointer key = NULL;
-    gpointer value = NULL;
+    void *key = NULL;
+    void *value = NULL;
 
     if (fencing_fail_counts == NULL) {
         fencing_fail_counts = pcmk__strikey_table(free, NULL);
@@ -160,7 +160,7 @@ increment_fencing_fail_count(const char *target)
 
     if (g_hash_table_lookup_extended(fencing_fail_counts, target, &key,
                                      &value)) {
-        gpointer new_value = GINT_TO_POINTER(GPOINTER_TO_INT(value) + 1);
+        void *new_value = GINT_TO_POINTER(GPOINTER_TO_INT(value) + 1);
 
         // Increment value in the table without freeing key
         g_hash_table_steal(fencing_fail_counts, key);
@@ -648,7 +648,7 @@ handle_fence_notification(stonith_t *st, stonith_event_t *event)
  *       30 attempts, meaning the controller could be blocked as long as 58s.
  */
 gboolean
-controld_timer_fencer_connect(gpointer user_data)
+controld_timer_fencer_connect(void *user_data)
 {
     int rc = pcmk_ok;
 
@@ -746,7 +746,7 @@ controld_disconnect_fencer(bool destroy)
 }
 
 static gboolean
-sync_fencing_history(gpointer user_data)
+sync_fencing_history(void *user_data)
 {
     if ((fencer_api != NULL) && (fencer_api->state != stonith_disconnected)) {
         stonith_history_t *history = NULL;
@@ -1044,7 +1044,7 @@ fencing_history_synced(stonith_t *st, stonith_event_t *st_event)
 }
 
 static gboolean
-fencing_history_sync_set_trigger(gpointer user_data)
+fencing_history_sync_set_trigger(void *user_data)
 {
     mainloop_set_trigger(fencing_history_sync_trigger);
     return FALSE;

--- a/daemons/controld/controld_fencing.h
+++ b/daemons/controld/controld_fencing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,7 +19,7 @@ void controld_configure_fencing(GHashTable *options);
 void controld_reset_fencing_fail_count(const char *target);
 
 // Fencer API client
-gboolean controld_timer_fencer_connect(gpointer user_data);
+gboolean controld_timer_fencer_connect(void *user_data);
 void controld_disconnect_fencer(bool destroy);
 int controld_execute_fence_action(pcmk__graph_t *graph,
                                   pcmk__graph_action_t *action);

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -131,7 +131,7 @@ log_fsa_input(fsa_data_t *stored_msg)
 }
 
 static void
-log_fsa_data(gpointer data, gpointer user_data)
+log_fsa_data(void *data, void *user_data)
 {
     fsa_data_t *fsa_data = data;
     unsigned int *offset = user_data;

--- a/daemons/controld/controld_fsa.c
+++ b/daemons/controld/controld_fsa.c
@@ -506,7 +506,7 @@ static void
 check_join_counts(fsa_data_t *msg_data)
 {
     int count;
-    guint npeers;
+    unsigned int npeers = 0;
 
     count = crmd_join_phase_count(controld_join_finalized);
     if (count > 0) {

--- a/daemons/controld/controld_globals.h
+++ b/daemons/controld/controld_globals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,7 +13,7 @@
 #include <crm_internal.h>       // pcmk__output_t, etc.
 
 #include <stdint.h>             // uint32_t, uint64_t
-#include <glib.h>               // GMainLoop, GQueue, guint, etc.
+#include <glib.h>               // GMainLoop, GQueue, etc.
 #include <crm/cib.h>            // cib_t
 #include <pacemaker-internal.h> // pcmk__graph_t
 #include <controld_fsa.h>       // enum crmd_fsa_state
@@ -97,10 +97,10 @@ typedef struct {
     char *our_uuid;
 
     // Max lifetime (in seconds) of a resource's shutdown lock to a node
-    guint shutdown_lock_limit;
+    unsigned int shutdown_lock_limit;
 
     // Node pending timeout
-    guint node_pending_timeout;
+    unsigned int node_pending_timeout;
 
     // Main event loop
     GMainLoop *mainloop;
@@ -114,7 +114,7 @@ extern controld_globals_t controld_globals;
  *
  * \return Length of the queue, or 0 if the queue is \c NULL
  */
-static inline guint
+static inline unsigned int
 controld_fsa_message_queue_length(void)
 {
     if (controld_globals.fsa_message_queue == NULL) {

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -39,7 +39,7 @@ static xmlNode *max_generation_xml = NULL;
  */
 static GHashTable *failed_sync_nodes = NULL;
 
-void finalize_join_for(gpointer key, gpointer value, gpointer user_data);
+void finalize_join_for(void *key, void *value, void *user_data);
 void finalize_sync_callback(xmlNode * msg, int call_id, int rc, xmlNode * output, void *user_data);
 gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
@@ -139,8 +139,8 @@ lookup_failed_sync_node(const char *node_name, int *join_id)
     *join_id = -1;
 
     if (failed_sync_nodes != NULL) {
-        gpointer result = g_hash_table_lookup(failed_sync_nodes,
-                                              (gchar *) node_name);
+        void *result = g_hash_table_lookup(failed_sync_nodes,
+                                           (gchar *) node_name);
         if (result != NULL) {
             *join_id = GPOINTER_TO_INT(result);
             return pcmk_rc_ok;
@@ -195,7 +195,7 @@ crm_update_peer_join(const char *source, pcmk__node_status_t *node,
 }
 
 static void
-set_join_phase_none(gpointer key, gpointer value, gpointer user_data)
+set_join_phase_none(void *key, void *value, void *user_data)
 {
     crm_update_peer_join(__func__, (pcmk__node_status_t *) value,
                          controld_join_none);
@@ -227,7 +227,7 @@ create_dc_message(const char *join_op, const char *host_to)
 }
 
 static void
-join_make_offer(gpointer key, gpointer value, gpointer user_data)
+join_make_offer(void *key, void *value, void *user_data)
 {
     /* @TODO We don't use user_data except to distinguish one particular call
      * from others. Make this clearer.
@@ -885,7 +885,7 @@ done:
 }
 
 void
-finalize_join_for(gpointer key, gpointer value, gpointer user_data)
+finalize_join_for(void *key, void *value, void *user_data)
 {
     xmlNode *acknak = NULL;
     xmlNode *tmp1 = NULL;
@@ -954,7 +954,7 @@ finalize_join_for(gpointer key, gpointer value, gpointer user_data)
             xmlNode *remotes = pcmk__xe_create(acknak, PCMK_XE_NODES);
 
             g_hash_table_iter_init(&iter, pcmk__remote_peer_cache);
-            while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+            while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
                 xmlNode *remote = NULL;
 
                 if (!node->conn_host) {
@@ -1065,7 +1065,7 @@ int crmd_join_phase_count(enum controld_join_phase phase)
     GHashTableIter iter;
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &peer)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &peer)) {
         if (controld_get_join_phase(peer) == phase) {
             count++;
         }
@@ -1079,7 +1079,7 @@ void crmd_join_phase_log(int level)
     GHashTableIter iter;
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &peer)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &peer)) {
         do_crm_log(level, "join-%d: %s=%s", current_join_id, peer->name,
                    join_phase_text(controld_get_join_phase(peer)));
     }

--- a/daemons/controld/controld_join_dc.c
+++ b/daemons/controld/controld_join_dc.c
@@ -109,7 +109,7 @@ controld_remove_failed_sync_node(const char *node_name)
  * \param[in] join_id    Join round when the failure occurred
  */
 static void
-record_failed_sync_node(const char *node_name, gint join_id)
+record_failed_sync_node(const char *node_name, int join_id)
 {
     if (failed_sync_nodes == NULL) {
         failed_sync_nodes = pcmk__strikey_table(g_free, NULL);
@@ -134,7 +134,7 @@ record_failed_sync_node(const char *node_name, gint join_id)
  * \note \p *join_id is set to -1 if the node is not found.
  */
 static int
-lookup_failed_sync_node(const char *node_name, gint *join_id)
+lookup_failed_sync_node(const char *node_name, int *join_id)
 {
     *join_id = -1;
 
@@ -433,7 +433,7 @@ do_dc_join_filter_offer(long long action, enum crmd_fsa_cause cause,
     pcmk__node_status_t *join_node = NULL;
     const char *join_version = NULL;
     const char *ref = NULL;
-    gint value = 0;
+    int value = 0;
     bool accept = true;
     int count = 0;
 

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -40,7 +40,7 @@ typedef struct {
     GHashTable *stop_params;
 } rsc_history_t;
 
-void history_free(gpointer data);
+void history_free(void *data);
 
 enum active_op_e {
     active_op_remove    = (UINT32_C(1) << 0),

--- a/daemons/controld/controld_lrm.h
+++ b/daemons/controld/controld_lrm.h
@@ -19,7 +19,7 @@
 
 extern gboolean verify_stopped(enum crmd_fsa_state cur_state, int log_level);
 void lrm_clear_last_failure(const char *rsc_id, const char *node_name,
-                            const char *operation, guint interval_ms);
+                            const char *operation, unsigned int interval_ms);
 void controld_invoke_execd(fsa_data_t *msg_data);
 
 void lrm_op_callback(lrmd_event_data_t * op);
@@ -49,7 +49,7 @@ enum active_op_e {
 
 // In-flight action (recurring or pending)
 typedef struct {
-    guint interval_ms;
+    unsigned int interval_ms;
     int call_id;
     uint32_t flags; // bitmask of active_op_e
     time_t start_time;
@@ -140,10 +140,10 @@ int lrm_state_get_metadata(lrm_state_t * lrm_state,
                            const char *provider,
                            const char *agent, char **output, enum lrmd_call_options options);
 int lrm_state_cancel(lrm_state_t *lrm_state, const char *rsc_id,
-                     const char *action, guint interval_ms);
+                     const char *action, unsigned int interval_ms);
 int controld_execute_resource_agent(lrm_state_t *lrm_state, const char *rsc_id,
                                     const char *action, const char *userdata,
-                                    guint interval_ms, int timeout_ms,
+                                    unsigned int interval_ms, int timeout_ms,
                                     int start_delay_ms,
                                     GHashTable *parameters, int *call_id);
 lrmd_rsc_info_t *lrm_state_get_rsc_info(lrm_state_t * lrm_state,
@@ -160,11 +160,11 @@ void remote_lrm_op_callback(lrmd_event_data_t * op);
 gboolean is_remote_lrmd_ra(const char *agent, const char *provider, const char *id);
 lrmd_rsc_info_t *remote_ra_get_rsc_info(lrm_state_t * lrm_state, const char *rsc_id);
 int remote_ra_cancel(lrm_state_t *lrm_state, const char *rsc_id,
-                     const char *action, guint interval_ms);
+                     const char *action, unsigned int interval_ms);
 int controld_execute_remote_agent(const lrm_state_t *lrm_state,
                                   const char *rsc_id, const char *action,
                                   const char *userdata,
-                                  guint interval_ms, int timeout_ms,
+                                  unsigned int interval_ms, int timeout_ms,
                                   int start_delay_ms, lrmd_key_value_t *params,
                                   int *call_id);
 void remote_ra_cleanup(lrm_state_t * lrm_state);

--- a/daemons/controld/controld_membership.c
+++ b/daemons/controld/controld_membership.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,7 +25,7 @@ void post_cache_update(int instance);
 extern gboolean check_join_state(enum crmd_fsa_state cur_state, const char *source);
 
 static void
-reap_dead_nodes(gpointer key, gpointer value, gpointer user_data)
+reap_dead_nodes(void *key, void *value, void *user_data)
 {
     pcmk__node_status_t *node = value;
 
@@ -261,7 +261,7 @@ search_conflicting_node_callback(xmlNode * msg, int call_id, int rc,
         }
 
         g_hash_table_iter_init(&iter, pcmk__peer_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if ((node != NULL)
                 && pcmk__str_eq(node->xml_id, node_uuid, pcmk__str_casei)
                 && pcmk__str_eq(node->name, node_uname, pcmk__str_casei)) {
@@ -314,7 +314,7 @@ populate_cib_nodes_from_cache(xmlNode *nodes_xml)
     pcmk__node_status_t *node = NULL;
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         cib_t *cib_conn = controld_globals.cib_conn;
         int call_id = 0;
         xmlNode *new_node = NULL;
@@ -412,13 +412,13 @@ populate_cib_nodes(uint32_t flags, const char *source)
     node_list = pcmk__xe_create(NULL, PCMK_XE_STATUS);
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         create_node_state_update(node, flags, node_list, source);
     }
 
     if (pcmk__remote_peer_cache != NULL) {
         g_hash_table_iter_init(&iter, pcmk__remote_peer_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             create_node_state_update(node, flags, node_list, source);
         }
     }

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -838,7 +838,7 @@ handle_node_list(const xmlNode *request)
     // Create message data for reply
     reply_data = pcmk__xe_create(NULL, PCMK_XE_NODES);
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         xmlNode *xml = pcmk__xe_create(reply_data, PCMK_XE_NODE);
 
         pcmk__xe_set_ll(xml, PCMK_XA_ID,

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -622,9 +622,9 @@ handle_failcount_op(xmlNode * stored_msg)
         if (xml_attrs) {
             op = pcmk__xe_get(xml_attrs,
                               CRM_META "_" PCMK__META_CLEAR_FAILURE_OP);
-            pcmk__xe_get_guint(xml_attrs,
-                               CRM_META "_" PCMK__META_CLEAR_FAILURE_INTERVAL,
-                               &interval_ms);
+            pcmk__xe_get_uint(xml_attrs,
+                              CRM_META "_" PCMK__META_CLEAR_FAILURE_INTERVAL,
+                              &interval_ms);
         }
     }
     uname = pcmk__xe_get(xml_op, PCMK__META_ON_NODE);

--- a/daemons/controld/controld_messages.c
+++ b/daemons/controld/controld_messages.c
@@ -603,7 +603,7 @@ handle_failcount_op(xmlNode * stored_msg)
     const char *uname = NULL;
     const char *op = NULL;
     char *interval_spec = NULL;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
     gboolean is_remote_node = FALSE;
 
     xmlNode *wrapper = pcmk__xe_first_child(stored_msg, PCMK__XE_CRM_XML, NULL,

--- a/daemons/controld/controld_remote_proxy.c
+++ b/daemons/controld/controld_remote_proxy.c
@@ -52,7 +52,7 @@ typedef struct {
 static GHashTable *proxy_table = NULL;
 
 static void
-remote_proxy_free(gpointer data)
+remote_proxy_free(void *data)
 {
     remote_proxy_t *proxy = data;
 
@@ -115,7 +115,7 @@ remote_proxy_relay_event(remote_proxy_t *proxy, xmlNode *msg)
 }
 
 static int
-remote_proxy_dispatch(const char *buffer, ssize_t length, gpointer userdata)
+remote_proxy_dispatch(const char *buffer, ssize_t length, void *userdata)
 {
     // Async responses from servers to clients via the remote executor
     xmlNode *xml = NULL;
@@ -157,7 +157,7 @@ remote_proxy_notify_destroy(lrmd_t *lrmd, const char *session_id)
 }
 
 static void
-remote_proxy_disconnected(gpointer userdata)
+remote_proxy_disconnected(void *userdata)
 {
     remote_proxy_t *proxy = userdata;
 
@@ -622,7 +622,7 @@ find_proxy_by_node(const char *node_name)
 
     g_hash_table_iter_init(&gIter, proxy_table);
 
-    while (g_hash_table_iter_next(&gIter, NULL, (gpointer *) &proxy)) {
+    while (g_hash_table_iter_next(&gIter, NULL, (void **) &proxy)) {
         if (proxy->source
             && pcmk__str_eq(node_name, proxy->node_name, pcmk__str_casei)) {
             return proxy;

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -82,7 +82,7 @@ static void handle_remote_ra_stop(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd
 static GList *fail_all_monitor_cmds(GList * list);
 
 static void
-free_cmd(gpointer user_data)
+free_cmd(void *user_data)
 {
     remote_ra_cmd_t *cmd = user_data;
 
@@ -124,7 +124,7 @@ generate_callid(void)
 }
 
 static gboolean
-recurring_helper(gpointer data)
+recurring_helper(void *data)
 {
     remote_ra_cmd_t *cmd = data;
     lrm_state_t *connection_rsc = NULL;
@@ -143,7 +143,7 @@ recurring_helper(gpointer data)
 }
 
 static gboolean
-start_delay_helper(gpointer data)
+start_delay_helper(void *data)
 {
     remote_ra_cmd_t *cmd = data;
     lrm_state_t *connection_rsc = NULL;
@@ -466,7 +466,7 @@ remaining_timeout_sec(const remote_ra_cmd_t *cmd)
 }
 
 static gboolean
-retry_start_cmd_cb(gpointer data)
+retry_start_cmd_cb(void *data)
 {
     lrm_state_t *lrm_state = data;
     remote_ra_data_t *ra_data = lrm_state->remote_ra_data;
@@ -508,7 +508,7 @@ retry_start_cmd_cb(gpointer data)
 
 
 static gboolean
-connection_takeover_timeout_cb(gpointer data)
+connection_takeover_timeout_cb(void *data)
 {
     lrm_state_t *lrm_state = NULL;
     remote_ra_cmd_t *cmd = data;
@@ -525,7 +525,7 @@ connection_takeover_timeout_cb(gpointer data)
 }
 
 static gboolean
-monitor_timeout_cb(gpointer data)
+monitor_timeout_cb(void *data)
 {
     lrm_state_t *lrm_state = NULL;
     remote_ra_cmd_t *cmd = data;
@@ -834,7 +834,7 @@ handle_remote_ra_start(lrm_state_t * lrm_state, remote_ra_cmd_t * cmd, int timeo
 }
 
 static gboolean
-handle_remote_ra_exec(gpointer user_data)
+handle_remote_ra_exec(void *user_data)
 {
     int rc = 0;
     lrm_state_t *lrm_state = user_data;

--- a/daemons/controld/controld_remote_ra.c
+++ b/daemons/controld/controld_remote_ra.c
@@ -1047,7 +1047,7 @@ fail_all_monitor_cmds(GList * list)
 }
 
 static GList *
-remove_cmd(GList * list, const char *action, guint interval_ms)
+remove_cmd(GList * list, const char *action, unsigned int interval_ms)
 {
     remote_ra_cmd_t *cmd = NULL;
     GList *gIter = NULL;
@@ -1069,7 +1069,7 @@ remove_cmd(GList * list, const char *action, guint interval_ms)
 
 int
 remote_ra_cancel(lrm_state_t *lrm_state, const char *rsc_id,
-                 const char *action, guint interval_ms)
+                 const char *action, unsigned int interval_ms)
 {
     lrm_state_t *connection_rsc = NULL;
     remote_ra_data_t *ra_data = NULL;
@@ -1096,7 +1096,7 @@ remote_ra_cancel(lrm_state_t *lrm_state, const char *rsc_id,
 }
 
 static remote_ra_cmd_t *
-handle_dup_monitor(remote_ra_data_t *ra_data, guint interval_ms,
+handle_dup_monitor(remote_ra_data_t *ra_data, unsigned int interval_ms,
                    const char *userdata)
 {
     GList *gIter = NULL;
@@ -1193,7 +1193,7 @@ handle_dup:
 int
 controld_execute_remote_agent(const lrm_state_t *lrm_state, const char *rsc_id,
                               const char *action, const char *userdata,
-                              guint interval_ms, int timeout_ms,
+                              unsigned int interval_ms, int timeout_ms,
                               int start_delay_ms, lrmd_key_value_t *params,
                               int *call_id)
 {

--- a/daemons/controld/controld_remote_ra.h
+++ b/daemons/controld/controld_remote_ra.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the Pacemaker project contributors
+ * Copyright 2013-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -15,7 +15,7 @@
 #include <stdint.h>                 // uint32_t
 #include <time.h>                   // time_t
 
-#include <glib.h>                   // GList, guint
+#include <glib.h>                   // GList
 
 #include <crm/lrmd.h>               // lrmd_key_value_t
 #include <crm/common/mainloop.h>    // crm_trigger_t
@@ -36,7 +36,7 @@ typedef struct {
     /*! timeout in ms for cmd */
     int timeout;
     /*! recurring interval in ms */
-    guint interval_ms;
+    unsigned int interval_ms;
     /*! interval timer id */
     int interval_id;
     int monitor_timeout_id;

--- a/daemons/controld/controld_schedulerd.c
+++ b/daemons/controld/controld_schedulerd.c
@@ -249,7 +249,7 @@ static mainloop_timer_t *controld_sched_timer = NULL;
  * \return FALSE (indicating that timer should not be restarted)
  */
 static gboolean
-controld_sched_timeout(gpointer user_data)
+controld_sched_timeout(void *user_data)
 {
     pcmk__err("Timeout waiting for reply from scheduler.");
     if (AM_I_DC) {
@@ -446,7 +446,7 @@ force_local_option(xmlNode *xml, const char *attr_name, const char *attr_value)
 }
 
 static gboolean
-sleep_timer(gpointer data)
+sleep_timer(void *data)
 {
     controld_set_fsa_action_flags(A_PE_INVOKE);
     controld_trigger_fsa();

--- a/daemons/controld/controld_te_actions.c
+++ b/daemons/controld/controld_te_actions.c
@@ -52,7 +52,7 @@ execute_pseudo_action(pcmk__graph_t *graph, pcmk__graph_action_t *pseudo)
         pcmk__node_status_t *node = NULL;
 
         g_hash_table_iter_init(&iter, pcmk__peer_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             xmlNode *cmd = NULL;
 
             if (controld_is_local_node(node->name)) {
@@ -477,7 +477,7 @@ struct te_peer_s
         int migrate_jobs;
 };
 
-static void te_peer_free(gpointer p)
+static void te_peer_free(void *p)
 {
     struct te_peer_s *peer = p;
 
@@ -495,7 +495,7 @@ void te_reset_job_counts(void)
     }
 
     g_hash_table_iter_init(&iter, te_targets);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & peer)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &peer)) {
         peer->jobs = 0;
         peer->migrate_jobs = 0;
     }

--- a/daemons/controld/controld_te_callbacks.c
+++ b/daemons/controld/controld_te_callbacks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -483,7 +483,7 @@ cib_action_updated(xmlNode * msg, int call_id, int rc, xmlNode * output, void *u
  * \return FALSE (indicating that source should be not be re-added)
  */
 gboolean
-action_timer_callback(gpointer data)
+action_timer_callback(void *data)
 {
     pcmk__graph_action_t *action = (pcmk__graph_action_t *) data;
     const char *task = NULL;

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -62,7 +62,7 @@ controld_destroy_outside_events_table(void)
  *         event was not already in the set, or \p pcmk_rc_already otherwise.
  */
 static int
-record_outside_event(gint action_num)
+record_outside_event(int action_num)
 {
     if (outside_events == NULL) {
         outside_events = g_hash_table_new(NULL, NULL);

--- a/daemons/controld/controld_te_events.c
+++ b/daemons/controld/controld_te_events.c
@@ -177,7 +177,7 @@ static gboolean
 update_failcount(const xmlNode *event, const char *event_node_uuid, int rc,
                  int target_rc, gboolean do_update, gboolean ignore_failures)
 {
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
 
     char *task = NULL;
     char *rsc_id = NULL;
@@ -492,7 +492,7 @@ process_graph_event(xmlNode *event, const char *event_node)
 
         // Action is not from currently active transition
 
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
 
         if (parse_op_key(id, NULL, NULL, &interval_ms)
             && (interval_ms != 0)) {

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -124,7 +124,7 @@ controld_trigger_graph_as(const char *fn, int line)
 
 static struct abort_timer_s {
     bool aborted;
-    guint id;
+    unsigned int id;
     int priority;
     enum pcmk__graph_next action;
     const char *text;
@@ -151,7 +151,7 @@ abort_timer_popped(gpointer data)
  */
 void
 abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
-                  const char *abort_text, guint delay_ms)
+                  const char *abort_text, unsigned int delay_ms)
 {
     if (abort_timer.id) {
         // Timer already in progress, stop and reschedule
@@ -205,7 +205,7 @@ node_pending_timer_popped(gpointer key)
 }
 
 static void
-init_node_pending_timer(const pcmk__node_status_t *node, guint timeout)
+init_node_pending_timer(const pcmk__node_status_t *node, unsigned int timeout)
 {
     struct abort_timer_s *node_pending_timer = NULL;
     char *key = NULL;

--- a/daemons/controld/controld_te_utils.c
+++ b/daemons/controld/controld_te_utils.c
@@ -39,7 +39,7 @@ stop_te_timer(pcmk__graph_action_t *action)
 }
 
 static gboolean
-te_graph_trigger(gpointer user_data)
+te_graph_trigger(void *user_data)
 {
     if (controld_globals.transition_graph == NULL) {
         pcmk__debug("Nothing to do");
@@ -131,7 +131,7 @@ static struct abort_timer_s {
 } abort_timer = { 0, };
 
 static gboolean
-abort_timer_popped(gpointer data)
+abort_timer_popped(void *data)
 {
     struct abort_timer_s *abort_timer = (struct abort_timer_s *) data;
 
@@ -165,7 +165,7 @@ abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
 }
 
 static void
-free_node_pending_timer(gpointer data)
+free_node_pending_timer(void *data)
 {
     struct abort_timer_s *node_pending_timer = (struct abort_timer_s *) data;
 
@@ -178,7 +178,7 @@ free_node_pending_timer(gpointer data)
 }
 
 static gboolean
-node_pending_timer_popped(gpointer key)
+node_pending_timer_popped(void *key)
 {
     struct abort_timer_s *node_pending_timer = NULL;
 

--- a/daemons/controld/controld_throttle.c
+++ b/daemons/controld/controld_throttle.c
@@ -199,14 +199,14 @@ throttle_send_command(enum throttle_state_e mode)
 }
 
 static gboolean
-throttle_timer_cb(gpointer data)
+throttle_timer_cb(void *data)
 {
     throttle_send_command(throttle_mode());
     return TRUE;
 }
 
 static void
-throttle_record_free(gpointer p)
+throttle_record_free(void *p)
 {
     struct throttle_record_s *r = p;
     free(r->node);
@@ -306,7 +306,7 @@ throttle_get_total_job_limit(int l)
 
     g_hash_table_iter_init(&iter, throttle_records);
 
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &r)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &r)) {
         switch(r->mode) {
 
             case throttle_extreme:

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -20,8 +20,8 @@
 
 //! FSA mainloop timer type
 typedef struct {
-    guint source_id;                        //!< Timer source ID
-    guint period_ms;                        //!< Timer period
+    unsigned int source_id;                 //!< Timer source ID
+    unsigned int period_ms;                 //!< Timer period
     enum crmd_fsa_input fsa_input;          //!< Input to register if timer pops
     gboolean (*callback) (gpointer data);   //!< What do if timer pops
     bool log_error;                         //!< Timer popping indicates error
@@ -50,7 +50,7 @@ static fsa_timer_t *finalization_timer = NULL;
 fsa_timer_t *shutdown_escalation_timer = NULL;
 
 //! Cluster recheck interval (from configuration)
-static guint recheck_interval_ms = 0;
+static unsigned int recheck_interval_ms = 0;
 
 static const char *
 get_timer_desc(fsa_timer_t * timer)
@@ -399,7 +399,7 @@ void
 controld_start_recheck_timer(void)
 {
     // Default to recheck interval configured in CIB (if any)
-    guint period_ms = recheck_interval_ms;
+    unsigned int period_ms = recheck_interval_ms;
 
     // If scheduler supplied a "recheck by" time, check whether that's sooner
     if (controld_globals.transition_graph->recheck_by > 0) {
@@ -410,7 +410,7 @@ controld_start_recheck_timer(void)
             // We're already past the desired time
             period_ms = 500;
         } else {
-            period_ms = (guint) QB_MIN(UINT_MAX, diff_seconds * 1000LL);
+            period_ms = (unsigned int) QB_MIN(UINT_MAX, diff_seconds * 1000LL);
         }
 
         // Use "recheck by" only if it's sooner than interval from CIB
@@ -451,7 +451,7 @@ controld_stop_recheck_timer(void)
  * \brief Get the transition timer's configured period
  * \return The transition_timer's period
  */
-guint
+unsigned int
 controld_get_period_transition_timer(void)
 {
     return transition_timer->period_ms;
@@ -497,7 +497,7 @@ controld_start_transition_timer(void)
  *                               timer's period is 0
  */
 void
-controld_shutdown_start_countdown(guint default_period_ms)
+controld_shutdown_start_countdown(unsigned int default_period_ms)
 {
     if (shutdown_escalation_timer->period_ms == 0) {
         shutdown_escalation_timer->period_ms = default_period_ms;

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -410,7 +410,7 @@ controld_start_recheck_timer(void)
             // We're already past the desired time
             period_ms = 500;
         } else {
-            period_ms = (guint) QB_MIN(G_MAXUINT, diff_seconds * 1000LL);
+            period_ms = (guint) QB_MIN(UINT_MAX, diff_seconds * 1000LL);
         }
 
         // Use "recheck by" only if it's sooner than interval from CIB

--- a/daemons/controld/controld_timers.c
+++ b/daemons/controld/controld_timers.c
@@ -20,12 +20,12 @@
 
 //! FSA mainloop timer type
 typedef struct {
-    unsigned int source_id;                 //!< Timer source ID
-    unsigned int period_ms;                 //!< Timer period
-    enum crmd_fsa_input fsa_input;          //!< Input to register if timer pops
-    gboolean (*callback) (gpointer data);   //!< What do if timer pops
-    bool log_error;                         //!< Timer popping indicates error
-    int counter;                            //!< For detecting loops
+    unsigned int source_id;             //!< Timer source ID
+    unsigned int period_ms;             //!< Timer period
+    enum crmd_fsa_input fsa_input;      //!< Input to register if timer pops
+    gboolean (*callback)(void *data);   //!< What do if timer pops
+    bool log_error;                     //!< Timer popping indicates error
+    int counter;                        //!< For detecting loops
 } fsa_timer_t;
 
 //! Wait before retrying a failed cib or executor connection
@@ -193,7 +193,7 @@ do_timer_control(long long action, enum crmd_fsa_cause cause,
 }
 
 static gboolean
-crm_timer_popped(gpointer data)
+crm_timer_popped(void *data)
 {
     fsa_timer_t *timer = (fsa_timer_t *) data;
 

--- a/daemons/controld/controld_timers.h
+++ b/daemons/controld/controld_timers.h
@@ -11,7 +11,7 @@
 #  define CONTROLD_TIMERS__H
 
 #  include <stdbool.h>              // bool
-#  include <glib.h>                 // gboolean, gpointer
+#  include <glib.h>                 // GHashTable
 #  include <controld_fsa.h>         // crmd_fsa_input
 
 bool controld_init_fsa_timers(void);

--- a/daemons/controld/controld_timers.h
+++ b/daemons/controld/controld_timers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,7 @@
 #  define CONTROLD_TIMERS__H
 
 #  include <stdbool.h>              // bool
-#  include <glib.h>                 // gboolean, gpointer, guint
+#  include <glib.h>                 // gboolean, gpointer
 #  include <controld_fsa.h>         // crmd_fsa_input
 
 bool controld_init_fsa_timers(void);
@@ -27,10 +27,10 @@ void controld_start_wait_timer(void);
 
 bool controld_is_started_transition_timer(void);
 
-guint controld_get_period_transition_timer(void);
+unsigned int controld_get_period_transition_timer(void);
 
 void controld_reset_counter_election_timer(void);
 
-void controld_shutdown_start_countdown(guint default_period_ms);
+void controld_shutdown_start_countdown(unsigned int default_period_ms);
 
 #endif

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -44,7 +44,7 @@ void notify_crmd(pcmk__graph_t * graph);
 
 void cib_action_updated(xmlNode *msg, int call_id, int rc, xmlNode *output,
                         void *user_data);
-gboolean action_timer_callback(gpointer data);
+gboolean action_timer_callback(void *data);
 void te_update_diff(const char *event, xmlNode *msg);
 
 void controld_init_transition_trigger(void);

--- a/daemons/controld/controld_transition.h
+++ b/daemons/controld/controld_transition.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -52,7 +52,7 @@ void controld_destroy_transition_trigger(void);
 
 void controld_trigger_graph_as(const char *fn, int line);
 void abort_after_delay(int abort_priority, enum pcmk__graph_next abort_action,
-                       const char *abort_text, guint delay_ms);
+                       const char *abort_text, unsigned int delay_ms);
 void controld_node_pending_timer(const pcmk__node_status_t *node);
 void controld_free_node_pending_timers(void);
 void abort_transition_graph(int abort_priority,

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -55,7 +55,7 @@ static struct {
 } options;
 
 static gboolean
-interval_cb(const gchar *option_name, const gchar *optarg, void *data,
+interval_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     return pcmk_parse_interval_spec(optarg,
@@ -63,7 +63,7 @@ interval_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-notify_cb(const gchar *option_name, const gchar *optarg, void *data,
+notify_cb(const char *option_name, const char *optarg, void *data,
           GError **error)
 {
     if (pcmk__str_any_of(option_name, "--notify-orig", "-n", NULL)) {
@@ -76,7 +76,7 @@ notify_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-param_key_val_cb(const gchar *option_name, const gchar *optarg, void *data,
+param_key_val_cb(const char *option_name, const char *optarg, void *data,
                  GError **error)
 {
     if (pcmk__str_any_of(option_name, "--param-key", "-k", NULL)) {

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -26,7 +26,7 @@
 #define SUMMARY "cts-exec-helper - inject commands into the Pacemaker executor and watch for events"
 
 static int exec_call_id = 0;
-static gboolean start_test(gpointer user_data);
+static gboolean start_test(void *user_data);
 static void try_connect(void);
 
 static char *key = NULL;
@@ -55,13 +55,17 @@ static struct {
 } options;
 
 static gboolean
-interval_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+interval_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     return pcmk_parse_interval_spec(optarg,
                                     &options.interval_ms) == pcmk_rc_ok;
 }
 
 static gboolean
-notify_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+notify_cb(const gchar *option_name, const gchar *optarg, void *data,
+          GError **error)
+{
     if (pcmk__str_any_of(option_name, "--notify-orig", "-n", NULL)) {
         options.exec_call_opts = lrmd_opt_notify_orig_only;
     } else if (pcmk__str_any_of(option_name, "--notify-changes", "-o", NULL)) {
@@ -72,7 +76,9 @@ notify_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError *
 }
 
 static gboolean
-param_key_val_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+param_key_val_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **error)
+{
     if (pcmk__str_any_of(option_name, "--param-key", "-k", NULL)) {
         pcmk__str_update(&key, optarg);
     } else if (pcmk__str_any_of(option_name, "--param-val", "-v", NULL)) {
@@ -213,7 +219,7 @@ read_events(lrmd_event_data_t * event)
 }
 
 static gboolean
-timeout_err(gpointer data)
+timeout_err(void *data)
 {
     print_result("LISTEN EVENT FAILURE - timeout occurred, never found");
     test_exit(CRM_EX_TIMEOUT);
@@ -263,7 +269,7 @@ try_connect(void)
 }
 
 static gboolean
-start_test(gpointer user_data)
+start_test(void *user_data)
 {
     int rc = 0;
 
@@ -487,16 +493,15 @@ generate_params(void)
     params = pe_rsc_params(rsc, NULL, scheduler);
     if (params != NULL) {
         g_hash_table_iter_init(&iter, params);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &key,
-                                      (gpointer *) &value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &key,
+                                      (void **) &value)) {
             options.params = lrmd_key_value_add(options.params, key, value);
         }
     }
 
     // Add resource meta-attributes to options.params
     g_hash_table_iter_init(&iter, rsc->priv->meta);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &key,
-                                  (gpointer *) &value)) {
+    while (g_hash_table_iter_next(&iter, (void **) &key, (void **) &value)) {
         char *crm_name = crm_meta_name(key);
 
         options.params = lrmd_key_value_add(options.params, crm_name, value);

--- a/daemons/execd/cts-exec-helper.c
+++ b/daemons/execd/cts-exec-helper.c
@@ -35,7 +35,7 @@ static char *val = NULL;
 static struct {
     int verbose;
     int quiet;
-    guint interval_ms;
+    unsigned int interval_ms;
     int timeout;
     int start_delay;
     int cancel_call_id;

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -48,7 +48,7 @@ static int
 max_inflight_timeout(void)
 {
     GHashTableIter iter;
-    gpointer timeout;
+    void *timeout;
     int max_timeout = 0;
 
     if (inflight_alerts) {

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -166,10 +166,10 @@ err:
 }
 
 static bool
-drain_check(guint remaining_timeout_ms)
+drain_check(unsigned int remaining_timeout_ms)
 {
     if (inflight_alerts != NULL) {
-        guint count = g_hash_table_size(inflight_alerts);
+        unsigned int count = g_hash_table_size(inflight_alerts);
 
         if (count > 0) {
             pcmk__trace("%d alerts pending (%.3fs timeout remaining)",
@@ -184,7 +184,7 @@ void
 lrmd_drain_alerts(GMainLoop *mloop)
 {
     if (inflight_alerts != NULL) {
-        guint timer_ms = max_inflight_timeout() + 5000;
+        unsigned int timer_ms = max_inflight_timeout() + 5000;
 
         pcmk__trace("Draining in-flight alerts (timeout %.3fs)",
                     (timer_ms / 1000.0));

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -39,7 +39,7 @@ GHashTable *rsc_list = NULL;
 
 typedef struct {
     int timeout;
-    guint interval_ms;
+    unsigned int interval_ms;
     int start_delay;
     int timeout_orig;
 
@@ -196,7 +196,8 @@ cmd_original_times(lrmd_cmd_t * cmd)
 #endif
 
 static inline bool
-action_matches(const lrmd_cmd_t *cmd, const char *action, guint interval_ms)
+action_matches(const lrmd_cmd_t *cmd, const char *action,
+               unsigned int interval_ms)
 {
     return (cmd->interval_ms == interval_ms)
            && pcmk__str_eq(cmd->action, action, pcmk__str_casei);
@@ -1700,7 +1701,7 @@ execd_process_rsc_exec(pcmk__client_t *client, xmlNode *request)
 }
 
 static int
-cancel_op(const char *rsc_id, const char *action, guint interval_ms)
+cancel_op(const char *rsc_id, const char *action, unsigned int interval_ms)
 {
     GList *gIter = NULL;
     lrmd_rsc_t *rsc = g_hash_table_lookup(rsc_list, rsc_id);
@@ -1804,7 +1805,7 @@ execd_process_rsc_cancel(pcmk__client_t *client, xmlNode *request)
                                             LOG_ERR);
     const char *rsc_id = pcmk__xe_get(rsc_xml, PCMK__XA_LRMD_RSC_ID);
     const char *action = pcmk__xe_get(rsc_xml, PCMK__XA_LRMD_RSC_ACTION);
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
 
     pcmk__xe_get_guint(rsc_xml, PCMK__XA_LRMD_RSC_INTERVAL, &interval_ms);
 

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -101,7 +101,7 @@ typedef struct {
 } lrmd_cmd_t;
 
 static void cmd_finalize(lrmd_cmd_t * cmd, lrmd_rsc_t * rsc);
-static gboolean execute_resource_action(gpointer user_data);
+static gboolean execute_resource_action(void *user_data);
 static void cancel_all_recurring(lrmd_rsc_t * rsc, const char *client_id);
 
 #ifdef PCMK__TIME_USE_CGT
@@ -379,7 +379,7 @@ free_lrmd_cmd(lrmd_cmd_t * cmd)
 }
 
 static gboolean
-stonith_recurring_op_helper(gpointer data)
+stonith_recurring_op_helper(void *data)
 {
     lrmd_cmd_t *cmd = data;
     lrmd_rsc_t *rsc;
@@ -418,7 +418,7 @@ start_recurring_timer(lrmd_cmd_t *cmd)
 }
 
 static gboolean
-start_delay_helper(gpointer data)
+start_delay_helper(void *data)
 {
     lrmd_cmd_t *cmd = data;
     lrmd_rsc_t *rsc = NULL;
@@ -559,7 +559,7 @@ execd_create_reply_as(const char *origin, int rc, int call_id)
 }
 
 static void
-send_client_notify(gpointer key, gpointer value, gpointer user_data)
+send_client_notify(void *key, void *value, void *user_data)
 {
     xmlNode *update_msg = user_data;
     pcmk__client_t *client = value;
@@ -675,8 +675,9 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
         xmlNode *args = pcmk__xe_create(notify, PCMK__XE_ATTRIBUTES);
 
         g_hash_table_iter_init(&iter, cmd->params);
-        while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & value)) {
-            hash2smartfield((gpointer) key, (gpointer) value, args);
+        while (g_hash_table_iter_next(&iter, (void **) &key,
+                                      (void **) &value)) {
+            hash2smartfield((void *) key, (void *) value, args);
         }
     }
     if ((cmd->client_id != NULL)
@@ -781,13 +782,13 @@ struct notify_new_client_data {
 };
 
 static void
-notify_one_client(gpointer key, gpointer value, gpointer user_data)
+notify_one_client(void *key, void *value, void *user_data)
 {
     pcmk__client_t *client = value;
     struct notify_new_client_data *data = user_data;
 
     if (!pcmk__str_eq(client->id, data->new_client->id, pcmk__str_casei)) {
-        send_client_notify(key, (gpointer) client, (gpointer) data->notify);
+        send_client_notify(key, (void *) client, (void *) data->notify);
     }
 }
 
@@ -812,7 +813,7 @@ client_disconnect_cleanup(const char *client_id)
     char *key = NULL;
 
     g_hash_table_iter_init(&iter, rsc_list);
-    while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & rsc)) {
+    while (g_hash_table_iter_next(&iter, (void **) &key, (void **) &rsc)) {
         if (pcmk__is_set(rsc->call_opts, lrmd_opt_drop_recurring)) {
             /* This client is disconnecting, drop any recurring operations
              * it may have initiated on the resource */
@@ -1130,7 +1131,7 @@ execd_fencer_connection_failed(void)
                "devices will be considered failed)");
 
     g_hash_table_iter_init(&iter, rsc_list);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &rsc)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &rsc)) {
         if (!pcmk__str_eq(rsc->class, PCMK_RESOURCE_CLASS_STONITH,
                           pcmk__str_none)) {
             continue;
@@ -1202,7 +1203,8 @@ start_fencing_rsc(stonith_t *fencer_api, const lrmd_rsc_t *rsc,
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, cmd->params);
-        while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &key,
+                                      (void **) &value)) {
             device_params = stonith__key_value_add(device_params, key, value);
         }
     }
@@ -1406,7 +1408,7 @@ execute_nonstonith_action(lrmd_rsc_t *rsc, lrmd_cmd_t *cmd)
 }
 
 static gboolean
-execute_resource_action(gpointer user_data)
+execute_resource_action(void *user_data)
 {
     lrmd_rsc_t *rsc = (lrmd_rsc_t *) user_data;
     lrmd_cmd_t *cmd = NULL;
@@ -1459,7 +1461,7 @@ execute_resource_action(gpointer user_data)
 }
 
 void
-execd_free_rsc(gpointer data)
+execd_free_rsc(void *data)
 {
     GList *gIter = NULL;
     lrmd_rsc_t *rsc = data;
@@ -1870,8 +1872,7 @@ execd_process_get_recurring(xmlNode *request, int call_id, xmlNode **reply)
         char *key = NULL;
 
         g_hash_table_iter_init(&iter, rsc_list);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &key,
-                                      (gpointer *) &rsc)) {
+        while (g_hash_table_iter_next(&iter, (void **) &key, (void **) &rsc)) {
             add_recurring_op_xml(*reply, rsc);
         }
     } else if (rsc) {

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -320,7 +320,7 @@ create_lrmd_cmd(xmlNode *msg, pcmk__client_t *client)
     cmd->client_id = pcmk__str_copy(client->id);
 
     pcmk__xe_get_int(msg, PCMK__XA_LRMD_CALLID, &cmd->call_id);
-    pcmk__xe_get_guint(rsc_xml, PCMK__XA_LRMD_RSC_INTERVAL, &cmd->interval_ms);
+    pcmk__xe_get_uint(rsc_xml, PCMK__XA_LRMD_RSC_INTERVAL, &cmd->interval_ms);
     pcmk__xe_get_int(rsc_xml, PCMK__XA_LRMD_TIMEOUT, &cmd->timeout);
     pcmk__xe_get_int(rsc_xml, PCMK__XA_LRMD_RSC_START_DELAY, &cmd->start_delay);
     cmd->timeout_orig = cmd->timeout;
@@ -1807,7 +1807,7 @@ execd_process_rsc_cancel(pcmk__client_t *client, xmlNode *request)
     const char *action = pcmk__xe_get(rsc_xml, PCMK__XA_LRMD_RSC_ACTION);
     unsigned int interval_ms = 0;
 
-    pcmk__xe_get_guint(rsc_xml, PCMK__XA_LRMD_RSC_INTERVAL, &interval_ms);
+    pcmk__xe_get_uint(rsc_xml, PCMK__XA_LRMD_RSC_INTERVAL, &interval_ms);
 
     if (!rsc_id || !action) {
         return EINVAL;

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -633,7 +633,7 @@ send_cmd_complete_notify(lrmd_cmd_t * cmd)
 
     pcmk__xe_set(notify, PCMK__XA_LRMD_ORIGIN, __func__);
     pcmk__xe_set_int(notify, PCMK__XA_LRMD_TIMEOUT, cmd->timeout);
-    pcmk__xe_set_guint(notify, PCMK__XA_LRMD_RSC_INTERVAL, cmd->interval_ms);
+    pcmk__xe_set_uint(notify, PCMK__XA_LRMD_RSC_INTERVAL, cmd->interval_ms);
     pcmk__xe_set_int(notify, PCMK__XA_LRMD_RSC_START_DELAY, cmd->start_delay);
     pcmk__xe_set_int(notify, PCMK__XA_LRMD_EXEC_RC, cmd->result.exit_status);
     pcmk__xe_set_int(notify, PCMK__XA_LRMD_EXEC_OP_STATUS,
@@ -1828,8 +1828,7 @@ add_recurring_op_xml(xmlNode *reply, lrmd_rsc_t *rsc)
 
         pcmk__xe_set(op_xml, PCMK__XA_LRMD_RSC_ACTION,
                      pcmk__s(cmd->real_action, cmd->action));
-        pcmk__xe_set_guint(op_xml, PCMK__XA_LRMD_RSC_INTERVAL,
-                           cmd->interval_ms);
+        pcmk__xe_set_uint(op_xml, PCMK__XA_LRMD_RSC_INTERVAL, cmd->interval_ms);
         pcmk__xe_set_int(op_xml, PCMK__XA_LRMD_TIMEOUT, cmd->timeout_orig);
     }
 }

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -177,7 +177,7 @@ lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
 static void
 exit_executor(void)
 {
-    const guint nclients = pcmk__ipc_client_count();
+    const unsigned int nclients = pcmk__ipc_client_count();
 
     pcmk__info("Terminating with %d client%s", nclients,
                pcmk__plural_s(nclients));

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -14,7 +14,7 @@
 #include <stdint.h>                 // uint32_t
 #include <time.h>                   // time_t
 
-#include <glib.h>                   // GList, GHashTable, GMainLoop, gpointer
+#include <glib.h>                   // GList, GHashTable, GMainLoop
 #include <libxml/tree.h>            // xmlNode
 
 #include <crm/common/internal.h>    // pcmk__client_t, pcmk__action_result_t
@@ -66,7 +66,7 @@ int lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg);
 
 void notify_of_new_client(pcmk__client_t *new_client);
 
-void execd_free_rsc(gpointer data);
+void execd_free_rsc(void *data);
 
 void handle_shutdown_ack(void);
 

--- a/daemons/execd/remoted_pidone.c
+++ b/daemons/execd/remoted_pidone.c
@@ -72,7 +72,7 @@ static struct {
  *       [a-zA-Z0-9_] characters and do not start with a digit.
  */
 static bool
-valid_env_var_name(const gchar *name)
+valid_env_var_name(const char *name)
 {
     if (!isalpha(*name) && (*name != '_')) {
         // Invalid first character

--- a/daemons/execd/remoted_pidone.c
+++ b/daemons/execd/remoted_pidone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 the Pacemaker project contributors
+ * Copyright 2017-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -104,7 +104,7 @@ valid_env_var_name(const gchar *name)
 static void
 load_env_var_line(const char *line)
 {
-    gint argc = 0;
+    int argc = 0;
     gchar **argv = NULL;
     GError *error = NULL;
 

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -491,7 +491,8 @@ ipc_proxy_remove_provider(pcmk__client_t *ipc_proxy)
     ipc_providers = g_list_remove(ipc_providers, ipc_proxy);
 
     g_hash_table_iter_init(&iter, ipc_clients);
-    while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & ipc_client)) {
+    while (g_hash_table_iter_next(&iter, (void **) &key,
+                                  (void **) &ipc_client)) {
         const char *proxy_id = ipc_client->userdata;
         if (pcmk__str_eq(proxy_id, ipc_proxy->id, pcmk__str_casei)) {
             pcmk__info("IPC proxy connection for client %s pid %d destroyed "

--- a/daemons/execd/remoted_tls.c
+++ b/daemons/execd/remoted_tls.c
@@ -18,7 +18,7 @@
 #include <sys/socket.h>                 // setsockopt, AF_INET6, bind
 #include <unistd.h>                     // close
 
-#include <glib.h>                       // gpointer, TRUE, FALSE
+#include <glib.h>                       // TRUE, FALSE
 #include <gnutls/gnutls.h>              // gnutls_bye, gnutls_datum_t
 #include <libxml/tree.h>                // xmlNode
 #include <qb/qblog.h>                   // QB_XS
@@ -85,7 +85,7 @@ remoted__read_handshake_data(pcmk__client_t *client)
 }
 
 static int
-lrmd_remote_client_msg(gpointer data)
+lrmd_remote_client_msg(void *data)
 {
     int rc = pcmk_rc_ok;
     xmlNode *msg = NULL;
@@ -157,7 +157,7 @@ done:
 }
 
 static void
-lrmd_remote_client_destroy(gpointer user_data)
+lrmd_remote_client_destroy(void *user_data)
 {
     pcmk__client_t *client = user_data;
 
@@ -188,7 +188,7 @@ lrmd_remote_client_destroy(gpointer user_data)
 }
 
 static gboolean
-lrmd_auth_timeout_cb(gpointer data)
+lrmd_auth_timeout_cb(void *data)
 {
     pcmk__client_t *client = data;
 
@@ -207,7 +207,7 @@ lrmd_auth_timeout_cb(gpointer data)
 
 // Dispatch callback for remote server socket
 static int
-lrmd_remote_listen(gpointer data)
+lrmd_remote_listen(void *data)
 {
     int csock = -1;
     gnutls_session_t session = NULL;
@@ -250,7 +250,7 @@ lrmd_remote_listen(gpointer data)
 }
 
 static void
-tls_server_dropped(gpointer user_data)
+tls_server_dropped(void *user_data)
 {
     pcmk__notice("TLS server session ended");
 }

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -55,8 +55,7 @@ struct {
 };
 
 static gboolean
-mode_cb(const gchar *option_name, const gchar *optarg, void *data,
-        GError **error)
+mode_cb(const char *option_name, const char *optarg, void *data, GError **error)
 {
     if (pcmk__str_any_of(option_name, "--mainloop_api_test", "-m", NULL)) {
         options.mode = test_api_mainloop;

--- a/daemons/fenced/cts-fence-helper.c
+++ b/daemons/fenced/cts-fence-helper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU General Public License version 2
  * or later (GPLv2+) WITHOUT ANY WARRANTY.
@@ -55,7 +55,9 @@ struct {
 };
 
 static gboolean
-mode_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+mode_cb(const gchar *option_name, const gchar *optarg, void *data,
+        GError **error)
+{
     if (pcmk__str_any_of(option_name, "--mainloop_api_test", "-m", NULL)) {
         options.mode = test_api_mainloop;
     } else if (pcmk__str_any_of(option_name, "--api_test", "-t", NULL)) {
@@ -571,7 +573,7 @@ iterate_mainloop_tests(gboolean event_ready)
 }
 
 static gboolean
-trigger_iterate_mainloop_tests(gpointer user_data)
+trigger_iterate_mainloop_tests(void *user_data)
 {
     iterate_mainloop_tests(FALSE);
     return TRUE;

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -206,7 +206,7 @@ get_fencing_watchdog_timeout(xmlNode *cib)
  * \note This function is suitable for use with \c g_hash_table_foreach().
  */
 static void
-mark_dirty_if_cib_registered(gpointer key, gpointer value, gpointer user_data)
+mark_dirty_if_cib_registered(void *key, void *value, void *user_data)
 {
     fenced_device_t *device = value;
 
@@ -229,7 +229,7 @@ mark_dirty_if_cib_registered(gpointer key, gpointer value, gpointer user_data)
  *       \c g_hash_table_foreach_remove().
  */
 static gboolean
-device_is_dirty(gpointer key, gpointer value, gpointer user_data)
+device_is_dirty(void *key, void *value, void *user_data)
 {
     fenced_device_t *device = value;
 
@@ -584,7 +584,7 @@ init_cib_cache_cb(xmlNode * msg, int call_id, int rc, xmlNode * output, void *us
 }
 
 static void
-cib_connection_destroy(gpointer user_data)
+cib_connection_destroy(void *user_data)
 {
     if (stonith_shutdown_flag) {
         pcmk__info("Connection to the CIB manager closed");

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -189,7 +189,7 @@ static int
 get_action_delay_max(const fenced_device_t *device, const char *action)
 {
     const char *value = NULL;
-    guint delay_max = 0U;
+    unsigned int delay_max = 0;
 
     if (!pcmk__is_fencing_action(action)) {
         return 0;
@@ -298,7 +298,7 @@ get_action_delay_base(const fenced_device_t *device, const char *action,
     const char *param = NULL;
     gchar *stripped = NULL;
     gchar *delay_base_s = NULL;
-    guint delay_base = 0U;
+    unsigned int delay_base = 0;
 
     if (!pcmk__is_fencing_action(action)) {
         return 0;
@@ -398,7 +398,7 @@ get_action_timeout(const fenced_device_t *device, const char *action,
     }
 
     timeout_ms = QB_MIN(timeout_ms, UINT_MAX);
-    timeout_sec = pcmk__timeout_ms2s((guint) timeout_ms);
+    timeout_sec = pcmk__timeout_ms2s((unsigned int) timeout_ms);
 
     return QB_MIN(timeout_sec, INT_MAX);
 }
@@ -624,7 +624,7 @@ fork_cb(int pid, void *user_data)
 static int
 get_agent_metadata_cb(gpointer data) {
     fenced_device_t *device = data;
-    guint period_ms;
+    unsigned int period_ms = 0;
     int rc = get_agent_metadata(device->agent, &device->agent_metadata);
 
     if (rc == pcmk_rc_ok) {
@@ -1521,7 +1521,7 @@ fenced_device_register(const xmlNode *dev, bool from_cib)
 
     dup = device_has_duplicate(device);
     if (dup != NULL) {
-        guint ndevices = g_hash_table_size(device_table);
+        unsigned int ndevices = g_hash_table_size(device_table);
 
         pcmk__debug("Device '%s' already in device list (%d active device%s)",
                     device->id, ndevices, pcmk__plural_s(ndevices));
@@ -1530,7 +1530,7 @@ fenced_device_register(const xmlNode *dev, bool from_cib)
         fenced_device_clear_flags(device, fenced_df_dirty);
 
     } else {
-        guint ndevices = 0;
+        unsigned int ndevices = 0;
         fenced_device_t *old = g_hash_table_lookup(device_table, device->id);
 
         if (from_cib && (old != NULL)
@@ -1573,7 +1573,7 @@ void
 stonith_device_remove(const char *id, bool from_cib)
 {
     fenced_device_t *device = g_hash_table_lookup(device_table, id);
-    guint ndevices = 0;
+    unsigned int ndevices = 0;
 
     if (device == NULL) {
         ndevices = g_hash_table_size(device_table);
@@ -1924,13 +1924,13 @@ fenced_unregister_level(xmlNode *msg, pcmk__action_result_t *result)
 
     tp = g_hash_table_lookup(topology, target);
     if (tp == NULL) {
-        guint nentries = g_hash_table_size(topology);
+        unsigned int nentries = g_hash_table_size(topology);
 
         pcmk__info("No fencing topology found for %s (%d active %s)", target,
                    nentries, pcmk__plural_alt(nentries, "entry", "entries"));
 
     } else if (id == 0 && g_hash_table_remove(topology, target)) {
-        guint nentries = g_hash_table_size(topology);
+        unsigned int nentries = g_hash_table_size(topology);
 
         pcmk__info("Removed all fencing topology entries related to %s (%d "
                    "active %s remaining)",
@@ -1938,7 +1938,7 @@ fenced_unregister_level(xmlNode *msg, pcmk__action_result_t *result)
                    pcmk__plural_alt(nentries, "entry", "entries"));
 
     } else if (tp->levels[id] != NULL) {
-        guint nlevels;
+        unsigned int nlevels;
 
         g_list_free_full(tp->levels[id], free);
         tp->levels[id] = NULL;
@@ -2092,8 +2092,7 @@ search_devices_record_result(struct device_search_s *search, const char *device,
     }
 
     if (search->replies_needed == search->replies_received) {
-
-        guint ndevices = g_list_length(search->capable);
+        unsigned int ndevices = g_list_length(search->capable);
 
         pcmk__debug("Search found %d device%s that can perform '%s' targeting "
                     "%s",
@@ -2338,7 +2337,7 @@ get_capable_devices(const char *host, const char *action, int timeout,
                     uint32_t support_action_only)
 {
     struct device_search_s *search;
-    guint ndevices = g_hash_table_size(device_table);
+    unsigned int ndevices = g_hash_table_size(device_table);
 
     if (ndevices == 0) {
         callback(NULL, user_data);
@@ -2640,7 +2639,7 @@ log_async_result(const async_command_t *cmd,
 {
     int log_level = LOG_ERR;
     int output_log_level = PCMK__LOG_NEVER;
-    guint devices_remaining = g_list_length(cmd->next_device_iter);
+    unsigned int devices_remaining = g_list_length(cmd->next_device_iter);
 
     GString *msg = g_string_sized_new(80); // Reasonable starting size
 
@@ -2930,7 +2929,7 @@ stonith_fence_get_devices_cb(GList * devices, void *user_data)
 {
     async_command_t *cmd = user_data;
     fenced_device_t *device = NULL;
-    guint ndevices = g_list_length(devices);
+    unsigned int ndevices = g_list_length(devices);
 
     pcmk__info("Found %d matching device%s for target '%s'", ndevices,
                pcmk__plural_s(ndevices), cmd->target);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -69,7 +69,7 @@ struct device_search_s {
     uint32_t support_action_only;
 };
 
-static gboolean stonith_device_dispatch(gpointer user_data);
+static gboolean stonith_device_dispatch(void *user_data);
 static void st_child_done(int pid, const pcmk__action_result_t *result,
                           void *user_data);
 
@@ -151,7 +151,7 @@ fenced_has_watchdog_device(void)
  * \param[in,out] user_data  User data
  */
 void
-fenced_foreach_device(GHFunc fn, gpointer user_data)
+fenced_foreach_device(GHFunc fn, void *user_data)
 {
     if (device_table == NULL) {
         return;
@@ -622,7 +622,8 @@ fork_cb(int pid, void *user_data)
 }
 
 static int
-get_agent_metadata_cb(gpointer data) {
+get_agent_metadata_cb(void *data)
+{
     fenced_device_t *device = data;
     unsigned int period_ms = 0;
     int rc = get_agent_metadata(device->agent, &device->agent_metadata);
@@ -789,13 +790,13 @@ done:
 }
 
 static gboolean
-stonith_device_dispatch(gpointer user_data)
+stonith_device_dispatch(void *user_data)
 {
     return stonith_device_execute(user_data);
 }
 
 static gboolean
-start_delay_helper(gpointer data)
+start_delay_helper(void *data)
 {
     async_command_t *cmd = data;
     fenced_device_t *device = cmd_device(cmd);
@@ -884,7 +885,7 @@ schedule_stonith_command(async_command_t *cmd, fenced_device_t *device)
 }
 
 static void
-free_device(gpointer data)
+free_device(void *data)
 {
     fenced_device_t *device = data;
 
@@ -1634,7 +1635,7 @@ count_active_levels(const stonith_topology_t *tp)
 }
 
 static void
-free_topology_entry(gpointer data)
+free_topology_entry(void *data)
 {
     stonith_topology_t *tp = data;
 
@@ -2321,7 +2322,7 @@ can_fence_host_with_device(fenced_device_t *dev,
 }
 
 static void
-search_devices(gpointer key, gpointer value, gpointer user_data)
+search_devices(void *key, void *value, void *user_data)
 {
     fenced_device_t *dev = value;
     struct device_search_s *search = user_data;

--- a/daemons/fenced/fenced_corosync.c
+++ b/daemons/fenced/fenced_corosync.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>                           // NULL, free, size_t
 
 #include <corosync/cpg.h>                     // cpg_handle_t, cpg_name
-#include <glib.h>                             // gpointer
+#include <glib.h>                             // g_clear_pointer
 #include <libxml/tree.h>                      // xmlNode
 
 #include <crm/cluster.h>                      // pcmk_cluster_connect
@@ -167,7 +167,7 @@ fenced_cpg_dispatch(cpg_handle_t handle, const struct cpg_name *group_name,
  * \param[in] unused Unused
  */
 static void
-fenced_cpg_destroy(gpointer unused)
+fenced_cpg_destroy(void *unused)
 {
     pcmk__crit("Lost connection to cluster layer, shutting down");
     stonith_shutdown(0);

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -146,7 +146,7 @@ stonith_fence_history_cleanup(const char *target,
  * \return Standard comparison result (a negative integer if \p a is lesser,
  *         0 if the values are equal, and a positive integer if \p a is greater)
  */
-static gint
+static int
 cmp_op_by_completion(gconstpointer a, gconstpointer b)
 {
     const remote_fencing_op_t *op1 = a;

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -145,7 +145,7 @@ stonith_fence_history_cleanup(const char *target,
  *         0 if the values are equal, and a positive integer if \p a is greater)
  */
 static int
-cmp_op_by_completion(gconstpointer a, gconstpointer b)
+cmp_op_by_completion(const void *a, const void *b)
 {
     const remote_fencing_op_t *op1 = a;
     const remote_fencing_op_t *op2 = b;

--- a/daemons/fenced/fenced_history.c
+++ b/daemons/fenced/fenced_history.c
@@ -62,9 +62,7 @@ stonith_send_broadcast_history(xmlNode *history,
 }
 
 static gboolean
-stonith_remove_history_entry (gpointer key,
-                              gpointer value,
-                              gpointer user_data)
+stonith_remove_history_entry(void *key, void *value, void *user_data)
 {
     remote_fencing_op_t *op = value;
     const char *target = (const char *) user_data;
@@ -97,8 +95,8 @@ stonith_fence_history_cleanup(const char *target,
         /* we'll do the local clean when we receive back our own broadcast */
     } else if (stonith_remote_op_list) {
         g_hash_table_foreach_remove(stonith_remote_op_list,
-                             stonith_remove_history_entry,
-                             (gpointer) target);
+                                    stonith_remove_history_entry,
+                                    (void *) target);
         fenced_send_notification(PCMK__VALUE_ST_NOTIFY_HISTORY, NULL, NULL);
     }
 }
@@ -186,7 +184,7 @@ cmp_op_by_completion(gconstpointer a, gconstpointer b)
  * \param[in] user_data  Ignored
  */
 static void
-remove_completed_remote_op(gpointer data, gpointer user_data)
+remove_completed_remote_op(void *data, void *user_data)
 {
     const remote_fencing_op_t *op = data;
 

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -89,7 +89,7 @@ static int get_op_total_timeout(const remote_fencing_op_t *op,
                                 const peer_device_info_t *chosen_peer);
 
 static int
-sort_strings(gconstpointer a, gconstpointer b)
+sort_strings(const void *a, const void *b)
 {
     return strcmp(a, b);
 }
@@ -2110,7 +2110,7 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
  *         if the first value comes after the second."
  */
 static int
-sort_peers(gconstpointer a, gconstpointer b)
+sort_peers(const void *a, const void *b)
 {
     const peer_device_info_t *peer_a = a;
     const peer_device_info_t *peer_b = b;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -88,7 +88,7 @@ static void report_timeout_period(remote_fencing_op_t * op, int op_timeout);
 static int get_op_total_timeout(const remote_fencing_op_t *op,
                                 const peer_device_info_t *chosen_peer);
 
-static gint
+static int
 sort_strings(gconstpointer a, gconstpointer b)
 {
     return strcmp(a, b);
@@ -2109,7 +2109,7 @@ request_peer_fencing(remote_fencing_op_t *op, peer_device_info_t *peer)
  *         comes before the second, 0 if they are equal, or a positive integer
  *         if the first value comes after the second."
  */
-static gint
+static int
 sort_peers(gconstpointer a, gconstpointer b)
 {
     const peer_device_info_t *peer_a = a;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -95,7 +95,7 @@ sort_strings(gconstpointer a, gconstpointer b)
 }
 
 static void
-free_remote_query(gpointer data)
+free_remote_query(void *data)
 {
     if (data != NULL) {
         peer_device_info_t *peer = data;
@@ -128,7 +128,7 @@ struct peer_count_data {
  * \param[in,out] user_data  Peer count data
  */
 static void
-count_peer_device(gpointer key, gpointer value, gpointer user_data)
+count_peer_device(void *key, void *value, void *user_data)
 {
     device_properties_t *props = (device_properties_t*)value;
     struct peer_count_data *data = user_data;
@@ -244,7 +244,7 @@ clear_remote_op_timers(remote_fencing_op_t * op)
 }
 
 static void
-free_remote_op(gpointer data)
+free_remote_op(void *data)
 {
     remote_fencing_op_t *op = data;
 
@@ -641,7 +641,7 @@ finalize_op(remote_fencing_op_t *op, xmlNode *data, bool dup)
  * \return G_SOURCE_REMOVE (which tells glib not to restart timer)
  */
 static gboolean
-remote_op_watchdog_done(gpointer userdata)
+remote_op_watchdog_done(void *userdata)
 {
     remote_fencing_op_t *op = userdata;
 
@@ -657,7 +657,7 @@ remote_op_watchdog_done(gpointer userdata)
 }
 
 static gboolean
-remote_op_timeout_one(gpointer userdata)
+remote_op_timeout_one(void *userdata)
 {
     remote_fencing_op_t *op = userdata;
 
@@ -719,7 +719,7 @@ finalize_timed_out_op(remote_fencing_op_t *op, const char *reason)
  * \return G_SOURCE_REMOVE (which tells glib not to restart timer)
  */
 static gboolean
-remote_op_timeout(gpointer userdata)
+remote_op_timeout(void *userdata)
 {
     remote_fencing_op_t *op = userdata;
 
@@ -739,7 +739,7 @@ remote_op_timeout(gpointer userdata)
 }
 
 static gboolean
-remote_op_query_timeout(gpointer data)
+remote_op_query_timeout(void *data)
 {
     remote_fencing_op_t *op = data;
 
@@ -914,7 +914,7 @@ find_topology_for_host(const char *host)
     }
 
     g_hash_table_iter_init(&tIter, topology);
-    while (g_hash_table_iter_next(&tIter, NULL, (gpointer *) & tp)) {
+    while (g_hash_table_iter_next(&tIter, NULL, (void **) &tp)) {
         if (topology_matches(tp, host)) {
             pcmk__trace("Found %s for %s in %u entries", tp->target, host,
                         g_hash_table_size(topology));
@@ -1585,7 +1585,7 @@ struct timeout_data {
  * \param[in,out] user_data  Timeout data
  */
 static void
-add_device_timeout(gpointer key, gpointer value, gpointer user_data)
+add_device_timeout(void *key, void *value, void *user_data)
 {
     const char *device_id = key;
     device_properties_t *props = value;

--- a/daemons/fenced/fenced_remote.c
+++ b/daemons/fenced/fenced_remote.c
@@ -1835,7 +1835,7 @@ static gboolean
 check_watchdog_fencing_and_wait(remote_fencing_op_t * op)
 {
     if (node_does_watchdog_fencing(op->target)) {
-        guint timeout_ms = QB_MIN(fencing_watchdog_timeout_ms, UINT_MAX);
+        unsigned int timeout_ms = QB_MIN(fencing_watchdog_timeout_ms, UINT_MAX);
 
         pcmk__notice("Waiting %s for %s to self-fence (%s) for client %s "
                      QB_XS " id=%.8s",

--- a/daemons/fenced/fenced_scheduler.c
+++ b/daemons/fenced/fenced_scheduler.c
@@ -137,7 +137,7 @@ local_node_allowed_for(const pcmk_resource_t *rsc)
  * \param[in,out] user_data  Ignored
  */
 static void
-register_if_fencing_device(gpointer data, gpointer user_data)
+register_if_fencing_device(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
     const char *rsc_id = pcmk__s(rsc->priv->history_id, rsc->id);
@@ -218,8 +218,8 @@ register_if_fencing_device(gpointer data, gpointer user_data)
                                        PCMK_FENCING_PROVIDES);
 
     g_hash_table_iter_init(&hash_iter, pe_rsc_params(rsc, node, scheduler));
-    while (g_hash_table_iter_next(&hash_iter, (gpointer *) &name,
-                                  (gpointer *) &value)) {
+    while (g_hash_table_iter_next(&hash_iter, (void **) &name,
+                                  (void **) &value)) {
         if ((name == NULL) || (value == NULL)) {
             continue;
         }

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -37,7 +37,7 @@
 
 #define SUMMARY "daemon for executing fencing devices in a Pacemaker cluster"
 
-// @TODO This should be guint
+// @TODO This should be unsigned int
 long long fencing_watchdog_timeout_ms = 0;
 
 GList *stonith_watchdog_targets = NULL;

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -122,9 +122,8 @@ fenced_parse_notify_flag(const char *type)
 }
 
 static void
-stonith_notify_client(gpointer key, gpointer value, gpointer user_data)
+stonith_notify_client(void *key, void *value, void *user_data)
 {
-
     const xmlNode *update_msg = user_data;
     pcmk__client_t *client = value;
     const char *type = NULL;

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -195,11 +195,11 @@ typedef struct {
     guint query_timer;
     /*! This is the default timeout to use for each fencing device if no
      * custom timeout is received in the query. */
-    gint base_timeout;
+    int base_timeout;
     /*! This is the calculated total timeout an operation can take before
      * expiring. This is calculated by adding together all the timeout
      * values associated with the devices this fencing operation may call */
-    gint total_timeout;
+    int total_timeout;
 
     /*!
      * Fencing delay (in seconds) requested by API client (used by controller to

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -300,7 +300,7 @@ void stonith_shutdown(int nsig);
 void fenced_init_device_table(void);
 void fenced_free_device_table(void);
 bool fenced_has_watchdog_device(void);
-void fenced_foreach_device(GHFunc fn, gpointer user_data);
+void fenced_foreach_device(GHFunc fn, void *user_data);
 void fenced_foreach_device_remove(GHRFunc fn);
 
 void init_topology_list(void);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -180,19 +180,19 @@ typedef struct {
     /*! Marks if the final notifications have been sent to local stonith clients. */
     gboolean notify_sent;
     /*! The number of query replies received */
-    guint replies;
+    unsigned int replies;
     /*! The number of query replies expected */
-    guint replies_expected;
+    unsigned int replies_expected;
     /*! Does this node own control of this operation */
     gboolean owner;
     /*! After query is complete, This the high level timer that expires the entire operation */
-    guint op_timer_total;
+    unsigned int op_timer_total;
     /*! This timer expires the current fencing request. Many fencing
      * requests may exist in a single operation */
-    guint op_timer_one;
+    unsigned int op_timer_one;
     /*! This timer expires the query request sent out to determine
      * what nodes are contain what devices, and who those devices can fence */
-    guint query_timer;
+    unsigned int query_timer;
     /*! This is the default timeout to use for each fencing device if no
      * custom timeout is received in the query. */
     int base_timeout;
@@ -235,7 +235,7 @@ typedef struct {
     xmlNode *request;
 
     /*! The current topology level being executed */
-    guint level;
+    unsigned int level;
     /*! The current operation phase being executed */
     enum st_remap_phase phase;
 

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -95,12 +95,15 @@ static pcmk__message_entry_t fmt_functions[] = {
 };
 
 static gboolean
-pid_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+pid_cb(const gchar *option_name, const gchar *optarg, void *data, GError **err)
+{
     return TRUE;
 }
 
 static gboolean
-standby_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+standby_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **err)
+{
     options.standby = TRUE;
     pcmk__set_env_option(PCMK__ENV_NODE_START_STATE, PCMK_VALUE_STANDBY, false);
     return TRUE;

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -95,13 +95,13 @@ static pcmk__message_entry_t fmt_functions[] = {
 };
 
 static gboolean
-pid_cb(const gchar *option_name, const gchar *optarg, void *data, GError **err)
+pid_cb(const char *option_name, const char *optarg, void *data, GError **err)
 {
     return TRUE;
 }
 
 static gboolean
-standby_cb(const gchar *option_name, const gchar *optarg, void *data,
+standby_cb(const char *option_name, const char *optarg, void *data,
            GError **err)
 {
     options.standby = TRUE;

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -66,7 +66,7 @@ static corosync_cfg_callbacks_t cfg_callbacks = {
 };
 
 static int
-pcmk_cfg_dispatch(gpointer user_data)
+pcmk_cfg_dispatch(void *user_data)
 {
     corosync_cfg_handle_t *handle = (corosync_cfg_handle_t *) user_data;
     cs_error_t rc = corosync_cfg_dispatch(*handle, CS_DISPATCH_ALL);
@@ -93,7 +93,7 @@ close_cfg(void)
 }
 
 static gboolean
-cluster_reconnect_cb(gpointer data)
+cluster_reconnect_cb(void *data)
 {
     if (cluster_connect_cfg()) {
         g_clear_pointer(&reconnect_timer, mainloop_timer_del);
@@ -114,7 +114,7 @@ cluster_reconnect_cb(gpointer data)
 
 
 static void
-cfg_connection_destroy(gpointer user_data)
+cfg_connection_destroy(void *user_data)
 {
     pcmk__warn("Lost connection to cluster layer (connection will be "
                "reattempted once per second)");

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 the Pacemaker project contributors
+ * Copyright 2010-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -102,12 +102,12 @@ GMainLoop *mainloop = NULL;
 static bool fatal_error = false;
 
 static int child_liveness(pcmkd_child_t *child);
-static gboolean escalate_shutdown(gpointer data);
+static gboolean escalate_shutdown(void *data);
 static int start_child(pcmkd_child_t *child);
 static void pcmk_child_exit(mainloop_child_t *p, int core, int signo,
                             int exitcode);
 static void pcmk_process_exit(pcmkd_child_t *child);
-static gboolean pcmk_shutdown_worker(gpointer user_data);
+static gboolean pcmk_shutdown_worker(void *user_data);
 static void stop_child(pcmkd_child_t *child, int signal);
 
 static void
@@ -145,7 +145,7 @@ pcmkd_cluster_connected(void)
 }
 
 static gboolean
-check_next_subdaemon(gpointer user_data)
+check_next_subdaemon(void *user_data)
 {
     static int next_child = 0;
 
@@ -236,7 +236,7 @@ check_next_subdaemon(gpointer user_data)
 }
 
 static gboolean
-escalate_shutdown(gpointer data)
+escalate_shutdown(void *data)
 {
     pcmkd_child_t *child = data;
 
@@ -350,7 +350,7 @@ pcmk_process_exit(pcmkd_child_t * child)
 }
 
 static gboolean
-pcmk_shutdown_worker(gpointer user_data)
+pcmk_shutdown_worker(void *user_data)
 {
     static int phase = PCMK__NELEM(pcmk_children) - 1;
     static time_t next_log = 0;

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -12,11 +12,13 @@
 #include <signal.h>                     // SIGTERM
 #include <stdbool.h>                    // true
 #include <stddef.h>                     // NULL
+#include <syslog.h>                     // LOG_INFO
 
-#include <glib.h>                       // g_set_error, FALSE, G_OPTION_*
-#include <qb/qblog.h>                   // LOG_INFO, LOG_TRACE
+#include <glib.h>                       // g_*, etc.
+#include <qb/qblog.h>                   // LOG_TRACE
 
 #include <crm_config.h>                 // PCMK_SCHEDULER_INPUT_DIR
+#include <crm/common/logging.h>         // crm_log_init, crm_log_preinit
 #include <crm/common/mainloop.h>        // mainloop_add_signal
 #include <crm/common/results.h>         // crm_exit_t, CRM_EX_*, pcmk_rc_*
 #include <crm/pengine/internal.h>       // pe__register_messages

--- a/include/crm/cib/cib_types.h
+++ b/include/crm/cib/cib_types.h
@@ -155,7 +155,7 @@ typedef struct cib_api_operations_s {
                                                   xmlNode *msg));
     // NOTE: sbd (as of at least 1.5.2) uses this
     int (*set_connection_dnotify) (cib_t *cib,
-                                   void (*dnotify) (gpointer user_data));
+                                   void (*dnotify)(void *user_data));
 
     // NOTE: sbd (as of at least 1.5.2) uses this
     //! \deprecated This method will be removed and should not be used

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -204,7 +204,7 @@ int cib__create_op(cib_t *cib, const char *op, const char *host,
 int cib__extend_transaction(cib_t *cib, xmlNode *request);
 
 void cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc);
-void cib_native_notify(gpointer data, gpointer user_data);
+void cib_native_notify(void *data, void *user_data);
 
 int cib__get_operation(const char *op, const cib__operation_t **operation);
 

--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -131,7 +131,7 @@ typedef struct {
 struct timer_rec_s {
     int call_id;
     int timeout;
-    guint ref;
+    unsigned int ref;
     cib_t *cib;
 };
 

--- a/include/crm/cluster.h
+++ b/include/crm/cluster.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,8 +9,6 @@
 
 #ifndef PCMK__CRM_CLUSTER__H
 #define PCMK__CRM_CLUSTER__H
-
-#include <glib.h>               // gpointer
 
 #if SUPPORT_COROSYNC
 #include <corosync/cpg.h>       // cpg_callbacks_t, etc.
@@ -37,7 +35,7 @@ struct pcmk__cluster {
 
     // NOTE: sbd (as of at least 1.5.2) uses this
     //! \deprecated Call pcmk_cluster_set_destroy_fn() to set this
-    void (*destroy) (gpointer);
+    void (*destroy)(void *);
 
 #if SUPPORT_COROSYNC
     // NOTE: sbd (as of at least 1.5.2) uses this
@@ -59,7 +57,7 @@ int pcmk_cluster_disconnect(pcmk_cluster_t *cluster);
 pcmk_cluster_t *pcmk_cluster_new(void);
 void pcmk_cluster_free(pcmk_cluster_t *cluster);
 
-int pcmk_cluster_set_destroy_fn(pcmk_cluster_t *cluster, void (*fn)(gpointer));
+int pcmk_cluster_set_destroy_fn(pcmk_cluster_t *cluster, void (*fn)(void *));
 #if SUPPORT_COROSYNC
 int pcmk_cpg_set_deliver_fn(pcmk_cluster_t *cluster, cpg_deliver_fn_t fn);
 int pcmk_cpg_set_confchg_fn(pcmk_cluster_t *cluster, cpg_confchg_fn_t fn);

--- a/include/crm/cluster/compat.h
+++ b/include/crm/cluster/compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,6 +9,8 @@
 
 #ifndef PCMK__CRM_CLUSTER_COMPAT__H
 #define PCMK__CRM_CLUSTER_COMPAT__H
+
+#include <glib.h>           // gboolean
 
 #include <crm/cluster.h>    // pcmk_cluster_t, enum pcmk_cluster_layer
 

--- a/include/crm/cluster/election_internal.h
+++ b/include/crm/cluster/election_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2024 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -12,7 +12,7 @@
 
 #include <stdbool.h>        // bool
 
-#include <glib.h>           // guint, GSourceFunc
+#include <glib.h>           // GSourceFunc
 #include <libxml/tree.h>    // xmlNode
 
 #include <crm/common/ipc.h> // enum pcmk_ipc_server
@@ -73,7 +73,8 @@ enum election_result {
 void election_reset(pcmk_cluster_t *cluster);
 void election_init(pcmk_cluster_t *cluster, void (*cb)(pcmk_cluster_t *));
 
-void election_timeout_set_period(pcmk_cluster_t *cluster, guint period_ms);
+void election_timeout_set_period(pcmk_cluster_t *cluster,
+                                 unsigned int period_ms);
 void election_timeout_stop(pcmk_cluster_t *cluster);
 
 void election_vote(pcmk_cluster_t *cluster);

--- a/include/crm/cluster/internal.h
+++ b/include/crm/cluster/internal.h
@@ -241,7 +241,7 @@ void pcmk__reap_unseen_nodes(uint64_t ring_id);
 
 void pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
                                                         gboolean),
-                                   void (*destroy) (gpointer));
+                                   void (*destroy)(void *));
 
 bool pcmk__cluster_send_message(const pcmk__node_status_t *node,
                                 enum pcmk_ipc_server service,

--- a/include/crm/common/action_relation_internal.h
+++ b/include/crm/common/action_relation_internal.h
@@ -16,7 +16,6 @@
 
 #include <stdbool.h>                        // bool
 #include <stdint.h>                         // uint32_t
-#include <glib.h>                           // gpointer
 #include <crm/common/scheduler_types.h>     // pcmk_resource_t, pcmk_action_t
 
 #ifdef __cplusplus
@@ -186,7 +185,7 @@ typedef struct {
                                         #flags_to_clear);                   \
     } while (0)
 
-void pcmk__free_action_relation(gpointer user_data);
+void pcmk__free_action_relation(void *user_data);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/actions.h
+++ b/include/crm/common/actions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,7 @@
 #define PCMK__CRM_COMMON_ACTIONS__H
 
 #include <stdbool.h>                    // bool
-#include <glib.h>                       // gboolean, guint
+#include <glib.h>                       // gboolean
 #include <libxml/tree.h>                // xmlNode
 
 #include <crm/lrmd_events.h>            // lrmd_event_data_t
@@ -68,7 +68,7 @@ extern "C" {
 
 // For parsing various action-related string specifications
 gboolean parse_op_key(const char *key, char **rsc_id, char **op_type,
-                      guint *interval_ms);
+                      unsigned int *interval_ms);
 gboolean decode_transition_key(const char *key, char **uuid, int *transition_id,
                                int *action_id, int *target_rc);
 gboolean decode_transition_magic(const char *magic, char **uuid,

--- a/include/crm/common/actions_internal.h
+++ b/include/crm/common/actions_internal.h
@@ -238,7 +238,7 @@ struct pcmk__action {
     GList *actions_after;
 };
 
-void pcmk__free_action(gpointer user_data);
+void pcmk__free_action(void *user_data);
 char *pcmk__op_key(const char *rsc_id, const char *op_type,
                    unsigned int interval_ms);
 char *pcmk__notify_key(const char *rsc_id, const char *notify_type,

--- a/include/crm/common/actions_internal.h
+++ b/include/crm/common/actions_internal.h
@@ -16,7 +16,7 @@
 
 #include <stdbool.h>                        // bool
 #include <stdint.h>                         // uint32_t, UINT32_C()
-#include <glib.h>                           // guint, GList, GHashTable
+#include <glib.h>                           // GList, GHashTable
 #include <libxml/tree.h>                    // xmlNode
 
 #include <crm/common/actions.h>             // PCMK_ACTION_MONITOR
@@ -239,7 +239,8 @@ struct pcmk__action {
 };
 
 void pcmk__free_action(gpointer user_data);
-char *pcmk__op_key(const char *rsc_id, const char *op_type, guint interval_ms);
+char *pcmk__op_key(const char *rsc_id, const char *op_type,
+                   unsigned int interval_ms);
 char *pcmk__notify_key(const char *rsc_id, const char *notify_type,
                        const char *op_type);
 char *pcmk__transition_key(int transition_id, int action_id, int target_rc,
@@ -261,7 +262,8 @@ const char *pcmk__on_fail_text(enum pcmk__on_fail on_fail);
  * \return Action name suitable for display
  */
 static inline const char *
-pcmk__readable_action(const char *action_name, guint interval_ms) {
+pcmk__readable_action(const char *action_name, unsigned int interval_ms)
+{
     if ((interval_ms == 0)
         && pcmk__str_eq(action_name, PCMK_ACTION_MONITOR, pcmk__str_none)) {
         return "probe";

--- a/include/crm/common/cmdline_internal.h
+++ b/include/crm/common/cmdline_internal.h
@@ -117,7 +117,7 @@ void pcmk__add_arg_group(GOptionContext *context, const char *name,
  *
  * \param[in,out] argv  Command line (typically from pcmk__cmdline_preproc())
  */
-gchar *pcmk__quote_cmdline(gchar **argv);
+gchar *pcmk__quote_cmdline(char **argv);
 
 /*!
  * \internal

--- a/include/crm/common/failcounts_internal.h
+++ b/include/crm/common/failcounts_internal.h
@@ -16,8 +16,6 @@
 
 #include <stdint.h>                         // UINT32_C
 
-#include <glib.h>                           // guint
-
 #include <crm/common/logging.h>             // CRM_CHECK
 #include <crm/common/strings_internal.h>    // pcmk__assert_asprintf
 
@@ -61,7 +59,7 @@ enum pcmk__fc_flags {
  */
 static inline char *
 pcmk__fail_attr_name(const char *prefix, const char *rsc_id, const char *op,
-                     guint interval_ms)
+                     unsigned int interval_ms)
 {
     CRM_CHECK(prefix && rsc_id && op, return NULL);
     return pcmk__assert_asprintf("%s-%s#%s_%u", prefix, rsc_id, op,
@@ -69,14 +67,16 @@ pcmk__fail_attr_name(const char *prefix, const char *rsc_id, const char *op,
 }
 
 static inline char *
-pcmk__failcount_name(const char *rsc_id, const char *op, guint interval_ms)
+pcmk__failcount_name(const char *rsc_id, const char *op,
+                     unsigned int interval_ms)
 {
     return pcmk__fail_attr_name(PCMK__FAIL_COUNT_PREFIX, rsc_id, op,
                                 interval_ms);
 }
 
 static inline char *
-pcmk__lastfailure_name(const char *rsc_id, const char *op, guint interval_ms)
+pcmk__lastfailure_name(const char *rsc_id, const char *op,
+                       unsigned int interval_ms)
 {
     return pcmk__fail_attr_name(PCMK__LAST_FAILURE_PREFIX, rsc_id, op,
                                 interval_ms);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -19,7 +19,7 @@
 #include <sys/uio.h>                // struct iovec
 #include <sys/types.h>              // uid_t, gid_t, pid_t, size_t
 
-#include <glib.h>                   // guint, gpointer, GQueue, ...
+#include <glib.h>                   // gpointer, GQueue, ...
 #include <libxml/tree.h>            // xmlNode
 #include <qb/qbipcs.h>              // qb_ipcs_connection_t, ...
 
@@ -199,7 +199,7 @@ typedef struct {
                                          #flags_to_clear);                  \
     } while (0)
 
-guint pcmk__ipc_client_count(void);
+unsigned int pcmk__ipc_client_count(void);
 void pcmk__foreach_ipc_client(GHFunc func, gpointer user_data);
 
 void pcmk__client_cleanup(void);

--- a/include/crm/common/ipc_internal.h
+++ b/include/crm/common/ipc_internal.h
@@ -19,7 +19,7 @@
 #include <sys/uio.h>                // struct iovec
 #include <sys/types.h>              // uid_t, gid_t, pid_t, size_t
 
-#include <glib.h>                   // gpointer, GQueue, ...
+#include <glib.h>                   // GQueue, ...
 #include <libxml/tree.h>            // xmlNode
 #include <qb/qbipcs.h>              // qb_ipcs_connection_t, ...
 
@@ -200,7 +200,7 @@ typedef struct {
     } while (0)
 
 unsigned int pcmk__ipc_client_count(void);
-void pcmk__foreach_ipc_client(GHFunc func, gpointer user_data);
+void pcmk__foreach_ipc_client(GHFunc func, void *user_data);
 
 void pcmk__client_cleanup(void);
 

--- a/include/crm/common/iso8601_internal.h
+++ b/include/crm/common/iso8601_internal.h
@@ -20,7 +20,6 @@
 #include <sys/time.h>
 #include <time.h>
 
-#include <glib.h>
 #include <crm/common/iso8601.h>
 
 #ifdef __cplusplus
@@ -32,7 +31,7 @@ void pcmk__time_get_ywd(const crm_time_t *dt, uint32_t *y, uint32_t *w,
 char *pcmk__time_format_hr(const char *format, const crm_time_t *dt, int usec);
 char *pcmk__epoch2str(const time_t *source, uint32_t flags);
 char *pcmk__timespec2str(const struct timespec *ts, uint32_t flags);
-const char *pcmk__readable_interval(guint interval_ms);
+const char *pcmk__readable_interval(unsigned int interval_ms);
 crm_time_t *pcmk__copy_timet(time_t source_sec);
 
 void pcmk__time_log_as(const char *file, const char *function, int line,

--- a/include/crm/common/location_internal.h
+++ b/include/crm/common/location_internal.h
@@ -14,7 +14,7 @@
 #ifndef PCMK__CRM_COMMON_LOCATION_INTERNAL__H
 #define PCMK__CRM_COMMON_LOCATION_INTERNAL__H
 
-#include <glib.h>                       // gpointer, GList
+#include <glib.h>                       // GList
 
 #include <crm/common/nodes_internal.h>  // enum pcmk__probe_mode
 #include <crm/common/resources.h>       // enum rsc_role_e
@@ -33,7 +33,7 @@ typedef struct {
     GList *nodes;                       // Copies of affected nodes, with score
 } pcmk__location_t;
 
-void pcmk__free_location(gpointer user_data);
+void pcmk__free_location(void *user_data);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/logging_internal.h
+++ b/include/crm/common/logging_internal.h
@@ -405,7 +405,7 @@ void pcmk__log_xml_patchset_as(const char *file, const char *function,
  */
 void pcmk__cli_init_logging(const char *name, unsigned int verbosity);
 
-void pcmk__add_logfiles(gchar **log_files, pcmk__output_t *out);
+void pcmk__add_logfiles(char **log_files, pcmk__output_t *out);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/mainloop.h
+++ b/include/crm/common/mainloop.h
@@ -14,7 +14,7 @@
 #include <signal.h>     // sighandler_t
 #include <sys/types.h>  // pid_t, ssize_t
 
-#include <glib.h>       // gpointer, gboolean, GSourceFunc, GMainLoop
+#include <glib.h>       // gboolean, GSourceFunc, GMainLoop
 #include <qb/qbipcs.h>  // qb_ipcs_service_t, etc.
 
 #include <crm/common/ipc.h>
@@ -51,8 +51,9 @@ typedef void (*pcmk__mainloop_child_exit_fn_t)(mainloop_child_t *p, int core,
 void mainloop_cleanup(void);
 
 // NOTE: sbd (as of at least 1.5.2) uses this
-crm_trigger_t *mainloop_add_trigger(int priority, int (*dispatch) (gpointer user_data),
-                                    gpointer userdata);
+crm_trigger_t *mainloop_add_trigger(int priority,
+                                    int (*dispatch)(void *user_data),
+                                    void *userdata);
 
 // NOTE: sbd (as of at least 1.5.2) uses this
 void mainloop_set_trigger(crm_trigger_t * source);
@@ -100,14 +101,14 @@ struct ipc_client_callbacks {
      *
      * \return Negative value to remove source, anything else to keep it
      */
-    int (*dispatch) (const char *buffer, ssize_t length, gpointer userdata);
+    int (*dispatch)(const char *buffer, ssize_t length, void *userdata);
 
     /*!
      * \brief Destroy function for mainloop IPC connection client data
      *
      * \param[in,out] userdata  User data passed when creating mainloop source
      */
-    void (*destroy) (gpointer userdata);
+    void (*destroy)(void *userdata);
 };
 
 qb_ipcs_service_t *mainloop_add_ipc_server(const char *name, enum qb_ipc_type type,
@@ -155,14 +156,14 @@ struct mainloop_fd_callbacks {
      *
      * \return Negative value to remove source, anything else to keep it
      */
-    int (*dispatch) (gpointer userdata);
+    int (*dispatch)(void *userdata);
 
     /*!
      * \brief Destroy function for mainloop file descriptor client data
      *
      * \param[in,out] userdata  User data passed when creating mainloop source
      */
-    void (*destroy) (gpointer userdata);
+    void (*destroy)(void *userdata);
 };
 
 mainloop_io_t *mainloop_add_fd(const char *name, int priority, int fd, void *userdata,

--- a/include/crm/common/mainloop.h
+++ b/include/crm/common/mainloop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
 #include <signal.h>     // sighandler_t
 #include <sys/types.h>  // pid_t, ssize_t
 
-#include <glib.h>       // gpointer, gboolean, guint, GSourceFunc, GMainLoop
+#include <glib.h>       // gpointer, gboolean, GSourceFunc, GMainLoop
 #include <qb/qbipcs.h>  // qb_ipcs_service_t, etc.
 
 #include <crm/common/ipc.h>
@@ -80,10 +80,13 @@ void mainloop_timer_start(mainloop_timer_t *t);
 // NOTE: sbd (as of at least 1.5.2) uses this
 void mainloop_timer_stop(mainloop_timer_t *t);
 
-guint mainloop_timer_set_period(mainloop_timer_t *t, guint period_ms);
+unsigned int mainloop_timer_set_period(mainloop_timer_t *t,
+                                       unsigned int period_ms);
 
 // NOTE: sbd (as of at least 1.5.2) uses this
-mainloop_timer_t *mainloop_timer_add(const char *name, guint period_ms, bool repeat, GSourceFunc cb, void *userdata);
+mainloop_timer_t *mainloop_timer_add(const char *name, unsigned int period_ms,
+                                     bool repeat, GSourceFunc cb,
+                                     void *userdata);
 
 void mainloop_timer_del(mainloop_timer_t *t);
 
@@ -188,8 +191,8 @@ void mainloop_clear_child_userdata(mainloop_child_t * child);
 gboolean mainloop_child_kill(pid_t pid);
 
 void pcmk_quit_main_loop(GMainLoop *mloop, unsigned int n);
-void pcmk_drain_main_loop(GMainLoop *mloop, guint timer_ms,
-                          bool (*check)(guint));
+void pcmk_drain_main_loop(GMainLoop *mloop, unsigned int timer_ms,
+                          bool (*check)(unsigned int));
 
 #define G_PRIORITY_MEDIUM (G_PRIORITY_HIGH/2)
 

--- a/include/crm/common/mainloop_internal.h
+++ b/include/crm/common/mainloop_internal.h
@@ -16,7 +16,7 @@
 
 #include <sys/types.h>              // pid_t
 
-#include <glib.h>                   // gboolean, guint
+#include <glib.h>                   // gboolean
 
 #include <crm/common/ipc.h>         // crm_ipc_t
 #include <crm/common/mainloop.h>    // ipc_client_callbacks, mainloop_*
@@ -41,7 +41,7 @@ struct mainloop_child_s {
 int pcmk__add_mainloop_ipc(crm_ipc_t *ipc, int priority, void *userdata,
                            const struct ipc_client_callbacks *callbacks,
                            mainloop_io_t **source);
-guint pcmk__mainloop_timer_get_period(const mainloop_timer_t *timer);
+unsigned int pcmk__mainloop_timer_get_period(const mainloop_timer_t *timer);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/nodes_internal.h
+++ b/include/crm/common/nodes_internal.h
@@ -18,7 +18,7 @@
 #include <stdbool.h>    // bool
 #include <stdint.h>     // uint32_t, UINT32_C()
 
-#include <glib.h>       // gpointer, GList, GHashTable
+#include <glib.h>       // GList, GHashTable
 #include <crm/common/nodes.h>
 
 #ifdef __cplusplus
@@ -156,7 +156,7 @@ pcmk_node_t *pcmk__find_node_in_list(const GList *nodes, const char *node_name);
             (node)->priv->flags, (flags_to_clear), #flags_to_clear);        \
     } while (0)
 
-void pcmk__free_node(gpointer user_data);
+void pcmk__free_node(void *user_data);
 
 /*!
  * \internal

--- a/include/crm/common/nvpair.h
+++ b/include/crm/common/nvpair.h
@@ -10,7 +10,7 @@
 #ifndef PCMK__CRM_COMMON_NVPAIR__H
 #define PCMK__CRM_COMMON_NVPAIR__H
 
-#include <glib.h>         // GHashTable, gpointer, GSList
+#include <glib.h>         // GHashTable, GSList
 #include <libxml/tree.h>  // xmlNode
 
 #ifdef __cplusplus
@@ -34,9 +34,9 @@ void pcmk_free_nvpairs(GSList *nvpairs);
 
 xmlNode *crm_create_nvpair_xml(xmlNode *parent, const char *id,
                                const char *name, const char *value);
-void hash2field(gpointer key, gpointer value, gpointer user_data);
-void hash2metafield(gpointer key, gpointer value, gpointer user_data);
-void hash2smartfield(gpointer key, gpointer value, gpointer user_data);
+void hash2field(void *key, void *value, void *user_data);
+void hash2metafield(void *key, void *value, void *user_data);
+void hash2smartfield(void *key, void *value, void *user_data);
 GHashTable *xml2list(const xmlNode *parent);
 
 char *crm_meta_name(const char *field);

--- a/include/crm/common/nvpair_compat.h
+++ b/include/crm/common/nvpair_compat.h
@@ -10,7 +10,7 @@
 #ifndef PCMK__CRM_COMMON_NVPAIR_COMPAT__H
 #define PCMK__CRM_COMMON_NVPAIR_COMPAT__H
 
-#include <glib.h>               // GHashTable, gpointer, GSList
+#include <glib.h>               // GHashTable, GSList
 #include <libxml/tree.h>        // xmlNode
 
 #include <crm/common/iso8601.h> // crm_time_t
@@ -39,7 +39,7 @@ GSList *pcmk_xml_attrs2nvpairs(const xmlNode *xml);
 void pcmk_nvpairs2xml_attrs(GSList *list, xmlNode *xml);
 
 //! \deprecated Do not use
-void hash2nvpair(gpointer key, gpointer value, gpointer user_data);
+void hash2nvpair(void *key, void *value, void *user_data);
 
 //! \deprecated Do not use
 void pcmk_unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -15,7 +15,7 @@
 #define PCMK__CRM_COMMON_NVPAIR_INTERNAL__H
 
 #include <stdbool.h>                        // bool
-#include <glib.h>                           // gboolean, gpointer, GHashTable
+#include <glib.h>                           // gboolean, GHashTable
 #include <libxml/tree.h>                    // xmlNode
 
 #include <crm/common/rules.h>               // pcmk_rule_input_t
@@ -44,10 +44,9 @@ typedef struct {
     crm_time_t *next_change;
 } pcmk__nvpair_unpack_t;
 
-int pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b,
-                            gpointer user_data);
+int pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, void *user_data);
 
-void pcmk__unpack_nvpair_block(gpointer data, gpointer user_data);
+void pcmk__unpack_nvpair_block(void *data, void *user_data);
 
 void pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                                 const char *first_id,

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -44,8 +44,8 @@ typedef struct {
     crm_time_t *next_change;
 } pcmk__nvpair_unpack_t;
 
-gint pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b,
-                             gpointer user_data);
+int pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b,
+                            gpointer user_data);
 
 void pcmk__unpack_nvpair_block(gpointer data, gpointer user_data);
 

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -44,7 +44,7 @@ typedef struct {
     crm_time_t *next_change;
 } pcmk__nvpair_unpack_t;
 
-int pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, void *user_data);
+int pcmk__cmp_nvpair_blocks(const void *a, const void *b, void *user_data);
 
 void pcmk__unpack_nvpair_block(void *data, void *user_data);
 

--- a/include/crm/common/nvpair_internal.h
+++ b/include/crm/common/nvpair_internal.h
@@ -54,7 +54,7 @@ void pcmk__unpack_nvpair_blocks(const xmlNode *xml, const char *element_name,
                                 GHashTable *values, crm_time_t *next_change,
                                 xmlDoc *doc);
 
-int pcmk__scan_nvpair(const gchar *input, gchar **name, gchar **value);
+int pcmk__scan_nvpair(const char *input, gchar **name, gchar **value);
 char *pcmk__format_nvpair(const char *name, const char *value,
                           const char *units);
 

--- a/include/crm/common/probes.h
+++ b/include/crm/common/probes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,6 @@
 #define PCMK__CRM_COMMON_PROBES__H
 
 #include <stdbool.h>                        // bool
-#include <glib.h>                           // guint
 #include <libxml/tree.h>                    // xmlNode
 
 #ifdef __cplusplus
@@ -24,7 +23,7 @@ extern "C" {
  * \ingroup core
  */
 
-bool pcmk_is_probe(const char *task, guint interval);
+bool pcmk_is_probe(const char *task, unsigned int interval);
 bool pcmk_xe_is_probe(const xmlNode *xml_op);
 bool pcmk_xe_mask_probe_failure(const xmlNode *xml_op);
 

--- a/include/crm/common/resources.h
+++ b/include/crm/common/resources.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
 #include <stdint.h>                     // UINT32_C
 #include <sys/types.h>                  // time_t
 #include <libxml/tree.h>                // xmlNode
-#include <glib.h>                       // gboolean, guint, GList, GHashTable
+#include <glib.h>                       // gboolean, GList, GHashTable
 
 #include <crm/common/roles.h>           // enum rsc_role_e
 #include <crm/common/scheduler_types.h> // pcmk_resource_t, etc.

--- a/include/crm/common/resources_internal.h
+++ b/include/crm/common/resources_internal.h
@@ -17,7 +17,7 @@
 #include <inttypes.h>                   // UINT64_C
 #include <stdbool.h>                    // bool
 #include <stdint.h>                     // uint32_t
-#include <glib.h>                       // gboolean, gpointer, guint, etc.
+#include <glib.h>                       // gboolean, gpointer, etc.
 #include <libxml/tree.h>                // xmlNode
 
 #include <crm/common/resources.h>       // pcmk_resource_t
@@ -328,9 +328,15 @@ struct pcmk__resource_private {
     enum rsc_role_e orig_role;      // Resource's role at start of transition
     enum rsc_role_e next_role;      // Resource's role at end of transition
     int stickiness;                 // Extra preference for current node
-    guint failure_expiration_ms;    // Failures expire after this much time
+
+    // Failures expire after this much time
+    unsigned int failure_expiration_ms;
+
     int ban_after_failures;         // Ban from node after this many failures
-    guint remote_reconnect_ms;      // Retry interval for remote connections
+
+    // Retry interval for remote connections
+    unsigned int remote_reconnect_ms;
+
     char *pending_action;           // Pending action in history, if any
     const pcmk_node_t *pending_node;// Node on which pending_action is happening
     time_t lock_time;               // When shutdown lock started

--- a/include/crm/common/resources_internal.h
+++ b/include/crm/common/resources_internal.h
@@ -17,7 +17,7 @@
 #include <inttypes.h>                   // UINT64_C
 #include <stdbool.h>                    // bool
 #include <stdint.h>                     // uint32_t
-#include <glib.h>                       // gboolean, gpointer, etc.
+#include <glib.h>                       // gboolean, etc.
 #include <libxml/tree.h>                // xmlNode
 
 #include <crm/common/resources.h>       // pcmk_resource_t
@@ -459,7 +459,7 @@ struct pcmk__resource_private {
     const pcmk__assignment_methods_t *cmds; // Resource assignment methods
 };
 
-void pcmk__free_resource(gpointer user_data);
+void pcmk__free_resource(void *user_data);
 const char *pcmk__multiply_active_text(const pcmk_resource_t *rsc);
 
 /*!

--- a/include/crm/common/rules.h
+++ b/include/crm/common/rules.h
@@ -12,7 +12,7 @@
 
 #include <regex.h>                  // regmatch_t
 
-#include <glib.h>                   // guint, GHashTable
+#include <glib.h>                   // GHashTable
 #include <libxml/tree.h>            // xmlNode
 
 #include <crm/common/iso8601.h>     // crm_time_t
@@ -63,16 +63,19 @@ enum expression_type {
  */
 typedef struct pcmk_rule_input {
     // Used to evaluate date expressions
-    const crm_time_t *now; //!< Current time for rule evaluation purposes
+    /*!
+     * Current time for rule evaluation purposes
+     */
+    const crm_time_t *now;
 
     // Used to evaluate resource type expressions
-    const char *rsc_standard;   //!< Resource standard that rule applies to
-    const char *rsc_provider;   //!< Resource provider that rule applies to
-    const char *rsc_agent;      //!< Resource agent that rule applies to
+    const char *rsc_standard;       //!< Resource standard that rule applies to
+    const char *rsc_provider;       //!< Resource provider that rule applies to
+    const char *rsc_agent;          //!< Resource agent that rule applies to
 
     // Used to evaluate operation type expressions
-    const char *op_name;        //!< Operation name that rule applies to
-    guint op_interval_ms;       //!< Operation interval that rule applies to
+    const char *op_name;            //!< Operation name that rule applies to
+    unsigned int op_interval_ms;    //!< Operation interval that rule applies to
 
     // Remaining members are used to evaluate node attribute expressions
 

--- a/include/crm/common/scheduler.h
+++ b/include/crm/common/scheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,7 +13,7 @@
 #include <stdbool.h>
 #include <sys/types.h>                  // time_t
 #include <libxml/tree.h>                // xmlNode
-#include <glib.h>                       // guint, GList, GHashTable
+#include <glib.h>                       // GList, GHashTable
 
 #include <crm/common/iso8601.h>         // crm_time_t
 

--- a/include/crm/common/scheduler_internal.h
+++ b/include/crm/common/scheduler_internal.h
@@ -186,10 +186,18 @@ struct pcmk__scheduler_private {
     pcmk__output_t *out;            // Output object for displaying messages
     GHashTable *options;            // Cluster options
     const char *fence_action;       // Default fencing action
-    guint fence_timeout_ms;         // Default fencing action timeout (in ms)
-    guint priority_fencing_ms;      // Priority-based fencing delay (in ms)
-    guint shutdown_lock_ms;         // How long to lock resources (in ms)
-    guint node_pending_ms;          // Pending join times out after this (in ms)
+
+    // Default fencing action timeout (in ms)
+    unsigned int fence_timeout_ms;
+
+    // Priority-based fencing delay (in ms)
+    unsigned int priority_fencing_ms;
+
+    // How long to lock resources (in ms)
+    unsigned int shutdown_lock_ms;
+
+    // Pending join times out after this (in ms)
+    unsigned int node_pending_ms;
 
     // @TODO convert to enum
     const char *placement_strategy; // Value of placement-strategy property

--- a/include/crm/common/strings.h
+++ b/include/crm/common/strings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,8 +9,6 @@
 
 #ifndef PCMK__CRM_COMMON_STRINGS__H
 #define PCMK__CRM_COMMON_STRINGS__H
-
-#include <glib.h>                    // gboolean, guint, G_GNUC_PRINTF
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,7 +20,7 @@ extern "C" {
  * \ingroup core
  */
 
-int pcmk_parse_interval_spec(const char *input, guint *result_ms);
+int pcmk_parse_interval_spec(const char *input, unsigned int *result_ms);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -17,7 +17,7 @@
 #include <stdbool.h>            // bool
 #include <stdint.h>             // uint32_t, etc.
 
-#include <glib.h>               // guint, GList, GHashTable
+#include <glib.h>               // GList, GHashTable
 
 #include <crm/common/options.h> // PCMK_VALUE_TRUE, PCMK_VALUE_FALSE
 #include <crm/common/results.h> // pcmk_rc_ok
@@ -43,8 +43,8 @@ enum pcmk__str_flags {
 
 int pcmk__scan_double(const char *text, double *result,
                       const char *default_text, char **end_text);
-int pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
-                          guint *result);
+int pcmk__guint_from_hash(GHashTable *table, const char *key,
+                          unsigned int default_val, unsigned int *result);
 void pcmk__add_separated_word(GString **list, size_t init_size,
                               const char *word, const char *separator);
 int pcmk__compress(const char *data, unsigned int length, unsigned int max,

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -128,7 +128,7 @@ pcmk__intkey_table(GDestroyNotify value_destroy_func)
  *       already exists in the table, the old value is freed and replaced.
  */
 static inline gboolean
-pcmk__intkey_table_insert(GHashTable *hash_table, int key, gpointer value)
+pcmk__intkey_table_insert(GHashTable *hash_table, int key, void *value)
 {
     return g_hash_table_insert(hash_table, GINT_TO_POINTER(key), value);
 }
@@ -142,7 +142,7 @@ pcmk__intkey_table_insert(GHashTable *hash_table, int key, gpointer value)
  *
  * \return Value in table for \key (or NULL if not found)
  */
-static inline gpointer
+static inline void *
 pcmk__intkey_table_lookup(GHashTable *hash_table, int key)
 {
     return g_hash_table_lookup(hash_table, GINT_TO_POINTER(key));

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -164,7 +164,7 @@ pcmk__intkey_table_remove(GHashTable *hash_table, int key)
 }
 
 bool pcmk__str_in_list(const char *str, const GList *list, uint32_t flags);
-bool pcmk__g_strv_contains(gchar **strv, const gchar *str);
+bool pcmk__g_strv_contains(char **strv, const char *str);
 
 bool pcmk__strcase_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;
 bool pcmk__str_any_of(const char *s, ...) G_GNUC_NULL_TERMINATED;

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -43,8 +43,8 @@ enum pcmk__str_flags {
 
 int pcmk__scan_double(const char *text, double *result,
                       const char *default_text, char **end_text);
-int pcmk__guint_from_hash(GHashTable *table, const char *key,
-                          unsigned int default_val, unsigned int *result);
+int pcmk__uint_from_hash(GHashTable *table, const char *key,
+                         unsigned int default_val, unsigned int *result);
 void pcmk__add_separated_word(GString **list, size_t init_size,
                               const char *word, const char *separator);
 int pcmk__compress(const char *data, unsigned int length, unsigned int max,

--- a/include/crm/common/utils_internal.h
+++ b/include/crm/common/utils_internal.h
@@ -15,7 +15,7 @@
 
 #include <sys/types.h>          // pid_t, uid_t, gid_t
 
-#include <glib.h>               // GSourceFunc, gpointer
+#include <glib.h>               // GSourceFunc
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,7 +32,7 @@ void pcmk__panic(const char *reason);
 pid_t pcmk__locate_sbd(void);
 void pcmk__sleep_ms(unsigned int ms);
 unsigned int pcmk__create_timer(unsigned int interval_ms, GSourceFunc fn,
-                                gpointer data);
+                                void *data);
 unsigned int pcmk__timeout_ms2s(unsigned int timeout_ms);
 
 #ifdef __cplusplus

--- a/include/crm/common/utils_internal.h
+++ b/include/crm/common/utils_internal.h
@@ -15,7 +15,7 @@
 
 #include <sys/types.h>          // pid_t, uid_t, gid_t
 
-#include <glib.h>               // GSourceFunc, gpointer, guint
+#include <glib.h>               // GSourceFunc, gpointer
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,8 +31,9 @@ int pcmk__lookup_user(const char *name, uid_t *uid, gid_t *gid);
 void pcmk__panic(const char *reason);
 pid_t pcmk__locate_sbd(void);
 void pcmk__sleep_ms(unsigned int ms);
-guint pcmk__create_timer(guint interval_ms, GSourceFunc fn, gpointer data);
-guint pcmk__timeout_ms2s(guint timeout_ms);
+unsigned int pcmk__create_timer(unsigned int interval_ms, GSourceFunc fn,
+                                gpointer data);
+unsigned int pcmk__timeout_ms2s(unsigned int timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/include/crm/common/xml_element_compat.h
+++ b/include/crm/common/xml_element_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -12,7 +12,7 @@
 
 #include <sys/time.h>       // struct timeval
 
-#include <glib.h>           // gboolean, guint
+#include <glib.h>           // gboolean
 #include <libxml/tree.h>    // xmlNode
 
 #ifdef __cplusplus
@@ -49,7 +49,8 @@ int crm_element_value_timeval(const xmlNode *data, const char *name_sec,
 int crm_element_value_epoch(const xmlNode *xml, const char *name, time_t *dest);
 
 //! \deprecated Do not use
-int crm_element_value_ms(const xmlNode *data, const char *name, guint *dest);
+int crm_element_value_ms(const xmlNode *data, const char *name,
+                         unsigned int *dest);
 
 //! \deprecated Do not use
 int crm_element_value_ll(const xmlNode *data, const char *name,
@@ -70,7 +71,7 @@ const char *crm_xml_add_timeval(xmlNode *xml, const char *name_sec,
                                 const struct timeval *value);
 
 //! \deprecated Do not use
-const char *crm_xml_add_ms(xmlNode *node, const char *name, guint ms);
+const char *crm_xml_add_ms(xmlNode *node, const char *name, unsigned int ms);
 
 //! \deprecated Do not use
 const char *crm_xml_add_ll(xmlNode *node, const char *name, long long value);

--- a/include/crm/common/xml_element_internal.h
+++ b/include/crm/common/xml_element_internal.h
@@ -24,7 +24,6 @@
 #include <stdio.h>                          // NULL
 #include <string.h>                         // strcmp()
 
-#include <glib.h>                           // guint
 #include <libxml/tree.h>                    // xmlNode, etc.
 
 #include <crm/common/iso8601.h>             // crm_time_t
@@ -151,8 +150,9 @@ int pcmk__xe_get_datetime(const xmlNode *xml, const char *attr, crm_time_t **t);
 int pcmk__xe_get_flags(const xmlNode *xml, const char *name, uint32_t *dest,
                        uint32_t default_value);
 
-int pcmk__xe_get_guint(const xmlNode *xml, const char *attr, guint *dest);
-void pcmk__xe_set_guint(xmlNode *xml, const char *attr, guint value);
+int pcmk__xe_get_guint(const xmlNode *xml, const char *attr,
+                       unsigned int *dest);
+void pcmk__xe_set_guint(xmlNode *xml, const char *attr, unsigned int value);
 
 int pcmk__xe_get_int(const xmlNode *xml, const char *name, int *dest);
 void pcmk__xe_set_int(xmlNode *xml, const char *attr, int value);

--- a/include/crm/common/xml_element_internal.h
+++ b/include/crm/common/xml_element_internal.h
@@ -150,8 +150,7 @@ int pcmk__xe_get_datetime(const xmlNode *xml, const char *attr, crm_time_t **t);
 int pcmk__xe_get_flags(const xmlNode *xml, const char *name, uint32_t *dest,
                        uint32_t default_value);
 
-int pcmk__xe_get_guint(const xmlNode *xml, const char *attr,
-                       unsigned int *dest);
+int pcmk__xe_get_uint(const xmlNode *xml, const char *attr, unsigned int *dest);
 void pcmk__xe_set_guint(xmlNode *xml, const char *attr, unsigned int value);
 
 int pcmk__xe_get_int(const xmlNode *xml, const char *name, int *dest);

--- a/include/crm/common/xml_element_internal.h
+++ b/include/crm/common/xml_element_internal.h
@@ -151,7 +151,7 @@ int pcmk__xe_get_flags(const xmlNode *xml, const char *name, uint32_t *dest,
                        uint32_t default_value);
 
 int pcmk__xe_get_uint(const xmlNode *xml, const char *attr, unsigned int *dest);
-void pcmk__xe_set_guint(xmlNode *xml, const char *attr, unsigned int value);
+void pcmk__xe_set_uint(xmlNode *xml, const char *attr, unsigned int value);
 
 int pcmk__xe_get_int(const xmlNode *xml, const char *name, int *dest);
 void pcmk__xe_set_int(xmlNode *xml, const char *attr, int value);

--- a/include/crm/common/xml_idref_internal.h
+++ b/include/crm/common/xml_idref_internal.h
@@ -14,8 +14,8 @@
 #ifndef PCMK__CRM_COMMON_XML_IDREF_INTERNAL__H
 #define PCMK__CRM_COMMON_XML_IDREF_INTERNAL__H
 
-#include <glib.h>           // gboolean, gpointer, GList, GHashTable
-#include <libxml/tree.h>    // xmlNode
+#include <glib.h>           // GList, GHashTable
+#include <libxml/tree.h>    // xmlDoc, xmlNode
 
 // An XML ID and references to it (used for tags and templates)
 typedef struct {
@@ -24,7 +24,7 @@ typedef struct {
 } pcmk__idref_t;
 
 void pcmk__add_idref(GHashTable *table, const char *id, const char *referrer);
-void pcmk__free_idref(gpointer data);
+void pcmk__free_idref(void *data);
 xmlNode *pcmk__xe_resolve_idref(xmlNode *xml, xmlDoc *doc);
 GList *pcmk__xe_dereference_children(const xmlNode *xml,
                                      const char *element_name, xmlDoc *doc);

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -192,6 +192,7 @@ typedef struct lrmd_list_s {
 void lrmd_list_freeall(lrmd_list_t * head);
 void lrmd_key_value_freeall(lrmd_key_value_t * head);
 
+// @COMPAT The enum lrmd_call_options arguments should be of type uint32_t
 /*!
  * \deprecated Use \c lrmd_api_operations_t instead of
  *             <tt>struct lrmd_api_operations_s</tt>.
@@ -333,9 +334,9 @@ typedef struct lrmd_api_operations_s {
      * \param[in]     interval_ms  If 0, execute action once; otherwise, execute
      *                             it on a recurring basis at this interval (in
      *                             milliseconds)
-     * \param[in]     timeout      Error if not complete within this time (in
+     * \param[in]     timeout_ms   Error if not complete within this time (in
      *                             milliseconds)
-     * \param[in]     start_delay  Wait this long before execution (in
+     * \param[in]     delay_ms     Wait this long before execution (in
      *                             milliseconds)
      * \param[in]     options      Group of <tt>enum lrmd_call_options</tt>
      * \param[in,out] params       Parameters to pass to agent (will be freed)
@@ -350,8 +351,8 @@ typedef struct lrmd_api_operations_s {
      *       any specific order.
      */
     int (*exec) (lrmd_t *lrmd, const char *rsc_id, const char *action,
-                 const char *userdata, unsigned int interval_ms, int timeout,
-                 int start_delay, enum lrmd_call_options options,
+                 const char *userdata, unsigned int interval_ms, int timeout_ms,
+                 int delay_ms, enum lrmd_call_options options,
                  lrmd_key_value_t *params);
 
     /*!

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -330,20 +330,21 @@ typedef struct lrmd_api_operations_s {
      * \param[in]     rsc_id       ID of resource
      * \param[in]     action       Name of resource action to execute
      * \param[in]     userdata     Arbitrary string to pass to event callback
-     * \param[in]     interval_ms  If 0, execute action once, otherwise
-     *                             recurring at this interval (in milliseconds)
+     * \param[in]     interval_ms  If 0, execute action once; otherwise, execute
+     *                             it on a recurring basis at this interval (in
+     *                             milliseconds)
      * \param[in]     timeout      Error if not complete within this time (in
      *                             milliseconds)
      * \param[in]     start_delay  Wait this long before execution (in
      *                             milliseconds)
-     * \param[in]     options      Group of enum lrmd_call_options flags
+     * \param[in]     options      Group of <tt>enum lrmd_call_options</tt>
      * \param[in,out] params       Parameters to pass to agent (will be freed)
      *
      * \return A call ID for the action on success (in which case the action is
      *         queued in the executor, and the event callback will be called
-     *         later with the result), otherwise a negative legacy Pacemaker
+     *         later with the result); otherwise, a negative legacy Pacemaker
      *         return code
-     * \note exec() and cancel() operations on an individual resource are
+     * \note \c exec() and \c cancel() operations on an individual resource are
      *       guaranteed to occur in the order the client API is called. However,
      *       operations on different resources are not guaranteed to occur in
      *       any specific order.

--- a/include/crm/lrmd.h
+++ b/include/crm/lrmd.h
@@ -13,7 +13,7 @@
 #include <stdbool.h>                // bool
 #include <stdint.h>                 // UINT32_C
 
-#include <glib.h>                   // guint, GList
+#include <glib.h>                   // GList
 
 #include <crm_config.h>
 #include <crm/common/internal.h>    // pcmk__compare_versions()
@@ -349,7 +349,7 @@ typedef struct lrmd_api_operations_s {
      *       any specific order.
      */
     int (*exec) (lrmd_t *lrmd, const char *rsc_id, const char *action,
-                 const char *userdata, guint interval_ms, int timeout,
+                 const char *userdata, unsigned int interval_ms, int timeout,
                  int start_delay, enum lrmd_call_options options,
                  lrmd_key_value_t *params);
 
@@ -372,7 +372,7 @@ typedef struct lrmd_api_operations_s {
      *       any specific order.
      */
     int (*cancel) (lrmd_t *lrmd, const char *rsc_id, const char *action,
-                   guint interval_ms);
+                   unsigned int interval_ms);
 
     /*!
      * \brief Retrieve resource agent metadata synchronously

--- a/include/crm/lrmd_events.h
+++ b/include/crm/lrmd_events.h
@@ -12,8 +12,6 @@
 
 #include <sys/types.h>          // time_t
 
-#include <glib.h>               // guint
-
 #include <crm/common/results.h> // enum ocf_exitcode
 
 #ifdef __cplusplus
@@ -58,7 +56,7 @@ typedef struct lrmd_event_data_s {
     int timeout;
 
     /*! The operation's recurring interval in ms. */
-    guint interval_ms;
+    unsigned int interval_ms;
 
     /*! The operation's start delay value in ms. */
     int start_delay;
@@ -104,7 +102,7 @@ typedef struct lrmd_event_data_s {
 } lrmd_event_data_t;
 
 lrmd_event_data_t *lrmd_new_event(const char *rsc_id, const char *task,
-                                  guint interval_ms);
+                                  unsigned int interval_ms);
 lrmd_event_data_t *lrmd_copy_event(lrmd_event_data_t *event);
 void lrmd_free_event(lrmd_event_data_t *event);
 

--- a/include/crm/lrmd_internal.h
+++ b/include/crm/lrmd_internal.h
@@ -12,7 +12,7 @@
 
 #include <stdint.h>                     // uint32_t
 
-#include <glib.h>                       // GList, GHashTable, gpointer
+#include <glib.h>                       // GList, GHashTable
 #include <gnutls/gnutls.h>              // gnutls_datum_t
 #include <libxml/tree.h>                // xmlNode
 

--- a/include/crm/pengine/common_compat.h
+++ b/include/crm/pengine/common_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2024 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,7 @@
 #define PCMK__CRM_PENGINE_COMMON_COMPAT__H
 
 #include <regex.h>                  // regmatch_t
-#include <glib.h>                   // guint, GHashTable
+#include <glib.h>                   // GHashTable
 
 #include <crm/common/iso8601.h>     // crm_time_t
 #include <crm/common/roles.h>       // enum rsc_role_e
@@ -52,7 +52,7 @@ typedef struct pe_rsc_eval_data {
 
 typedef struct pe_op_eval_data {
     const char *op_name;
-    guint interval;
+    unsigned int interval;
 } pe_op_eval_data_t;
 
 typedef struct pe_rule_eval_data {

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -160,13 +160,15 @@ void pe__show_node_scores_as(const char *file, const char *function,
 
 GHashTable *pcmk__unpack_action_meta(pcmk_resource_t *rsc,
                                      const pcmk_node_t *node,
-                                     const char *action_name, guint interval_ms,
+                                     const char *action_name,
+                                     unsigned int interval_ms,
                                      const xmlNode *action_config);
 GHashTable *pcmk__unpack_action_rsc_params(const xmlNode *action_xml,
                                            GHashTable *node_attrs,
                                            pcmk_scheduler_t *data_set);
 xmlNode *pcmk__find_action_config(const pcmk_resource_t *rsc,
-                                  const char *action_name, guint interval_ms,
+                                  const char *action_name,
+                                  unsigned int interval_ms,
                                   bool include_disabled);
 
 enum pcmk__requires pcmk__action_requires(const pcmk_resource_t *rsc,
@@ -174,7 +176,8 @@ enum pcmk__requires pcmk__action_requires(const pcmk_resource_t *rsc,
 
 enum pcmk__on_fail pcmk__parse_on_fail(const pcmk_resource_t *rsc,
                                        const char *action_name,
-                                       guint interval_ms, const char *value);
+                                       unsigned int interval_ms,
+                                       const char *value);
 
 enum rsc_role_e pcmk__role_after_failure(const pcmk_resource_t *rsc,
                                          const char *action_name,
@@ -259,7 +262,7 @@ int pe__cmp_node_name(gconstpointer a, gconstpointer b);
 bool is_set_recursive(const pcmk_resource_t *rsc, long long flag, bool any);
 
 pcmk__op_digest_t *pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
-                                         guint *interval_ms,
+                                         unsigned int *interval_ms,
                                          const pcmk_node_t *node,
                                          const xmlNode *xml_op,
                                          GHashTable *overrides,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -236,7 +236,7 @@ gboolean get_target_role(const pcmk_resource_t *rsc, enum rsc_role_e *role);
 void pe__set_next_role(pcmk_resource_t *rsc, enum rsc_role_e role,
                        const char *why);
 
-extern void destroy_ticket(gpointer data);
+void destroy_ticket(void *data);
 pcmk__ticket_t *ticket_new(const char *ticket_id, pcmk_scheduler_t *scheduler);
 
 // Resources for manipulating resource names
@@ -269,7 +269,7 @@ pcmk__op_digest_t *pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
                                          bool calc_secure,
                                          pcmk_scheduler_t *scheduler);
 
-void pe__free_digests(gpointer ptr);
+void pe__free_digests(void *ptr);
 
 pcmk__op_digest_t *rsc_action_digest_cmp(pcmk_resource_t *rsc,
                                          const xmlNode *xml_op,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -226,7 +226,7 @@ void resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
                        const char *tag, pcmk_scheduler_t *scheduler);
 
 int pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b);
-extern gint sort_op_by_callid(gconstpointer a, gconstpointer b);
+int sort_op_by_callid(gconstpointer a, gconstpointer b);
 gboolean get_target_role(const pcmk_resource_t *rsc, enum rsc_role_e *role);
 void pe__set_next_role(pcmk_resource_t *rsc, enum rsc_role_e role,
                        const char *why);
@@ -253,7 +253,7 @@ pe_base_name_eq(const pcmk_resource_t *rsc, const char *id)
 
 int pe__target_rc_from_xml(const xmlNode *xml_op);
 
-gint pe__cmp_node_name(gconstpointer a, gconstpointer b);
+int pe__cmp_node_name(gconstpointer a, gconstpointer b);
 bool is_set_recursive(const pcmk_resource_t *rsc, long long flag, bool any);
 
 pcmk__op_digest_t *pe__calculate_digests(pcmk_resource_t *rsc, const char *task,

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -10,13 +10,15 @@
 #ifndef PCMK__CRM_PENGINE_INTERNAL__H
 #define PCMK__CRM_PENGINE_INTERNAL__H
 
-#include <stdbool.h>
+#include <stdbool.h>                        // bool, false
 #include <stdint.h>                         // uint32_t
-#include <string.h>
-#include <crm/common/xml.h>
-#include <crm/pengine/status.h>
+#include <string.h>                         // strncmp
+
+#include <libxml/tree.h>                    // xmlNode
+
+#include <crm/common/internal.h>            // pcmk__clone_flags, etc.
+#include <crm/common/scheduler.h>           // pcmk_scheduler_t, etc.
 #include <crm/pengine/remote_internal.h>
-#include <crm/common/internal.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/pengine/internal.h
+++ b/include/crm/pengine/internal.h
@@ -231,7 +231,7 @@ void resource_location(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
                        const char *tag, pcmk_scheduler_t *scheduler);
 
 int pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b);
-int sort_op_by_callid(gconstpointer a, gconstpointer b);
+int sort_op_by_callid(const void *a, const void *b);
 gboolean get_target_role(const pcmk_resource_t *rsc, enum rsc_role_e *role);
 void pe__set_next_role(pcmk_resource_t *rsc, enum rsc_role_e role,
                        const char *why);
@@ -258,7 +258,7 @@ pe_base_name_eq(const pcmk_resource_t *rsc, const char *id)
 
 int pe__target_rc_from_xml(const xmlNode *xml_op);
 
-int pe__cmp_node_name(gconstpointer a, gconstpointer b);
+int pe__cmp_node_name(const void *a, const void *b);
 bool is_set_recursive(const pcmk_resource_t *rsc, long long flag, bool any);
 
 pcmk__op_digest_t *pe__calculate_digests(pcmk_resource_t *rsc, const char *task,

--- a/include/crm/pengine/pe_types.h
+++ b/include/crm/pengine/pe_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2023 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -8,15 +8,7 @@
  */
 
 #ifndef PCMK__CRM_PENGINE_PE_TYPES__H
-#  define PCMK__CRM_PENGINE_PE_TYPES__H
-
-
-#  include <stdbool.h>              // bool
-#  include <sys/types.h>            // time_t
-#  include <libxml/tree.h>          // xmlNode
-#  include <glib.h>                 // gboolean, guint, GList, GHashTable
-#  include <crm/common/iso8601.h>
-#  include <crm/common/scheduler.h>
+#define PCMK__CRM_PENGINE_PE_TYPES__H
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,7 +25,6 @@ extern "C" {
 #endif
 
 #if !defined(PCMK_ALLOW_DEPRECATED) || (PCMK_ALLOW_DEPRECATED == 1)
-#include <crm/pengine/common.h>
 #include <crm/pengine/pe_types_compat.h>
 #endif
 

--- a/include/crm/pengine/pe_types_compat.h
+++ b/include/crm/pengine/pe_types_compat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -12,6 +12,7 @@
 
 #include <stdint.h>                // UINT64_C
 #include <crm/common/scheduler.h>
+#include <crm/pengine/common.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/crm/services.h
+++ b/include/crm/services.h
@@ -110,7 +110,7 @@ typedef struct svc_action_s {
     char *action;
 
     //! Action interval for recurring resource actions, otherwise 0
-    guint interval_ms;
+    unsigned int interval_ms;
 
     //! Resource standard for resource actions, otherwise NULL
     char *standard;
@@ -225,8 +225,9 @@ gboolean resources_agent_exists(const char *standard, const char *provider,
  */
 svc_action_t *resources_action_create(const char *name, const char *standard,
                                       const char *provider, const char *agent,
-                                      const char *action, guint interval_ms,
-                                      int timeout, GHashTable *params,
+                                      const char *action,
+                                      unsigned int interval_ms, int timeout,
+                                      GHashTable *params,
                                       enum svc_action_flags flags);
 
 /*!
@@ -239,7 +240,7 @@ svc_action_t *resources_action_create(const char *name, const char *standard,
  * \return TRUE on success, otherwise FALSE
  */
 gboolean services_action_kick(const char *name, const char *action,
-                              guint interval_ms);
+                              unsigned int interval_ms);
 
 const char *resources_find_service_class(const char *agent);
 
@@ -332,7 +333,7 @@ gboolean services_action_async(svc_action_t *op,
                                void (*action_callback) (svc_action_t *));
 
 gboolean services_action_cancel(const char *name, const char *action,
-                                guint interval_ms);
+                                unsigned int interval_ms);
 
 /* functions for alert agents */
 svc_action_t *services_alert_create(const char *id, const char *exec,

--- a/include/crm/services_internal.h
+++ b/include/crm/services_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 the Pacemaker project contributors
+ * Copyright 2010-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -42,7 +42,7 @@ svc_action_t *services__create_resource_action(const char *name,
                                                const char *provider,
                                                const char *agent,
                                                const char *action,
-                                               guint interval_ms,
+                                               unsigned int interval_ms,
                                                int timeout, GHashTable *params,
                                                enum svc_action_flags flags);
 

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -295,7 +295,7 @@ int pcmk_list_nodes(xmlNode **xml, const char *types);
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_status(xmlNodePtr *xml);
+int pcmk_status(xmlNode **xml);
 
 /*!
  * \brief Check whether each rule in a list is in effect

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -211,7 +211,8 @@ int pcmk_pacemakerd_status(xmlNodePtr *xml, const char *ipc_name,
  *       or if \p rsc_type is incorrect for \p rsc_id (deleting something
  *       that doesn't exist always succeeds).
  */
-int pcmk_resource_delete(xmlNodePtr *xml, const char *rsc_id, const char *rsc_type);
+int pcmk_resource_delete(xmlNode **xml, const char *rsc_id,
+                         const char *rsc_type);
 
 /*!
  * \brief Calculate and output resource operation digests
@@ -223,7 +224,7 @@ int pcmk_resource_delete(xmlNodePtr *xml, const char *rsc_id, const char *rsc_ty
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
+int pcmk_resource_digests(xmlNode **xml, pcmk_resource_t *rsc,
                           const pcmk_node_t *node, GHashTable *overrides);
 
 /*!

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -463,7 +463,7 @@ int pcmk_list_primitive_meta(xmlNode **xml, bool all);
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_ticket_constraints(xmlNodePtr *xml, const char *ticket_id);
+int pcmk_ticket_constraints(xmlNode **xml, const char *ticket_id);
 
 
 /*!
@@ -476,7 +476,7 @@ int pcmk_ticket_constraints(xmlNodePtr *xml, const char *ticket_id);
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_ticket_delete(xmlNodePtr *xml, const char *ticket_id, bool force);
+int pcmk_ticket_delete(xmlNode **xml, const char *ticket_id, bool force);
 
 /*!
  * \brief Return the value of a ticket's attribute
@@ -489,7 +489,7 @@ int pcmk_ticket_delete(xmlNodePtr *xml, const char *ticket_id, bool force);
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_ticket_get_attr(xmlNodePtr *xml, const char *ticket_id,
+int pcmk_ticket_get_attr(xmlNode **xml, const char *ticket_id,
                          const char *attr_name, const char *attr_default);
 
 /*!
@@ -501,7 +501,7 @@ int pcmk_ticket_get_attr(xmlNodePtr *xml, const char *ticket_id,
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_ticket_info(xmlNodePtr *xml, const char *ticket_id);
+int pcmk_ticket_info(xmlNode **xml, const char *ticket_id);
 
 /*!
  * \brief Remove the given attribute(s) from a ticket
@@ -515,8 +515,8 @@ int pcmk_ticket_info(xmlNodePtr *xml, const char *ticket_id);
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_ticket_remove_attr(xmlNodePtr *xml, const char *ticket_id, GList *attr_delete,
-                            bool force);
+int pcmk_ticket_remove_attr(xmlNode **xml, const char *ticket_id,
+                            GList *attr_delete, bool force);
 
 /*!
  * \brief Set the given attribute(s) on a ticket
@@ -535,8 +535,8 @@ int pcmk_ticket_remove_attr(xmlNodePtr *xml, const char *ticket_id, GList *attr_
  * \note If no \p ticket_id attribute exists but \p attr_set is non-NULL, the
  *       ticket will be created with the given attributes.
  */
-int pcmk_ticket_set_attr(xmlNodePtr *xml, const char *ticket_id, GHashTable *attr_set,
-                         bool force);
+int pcmk_ticket_set_attr(xmlNode **xml, const char *ticket_id,
+                         GHashTable *attr_set, bool force);
 
 /*!
  * \brief Return a ticket's state XML
@@ -550,7 +550,7 @@ int pcmk_ticket_set_attr(xmlNodePtr *xml, const char *ticket_id, GHashTable *att
  * \note If \p ticket_id is not \c NULL and more than one ticket exists with
  *       that ID, this function returns \c pcmk_rc_duplicate_id.
  */
-int pcmk_ticket_state(xmlNodePtr *xml, const char *ticket_id);
+int pcmk_ticket_state(xmlNode **xml, const char *ticket_id);
 
 /*!
  * \brief Ask the cluster to perform fencing

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -50,31 +50,33 @@ enum pcmk_sim_flags {
 /*!
  * \brief Synthetic cluster events that can be injected into the cluster
  *        for running simulations.
+ *
+ * \note This struct should typically be freed using \c pcmk_free_injections().
  */
 typedef struct {
-    /*! A list of node names (gchar *) to simulate bringing online */
+    /*! A list of node names (char *) to simulate bringing online */
     GList *node_up;
-    /*! A list of node names (gchar *) to simulate bringing offline */
+    /*! A list of node names (char *) to simulate bringing offline */
     GList *node_down;
-    /*! A list of node names (gchar *) to simulate failing */
+    /*! A list of node names (char *) to simulate failing */
     GList *node_fail;
-    /*! A list of operations (gchar *) to inject.  The format of these strings
+    /*! A list of operations (char *) to inject.  The format of these strings
      * is described in the "Operation Specification" section of crm_simulate
      * help output.
      */
     GList *op_inject;
-    /*! A list of operations (gchar *) that should return a given error code
+    /*! A list of operations (char *) that should return a given error code
      * if they fail.  The format of these strings is described in the
      * "Operation Specification" section of crm_simulate help output.
      */
     GList *op_fail;
-    /*! A list of tickets (gchar *) to simulate granting */
+    /*! A list of tickets (char *) to simulate granting */
     GList *ticket_grant;
-    /*! A list of tickets (gchar *) to simulate revoking */
+    /*! A list of tickets (char *) to simulate revoking */
     GList *ticket_revoke;
-    /*! A list of tickets (gchar *) to simulate putting on standby */
+    /*! A list of tickets (char *) to simulate putting on standby */
     GList *ticket_standby;
-    /*! A list of tickets (gchar *) to simulate activating */
+    /*! A list of tickets (char *) to simulate activating */
     GList *ticket_activate;
     /*! Does the cluster have an active watchdog device? */
     char *watchdog;

--- a/include/pacemaker.h
+++ b/include/pacemaker.h
@@ -309,7 +309,7 @@ int pcmk_status(xmlNodePtr *xml);
  *
  * \return Standard Pacemaker return code
  */
-int pcmk_check_rules(xmlNodePtr *xml, xmlNodePtr input, const crm_time_t *date,
+int pcmk_check_rules(xmlNode **xml, xmlNode *input, const crm_time_t *date,
                      const char **rule_ids);
 
 /*!
@@ -324,7 +324,7 @@ int pcmk_check_rules(xmlNodePtr *xml, xmlNodePtr input, const crm_time_t *date,
  * \return Standard Pacemaker return code
  */
 static inline int
-pcmk_check_rule(xmlNodePtr *xml, xmlNodePtr input, const crm_time_t *date,
+pcmk_check_rule(xmlNode **xml, xmlNode *input, const crm_time_t *date,
                 const char *rule_id)
 {
     const char *rule_ids[] = {rule_id, NULL};

--- a/include/pcmki/pcmki_fence.h
+++ b/include/pcmki/pcmki_fence.h
@@ -54,7 +54,8 @@ enum pcmk__fence_history {
  * \return Standard Pacemaker return code
  * \note If \p reason is not NULL, the caller is responsible for freeing its
  *       returned value.
- * \todo delay is eventually used with pcmk__create_timer() and should be guint
+ * \todo \c delay is eventually used with \c pcmk__create_timer() and should be
+ *       <tt>unsigned int</tt>
  */
 int pcmk__request_fencing(stonith_t *st, const char *target, const char *action,
                           const char *name, unsigned int timeout,

--- a/include/pcmki/pcmki_rule.h
+++ b/include/pcmki/pcmki_rule.h
@@ -21,7 +21,7 @@
 extern "C" {
 #endif
 
-int pcmk__check_rules(pcmk__output_t *out, xmlNodePtr input,
+int pcmk__check_rules(pcmk__output_t *out, xmlNode *input,
                       const crm_time_t *date_time, const char **rule_ids);
 
 /*!
@@ -37,7 +37,7 @@ int pcmk__check_rules(pcmk__output_t *out, xmlNodePtr input,
  * \return Standard Pacemaker return code
  */
 static inline int
-pcmk__check_rule(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
+pcmk__check_rule(pcmk__output_t *out, xmlNode *input, const crm_time_t *date,
                  const char *rule_id)
 {
     const char *rule_ids[] = {rule_id, NULL};

--- a/include/pcmki/pcmki_transition.h
+++ b/include/pcmki/pcmki_transition.h
@@ -17,7 +17,7 @@
 #include <stdint.h>                     // uint32_t
 #include <sys/types.h>                  // time_t
 
-#include <glib.h>                       // guint, GList, GHashTable
+#include <glib.h>                       // GList, GHashTable
 #include <libxml/tree.h>                // xmlNode
 
 #include <crm/common/scheduler_types.h> // pcmk_scheduler_t
@@ -83,7 +83,7 @@ typedef struct {
     int id;
     int timeout;
     int timer;
-    guint interval_ms;
+    unsigned int interval_ms;
     GHashTable *params;
     enum pcmk__graph_action_type type;
     pcmk__graph_synapse_t *synapse;
@@ -130,8 +130,8 @@ typedef struct {
     int num_synapses;
 
     int batch_limit;
-    guint network_delay;
-    guint fencing_timeout;
+    unsigned int network_delay;
+    unsigned int fencing_timeout;
 
     int fired;
     int pending;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -152,7 +152,7 @@ cib_client_del_notify_callback(cib_t *cib, const char *event,
 }
 
 static gboolean
-cib_async_timeout_handler(gpointer data)
+cib_async_timeout_handler(void *data)
 {
     struct timer_rec_s *timer = data;
 
@@ -416,7 +416,7 @@ cib_client_set_user(cib_t *cib, const char *user)
 }
 
 static void
-cib_destroy_op_callback(gpointer data)
+cib_destroy_op_callback(void *data)
 {
     cib_callback_client_t *blob = data;
 
@@ -730,7 +730,7 @@ num_cib_op_callbacks(void)
 }
 
 static void
-cib_dump_pending_op(gpointer key, gpointer value, gpointer user_data)
+cib_dump_pending_op(void *key, void *value, void *user_data)
 {
     int call = GPOINTER_TO_INT(key);
     cib_callback_client_t *blob = value;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -27,7 +27,7 @@
 
 static GHashTable *cib_op_callback_table = NULL;
 
-static gint
+static int
 ciblib_GCompareFunc(gconstpointer a, gconstpointer b)
 {
     int rc = 0;

--- a/lib/cib/cib_client.c
+++ b/lib/cib/cib_client.c
@@ -28,7 +28,7 @@
 static GHashTable *cib_op_callback_table = NULL;
 
 static int
-ciblib_GCompareFunc(gconstpointer a, gconstpointer b)
+ciblib_GCompareFunc(const void *a, const void *b)
 {
     int rc = 0;
     const cib_notify_client_t *a_client = a;

--- a/lib/cib/cib_file.c
+++ b/lib/cib/cib_file.c
@@ -89,7 +89,7 @@ register_client(const cib_t *cib)
     if (client_table == NULL) {
         client_table = pcmk__strkey_table(NULL, NULL);
     }
-    g_hash_table_insert(client_table, private->id, (gpointer) cib);
+    g_hash_table_insert(client_table, private->id, (void *) cib);
 }
 
 /*!
@@ -131,7 +131,7 @@ get_client(const char *client_id)
     if (client_table == NULL) {
         return NULL;
     }
-    return g_hash_table_lookup(client_table, (gpointer) client_id);
+    return g_hash_table_lookup(client_table, (void *) client_id);
 }
 
 static int
@@ -710,7 +710,7 @@ file_register_notification(cib_t *cib, const char *callback, int enabled)
 }
 
 static int
-file_set_connection_dnotify(cib_t *cib, void (*dnotify)(gpointer user_data))
+file_set_connection_dnotify(cib_t *cib, void (*dnotify)(void *user_data))
 {
     return -EPROTONOSUPPORT;
 }

--- a/lib/cib/cib_native.c
+++ b/lib/cib/cib_native.c
@@ -30,7 +30,7 @@
 typedef struct {
     char *token;
     crm_ipc_t *ipc;
-    void (*dnotify_fn) (gpointer user_data);
+    void (*dnotify_fn)(void *user_data);
     mainloop_io_t *source;
 } cib_native_opaque_t;
 
@@ -191,8 +191,7 @@ cib_native_perform_op_delegate(cib_t *cib, const char *op, const char *host,
 }
 
 static int
-cib_native_dispatch_internal(const char *buffer, ssize_t length,
-                             gpointer userdata)
+cib_native_dispatch_internal(const char *buffer, ssize_t length, void *userdata)
 {
     const char *type = NULL;
     xmlNode *msg = NULL;
@@ -435,8 +434,7 @@ cib_native_register_notification(cib_t *cib, const char *callback, int enabled)
 }
 
 static int
-cib_native_set_connection_dnotify(cib_t *cib,
-                                  void (*dnotify) (gpointer user_data))
+cib_native_set_connection_dnotify(cib_t *cib, void (*dnotify)(void *user_data))
 {
     cib_native_opaque_t *native = NULL;
 

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -150,8 +150,8 @@ cib__get_operation(const char *op, const cib__operation_t **operation)
         for (int lpc = 0; lpc < PCMK__NELEM(cib_ops); lpc++) {
             const cib__operation_t *oper = &(cib_ops[lpc]);
 
-            g_hash_table_insert(operation_table, (gpointer) oper->name,
-                                (gpointer) oper);
+            g_hash_table_insert(operation_table, (void *) oper->name,
+                                (void *) oper);
         }
     }
 

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -17,7 +17,7 @@
 #include <time.h>                   // time, time_t
 #include <unistd.h>                 // close
 
-#include <glib.h>                   // gpointer, gboolean, g_list_foreach
+#include <glib.h>                   // gboolean, g_*, G_*
 #include <gnutls/gnutls.h>          // gnutls_deinit, gnutls_bye
 #include <libxml/tree.h>            // xmlNode
 #include <qb/qblog.h>               // QB_XS
@@ -217,7 +217,7 @@ cib_remote_perform_op(cib_t *cib, const char *op, const char *host,
 }
 
 static int
-cib_remote_callback_dispatch(gpointer user_data)
+cib_remote_callback_dispatch(void *user_data)
 {
     int rc;
     cib_t *cib = user_data;
@@ -283,7 +283,7 @@ cib_remote_callback_dispatch(gpointer user_data)
 }
 
 static int
-cib_remote_command_dispatch(gpointer user_data)
+cib_remote_command_dispatch(void *user_data)
 {
     int rc;
     cib_t *cib = user_data;
@@ -359,7 +359,7 @@ cib_tls_close(cib_t *cib)
 }
 
 static void
-cib_remote_connection_destroy(gpointer user_data)
+cib_remote_connection_destroy(void *user_data)
 {
     pcmk__err("Connection destroyed");
     cib_tls_close(user_data);
@@ -672,7 +672,7 @@ cib_remote_register_notification(cib_t * cib, const char *callback, int enabled)
 }
 
 static int
-cib_remote_set_connection_dnotify(cib_t * cib, void (*dnotify) (gpointer user_data))
+cib_remote_set_connection_dnotify(cib_t *cib, void (*dnotify)(void *user_data))
 {
     return -EPROTONOSUPPORT;
 }

--- a/lib/cib/cib_utils.c
+++ b/lib/cib/cib_utils.c
@@ -829,7 +829,7 @@ cib_native_callback(cib_t * cib, xmlNode * msg, int call_id, int rc)
 }
 
 void
-cib_native_notify(gpointer data, gpointer user_data)
+cib_native_notify(void *data, void *user_data)
 {
     xmlNode *msg = user_data;
     cib_notify_client_t *entry = data;

--- a/lib/cluster/cluster.c
+++ b/lib/cluster/cluster.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -180,7 +180,7 @@ pcmk_cluster_free(pcmk_cluster_t *cluster)
  * \return Standard Pacemaker return code
  */
 int
-pcmk_cluster_set_destroy_fn(pcmk_cluster_t *cluster, void (*fn)(gpointer))
+pcmk_cluster_set_destroy_fn(pcmk_cluster_t *cluster, void (*fn)(void *))
 {
     if (cluster == NULL) {
         return EINVAL;
@@ -336,7 +336,7 @@ pcmk__node_name_from_uuid(const char *uuid)
     }
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         if (pcmk__str_eq(uuid, pcmk__cluster_get_xml_id(node),
                          pcmk__str_none)) {
             return node->name;

--- a/lib/cluster/corosync.c
+++ b/lib/cluster/corosync.c
@@ -241,7 +241,7 @@ pcmk__corosync_disconnect(pcmk_cluster_t *cluster)
  * \return 0 on success, -1 on error (per mainloop_io_t interface)
  */
 static int
-quorum_dispatch_cb(gpointer user_data)
+quorum_dispatch_cb(void *user_data)
 {
     int rc = quorum_dispatch(pcmk_quorum_handle, CS_DISPATCH_ALL);
 
@@ -306,7 +306,7 @@ quorum_notification_cb(quorum_handle_t handle, uint32_t quorate,
     /* Reset membership_id for all cached nodes so we can tell which ones aren't
      * in the view list */
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         node->membership_id = 0;
     }
 
@@ -349,7 +349,7 @@ quorum_notification_cb(quorum_handle_t handle, uint32_t quorate,
 void
 pcmk__corosync_quorum_connect(gboolean (*dispatch)(unsigned long long,
                                                    gboolean),
-                              void (*destroy)(gpointer))
+                              void (*destroy)(void *))
 {
     cs_error_t rc;
     int fd = 0;
@@ -636,7 +636,7 @@ pcmk__corosync_add_nodes(xmlNode *xml_parent)
             pcmk__node_status_t *node = NULL;
 
             g_hash_table_iter_init(&iter, pcmk__peer_cache);
-            while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+            while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
                 if ((node != NULL)
                     && (node->cluster_layer_id > 0)
                     && (node->cluster_layer_id != nodeid)

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -204,7 +204,7 @@ static void
 crm_cs_flush(gpointer data)
 {
     unsigned int sent = 0;
-    guint queue_len = 0;
+    unsigned int queue_len = 0;
     cs_error_t rc = 0;
     cpg_handle_t *handle = (cpg_handle_t *) data;
 

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -78,7 +78,7 @@ struct pcmk__cpg_msg_s {
 
 typedef struct pcmk__cpg_msg_s pcmk__cpg_msg_t;
 
-static void crm_cs_flush(gpointer data);
+static void crm_cs_flush(void *data);
 
 #define msg_data_len(msg) (msg->is_compressed?msg->compressed_size:msg->size)
 
@@ -184,7 +184,7 @@ bail:
  * \return FALSE (to indicate to glib that timer should not be removed)
  */
 static gboolean
-crm_cs_flush_cb(gpointer data)
+crm_cs_flush_cb(void *data)
 {
     cs_message_timer = 0;
     crm_cs_flush(data);
@@ -201,7 +201,7 @@ crm_cs_flush_cb(gpointer data)
  * \param[in] data   CPG handle
  */
 static void
-crm_cs_flush(gpointer data)
+crm_cs_flush(void *data)
 {
     unsigned int sent = 0;
     unsigned int queue_len = 0;
@@ -268,7 +268,7 @@ crm_cs_flush(gpointer data)
  * \return 0 on success, -1 on error (per mainloop_io_t interface)
  */
 static int
-pcmk_cpg_dispatch(gpointer user_data)
+pcmk_cpg_dispatch(void *user_data)
 {
     cs_error_t rc = CS_OK;
     pcmk_cluster_t *cluster = (pcmk_cluster_t *) user_data;

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -47,7 +47,7 @@ election_complete(pcmk_cluster_t *cluster)
 }
 
 static gboolean
-election_timer_cb(gpointer user_data)
+election_timer_cb(void *user_data)
 {
     pcmk_cluster_t *cluster = user_data;
 
@@ -374,14 +374,14 @@ election_check(pcmk_cluster_t *cluster)
 
             pcmk__warn("Received too many votes in election");
             g_hash_table_iter_init(&gIter, pcmk__peer_cache);
-            while (g_hash_table_iter_next(&gIter, NULL, (gpointer *) & node)) {
+            while (g_hash_table_iter_next(&gIter, NULL, (void **) &node)) {
                 if (pcmk__cluster_is_node_active(node)) {
                     pcmk__warn("* expected vote: %s", node->name);
                 }
             }
 
             g_hash_table_iter_init(&gIter, cluster->priv->election->voted);
-            while (g_hash_table_iter_next(&gIter, (gpointer *) & key, NULL)) {
+            while (g_hash_table_iter_next(&gIter, (void **) &key, NULL)) {
                 pcmk__warn("* actual vote: %s", key);
             }
 

--- a/lib/cluster/election.c
+++ b/lib/cluster/election.c
@@ -25,7 +25,7 @@
 
 struct pcmk__election {
     enum election_result state;     // Current state of election
-    guint count;                    // How many times local node has voted
+    unsigned int count;             // How many times local node has voted
     void (*cb)(pcmk_cluster_t *);   // Function to call if election is won
     GHashTable *voted;  // Key = node name, value = how node voted
     mainloop_timer_t *timeout; // When to abort if all votes not received
@@ -189,7 +189,7 @@ election_timeout_stop(pcmk_cluster_t *cluster)
  * \param[in]     period   New timeout
  */
 void
-election_timeout_set_period(pcmk_cluster_t *cluster, guint period)
+election_timeout_set_period(pcmk_cluster_t *cluster, unsigned int period)
 {
     CRM_CHECK((cluster != NULL) && (cluster->priv->election != NULL), return);
     mainloop_timer_set_period(cluster->priv->election->timeout, period);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -300,13 +300,13 @@ remote_cache_refresh_helper(xmlNode *result, void *user_data)
 }
 
 static void
-mark_dirty(gpointer key, gpointer value, gpointer user_data)
+mark_dirty(void *key, void *value, void *user_data)
 {
     set_peer_flags((pcmk__node_status_t *) value, pcmk__node_status_dirty);
 }
 
 static gboolean
-is_dirty(gpointer key, gpointer value, gpointer user_data)
+is_dirty(void *key, void *value, void *user_data)
 {
     const pcmk__node_status_t *node = value;
 
@@ -420,7 +420,7 @@ pcmk__cluster_is_node_active(const pcmk__node_status_t *node)
  *         or \c FALSE otherwise
  */
 static gboolean
-should_forget_cluster_node(gpointer key, gpointer value, gpointer user_data)
+should_forget_cluster_node(void *key, void *value, void *user_data)
 {
     pcmk__node_status_t *node = value;
     pcmk__node_status_t *search = user_data;
@@ -513,7 +513,7 @@ pcmk__cluster_forget_cluster_node(uint32_t id, const char *node_name)
 }
 
 static void
-count_peer(gpointer key, gpointer value, gpointer user_data)
+count_peer(void *key, void *value, void *user_data)
 {
     unsigned int *count = user_data;
     pcmk__node_status_t *node = value;
@@ -544,7 +544,7 @@ pcmk__cluster_num_active_nodes(void)
 }
 
 static void
-destroy_crm_node(gpointer data)
+destroy_crm_node(void *data)
 {
     pcmk__node_status_t *node = data;
 
@@ -642,14 +642,14 @@ dump_peer_hash(int level, const char *caller)
     pcmk__node_status_t *node = NULL;
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &id, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, (void **) &id, (void **) &node)) {
         do_crm_log(level, "%s: Node %" PRIu32 "/%s = %p - %s",
                    caller, node->cluster_layer_id, node->name, node, id);
     }
 }
 
 static gboolean
-hash_find_by_data(gpointer key, gpointer value, gpointer user_data)
+hash_find_by_data(void *key, void *value, void *user_data)
 {
     return value == user_data;
 }
@@ -680,7 +680,7 @@ search_cluster_member_cache(unsigned int id, const char *uname,
 
     if (uname != NULL) {
         g_hash_table_iter_init(&iter, pcmk__peer_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (pcmk__str_eq(node->name, uname, pcmk__str_casei)) {
                 pcmk__trace("Name match: %s", node->name);
                 by_name = node;
@@ -691,7 +691,7 @@ search_cluster_member_cache(unsigned int id, const char *uname,
 
     if (id > 0) {
         g_hash_table_iter_init(&iter, pcmk__peer_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (node->cluster_layer_id == id) {
                 pcmk__trace("ID match: %" PRIu32, node->cluster_layer_id);
                 by_id = node;
@@ -701,7 +701,7 @@ search_cluster_member_cache(unsigned int id, const char *uname,
 
     } else if (uuid != NULL) {
         g_hash_table_iter_init(&iter, pcmk__peer_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             const char *this_xml_id = pcmk__cluster_get_xml_id(node);
 
             if (pcmk__str_eq(uuid, this_xml_id, pcmk__str_none)) {
@@ -888,7 +888,7 @@ remove_conflicting_peer(pcmk__node_status_t *node)
     }
 
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &existing_node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &existing_node)) {
         if ((existing_node->cluster_layer_id > 0)
             && (existing_node->cluster_layer_id != node->cluster_layer_id)
             && pcmk__str_eq(existing_node->name, node->name, pcmk__str_casei)) {
@@ -1343,7 +1343,7 @@ pcmk__reap_unseen_nodes(uint64_t membership)
 
     pcmk__trace("Reaping unseen nodes...");
     g_hash_table_iter_init(&iter, pcmk__peer_cache);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *)&node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         if (node->membership_id != membership) {
             if (node->state) {
                 /* Calling update_peer_state_iter() allows us to remove the node
@@ -1370,7 +1370,7 @@ find_cib_cluster_node(const char *id, const char *uname)
 
     if (uname) {
         g_hash_table_iter_init(&iter, cluster_node_cib_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (pcmk__str_eq(node->name, uname, pcmk__str_casei)) {
                 pcmk__trace("Name match: %s = %p", node->name, node);
                 by_name = node;
@@ -1381,7 +1381,7 @@ find_cib_cluster_node(const char *id, const char *uname)
 
     if (id) {
         g_hash_table_iter_init(&iter, cluster_node_cib_cache);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (pcmk__str_eq(id, pcmk__cluster_get_xml_id(node),
                              pcmk__str_none)) {
                 pcmk__trace("ID match: %s= %p", id, node);

--- a/lib/cluster/membership.c
+++ b/lib/cluster/membership.c
@@ -470,7 +470,7 @@ pcmk__cluster_forget_cluster_node(uint32_t id, const char *node_name)
 {
     pcmk__node_status_t search = { 0, };
     char *criterion = NULL; // For logging
-    guint matches = 0;
+    unsigned int matches = 0;
 
     if (pcmk__peer_cache == NULL) {
         pcmk__trace("Membership cache not initialized, ignoring removal "
@@ -872,7 +872,7 @@ pcmk__purge_node_from_cache(const char *node_name, uint32_t node_id)
 }
 
 #if SUPPORT_COROSYNC
-static guint
+static unsigned int
 remove_conflicting_peer(pcmk__node_status_t *node)
 {
     int matches = 0;

--- a/lib/cluster/tests/cluster/pcmk_cluster_set_destroy_fn_test.c
+++ b/lib/cluster/tests/cluster/pcmk_cluster_set_destroy_fn_test.c
@@ -9,18 +9,16 @@
 
 #include <crm_internal.h>
 
-#include <glib.h>                           // gpointer
-
 #include <crm/cluster.h>                    // pcmk_cluster_t, etc.
 #include <crm/common/unittest_internal.h>
 
 static void
-destroy_fn1(gpointer arg)
+destroy_fn1(void *arg)
 {
 }
 
 static void
-destroy_fn2(gpointer arg)
+destroy_fn2(void *arg)
 {
 }
 

--- a/lib/common/acl.c
+++ b/lib/common/acl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -680,7 +680,7 @@ apply_acl_to_match(xmlNode *match, void *user_data)
  * \param[in,out] user_data  XML document to match against (<tt>xmlDoc *</tt>)
  */
 static void
-apply_acl_to_doc(gpointer data, gpointer user_data)
+apply_acl_to_doc(void *data, void *user_data)
 {
     xml_acl_t *acl = data;
     xmlDoc *doc = user_data;

--- a/lib/common/action_relation.c
+++ b/lib/common/action_relation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -10,7 +10,6 @@
 #include <crm_internal.h>
 
 #include <stdlib.h>                 // free()
-#include <glib.h>                   // gpointer
 
 #include <crm/common/scheduler.h>
 
@@ -21,7 +20,7 @@
  * \param[in,out] user_data  Action relation to free
  */
 void
-pcmk__free_action_relation(gpointer user_data)
+pcmk__free_action_relation(void *user_data)
 {
     pcmk__action_relation_t *relation = user_data;
 

--- a/lib/common/actions.c
+++ b/lib/common/actions.c
@@ -186,7 +186,7 @@ pcmk__on_fail_text(enum pcmk__on_fail on_fail)
  * \param[in,out] user_data  Action object to free
  */
 void
-pcmk__free_action(gpointer user_data)
+pcmk__free_action(void *user_data)
 {
     pcmk_action_t *action = user_data;
 

--- a/lib/common/actions.c
+++ b/lib/common/actions.c
@@ -220,14 +220,14 @@ pcmk__free_action(gpointer user_data)
  *       The caller is responsible for freeing the result with free().
  */
 char *
-pcmk__op_key(const char *rsc_id, const char *op_type, guint interval_ms)
+pcmk__op_key(const char *rsc_id, const char *op_type, unsigned int interval_ms)
 {
     pcmk__assert((rsc_id != NULL) && (op_type != NULL));
     return pcmk__assert_asprintf(PCMK__OP_FMT, rsc_id, op_type, interval_ms);
 }
 
 static inline gboolean
-convert_interval(const char *s, guint *interval_ms)
+convert_interval(const char *s, unsigned int *interval_ms)
 {
     unsigned long l;
 
@@ -238,7 +238,7 @@ convert_interval(const char *s, guint *interval_ms)
         return FALSE;
     }
 
-    *interval_ms = (guint) l;
+    *interval_ms = (unsigned int) l;
     return TRUE;
 }
 
@@ -273,9 +273,10 @@ match_before(const char *key, size_t position, const char **matches)
 }
 
 gboolean
-parse_op_key(const char *key, char **rsc_id, char **op_type, guint *interval_ms)
+parse_op_key(const char *key, char **rsc_id, char **op_type,
+             unsigned int *interval_ms)
 {
-    guint local_interval_ms = 0;
+    unsigned int local_interval_ms = 0;
     const size_t key_len = (key == NULL)? 0 : strlen(key);
 
     // Operation keys must be formatted as RSC_ACTION_INTERVAL

--- a/lib/common/alerts.c
+++ b/lib/common/alerts.c
@@ -142,7 +142,8 @@ pcmk__add_alert_key_int(GHashTable *table, enum pcmk__alert_keys_e name,
  * \return Standard Pacemaker return code
  */
 static int
-unpack_alert_options(xmlNode *xml, pcmk__alert_t *entry, guint *max_timeout)
+unpack_alert_options(xmlNode *xml, pcmk__alert_t *entry,
+                     unsigned int *max_timeout)
 {
     GHashTable *config_hash = pcmk__strkey_table(free, free);
     crm_time_t *now = crm_time_new(NULL);
@@ -334,7 +335,7 @@ unpack_alert_filter(xmlNode *xml, pcmk__alert_t *entry)
  * \return Standard Pacemaker return code
  */
 static int
-unpack_alert(xmlNode *alert, pcmk__alert_t *entry, guint *max_timeout)
+unpack_alert(xmlNode *alert, pcmk__alert_t *entry, unsigned int *max_timeout)
 {
     int rc = pcmk_rc_ok;
 
@@ -359,7 +360,7 @@ pcmk__unpack_alerts(const xmlNode *alerts)
 {
     xmlNode *alert;
     pcmk__alert_t *entry;
-    guint max_timeout = 0U;
+    unsigned int max_timeout = 0;
     GList *alert_list = NULL;
 
     for (alert = pcmk__xe_first_child(alerts, PCMK_XE_ALERT, NULL, NULL);
@@ -406,7 +407,7 @@ pcmk__unpack_alerts(const xmlNode *alerts)
              recipient = pcmk__xe_next(recipient, PCMK_XE_RECIPIENT)) {
 
             pcmk__alert_t *recipient_entry = pcmk__dup_alert(entry);
-            guint n_envvars = 0;
+            unsigned int n_envvars = 0;
 
             recipients++;
             recipient_entry->recipient = pcmk__xe_get_copy(recipient,

--- a/lib/common/cib_secrets.c
+++ b/lib/common/cib_secrets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2025 the Pacemaker project contributors
+ * Copyright 2011-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -141,8 +141,7 @@ pcmk__substitute_secrets(const char *rsc_id, GHashTable *params)
 
     // Some params are sent with operations, so we cannot cache secret params
     g_hash_table_iter_init(&iter, params);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &param,
-                                  (gpointer *) &value)) {
+    while (g_hash_table_iter_next(&iter, (void **) &param, (void **) &value)) {
         char *secret_value = NULL;
         int hash_rc = pcmk_rc_ok;
 
@@ -185,7 +184,7 @@ pcmk__substitute_secrets(const char *rsc_id, GHashTable *params)
             continue;
         }
 
-        g_hash_table_iter_replace(&iter, (gpointer) secret_value);
+        g_hash_table_iter_replace(&iter, (void *) secret_value);
     }
 
     if (filename != NULL) {

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -152,7 +152,7 @@ pcmk__quote_cmdline(gchar **argv)
     }
 
     for (int i = 0; argv[i] != NULL; i++) {
-        gint argc = 0;
+        int argc = 0;
 
         /* Quote the argument if it's unparsable as-is (empty, all whitespace,
          * or having mismatched quotes), or if it contains more than one token

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -18,7 +18,9 @@
 #include <crm/common/util.h>
 
 static gboolean
-bump_verbosity(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+bump_verbosity(const gchar *option_name, const gchar *optarg, void *data,
+               GError **error)
+{
     pcmk__common_args_t *common_args = (pcmk__common_args_t *) data;
     common_args->verbosity++;
     return TRUE;
@@ -46,7 +48,8 @@ pcmk__new_common_args(const char *summary)
 }
 
 static void
-free_common_args(gpointer data) {
+free_common_args(void *data)
+{
     pcmk__common_args_t *common_args = (pcmk__common_args_t *) data;
 
     free(common_args->summary);

--- a/lib/common/cmdline.c
+++ b/lib/common/cmdline.c
@@ -18,7 +18,7 @@
 #include <crm/common/util.h>
 
 static gboolean
-bump_verbosity(const gchar *option_name, const gchar *optarg, void *data,
+bump_verbosity(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     pcmk__common_args_t *common_args = (pcmk__common_args_t *) data;
@@ -146,7 +146,7 @@ pcmk__add_arg_group(GOptionContext *context, const char *name,
 }
 
 gchar *
-pcmk__quote_cmdline(gchar **argv)
+pcmk__quote_cmdline(char **argv)
 {
     GString *cmdline = NULL;
 

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -325,7 +325,7 @@ pcmk__filter_op_for_digest(xmlNode *param_set)
 {
     char *key = NULL;
     char *timeout = NULL;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
 
     if (param_set == NULL) {
         return;

--- a/lib/common/digest.c
+++ b/lib/common/digest.c
@@ -335,8 +335,7 @@ pcmk__filter_op_for_digest(xmlNode *param_set)
      * removing meta-attributes
      */
     key = crm_meta_name(PCMK_META_INTERVAL);
-    pcmk__xe_get_guint(param_set, key, &interval_ms);
-
+    pcmk__xe_get_uint(param_set, key, &interval_ms);
     g_clear_pointer(&key, free);
 
     if (interval_ms != 0) {

--- a/lib/common/fuzzers/scores_fuzzer.c
+++ b/lib/common/fuzzers/scores_fuzzer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -18,7 +18,7 @@ int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     char *ns = NULL;
-    guint result = 0U;
+    unsigned int result = 0;
 
     if (size > 0) {
         ns = pcmk__assert_alloc(size + 1, sizeof(char));

--- a/lib/common/fuzzers/strings_fuzzer.c
+++ b/lib/common/fuzzers/strings_fuzzer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -22,7 +22,7 @@ int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     char *ns = NULL;
-    guint res = 0U;
+    unsigned int res = 0;
     long long msec = 0LL;
 
     if (size < 10) {

--- a/lib/common/ipc_client.c
+++ b/lib/common/ipc_client.c
@@ -153,7 +153,7 @@ pcmk__call_ipc_callback(pcmk_ipc_api_t *api, enum pcmk_ipc_event event_type,
  * \note This function can be used as a main loop IPC destroy callback.
  */
 static void
-ipc_post_disconnect(gpointer user_data)
+ipc_post_disconnect(void *user_data)
 {
     pcmk_ipc_api_t *api = user_data;
 
@@ -347,7 +347,7 @@ dispatch_ipc_data(const char *buffer, pcmk_ipc_api_t *api)
  * \note This function can be used as a main loop IPC dispatch callback.
  */
 static int
-dispatch_ipc_source_data(const char *buffer, ssize_t length, gpointer user_data)
+dispatch_ipc_source_data(const char *buffer, ssize_t length, void *user_data)
 {
     pcmk_ipc_api_t *api = user_data;
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -32,7 +32,7 @@ static GHashTable *client_connections = NULL;
  *
  * \return Number of active IPC client connections
  */
-guint
+unsigned int
 pcmk__ipc_client_count(void)
 {
     return client_connections? g_hash_table_size(client_connections) : 0;
@@ -455,7 +455,7 @@ static inline void
 delay_next_flush(pcmk__client_t *c, unsigned int queue_len)
 {
     /* Delay a maximum of 1.5 seconds */
-    guint delay = (queue_len < 5)? (1000 + 100 * queue_len) : 1500;
+    unsigned int delay = (queue_len < 5)? (1000 + 100 * queue_len) : 1500;
 
     c->event_timer = pcmk__create_timer(delay, crm_ipcs_flush_events_cb, c);
 }

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -48,7 +48,7 @@ pcmk__ipc_client_count(void)
  * \note The parameters are the same as for g_hash_table_foreach().
  */
 void
-pcmk__foreach_ipc_client(GHFunc func, gpointer user_data)
+pcmk__foreach_ipc_client(GHFunc func, void *user_data)
 {
     if ((func != NULL) && (client_connections != NULL)) {
         g_hash_table_foreach(client_connections, func, user_data);
@@ -70,12 +70,12 @@ pcmk__client_t *
 pcmk__find_client_by_id(const char *id)
 {
     if ((client_connections != NULL) && (id != NULL)) {
-        gpointer key;
+        void *key = NULL;
         pcmk__client_t *client = NULL;
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, client_connections);
-        while (g_hash_table_iter_next(&iter, &key, (gpointer *) & client)) {
+        while (g_hash_table_iter_next(&iter, &key, (void **) &client)) {
             if (strcmp(client->id, id) == 0) {
                 return client;
             }
@@ -267,7 +267,7 @@ pcmk_free_ipc_event(struct iovec *event)
 }
 
 static void
-free_event(gpointer data)
+free_event(void *data)
 {
     pcmk_free_ipc_event((struct iovec *) data);
 }
@@ -435,7 +435,7 @@ pcmk__client_data2xml(pcmk__client_t *c, uint32_t *id, uint32_t *flags)
 static int crm_ipcs_flush_events(pcmk__client_t *c);
 
 static gboolean
-crm_ipcs_flush_events_cb(gpointer data)
+crm_ipcs_flush_events_cb(void *data)
 {
     pcmk__client_t *c = data;
 

--- a/lib/common/iso8601.c
+++ b/lib/common/iso8601.c
@@ -2197,7 +2197,7 @@ pcmk__timespec2str(const struct timespec *ts, uint32_t flags)
  *       by later calls to this function.
  */
 const char *
-pcmk__readable_interval(guint interval_ms)
+pcmk__readable_interval(unsigned int interval_ms)
 {
 #define MS_IN_S (1000)
 #define MS_IN_M (MS_IN_S * SECONDS_IN_MINUTE)

--- a/lib/common/location.c
+++ b/lib/common/location.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -10,7 +10,7 @@
 #include <crm_internal.h>
 
 #include <stdlib.h>                 // free()
-#include <glib.h>                   // gpointer, g_list_free_full()
+#include <glib.h>                   // g_list_free_full()
 
 #include <crm/common/scheduler.h>
 
@@ -21,7 +21,7 @@
  * \param[in,out] user_data  Location constraint to free
  */
 void
-pcmk__free_location(gpointer user_data)
+pcmk__free_location(void *user_data)
 {
     pcmk__location_t *location = user_data;
 

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -83,7 +83,7 @@ struct log_handler_id {
      * based on the implementation, a valid ID is always positive unless we set
      * UINT_MAX handlers.
      */
-    guint handler_id;
+    unsigned int handler_id;
 };
 
 // Log domains that we care about, and their handler function IDs once set

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -143,8 +143,7 @@ log_level_from_glib(GLogLevelFlags log_level)
  */
 static void
 handle_glib_message(const gchar *log_domain, GLogLevelFlags log_level,
-                    const gchar *message, gpointer user_data)
-
+                    const gchar *message, void *user_data)
 {
     uint8_t syslog_level = log_level_from_glib(log_level);
 

--- a/lib/common/logging.c
+++ b/lib/common/logging.c
@@ -142,8 +142,8 @@ log_level_from_glib(GLogLevelFlags log_level)
  * \param[in] user_data   Ignored
  */
 static void
-handle_glib_message(const gchar *log_domain, GLogLevelFlags log_level,
-                    const gchar *message, void *user_data)
+handle_glib_message(const char *log_domain, GLogLevelFlags log_level,
+                    const char *message, void *user_data)
 {
     uint8_t syslog_level = log_level_from_glib(log_level);
 
@@ -538,13 +538,13 @@ pcmk__add_logfile(const char *filename)
  * \return Standard Pacemaker return code
  */
 void
-pcmk__add_logfiles(gchar **log_files, pcmk__output_t *out)
+pcmk__add_logfiles(char **log_files, pcmk__output_t *out)
 {
     if (log_files == NULL) {
         return;
     }
 
-    for (gchar **fname = log_files; *fname != NULL; fname++) {
+    for (char **fname = log_files; *fname != NULL; fname++) {
         int rc = pcmk__add_logfile(*fname);
 
         if (rc != pcmk_rc_ok) {

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -28,13 +28,13 @@ struct trigger_s {
     gboolean running;
     gboolean trigger;
     void *user_data;
-    guint id;
+    unsigned int id;
 
 };
 
 struct mainloop_timer_s {
-        guint id;
-        guint period_ms;
+        unsigned int id;
+        unsigned int period_ms;
         bool repeat;
         char *name;
         GSourceFunc cb;
@@ -415,7 +415,7 @@ mainloop_cleanup(void)
  */
 struct gio_to_qb_poll {
     int32_t is_used;
-    guint source;
+    unsigned int source;
     int32_t events;
     void *data;
     qb_ipcs_dispatch_fn_t fn;
@@ -675,7 +675,7 @@ struct mainloop_io_s {
     void *userdata;
 
     int fd;
-    guint source;
+    unsigned int source;
     crm_ipc_t *ipc;
     GIOChannel *channel;
 
@@ -897,7 +897,7 @@ pcmk__add_mainloop_ipc(crm_ipc_t *ipc, int priority, void *userdata,
  *
  * \return Period in ms
  */
-guint
+unsigned int
 pcmk__mainloop_timer_get_period(const mainloop_timer_t *timer)
 {
     if (timer) {
@@ -1349,10 +1349,10 @@ mainloop_timer_stop(mainloop_timer_t *t)
     }
 }
 
-guint
-mainloop_timer_set_period(mainloop_timer_t *t, guint period_ms)
+unsigned int
+mainloop_timer_set_period(mainloop_timer_t *t, unsigned int period_ms)
 {
-    guint last = 0;
+    unsigned int last = 0;
 
     if(t) {
         last = t->period_ms;
@@ -1366,7 +1366,8 @@ mainloop_timer_set_period(mainloop_timer_t *t, guint period_ms)
 }
 
 mainloop_timer_t *
-mainloop_timer_add(const char *name, guint period_ms, bool repeat, GSourceFunc cb, void *userdata)
+mainloop_timer_add(const char *name, unsigned int period_ms, bool repeat,
+                   GSourceFunc cb, void *userdata)
 {
     mainloop_timer_t *t = pcmk__assert_alloc(1, sizeof(mainloop_timer_t));
 
@@ -1444,10 +1445,11 @@ pcmk_quit_main_loop(GMainLoop *mloop, unsigned int n)
  *       passed the remaining timeout in milliseconds.
  */
 void
-pcmk_drain_main_loop(GMainLoop *mloop, guint timer_ms, bool (*check)(guint))
+pcmk_drain_main_loop(GMainLoop *mloop, unsigned int timer_ms,
+                     bool (*check)(unsigned int))
 {
     bool timeout_popped = FALSE;
-    guint timer = 0;
+    unsigned int timer = 0;
     GMainContext *ctx = NULL;
 
     CRM_CHECK(mloop && check, return);

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -42,7 +42,7 @@ struct mainloop_timer_s {
 };
 
 static gboolean
-crm_trigger_prepare(GSource * source, gint * timeout)
+crm_trigger_prepare(GSource *source, int *timeout)
 {
     crm_trigger_t *trig = (crm_trigger_t *) source;
 
@@ -426,7 +426,7 @@ static gboolean
 gio_read_socket(GIOChannel * gio, GIOCondition condition, gpointer data)
 {
     struct gio_to_qb_poll *adaptor = (struct gio_to_qb_poll *)data;
-    gint fd = g_io_channel_unix_get_fd(gio);
+    int fd = g_io_channel_unix_get_fd(gio);
 
     pcmk__trace("%p.%d %d", data, fd, condition);
 
@@ -459,7 +459,7 @@ gio_poll_destroy(gpointer data)
  *
  * \return  best matching GLib's priority
  */
-static gint
+static int
 conv_prio_libqb2glib(enum qb_loop_priority prio)
 {
     switch (prio) {

--- a/lib/common/mainloop.c
+++ b/lib/common/mainloop.c
@@ -87,7 +87,7 @@ crm_trigger_check(GSource * source)
  * \return G_SOURCE_REMOVE to remove source, G_SOURCE_CONTINUE to keep it
  */
 static gboolean
-crm_trigger_dispatch(GSource *source, GSourceFunc callback, gpointer userdata)
+crm_trigger_dispatch(GSource *source, GSourceFunc callback, void *userdata)
 {
     gboolean rc = G_SOURCE_CONTINUE;
     crm_trigger_t *trig = (crm_trigger_t *) source;
@@ -125,8 +125,8 @@ static GSourceFuncs crm_trigger_funcs = {
 };
 
 static crm_trigger_t *
-mainloop_setup_trigger(GSource * source, int priority, int (*dispatch) (gpointer user_data),
-                       gpointer userdata)
+mainloop_setup_trigger(GSource * source, int priority,
+                       int (*dispatch)(void *user_data), void *userdata)
 {
     crm_trigger_t *trigger = NULL;
 
@@ -167,8 +167,8 @@ mainloop_trigger_complete(crm_trigger_t * trig)
  * \return Newly allocated mainloop source for trigger
  */
 crm_trigger_t *
-mainloop_add_trigger(int priority, int (*dispatch) (gpointer user_data),
-                     gpointer userdata)
+mainloop_add_trigger(int priority, int (*dispatch) (void *user_data),
+                     void *userdata)
 {
     GSource *source = NULL;
 
@@ -233,7 +233,7 @@ static crm_signal_t *crm_signals[NSIG];
  * \param[in] userdata  (ignored)
  */
 static gboolean
-crm_signal_dispatch(GSource *source, GSourceFunc callback, gpointer userdata)
+crm_signal_dispatch(GSource *source, GSourceFunc callback, void *userdata)
 {
     crm_signal_t *sig = (crm_signal_t *) source;
 
@@ -423,7 +423,7 @@ struct gio_to_qb_poll {
 };
 
 static gboolean
-gio_read_socket(GIOChannel * gio, GIOCondition condition, gpointer data)
+gio_read_socket(GIOChannel * gio, GIOCondition condition, void *data)
 {
     struct gio_to_qb_poll *adaptor = (struct gio_to_qb_poll *)data;
     int fd = g_io_channel_unix_get_fd(gio);
@@ -438,7 +438,7 @@ gio_read_socket(GIOChannel * gio, GIOCondition condition, gpointer data)
 }
 
 static void
-gio_poll_destroy(gpointer data)
+gio_poll_destroy(void *data)
 {
     struct gio_to_qb_poll *adaptor = (struct gio_to_qb_poll *)data;
 
@@ -679,10 +679,9 @@ struct mainloop_io_s {
     crm_ipc_t *ipc;
     GIOChannel *channel;
 
-    int (*dispatch_fn_ipc) (const char *buffer, ssize_t length, gpointer userdata);
-    int (*dispatch_fn_io) (gpointer userdata);
-    void (*destroy_fn) (gpointer userdata);
-
+    int (*dispatch_fn_ipc)(const char *buffer, ssize_t length, void *userdata);
+    int (*dispatch_fn_io)(void *userdata);
+    void (*destroy_fn)(void *userdata);
 };
 
 /*!
@@ -696,7 +695,7 @@ struct mainloop_io_s {
  * \return G_SOURCE_REMOVE to remove source, G_SOURCE_CONTINUE to keep it
  */
 static gboolean
-mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, gpointer data)
+mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, void *data)
 {
     gboolean rc = G_SOURCE_CONTINUE;
     mainloop_io_t *client = data;
@@ -797,7 +796,7 @@ mainloop_gio_callback(GIOChannel *gio, GIOCondition condition, gpointer data)
 }
 
 static void
-mainloop_gio_destroy(gpointer c)
+mainloop_gio_destroy(void *c)
 {
     mainloop_io_t *client = c;
     char *c_name = strdup(client->name);
@@ -812,7 +811,7 @@ mainloop_gio_destroy(gpointer c)
     }
 
     if (client->destroy_fn) {
-        void (*destroy_fn) (gpointer userdata) = client->destroy_fn;
+        void (*destroy_fn)(void *userdata) = client->destroy_fn;
 
         client->destroy_fn = NULL;
         destroy_fn(client->userdata);
@@ -1077,7 +1076,7 @@ child_kill_helper(mainloop_child_t *child)
 }
 
 static gboolean
-child_timeout_callback(gpointer p)
+child_timeout_callback(void *p)
 {
     mainloop_child_t *child = p;
     int rc = 0;
@@ -1182,7 +1181,7 @@ child_death_dispatch(int signal)
 }
 
 static gboolean
-child_signal_init(gpointer p)
+child_signal_init(void *p)
 {
     pcmk__trace("Installed SIGCHLD handler");
     /* Do NOT use g_child_watch_add() and friends, they rely on pthreads */
@@ -1290,7 +1289,7 @@ mainloop_child_add(pid_t pid, int timeout, const char *desc, void *privatedata,
 }
 
 static gboolean
-mainloop_timer_cb(gpointer user_data)
+mainloop_timer_cb(void *user_data)
 {
     int id = 0;
     bool repeat = FALSE;
@@ -1401,7 +1400,7 @@ mainloop_timer_del(mainloop_timer_t *t)
  */
 
 static gboolean
-drain_timeout_cb(gpointer user_data)
+drain_timeout_cb(void *user_data)
 {
     bool *timeout_popped = (bool*) user_data;
 

--- a/lib/common/messages.c
+++ b/lib/common/messages.c
@@ -184,12 +184,12 @@ pcmk__register_handlers(const pcmk__server_command_t handlers[])
         int i;
 
         for (i = 0; handlers[i].command != NULL; ++i) {
-            g_hash_table_insert(commands, (gpointer) handlers[i].command,
+            g_hash_table_insert(commands, (void *) handlers[i].command,
                                 handlers[i].handler);
         }
         if (handlers[i].handler != NULL) {
             // g_str_hash() can't handle NULL, so use empty string for default
-            g_hash_table_insert(commands, (gpointer) "", handlers[i].handler);
+            g_hash_table_insert(commands, (void *) "", handlers[i].handler);
         }
     }
     return commands;

--- a/lib/common/nodes.c
+++ b/lib/common/nodes.c
@@ -22,7 +22,7 @@
  * \param[in,out] user_data  Node object to free
  */
 void
-pcmk__free_node(gpointer user_data)
+pcmk__free_node(void *user_data)
 {
     pcmk_node_t *node = user_data;
 

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -66,7 +66,7 @@ pcmk__new_nvpair(const char *name, const char *value)
  * \param[in,out] nvpair  Name/value pair to free
  */
 static void
-pcmk__free_nvpair(gpointer data)
+pcmk__free_nvpair(void *data)
 {
     if (data) {
         pcmk_nvpair_t *nvpair = data;
@@ -194,7 +194,7 @@ pcmk__format_nvpair(const char *name, const char *value, const char *units)
  * \param[in,out] user_data  XML node
  */
 void
-hash2smartfield(gpointer key, gpointer value, gpointer user_data)
+hash2smartfield(void *key, void *value, void *user_data)
 {
     /* @TODO Generate PCMK__XE_PARAM nodes for all keys that aren't valid XML
      * attribute names (not just those that start with digits), or possibly for
@@ -236,7 +236,7 @@ hash2smartfield(gpointer key, gpointer value, gpointer user_data)
  * \param[in,out] user_data  XML node
  */
 void
-hash2field(gpointer key, gpointer value, gpointer user_data)
+hash2field(void *key, void *value, void *user_data)
 {
     const char *name = key;
     const char *s_value = value;
@@ -264,7 +264,7 @@ hash2field(gpointer key, gpointer value, gpointer user_data)
  * \param[in,out] user_data  XML node
  */
 void
-hash2metafield(gpointer key, gpointer value, gpointer user_data)
+hash2metafield(void *key, void *value, void *user_data)
 {
     char *crm_name = NULL;
 
@@ -444,7 +444,7 @@ unpack_nvpair(xmlNode *nvpair, void *userdata)
  * \note This is suitable for use as a GList iterator function
  */
 void
-pcmk__unpack_nvpair_block(gpointer data, gpointer user_data)
+pcmk__unpack_nvpair_block(void *data, void *user_data)
 {
     xmlNode *pair = data;
     pcmk__nvpair_unpack_t *unpack_data = user_data;
@@ -589,7 +589,7 @@ crm_meta_value(GHashTable *meta, const char *attr_name)
  * \note This is suitable for use as a GList sorting function.
  */
 int
-pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
+pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, void *user_data)
 {
     const xmlNode *pair_a = a;
     const xmlNode *pair_b = b;
@@ -707,7 +707,7 @@ pcmk_xml_attrs2nvpairs(const xmlNode *xml)
 }
 
 static void
-pcmk__nvpair_add_xml_attr(gpointer data, gpointer user_data)
+pcmk__nvpair_add_xml_attr(void *data, void *user_data)
 {
     pcmk_nvpair_t *pair = data;
     xmlNode *parent = user_data;
@@ -722,7 +722,7 @@ pcmk_nvpairs2xml_attrs(GSList *list, xmlNode *xml)
 }
 
 void
-hash2nvpair(gpointer key, gpointer value, gpointer user_data)
+hash2nvpair(void *key, void *value, void *user_data)
 {
     const char *name = key;
     const char *s_value = value;

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -589,7 +589,7 @@ crm_meta_value(GHashTable *meta, const char *attr_name)
  * \note This is suitable for use as a GList sorting function.
  */
 int
-pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, void *user_data)
+pcmk__cmp_nvpair_blocks(const void *a, const void *b, void *user_data)
 {
     const xmlNode *pair_a = a;
     const xmlNode *pair_b = b;
@@ -667,7 +667,7 @@ pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, void *user_data)
 #include <crm/common/nvpair_compat.h>
 
 static int
-pcmk__compare_nvpair(gconstpointer a, gconstpointer b)
+pcmk__compare_nvpair(const void *a, const void *b)
 {
     int rc = 0;
     const pcmk_nvpair_t *pair_a = a;

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -122,7 +122,7 @@ pcmk_free_nvpairs(GSList *nvpairs)
  *       \p *value using \c g_free(). On failure, nothing is allocated.
  */
 int
-pcmk__scan_nvpair(const gchar *input, gchar **name, gchar **value)
+pcmk__scan_nvpair(const char *input, gchar **name, gchar **value)
 {
     /* @COMPAT Consider rejecting leading (and possibly trailing) whitespace in
      * value and stripping outer quotes from value (for example,

--- a/lib/common/nvpair.c
+++ b/lib/common/nvpair.c
@@ -16,7 +16,7 @@
 #include <sys/types.h>
 #include <string.h>
 #include <ctype.h>
-#include <glib.h>           // gchar, gint, etc.
+#include <glib.h>           // gchar, etc.
 #include <libxml/tree.h>
 
 #include <crm/crm.h>
@@ -588,7 +588,7 @@ crm_meta_value(GHashTable *meta, const char *attr_name)
  *         should sort equally)
  * \note This is suitable for use as a GList sorting function.
  */
-gint
+int
 pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
 {
     const xmlNode *pair_a = a;
@@ -604,9 +604,9 @@ pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
      * lower-priority ones. If we're not overwriting values, we want to process
      * from highest priority to lowest.
      */
-    const gint a_is_higher = ((unpack_data != NULL)
-                              && unpack_data->overwrite)? 1 : -1;
-    const gint b_is_higher = -a_is_higher;
+    const int a_is_higher = ((unpack_data != NULL)
+                             && unpack_data->overwrite)? 1 : -1;
+    const int b_is_higher = -a_is_higher;
 
     /* NULL values have lowest priority, regardless of the other's score
      * (it won't be possible in practice anyway, this is just a failsafe)
@@ -666,7 +666,7 @@ pcmk__cmp_nvpair_blocks(gconstpointer a, gconstpointer b, gpointer user_data)
 
 #include <crm/common/nvpair_compat.h>
 
-static gint
+static int
 pcmk__compare_nvpair(gconstpointer a, gconstpointer b)
 {
     int rc = 0;

--- a/lib/common/options_display.c
+++ b/lib/common/options_display.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -166,12 +166,12 @@ option_list_default(pcmk__output_t *out, va_list args)
         // Store deprecated and advanced options to display later if appropriate
         if (pcmk__is_set(option->flags, pcmk__opt_deprecated)) {
             if (show_deprecated) {
-                deprecated = g_slist_prepend(deprecated, (gpointer) option);
+                deprecated = g_slist_prepend(deprecated, (void *) option);
             }
 
         } else if (pcmk__is_set(option->flags, pcmk__opt_advanced)) {
             if (show_advanced) {
-                advanced = g_slist_prepend(advanced, (gpointer) option);
+                advanced = g_slist_prepend(advanced, (void *) option);
             }
 
         } else {
@@ -180,7 +180,7 @@ option_list_default(pcmk__output_t *out, va_list args)
         }
 
         if (show_deprecated && (option->alt_name != NULL)) {
-            aliased = g_slist_prepend(aliased, (gpointer) option);
+            aliased = g_slist_prepend(aliased, (void *) option);
         }
     }
 

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -130,7 +130,7 @@ html_init(pcmk__output_t *out) {
 }
 
 static void
-add_error_node(gpointer data, gpointer user_data) {
+add_error_node(void *data, void *user_data) {
     char *str = (char *) data;
     pcmk__output_t *out = (pcmk__output_t *) user_data;
     out->list_item(out, NULL, "%s", str);
@@ -199,7 +199,7 @@ html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy
 
     if (g_slist_length(priv->errors) > 0) {
         out->begin_list(out, "Errors", NULL, NULL);
-        g_slist_foreach(priv->errors, add_error_node, (gpointer) out);
+        g_slist_foreach(priv->errors, add_error_node, (void *) out);
         out->end_list(out);
     }
 

--- a/lib/common/output_html.c
+++ b/lib/common/output_html.c
@@ -78,7 +78,8 @@ typedef struct {
 } private_data_t;
 
 static void
-html_free_priv(pcmk__output_t *out) {
+html_free_priv(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     if (out == NULL || out->priv == NULL) {
@@ -98,7 +99,8 @@ html_free_priv(pcmk__output_t *out) {
 }
 
 static bool
-html_init(pcmk__output_t *out) {
+html_init(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert(out != NULL);
@@ -130,14 +132,17 @@ html_init(pcmk__output_t *out) {
 }
 
 static void
-add_error_node(void *data, void *user_data) {
+add_error_node(void *data, void *user_data)
+{
     char *str = (char *) data;
     pcmk__output_t *out = (pcmk__output_t *) user_data;
     out->list_item(out, NULL, "%s", str);
 }
 
 static void
-html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print,
+            void **copy_dest)
+{
     private_data_t *priv = NULL;
     htmlNodePtr head_node = NULL;
     htmlNodePtr charset_node = NULL;
@@ -216,7 +221,8 @@ html_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy
 }
 
 static void
-html_reset(pcmk__output_t *out) {
+html_reset(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
 
     out->dest = freopen(NULL, "w", out->dest);
@@ -228,7 +234,8 @@ html_reset(pcmk__output_t *out) {
 
 static void
 html_subprocess_output(pcmk__output_t *out, int exit_status,
-                       const char *proc_stdout, const char *proc_stderr) {
+                       const char *proc_stdout, const char *proc_stderr)
+{
     char *rc_buf = NULL;
 
     pcmk__assert(out != NULL);
@@ -273,7 +280,8 @@ html_version(pcmk__output_t *out)
 
 G_GNUC_PRINTF(2, 3)
 static void
-html_err(pcmk__output_t *out, const char *format, ...) {
+html_err(pcmk__output_t *out, const char *format, ...)
+{
     private_data_t *priv = NULL;
     int len = 0;
     char *buf = NULL;
@@ -292,12 +300,14 @@ html_err(pcmk__output_t *out, const char *format, ...) {
 
 G_GNUC_PRINTF(2, 3)
 static int
-html_info(pcmk__output_t *out, const char *format, ...) {
+html_info(pcmk__output_t *out, const char *format, ...)
+{
     return pcmk_rc_no_output;
 }
 
 static void
-html_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+html_output_xml(pcmk__output_t *out, const char *name, const char *buf)
+{
     htmlNodePtr node = NULL;
 
     pcmk__assert(out != NULL);
@@ -309,7 +319,8 @@ html_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
 G_GNUC_PRINTF(4, 5)
 static void
 html_begin_list(pcmk__output_t *out, const char *singular_noun,
-                const char *plural_noun, const char *format, ...) {
+                const char *plural_noun, const char *format, ...)
+{
     int q_len = 0;
     private_data_t *priv = NULL;
     xmlNodePtr node = NULL;
@@ -351,7 +362,8 @@ html_begin_list(pcmk__output_t *out, const char *singular_noun,
 
 G_GNUC_PRINTF(3, 4)
 static void
-html_list_item(pcmk__output_t *out, const char *name, const char *format, ...) {
+html_list_item(pcmk__output_t *out, const char *name, const char *format, ...)
+{
     htmlNodePtr item_node = NULL;
     va_list ap;
     char *buf = NULL;
@@ -373,12 +385,14 @@ html_list_item(pcmk__output_t *out, const char *name, const char *format, ...) {
 }
 
 static void
-html_increment_list(pcmk__output_t *out) {
+html_increment_list(pcmk__output_t *out)
+{
     /* This function intentially left blank */
 }
 
 static void
-html_end_list(pcmk__output_t *out) {
+html_end_list(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));
@@ -397,23 +411,27 @@ html_end_list(pcmk__output_t *out) {
 }
 
 static bool
-html_is_quiet(pcmk__output_t *out) {
+html_is_quiet(pcmk__output_t *out)
+{
     return false;
 }
 
 static void
-html_spacer(pcmk__output_t *out) {
+html_spacer(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
     pcmk__output_create_xml_node(out, "br", NULL);
 }
 
 static void
-html_progress(pcmk__output_t *out, bool end) {
+html_progress(pcmk__output_t *out, bool end)
+{
     /* This function intentially left blank */
 }
 
 pcmk__output_t *
-pcmk__mk_html_output(char **argv) {
+pcmk__mk_html_output(char **argv)
+{
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
 
     if (retval == NULL) {
@@ -452,8 +470,10 @@ pcmk__mk_html_output(char **argv) {
 }
 
 xmlNodePtr
-pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name, const char *id,
-                              const char *class_name, const char *text) {
+pcmk__output_create_html_node(pcmk__output_t *out, const char *element_name,
+                              const char *id, const char *class_name,
+                              const char *text)
+{
     htmlNodePtr node = NULL;
 
     pcmk__assert(out != NULL);
@@ -506,7 +526,8 @@ pcmk__html_set_title(const char *name)
 }
 
 void
-pcmk__html_add_header(const char *name, ...) {
+pcmk__html_add_header(const char *name, ...)
+{
     htmlNodePtr header_node;
     va_list ap;
 

--- a/lib/common/output_log.c
+++ b/lib/common/output_log.c
@@ -59,12 +59,14 @@ typedef struct {
 
 static void
 log_subprocess_output(pcmk__output_t *out, int exit_status,
-                      const char *proc_stdout, const char *proc_stderr) {
+                      const char *proc_stdout, const char *proc_stderr)
+{
     /* This function intentionally left blank */
 }
 
 static void
-log_free_priv(pcmk__output_t *out) {
+log_free_priv(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     if (out == NULL || out->priv == NULL) {
@@ -78,7 +80,8 @@ log_free_priv(pcmk__output_t *out) {
 }
 
 static bool
-log_init(pcmk__output_t *out) {
+log_init(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert(out != NULL);
@@ -102,12 +105,15 @@ log_init(pcmk__output_t *out) {
 }
 
 static void
-log_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+log_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print,
+           void **copy_dest)
+{
     /* This function intentionally left blank */
 }
 
 static void
-log_reset(pcmk__output_t *out) {
+log_reset(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
 
     out->dest = freopen(NULL, "w", out->dest);
@@ -149,7 +155,8 @@ log_err(pcmk__output_t *out, const char *format, ...)
 }
 
 static void
-log_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+log_output_xml(pcmk__output_t *out, const char *name, const char *buf)
+{
     xmlNodePtr node = NULL;
     private_data_t *priv = NULL;
 
@@ -164,8 +171,9 @@ log_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
 
 G_GNUC_PRINTF(4, 5)
 static void
-log_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plural_noun,
-               const char *format, ...) {
+log_begin_list(pcmk__output_t *out, const char *singular_noun,
+               const char *plural_noun, const char *format, ...)
+{
     int len = 0;
     va_list ap;
     char* buffer = NULL;
@@ -227,7 +235,8 @@ log_list_item(pcmk__output_t *out, const char *name, const char *format, ...)
 }
 
 static void
-log_end_list(pcmk__output_t *out) {
+log_end_list(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));
@@ -280,27 +289,32 @@ log_transient(pcmk__output_t *out, const char *format, ...)
 }
 
 static bool
-log_is_quiet(pcmk__output_t *out) {
+log_is_quiet(pcmk__output_t *out)
+{
     return false;
 }
 
 static void
-log_spacer(pcmk__output_t *out) {
+log_spacer(pcmk__output_t *out)
+{
     /* This function intentionally left blank */
 }
 
 static void
-log_progress(pcmk__output_t *out, bool end) {
+log_progress(pcmk__output_t *out, bool end)
+{
     /* This function intentionally left blank */
 }
 
 static void
-log_prompt(const char *prompt, bool echo, char **dest) {
+log_prompt(const char *prompt, bool echo, char **dest)
+{
     /* This function intentionally left blank */
 }
 
 pcmk__output_t *
-pcmk__mk_log_output(char **argv) {
+pcmk__mk_log_output(char **argv)
+{
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
 
     if (retval == NULL) {

--- a/lib/common/output_none.c
+++ b/lib/common/output_none.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -17,22 +17,27 @@
 #include <crm/crm.h>
 
 static void
-none_free_priv(pcmk__output_t *out) {
+none_free_priv(pcmk__output_t *out)
+{
     /* This function intentionally left blank */
 }
 
 static bool
-none_init(pcmk__output_t *out) {
+none_init(pcmk__output_t *out)
+{
     return true;
 }
 
 static void
-none_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+none_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print,
+            void **copy_dest)
+{
     /* This function intentionally left blank */
 }
 
 static void
-none_reset(pcmk__output_t *out) {
+none_reset(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
     none_free_priv(out);
     none_init(out);
@@ -40,7 +45,8 @@ none_reset(pcmk__output_t *out) {
 
 static void
 none_subprocess_output(pcmk__output_t *out, int exit_status,
-                       const char *proc_stdout, const char *proc_stderr) {
+                       const char *proc_stdout, const char *proc_stderr)
+{
     /* This function intentionally left blank */
 }
 
@@ -52,66 +58,78 @@ none_version(pcmk__output_t *out)
 
 G_GNUC_PRINTF(2, 3)
 static void
-none_err(pcmk__output_t *out, const char *format, ...) {
+none_err(pcmk__output_t *out, const char *format, ...)
+{
     /* This function intentionally left blank */
 }
 
 G_GNUC_PRINTF(2, 3)
 static int
-none_info(pcmk__output_t *out, const char *format, ...) {
+none_info(pcmk__output_t *out, const char *format, ...)
+{
     return pcmk_rc_no_output;
 }
 
 static void
-none_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+none_output_xml(pcmk__output_t *out, const char *name, const char *buf)
+{
     /* This function intentionally left blank */
 }
 
 G_GNUC_PRINTF(4, 5)
 static void
-none_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plural_noun,
-                const char *format, ...) {
+none_begin_list(pcmk__output_t *out, const char *singular_noun,
+                const char *plural_noun, const char *format, ...)
+{
     /* This function intentionally left blank */
 }
 
 G_GNUC_PRINTF(3, 4)
 static void
-none_list_item(pcmk__output_t *out, const char *id, const char *format, ...) {
+none_list_item(pcmk__output_t *out, const char *id, const char *format, ...)
+{
     /* This function intentionally left blank */
 }
 
 static void
-none_increment_list(pcmk__output_t *out) {
+none_increment_list(pcmk__output_t *out)
+{
     /* This function intentionally left blank */
 }
 
 static void
-none_end_list(pcmk__output_t *out) {
+none_end_list(pcmk__output_t *out)
+{
     /* This function intentionally left blank */
 }
 
 static bool
-none_is_quiet(pcmk__output_t *out) {
+none_is_quiet(pcmk__output_t *out)
+{
     return out->quiet;
 }
 
 static void
-none_spacer(pcmk__output_t *out) {
+none_spacer(pcmk__output_t *out)
+{
     /* This function intentionally left blank */
 }
 
 static void
-none_progress(pcmk__output_t *out, bool end) {
+none_progress(pcmk__output_t *out, bool end)
+{
     /* This function intentionally left blank */
 }
 
 static void
-none_prompt(const char *prompt, bool echo, char **dest) {
+none_prompt(const char *prompt, bool echo, char **dest)
+{
     /* This function intentionally left blank */
 }
 
 pcmk__output_t *
-pcmk__mk_none_output(char **argv) {
+pcmk__mk_none_output(char **argv)
+{
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
 
     if (retval == NULL) {

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -29,7 +29,8 @@ typedef struct {
 } private_data_t;
 
 static void
-free_list_data(gpointer data) {
+free_list_data(void *data)
+{
     text_list_data_t *list_data = data;
 
     free(list_data->singular_noun);
@@ -248,7 +249,7 @@ text_list_item(pcmk__output_t *out, const char *id, const char *format, ...) {
 static void
 text_increment_list(pcmk__output_t *out) {
     private_data_t *priv = NULL;
-    gpointer tail;
+    void *tail = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));
     priv = out->priv;

--- a/lib/common/output_text.c
+++ b/lib/common/output_text.c
@@ -39,7 +39,8 @@ free_list_data(void *data)
 }
 
 static void
-text_free_priv(pcmk__output_t *out) {
+text_free_priv(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     if (out == NULL || out->priv == NULL) {
@@ -53,7 +54,8 @@ text_free_priv(pcmk__output_t *out) {
 }
 
 static bool
-text_init(pcmk__output_t *out) {
+text_init(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert(out != NULL);
@@ -74,14 +76,16 @@ text_init(pcmk__output_t *out) {
 }
 
 static void
-text_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest)
+text_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print,
+            void **copy_dest)
 {
     pcmk__assert((out != NULL) && (out->dest != NULL));
     fflush(out->dest);
 }
 
 static void
-text_reset(pcmk__output_t *out) {
+text_reset(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
     bool old_fancy = false;
 
@@ -106,7 +110,8 @@ text_reset(pcmk__output_t *out) {
 
 static void
 text_subprocess_output(pcmk__output_t *out, int exit_status,
-                       const char *proc_stdout, const char *proc_stderr) {
+                       const char *proc_stdout, const char *proc_stderr)
+{
     pcmk__assert(out != NULL);
 
     if (proc_stdout != NULL) {
@@ -131,7 +136,8 @@ text_version(pcmk__output_t *out)
 
 G_GNUC_PRINTF(2, 3)
 static void
-text_err(pcmk__output_t *out, const char *format, ...) {
+text_err(pcmk__output_t *out, const char *format, ...)
+{
     va_list ap;
 
     pcmk__assert(out != NULL);
@@ -150,7 +156,8 @@ text_err(pcmk__output_t *out, const char *format, ...) {
 
 G_GNUC_PRINTF(2, 3)
 static int
-text_info(pcmk__output_t *out, const char *format, ...) {
+text_info(pcmk__output_t *out, const char *format, ...)
+{
     va_list ap;
 
     pcmk__assert(out != NULL);
@@ -180,15 +187,17 @@ text_transient(pcmk__output_t *out, const char *format, ...)
 }
 
 static void
-text_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+text_output_xml(pcmk__output_t *out, const char *name, const char *buf)
+{
     pcmk__assert(out != NULL);
     pcmk__indented_printf(out, "%s", buf);
 }
 
 G_GNUC_PRINTF(4, 5)
 static void
-text_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plural_noun,
-                const char *format, ...) {
+text_begin_list(pcmk__output_t *out, const char *singular_noun,
+                const char *plural_noun, const char *format, ...)
+{
     private_data_t *priv = NULL;
     text_list_data_t *new_list = NULL;
     va_list ap;
@@ -215,7 +224,8 @@ text_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plur
 
 G_GNUC_PRINTF(3, 4)
 static void
-text_list_item(pcmk__output_t *out, const char *id, const char *format, ...) {
+text_list_item(pcmk__output_t *out, const char *id, const char *format, ...)
+{
     private_data_t *priv = NULL;
     va_list ap;
 
@@ -247,7 +257,8 @@ text_list_item(pcmk__output_t *out, const char *id, const char *format, ...) {
 }
 
 static void
-text_increment_list(pcmk__output_t *out) {
+text_increment_list(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
     void *tail = NULL;
 
@@ -260,7 +271,8 @@ text_increment_list(pcmk__output_t *out) {
 }
 
 static void
-text_end_list(pcmk__output_t *out) {
+text_end_list(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
     text_list_data_t *node = NULL;
 
@@ -281,19 +293,22 @@ text_end_list(pcmk__output_t *out) {
 }
 
 static bool
-text_is_quiet(pcmk__output_t *out) {
+text_is_quiet(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
     return out->quiet;
 }
 
 static void
-text_spacer(pcmk__output_t *out) {
+text_spacer(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
     fprintf(out->dest, "\n");
 }
 
 static void
-text_progress(pcmk__output_t *out, bool end) {
+text_progress(pcmk__output_t *out, bool end)
+{
     pcmk__assert(out != NULL);
 
     if (out->dest == stdout) {
@@ -306,7 +321,8 @@ text_progress(pcmk__output_t *out, bool end) {
 }
 
 pcmk__output_t *
-pcmk__mk_text_output(char **argv) {
+pcmk__mk_text_output(char **argv)
+{
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
 
     if (retval == NULL) {
@@ -392,7 +408,8 @@ pcmk__output_text_set_fancy(pcmk__output_t *out, bool enabled)
 
 G_GNUC_PRINTF(2, 0)
 void
-pcmk__formatted_vprintf(pcmk__output_t *out, const char *format, va_list args) {
+pcmk__formatted_vprintf(pcmk__output_t *out, const char *format, va_list args)
+{
     pcmk__assert(out != NULL);
     CRM_CHECK(pcmk__str_eq(out->fmt_name, "text", pcmk__str_none), return);
     vfprintf(out->dest, format, args);
@@ -400,7 +417,8 @@ pcmk__formatted_vprintf(pcmk__output_t *out, const char *format, va_list args) {
 
 G_GNUC_PRINTF(2, 3)
 void
-pcmk__formatted_printf(pcmk__output_t *out, const char *format, ...) {
+pcmk__formatted_printf(pcmk__output_t *out, const char *format, ...)
+{
     va_list ap;
 
     pcmk__assert(out != NULL);
@@ -412,7 +430,8 @@ pcmk__formatted_printf(pcmk__output_t *out, const char *format, ...) {
 
 G_GNUC_PRINTF(2, 0)
 void
-pcmk__indented_vprintf(pcmk__output_t *out, const char *format, va_list args) {
+pcmk__indented_vprintf(pcmk__output_t *out, const char *format, va_list args)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert(out != NULL);
@@ -442,7 +461,8 @@ pcmk__indented_vprintf(pcmk__output_t *out, const char *format, va_list args) {
 
 G_GNUC_PRINTF(2, 3)
 void
-pcmk__indented_printf(pcmk__output_t *out, const char *format, ...) {
+pcmk__indented_printf(pcmk__output_t *out, const char *format, ...)
+{
     va_list ap;
 
     pcmk__assert(out != NULL);

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -173,7 +173,8 @@ xml_init(pcmk__output_t *out) {
 }
 
 static void
-add_error_node(gpointer data, gpointer user_data) {
+add_error_node(void *data, void *user_data)
+{
     const char *str = (const char *) data;
     xmlNodePtr node = (xmlNodePtr) user_data;
 
@@ -217,7 +218,7 @@ xml_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_
 
         if (g_slist_length(priv->errors) > 0) {
             xmlNodePtr errors_node = pcmk__xe_create(node, PCMK_XE_ERRORS);
-            g_slist_foreach(priv->errors, add_error_node, (gpointer) errors_node);
+            g_slist_foreach(priv->errors, add_error_node, (void *) errors_node);
         }
 
         free(rc_as_str);

--- a/lib/common/output_xml.c
+++ b/lib/common/output_xml.c
@@ -127,7 +127,8 @@ add_root_node(pcmk__output_t *out)
 }
 
 static void
-xml_free_priv(pcmk__output_t *out) {
+xml_free_priv(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     if (out == NULL || out->priv == NULL) {
@@ -150,7 +151,8 @@ xml_free_priv(pcmk__output_t *out) {
 }
 
 static bool
-xml_init(pcmk__output_t *out) {
+xml_init(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert(out != NULL);
@@ -183,7 +185,9 @@ add_error_node(void *data, void *user_data)
 }
 
 static void
-xml_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_dest) {
+xml_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print,
+           void **copy_dest)
+{
     private_data_t *priv = NULL;
     xmlNodePtr node;
 
@@ -234,7 +238,8 @@ xml_finish(pcmk__output_t *out, crm_exit_t exit_status, bool print, void **copy_
 }
 
 static void
-xml_reset(pcmk__output_t *out) {
+xml_reset(pcmk__output_t *out)
+{
     pcmk__assert(out != NULL);
 
     out->dest = freopen(NULL, "w", out->dest);
@@ -246,7 +251,8 @@ xml_reset(pcmk__output_t *out) {
 
 static void
 xml_subprocess_output(pcmk__output_t *out, int exit_status,
-                      const char *proc_stdout, const char *proc_stderr) {
+                      const char *proc_stdout, const char *proc_stderr)
+{
     xmlNodePtr node, child_node;
     char *rc_as_str = NULL;
 
@@ -291,7 +297,8 @@ xml_version(pcmk__output_t *out)
 
 G_GNUC_PRINTF(2, 3)
 static void
-xml_err(pcmk__output_t *out, const char *format, ...) {
+xml_err(pcmk__output_t *out, const char *format, ...)
+{
     private_data_t *priv = NULL;
     int len = 0;
     char *buf = NULL;
@@ -312,12 +319,14 @@ xml_err(pcmk__output_t *out, const char *format, ...) {
 
 G_GNUC_PRINTF(2, 3)
 static int
-xml_info(pcmk__output_t *out, const char *format, ...) {
+xml_info(pcmk__output_t *out, const char *format, ...)
+{
     return pcmk_rc_no_output;
 }
 
 static void
-xml_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
+xml_output_xml(pcmk__output_t *out, const char *name, const char *buf)
+{
     xmlNodePtr parent = NULL;
     xmlNodePtr cdata_node = NULL;
 
@@ -334,8 +343,9 @@ xml_output_xml(pcmk__output_t *out, const char *name, const char *buf) {
 
 G_GNUC_PRINTF(4, 5)
 static void
-xml_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plural_noun,
-               const char *format, ...) {
+xml_begin_list(pcmk__output_t *out, const char *singular_noun,
+               const char *plural_noun, const char *format, ...)
+{
     va_list ap;
     char *name = NULL;
     char *buf = NULL;
@@ -375,7 +385,8 @@ xml_begin_list(pcmk__output_t *out, const char *singular_noun, const char *plura
 
 G_GNUC_PRINTF(3, 4)
 static void
-xml_list_item(pcmk__output_t *out, const char *name, const char *format, ...) {
+xml_list_item(pcmk__output_t *out, const char *name, const char *format, ...)
+{
     xmlNodePtr item_node = NULL;
     va_list ap;
     char *buf = NULL;
@@ -398,12 +409,14 @@ xml_list_item(pcmk__output_t *out, const char *name, const char *format, ...) {
 }
 
 static void
-xml_increment_list(pcmk__output_t *out) {
+xml_increment_list(pcmk__output_t *out)
+{
     /* This function intentially left blank */
 }
 
 static void
-xml_end_list(pcmk__output_t *out) {
+xml_end_list(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));
@@ -425,22 +438,26 @@ xml_end_list(pcmk__output_t *out) {
 }
 
 static bool
-xml_is_quiet(pcmk__output_t *out) {
+xml_is_quiet(pcmk__output_t *out)
+{
     return false;
 }
 
 static void
-xml_spacer(pcmk__output_t *out) {
+xml_spacer(pcmk__output_t *out)
+{
     /* This function intentionally left blank */
 }
 
 static void
-xml_progress(pcmk__output_t *out, bool end) {
+xml_progress(pcmk__output_t *out, bool end)
+{
     /* This function intentionally left blank */
 }
 
 pcmk__output_t *
-pcmk__mk_xml_output(char **argv) {
+pcmk__mk_xml_output(char **argv)
+{
     pcmk__output_t *retval = calloc(1, sizeof(pcmk__output_t));
 
     if (retval == NULL) {
@@ -479,7 +496,8 @@ pcmk__mk_xml_output(char **argv) {
 }
 
 xmlNodePtr
-pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name, ...) {
+pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name, ...)
+{
     va_list args;
     xmlNodePtr node = NULL;
 
@@ -497,7 +515,8 @@ pcmk__output_xml_create_parent(pcmk__output_t *out, const char *name, ...) {
 }
 
 void
-pcmk__output_xml_add_node_copy(pcmk__output_t *out, xmlNodePtr node) {
+pcmk__output_xml_add_node_copy(pcmk__output_t *out, xmlNodePtr node)
+{
     private_data_t *priv = NULL;
     xmlNodePtr parent = NULL;
 
@@ -516,7 +535,8 @@ pcmk__output_xml_add_node_copy(pcmk__output_t *out, xmlNodePtr node) {
 }
 
 xmlNodePtr
-pcmk__output_create_xml_node(pcmk__output_t *out, const char *name, ...) {
+pcmk__output_create_xml_node(pcmk__output_t *out, const char *name, ...)
+{
     xmlNodePtr node = NULL;
     private_data_t *priv = NULL;
     va_list args;
@@ -537,7 +557,9 @@ pcmk__output_create_xml_node(pcmk__output_t *out, const char *name, ...) {
 }
 
 xmlNodePtr
-pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name, const char *content) {
+pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name,
+                                  const char *content)
+{
     xmlNodePtr node = NULL;
 
     pcmk__assert(out != NULL);
@@ -549,7 +571,8 @@ pcmk__output_create_xml_text_node(pcmk__output_t *out, const char *name, const c
 }
 
 void
-pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
+pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr parent)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL) && (parent != NULL));
@@ -563,7 +586,8 @@ pcmk__output_xml_push_parent(pcmk__output_t *out, xmlNodePtr parent) {
 }
 
 void
-pcmk__output_xml_pop_parent(pcmk__output_t *out) {
+pcmk__output_xml_pop_parent(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));
@@ -579,7 +603,8 @@ pcmk__output_xml_pop_parent(pcmk__output_t *out) {
 }
 
 xmlNodePtr
-pcmk__output_xml_peek_parent(pcmk__output_t *out) {
+pcmk__output_xml_peek_parent(pcmk__output_t *out)
+{
     private_data_t *priv = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -621,7 +621,7 @@ typedef struct {
     xmlNode *match;
 } xml_change_obj_t;
 
-static gint
+static int
 sort_change_obj_by_position(gconstpointer a, gconstpointer b)
 {
     const xml_change_obj_t *change_obj_a = a;

--- a/lib/common/patchset.c
+++ b/lib/common/patchset.c
@@ -622,7 +622,7 @@ typedef struct {
 } xml_change_obj_t;
 
 static int
-sort_change_obj_by_position(gconstpointer a, gconstpointer b)
+sort_change_obj_by_position(const void *a, const void *b)
 {
     const xml_change_obj_t *change_obj_a = a;
     const xml_change_obj_t *change_obj_b = b;

--- a/lib/common/probes.c
+++ b/lib/common/probes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,7 @@
 
 #include <stdio.h>                  // NULL
 #include <stdbool.h>                // bool, true, false
-#include <glib.h>                   // guint
+
 #include <libxml/tree.h>            // xmlNode
 
 #include <crm/common/options.h>     // PCMK_META_INTERVAL
@@ -28,7 +28,7 @@
  *         otherwise false
  */
 bool
-pcmk_is_probe(const char *task, guint interval_ms)
+pcmk_is_probe(const char *task, unsigned int interval_ms)
 {
     // @COMPAT This should be made inline at an API compatibility break
     return (interval_ms == 0)

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 the Pacemaker project contributors
+ * Copyright 2008-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -593,7 +593,7 @@ struct tcp_async_cb_data {
 
 // \return TRUE if timer should be rescheduled, FALSE otherwise
 static gboolean
-check_connect_finished(gpointer userdata)
+check_connect_finished(void *userdata)
 {
     struct tcp_async_cb_data *cb_data = userdata;
     int rc;

--- a/lib/common/resources.c
+++ b/lib/common/resources.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -21,7 +21,7 @@
  * \param[in,out] user_data  Resource object to free
  */
 void
-pcmk__free_resource(gpointer user_data)
+pcmk__free_resource(void *user_data)
 {
     pcmk_resource_t *rsc = user_data;
 

--- a/lib/common/rules.c
+++ b/lib/common/rules.c
@@ -1181,7 +1181,7 @@ pcmk__evaluate_op_expression(const xmlNode *op_expression,
     const char *id = NULL;
     const char *name = NULL;
     const char *interval_s = NULL;
-    guint interval_ms = 0U;
+    unsigned int interval_ms = 0;
 
     if ((op_expression == NULL) || (rule_input == NULL)) {
         return EINVAL;

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -483,7 +483,7 @@ done:
 }
 
 static int
-schema_sort_GCompareFunc(gconstpointer a, gconstpointer b)
+schema_sort_GCompareFunc(const void *a, const void *b)
 {
     const pcmk__schema_t *schema_a = a;
     const pcmk__schema_t *schema_b = b;

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -455,8 +455,8 @@ pcmk__load_schemas_from_dir(const char *dir)
             if (transforms != NULL) {
                 // The schema becomes the owner of transform_list
                 g_hash_table_lookup_extended(transforms, version_s,
-                                             (gpointer *) &orig_key,
-                                             (gpointer *) &transform_list);
+                                             (void **) &orig_key,
+                                             (void **) &transform_list);
                 g_hash_table_steal(transforms, version_s);
             }
 
@@ -641,7 +641,7 @@ validate_with_relaxng(xmlDocPtr doc, xmlRelaxNGValidityErrorFunc error_handler,
 }
 
 static void
-free_schema(gpointer data)
+free_schema(void *data)
 {
     pcmk__schema_t *schema = data;
     relaxng_ctx_cache_t *ctx = NULL;

--- a/lib/common/schemas.c
+++ b/lib/common/schemas.c
@@ -482,7 +482,7 @@ done:
     g_clear_pointer(&transforms, g_hash_table_destroy);
 }
 
-static gint
+static int
 schema_sort_GCompareFunc(gconstpointer a, gconstpointer b)
 {
     const pcmk__schema_t *schema_a = a;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -308,8 +308,8 @@ pcmk__scan_double(const char *text, double *result, const char *default_text,
  * \return Standard Pacemaker return code
  */
 int
-pcmk__guint_from_hash(GHashTable *table, const char *key,
-                      unsigned int default_val, unsigned int *result)
+pcmk__uint_from_hash(GHashTable *table, const char *key,
+                     unsigned int default_val, unsigned int *result)
 {
     const char *value;
     long long value_ll;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -724,8 +724,8 @@ pcmk__parse_ll_range(const char *text, long long *start, long long *end)
     long long local_end = 0;
     gchar **split = NULL;
     unsigned int length = 0;
-    const gchar *start_s = NULL;
-    const gchar *end_s = NULL;
+    const char *start_s = NULL;
+    const char *end_s = NULL;
 
     // Do not free
     char *remainder = NULL;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -943,7 +943,7 @@ struct str_in_list_data {
  *         if \p a comes after \p b->str, or 0 if \p a is equal to \p b->str
  *         (according to \p b->flags)
  */
-static gint
+static int
 cmp_str_in_list(gconstpointer a, gconstpointer b)
 {
     const char *element = a;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -334,7 +334,7 @@ pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
         return rc;
     }
 
-    if ((value_ll < 0) || (value_ll > G_MAXUINT)) {
+    if ((value_ll < 0) || (value_ll > UINT_MAX)) {
         pcmk__warn("Using default (%u) for %s because '%s' is not in valid "
                    "range",
                    default_val, key, value);
@@ -376,7 +376,7 @@ pcmk_parse_interval_spec(const char *input, guint *result_ms)
 
         if (period_s != NULL) {
             msec = crm_time_get_seconds(period_s);
-            msec = QB_MIN(msec, G_MAXUINT / 1000) * 1000;
+            msec = QB_MIN(msec, UINT_MAX / 1000) * 1000;
             crm_time_free(period_s);
         }
 
@@ -397,7 +397,7 @@ pcmk_parse_interval_spec(const char *input, guint *result_ms)
 
 done:
     if (result_ms != NULL) {
-        *result_ms = (msec >= G_MAXUINT)? G_MAXUINT : (guint) msec;
+        *result_ms = (msec >= UINT_MAX)? UINT_MAX : (guint) msec;
     }
     return rc;
 }

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -422,7 +422,7 @@ done:
  * in the transition graph.
  */
 static unsigned int
-pcmk__str_hash(gconstpointer v)
+pcmk__str_hash(const void *v)
 {
     const signed char *p;
     guint32 h = 0;
@@ -472,13 +472,13 @@ pcmk__insert_dup(GHashTable *table, const char *name, const char *value)
 
 /* used with hash tables where case does not matter */
 static gboolean
-pcmk__strcase_equal(gconstpointer a, gconstpointer b)
+pcmk__strcase_equal(const void *a, const void *b)
 {
     return pcmk__str_eq((const char *)a, (const char *)b, pcmk__str_casei);
 }
 
 static unsigned int
-pcmk__strcase_hash(gconstpointer v)
+pcmk__strcase_hash(const void *v)
 {
     const signed char *p;
     guint32 h = 0;
@@ -944,7 +944,7 @@ struct str_in_list_data {
  *         (according to \p b->flags)
  */
 static int
-cmp_str_in_list(gconstpointer a, gconstpointer b)
+cmp_str_in_list(const void *a, const void *b)
 {
     const char *element = a;
     const struct str_in_list_data *data = b;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -509,7 +509,7 @@ pcmk__strikey_table(GDestroyNotify key_destroy_func,
 }
 
 static void
-copy_str_table_entry(gpointer key, gpointer value, gpointer user_data)
+copy_str_table_entry(void *key, void *value, void *user_data)
 {
     if (key && value && user_data) {
         pcmk__insert_dup((GHashTable *) user_data,

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -298,7 +298,7 @@ pcmk__scan_double(const char *text, double *result, const char *default_text,
 
 /*!
  * \internal
- * \brief Parse a guint from a string stored in a hash table
+ * \brief Parse an <tt>unsigned int</tt> from a string stored in a hash table
  *
  * \param[in]     table        Hash table to search
  * \param[in]     key          Hash table key to use to retrieve string
@@ -308,8 +308,8 @@ pcmk__scan_double(const char *text, double *result, const char *default_text,
  * \return Standard Pacemaker return code
  */
 int
-pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
-                      guint *result)
+pcmk__guint_from_hash(GHashTable *table, const char *key,
+                      unsigned int default_val, unsigned int *result)
 {
     const char *value;
     long long value_ll;
@@ -342,7 +342,7 @@ pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
     }
 
     if (result != NULL) {
-        *result = (guint) value_ll;
+        *result = (unsigned int) value_ll;
     }
     return pcmk_rc_ok;
 }
@@ -361,7 +361,7 @@ pcmk__guint_from_hash(GHashTable *table, const char *key, guint default_val,
  * \return Standard Pacemaker return code
  */
 int
-pcmk_parse_interval_spec(const char *input, guint *result_ms)
+pcmk_parse_interval_spec(const char *input, unsigned int *result_ms)
 {
     long long msec = PCMK__PARSE_INT_DEFAULT;
     int rc = pcmk_rc_ok;
@@ -397,7 +397,7 @@ pcmk_parse_interval_spec(const char *input, guint *result_ms)
 
 done:
     if (result_ms != NULL) {
-        *result_ms = (msec >= UINT_MAX)? UINT_MAX : (guint) msec;
+        *result_ms = (msec >= UINT_MAX)? UINT_MAX : (unsigned int) msec;
     }
     return rc;
 }
@@ -421,7 +421,7 @@ done:
  * appears to have some minor impact on the ordering of a few pseudo_event IDs
  * in the transition graph.
  */
-static guint
+static unsigned int
 pcmk__str_hash(gconstpointer v)
 {
     const signed char *p;
@@ -477,7 +477,7 @@ pcmk__strcase_equal(gconstpointer a, gconstpointer b)
     return pcmk__str_eq((const char *)a, (const char *)b, pcmk__str_casei);
 }
 
-static guint
+static unsigned int
 pcmk__strcase_hash(gconstpointer v)
 {
     const signed char *p;
@@ -723,7 +723,7 @@ pcmk__parse_ll_range(const char *text, long long *start, long long *end)
     long long local_start = 0;
     long long local_end = 0;
     gchar **split = NULL;
-    guint length = 0;
+    unsigned int length = 0;
     const gchar *start_s = NULL;
     const gchar *end_s = NULL;
 

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -984,7 +984,7 @@ pcmk__str_in_list(const char *str, const GList *list, uint32_t flags)
  * \return \c true if \p str is an element of \p strv, or \c false otherwise
  */
 bool
-pcmk__g_strv_contains(gchar **strv, const gchar *str)
+pcmk__g_strv_contains(char **strv, const char *str)
 {
     // @COMPAT Replace with calls to g_strv_contains() when we require glib 2.44
     CRM_CHECK((strv != NULL) && (str != NULL), return false);

--- a/lib/common/tests/actions/parse_op_key_test.c
+++ b/lib/common/tests/actions/parse_op_key_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 the Pacemaker project contributors
+ * Copyright 2020-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -18,7 +18,7 @@ basic(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("Fencing_monitor_60000", &rsc, &ty, &ms));
     assert_string_equal(rsc, "Fencing");
@@ -49,7 +49,7 @@ rsc_just_underbars(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("__monitor_1000", &rsc, &ty, &ms));
     assert_string_equal(rsc, "_");
@@ -78,7 +78,7 @@ colon_in_rsc(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("ClusterIP:0_start_0", &rsc, &ty, &ms));
     assert_string_equal(rsc, "ClusterIP:0");
@@ -100,7 +100,7 @@ dashes_in_rsc(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("httpd-bundle-0_monitor_30000", &rsc, &ty, &ms));
     assert_string_equal(rsc, "httpd-bundle-0");
@@ -122,7 +122,7 @@ migrate_to_from(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("vm_migrate_from_0", &rsc, &ty, &ms));
     assert_string_equal(rsc, "vm");
@@ -151,7 +151,7 @@ pre_post(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("rsc_drbd_7788:1_post_notify_start_0", &rsc, &ty, &ms));
     assert_string_equal(rsc, "rsc_drbd_7788:1");
@@ -187,7 +187,7 @@ static void
 skip_rsc(void **state)
 {
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("Fencing_monitor_60000", NULL, &ty, &ms));
     assert_string_equal(ty, "monitor");
@@ -199,7 +199,7 @@ static void
 skip_ty(void **state)
 {
     char *rsc = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_true(parse_op_key("Fencing_monitor_60000", &rsc, NULL, &ms));
     assert_string_equal(rsc, "Fencing");
@@ -225,7 +225,7 @@ empty_input(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_false(parse_op_key("", &rsc, &ty, &ms));
     assert_null(rsc);
@@ -243,7 +243,7 @@ malformed_input(void **state)
 {
     char *rsc = NULL;
     char *ty = NULL;
-    guint ms = 0;
+    unsigned int ms = 0;
 
     assert_false(parse_op_key("httpd-bundle-0", &rsc, &ty, &ms));
     assert_null(rsc);

--- a/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
+++ b/lib/common/tests/cmdline/pcmk__cmdline_preproc_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 the Pacemaker project contributors
+ * Copyright 2020-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,8 +14,10 @@
 #include <glib.h>
 #include <stdint.h>
 
+// @COMPAT Consider replacing with g_strv_equal() when we require GLib 2.60
 #define LISTS_EQ(a, b) { \
-    assert_int_equal(g_strv_length((gchar **) (a)), g_strv_length((gchar **) (b))); \
+    assert_int_equal(g_strv_length((char **) (a)), \
+                     g_strv_length((char **) (b))); \
     for (int i = 0; i < g_strv_length((a)); i++) { \
         assert_string_equal((a)[i], (b)[i]); \
     } \
@@ -27,9 +29,10 @@ empty_input(void **state) {
 }
 
 static void
-no_specials(void **state) {
+no_specials(void **state)
+{
     const char *argv[] = { "crm_mon", "-a", "-b", "-c", "-d", "-1", NULL };
-    const gchar *expected[] = { "crm_mon", "-a", "-b", "-c", "-d", "-1", NULL };
+    const char *expected[] = { "crm_mon", "-a", "-b", "-c", "-d", "-1", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, NULL);
     LISTS_EQ(processed, expected);
@@ -41,9 +44,10 @@ no_specials(void **state) {
 }
 
 static void
-single_dash(void **state) {
+single_dash(void **state)
+{
     const char *argv[] = { "crm_mon", "-", NULL };
-    const gchar *expected[] = { "crm_mon", "-", NULL };
+    const char *expected[] = { "crm_mon", "-", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, NULL);
     LISTS_EQ(processed, expected);
@@ -51,9 +55,10 @@ single_dash(void **state) {
 }
 
 static void
-double_dash(void **state) {
+double_dash(void **state)
+{
     const char *argv[] = { "crm_mon", "-a", "--", "-bc", NULL };
-    const gchar *expected[] = { "crm_mon", "-a", "--", "-bc", NULL };
+    const char *expected[] = { "crm_mon", "-a", "--", "-bc", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, NULL);
     LISTS_EQ(processed, expected);
@@ -61,9 +66,10 @@ double_dash(void **state) {
 }
 
 static void
-special_args(void **state) {
+special_args(void **state)
+{
     const char *argv[] = { "crm_mon", "-aX", "-Fval", NULL };
-    const gchar *expected[] = { "crm_mon", "-a", "X", "-F", "val", NULL };
+    const char *expected[] = { "crm_mon", "-a", "X", "-F", "val", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "aF");
     LISTS_EQ(processed, expected);
@@ -71,9 +77,10 @@ special_args(void **state) {
 }
 
 static void
-special_arg_at_end(void **state) {
+special_arg_at_end(void **state)
+{
     const char *argv[] = { "crm_mon", "-a", NULL };
-    const gchar *expected[] = { "crm_mon", "-a", NULL };
+    const char *expected[] = { "crm_mon", "-a", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "a");
     LISTS_EQ(processed, expected);
@@ -81,9 +88,10 @@ special_arg_at_end(void **state) {
 }
 
 static void
-long_arg(void **state) {
+long_arg(void **state)
+{
     const char *argv[] = { "crm_mon", "--blah=foo", NULL };
-    const gchar *expected[] = { "crm_mon", "--blah=foo", NULL };
+    const char *expected[] = { "crm_mon", "--blah=foo", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, NULL);
     LISTS_EQ(processed, expected);
@@ -91,9 +99,10 @@ long_arg(void **state) {
 }
 
 static void
-negative_score(void **state) {
+negative_score(void **state)
+{
     const char *argv[] = { "crm_mon", "-v", "-1000", NULL };
-    const gchar *expected[] = { "crm_mon", "-v", "-1000", NULL };
+    const char *expected[] = { "crm_mon", "-v", "-1000", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "v");
     LISTS_EQ(processed, expected);
@@ -101,9 +110,10 @@ negative_score(void **state) {
 }
 
 static void
-negative_score_2(void **state) {
+negative_score_2(void **state)
+{
     const char *argv[] = { "crm_mon", "-1i3", NULL };
-    const gchar *expected[] = { "crm_mon", "-1", "-i", "-3", NULL };
+    const char *expected[] = { "crm_mon", "-1", "-i", "-3", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, NULL);
     LISTS_EQ(processed, expected);
@@ -111,9 +121,10 @@ negative_score_2(void **state) {
 }
 
 static void
-negative_score_3(void **state) {
+negative_score_3(void **state)
+{
     const char *argv[] = { "crm_attribute", "-p", "-v", "-INFINITY", NULL };
-    const gchar *expected[] = { "crm_attribute", "-p", "-v", "-INFINITY", NULL };
+    const char *expected[] = { "crm_attribute", "-p", "-v", "-INFINITY", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "pv");
     LISTS_EQ(processed, expected);
@@ -121,9 +132,12 @@ negative_score_3(void **state) {
 }
 
 static void
-string_arg_with_dash(void **state) {
-    const char *argv[] = { "crm_mon", "-n", "crm_mon_options", "-v", "--opt1 --opt2", NULL };
-    const gchar *expected[] = { "crm_mon", "-n", "crm_mon_options", "-v", "--opt1 --opt2", NULL };
+string_arg_with_dash(void **state)
+{
+    const char *argv[] = { "crm_mon", "-n", "crm_mon_options", "-v",
+                           "--opt1 --opt2", NULL };
+    const char *expected[] = { "crm_mon", "-n", "crm_mon_options", "-v",
+                               "--opt1 --opt2", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "v");
     LISTS_EQ(processed, expected);
@@ -131,9 +145,12 @@ string_arg_with_dash(void **state) {
 }
 
 static void
-string_arg_with_dash_2(void **state) {
-    const char *argv[] = { "crm_mon", "-n", "crm_mon_options", "-v", "-1i3", NULL };
-    const gchar *expected[] = { "crm_mon", "-n", "crm_mon_options", "-v", "-1i3", NULL };
+string_arg_with_dash_2(void **state)
+{
+    const char *argv[] = { "crm_mon", "-n", "crm_mon_options", "-v", "-1i3",
+                           NULL };
+    const char *expected[] = { "crm_mon", "-n", "crm_mon_options", "-v", "-1i3",
+                               NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "v");
     LISTS_EQ(processed, expected);
@@ -141,9 +158,10 @@ string_arg_with_dash_2(void **state) {
 }
 
 static void
-string_arg_with_dash_3(void **state) {
+string_arg_with_dash_3(void **state)
+{
     const char *argv[] = { "crm_mon", "-abc", "-1i3", NULL };
-    const gchar *expected[] = { "crm_mon", "-a", "-b", "-c", "-1i3", NULL };
+    const char *expected[] = { "crm_mon", "-a", "-b", "-c", "-1i3", NULL };
 
     gchar **processed = pcmk__cmdline_preproc((char **) argv, "c");
     LISTS_EQ(processed, expected);

--- a/lib/common/tests/cmdline/pcmk__quote_cmdline_test.c
+++ b/lib/common/tests/cmdline/pcmk__quote_cmdline_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -18,10 +18,10 @@
  * used)."
  */
 static void
-assert_quote_cmdline(const char **argv, const gchar *expected_single,
-                     const gchar *expected_double)
+assert_quote_cmdline(const char **argv, const char *expected_single,
+                     const char *expected_double)
 {
-    gchar *processed = pcmk__quote_cmdline((gchar **) argv);
+    gchar *processed = pcmk__quote_cmdline((char **) argv);
 
     assert_true(pcmk__str_any_of(processed, expected_single, expected_double,
                                  NULL));

--- a/lib/common/tests/nvpair/pcmk__scan_nvpair_test.c
+++ b/lib/common/tests/nvpair/pcmk__scan_nvpair_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the Pacemaker project contributors
+ * Copyright 2025-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,8 +14,8 @@
 #include <crm/common/unittest_internal.h>
 
 static void
-assert_scan_nvpair(const gchar *input, int expected_rc,
-                   const gchar *expected_name, const gchar *expected_value)
+assert_scan_nvpair(const char *input, int expected_rc,
+                   const char *expected_name, const char *expected_value)
 {
     gchar *name = NULL;
     gchar *value = NULL;
@@ -42,7 +42,7 @@ assert_scan_nvpair(const gchar *input, int expected_rc,
 static void
 null_asserts(void **state)
 {
-    const gchar *input = "key=value";
+    const char *input = "key=value";
     gchar *name = NULL;
     gchar *value = NULL;
 
@@ -54,7 +54,7 @@ null_asserts(void **state)
 static void
 already_allocated_asserts(void **state)
 {
-    const gchar *input = "key=value";
+    const char *input = "key=value";
     gchar *buf_null = NULL;
     gchar *buf_allocated = g_strdup("allocated string");
 

--- a/lib/common/tests/output/pcmk__register_format_test.c
+++ b/lib/common/tests/output/pcmk__register_format_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -28,7 +28,7 @@ add_format(void **state)
 {
     int rc = pcmk_rc_ok;
     GHashTable *formatters = NULL;
-    gpointer value = NULL;
+    void *value = NULL;
 
     /* For starters, there should be no formatters defined. */
     assert_null(pcmk__output_formatters());

--- a/lib/common/tests/strings/Makefile.am
+++ b/lib/common/tests/strings/Makefile.am
@@ -16,7 +16,6 @@ check_PROGRAMS = pcmk__add_word_test
 check_PROGRAMS += pcmk__btoa_test
 check_PROGRAMS += pcmk__compress_test
 check_PROGRAMS += pcmk__g_strcat_test
-check_PROGRAMS += pcmk__guint_from_hash_test
 check_PROGRAMS += pcmk__numeric_strcasecmp_test
 check_PROGRAMS += pcmk__parse_bool_test
 check_PROGRAMS += pcmk__parse_ll_range_test
@@ -33,5 +32,6 @@ check_PROGRAMS += pcmk__str_update_test
 check_PROGRAMS += pcmk__strcmp_test
 check_PROGRAMS += pcmk__strkey_table_test
 check_PROGRAMS += pcmk__strikey_table_test
+check_PROGRAMS += pcmk__uint_from_hash_test
 
 TESTS = $(check_PROGRAMS)

--- a/lib/common/tests/strings/pcmk__guint_from_hash_test.c
+++ b/lib/common/tests/strings/pcmk__guint_from_hash_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -17,7 +17,7 @@ static void
 null_args(void **state)
 {
     GHashTable *tbl = pcmk__strkey_table(free, free);
-    guint result;
+    unsigned int result = 0;
 
     assert_int_equal(pcmk__guint_from_hash(NULL, "abc", 123, &result), EINVAL);
     assert_int_equal(pcmk__guint_from_hash(tbl, NULL, 123, &result), EINVAL);
@@ -29,7 +29,7 @@ static void
 missing_key(void **state)
 {
     GHashTable *tbl = pcmk__strkey_table(free, free);
-    guint result;
+    unsigned int result = 0;
 
     assert_int_equal(pcmk__guint_from_hash(tbl, "abc", 123, &result), pcmk_rc_ok);
     assert_int_equal(result, 123);
@@ -41,7 +41,7 @@ static void
 standard_usage(void **state)
 {
     GHashTable *tbl = pcmk__strkey_table(free, free);
-    guint result;
+    unsigned int result = 0;
 
     g_hash_table_insert(tbl, strdup("abc"), strdup("123"));
 
@@ -55,7 +55,7 @@ static void
 conversion_errors(void **state)
 {
     GHashTable *tbl = pcmk__strkey_table(free, free);
-    guint result;
+    unsigned int result = 0;
 
     g_hash_table_insert(tbl, strdup("negative"), strdup("-3"));
     g_hash_table_insert(tbl, strdup("toobig"), strdup("20000000000000000"));

--- a/lib/common/tests/strings/pcmk__str_in_list_test.c
+++ b/lib/common/tests/strings/pcmk__str_in_list_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the Pacemaker project contributors
+ * Copyright 2021-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,7 +25,7 @@ static void
 empty_string(void **state) {
     GList *list = NULL;
 
-    list = g_list_prepend(list, (gpointer) "xxx");
+    list = g_list_prepend(list, (void *) "xxx");
 
     assert_false(pcmk__str_in_list(NULL, list, pcmk__str_none));
     assert_true(pcmk__str_in_list(NULL, list, pcmk__str_null_matches));
@@ -39,8 +39,8 @@ static void
 star_matches(void **state) {
     GList *list = NULL;
 
-    list = g_list_prepend(list, (gpointer) "*");
-    list = g_list_append(list, (gpointer) "more");
+    list = g_list_prepend(list, (void *) "*");
+    list = g_list_append(list, (void *) "more");
 
     assert_true(pcmk__str_in_list("xxx", list, pcmk__str_star_matches));
     assert_true(pcmk__str_in_list("yyy", list, pcmk__str_star_matches));
@@ -54,7 +54,7 @@ static void
 star_doesnt_match(void **state) {
     GList *list = NULL;
 
-    list = g_list_prepend(list, (gpointer) "*");
+    list = g_list_prepend(list, (void *) "*");
 
     assert_false(pcmk__str_in_list("xxx", list, pcmk__str_none));
     assert_false(pcmk__str_in_list("yyy", list, pcmk__str_none));
@@ -69,9 +69,9 @@ static void
 in_list(void **state) {
     GList *list = NULL;
 
-    list = g_list_prepend(list, (gpointer) "xxx");
-    list = g_list_prepend(list, (gpointer) "yyy");
-    list = g_list_prepend(list, (gpointer) "zzz");
+    list = g_list_prepend(list, (void *) "xxx");
+    list = g_list_prepend(list, (void *) "yyy");
+    list = g_list_prepend(list, (void *) "zzz");
 
     assert_true(pcmk__str_in_list("xxx", list, pcmk__str_none));
     assert_true(pcmk__str_in_list("XXX", list, pcmk__str_casei));
@@ -87,8 +87,8 @@ static void
 not_in_list(void **state) {
     GList *list = NULL;
 
-    list = g_list_prepend(list, (gpointer) "xxx");
-    list = g_list_prepend(list, (gpointer) "yyy");
+    list = g_list_prepend(list, (void *) "xxx");
+    list = g_list_prepend(list, (void *) "yyy");
 
     assert_false(pcmk__str_in_list("xx", list, pcmk__str_none));
     assert_false(pcmk__str_in_list("XXX", list, pcmk__str_none));

--- a/lib/common/tests/strings/pcmk__uint_from_hash_test.c
+++ b/lib/common/tests/strings/pcmk__uint_from_hash_test.c
@@ -19,8 +19,8 @@ null_args(void **state)
     GHashTable *tbl = pcmk__strkey_table(free, free);
     unsigned int result = 0;
 
-    assert_int_equal(pcmk__guint_from_hash(NULL, "abc", 123, &result), EINVAL);
-    assert_int_equal(pcmk__guint_from_hash(tbl, NULL, 123, &result), EINVAL);
+    assert_int_equal(pcmk__uint_from_hash(NULL, "abc", 123, &result), EINVAL);
+    assert_int_equal(pcmk__uint_from_hash(tbl, NULL, 123, &result), EINVAL);
 
     g_hash_table_destroy(tbl);
 }
@@ -31,7 +31,8 @@ missing_key(void **state)
     GHashTable *tbl = pcmk__strkey_table(free, free);
     unsigned int result = 0;
 
-    assert_int_equal(pcmk__guint_from_hash(tbl, "abc", 123, &result), pcmk_rc_ok);
+    assert_int_equal(pcmk__uint_from_hash(tbl, "abc", 123, &result),
+                     pcmk_rc_ok);
     assert_int_equal(result, 123);
 
     g_hash_table_destroy(tbl);
@@ -45,7 +46,8 @@ standard_usage(void **state)
 
     g_hash_table_insert(tbl, strdup("abc"), strdup("123"));
 
-    assert_int_equal(pcmk__guint_from_hash(tbl, "abc", 456, &result), pcmk_rc_ok);
+    assert_int_equal(pcmk__uint_from_hash(tbl, "abc", 456, &result),
+                     pcmk_rc_ok);
     assert_int_equal(result, 123);
 
     g_hash_table_destroy(tbl);
@@ -61,13 +63,14 @@ conversion_errors(void **state)
     g_hash_table_insert(tbl, strdup("toobig"), strdup("20000000000000000"));
     g_hash_table_insert(tbl, strdup("baddata"), strdup("asdf"));
 
-    assert_int_equal(pcmk__guint_from_hash(tbl, "negative", 456, &result), ERANGE);
+    assert_int_equal(pcmk__uint_from_hash(tbl, "negative", 456, &result),
+                     ERANGE);
     assert_int_equal(result, 456);
 
-    assert_int_equal(pcmk__guint_from_hash(tbl, "toobig", 456, &result), ERANGE);
+    assert_int_equal(pcmk__uint_from_hash(tbl, "toobig", 456, &result), ERANGE);
     assert_int_equal(result, 456);
 
-    assert_int_equal(pcmk__guint_from_hash(tbl, "baddata", 456, &result),
+    assert_int_equal(pcmk__uint_from_hash(tbl, "baddata", 456, &result),
                      pcmk_rc_bad_input);
     assert_int_equal(result, 456);
 

--- a/lib/common/tests/xml/pcmk__xml_is_name_char_test.c
+++ b/lib/common/tests/xml/pcmk__xml_is_name_char_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,7 +11,7 @@
 
 #include <stdbool.h>
 
-#include <glib.h>                           // gchar, g_ascii_isalnum(), etc.
+#include <glib.h>                           // g_*
 
 #include <crm/common/unittest_internal.h>
 
@@ -28,7 +28,7 @@
 static void
 assert_name_char(int c, bool reference)
 {
-    gchar utf8_buf[6] = { 0, };
+    char utf8_buf[6] = { 0, };
     int len = 4;
     int ref_len = g_unichar_to_utf8(c, utf8_buf);
     bool result = pcmk__xml_is_name_char(utf8_buf, &len);

--- a/lib/common/tests/xml/pcmk__xml_is_name_start_char_test.c
+++ b/lib/common/tests/xml/pcmk__xml_is_name_start_char_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -11,8 +11,7 @@
 
 #include <stdbool.h>
 
-#include <glib.h>                           // gchar, g_ascii_isalpha(), etc.
-#include <libxml/xmlstring.h>               // xmlGetUTF8Char()
+#include <glib.h>                           // g_*
 
 #include <crm/common/unittest_internal.h>
 
@@ -29,7 +28,7 @@
 static void
 assert_name_start_char(int c, bool reference)
 {
-    gchar utf8_buf[6] = { 0, };
+    char utf8_buf[6] = { 0, };
     int len = 4;
     int ref_len = g_unichar_to_utf8(c, utf8_buf);
     bool result = pcmk__xml_is_name_start_char(utf8_buf, &len);

--- a/lib/common/tests/xml_element/pcmk__xe_sort_attrs_test.c
+++ b/lib/common/tests/xml_element/pcmk__xe_sort_attrs_test.c
@@ -60,7 +60,7 @@ assert_order(xmlNode *test_xml, const xmlNode *reference_xml)
         xml_node_private_t *nodepriv = test_attr->_private;
         uint32_t flags = (nodepriv != NULL)? nodepriv->flags : pcmk__xf_none;
 
-        gpointer old_flags_ptr = g_hash_table_lookup(attr_flags, test_name);
+        void *old_flags_ptr = g_hash_table_lookup(attr_flags, test_name);
         uint32_t old_flags = pcmk__xf_none;
 
         if (old_flags_ptr != NULL) {

--- a/lib/common/tests/xml_element/pcmk__xe_sort_attrs_test.c
+++ b/lib/common/tests/xml_element/pcmk__xe_sort_attrs_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -45,7 +45,7 @@ assert_order(xmlNode *test_xml, const xmlNode *reference_xml)
 
         g_hash_table_insert(attr_flags,
                             pcmk__str_copy((const char *) attr->name),
-                            GUINT_TO_POINTER((guint) flags));
+                            GUINT_TO_POINTER((unsigned int) flags));
     }
 
     pcmk__xe_sort_attrs(test_xml);

--- a/lib/common/unittest.c
+++ b/lib/common/unittest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -31,7 +31,7 @@ pcmk__assert_validates(xmlNode *xml)
     char *cmd = NULL;
     gchar *out = NULL;
     gchar *err = NULL;
-    gint status;
+    int status;
     GError *gerr = NULL;
     char *xmllint_input = pcmk__assert_asprintf("%s/test-xmllint.XXXXXX",
                                                 pcmk__get_tmpdir());

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -376,7 +376,7 @@ pcmk__sleep_ms(unsigned int ms)
  *       \p data is left intact.
  */
 unsigned int
-pcmk__create_timer(unsigned int interval_ms, GSourceFunc fn, gpointer data)
+pcmk__create_timer(unsigned int interval_ms, GSourceFunc fn, void *data)
 {
     pcmk__assert(interval_ms != 0 && fn != NULL);
 

--- a/lib/common/utils.c
+++ b/lib/common/utils.c
@@ -375,8 +375,8 @@ pcmk__sleep_ms(unsigned int ms)
  *       \c g_timeout_add_seconds_full()), so only the timeout is destroyed.
  *       \p data is left intact.
  */
-guint
-pcmk__create_timer(guint interval_ms, GSourceFunc fn, gpointer data)
+unsigned int
+pcmk__create_timer(unsigned int interval_ms, GSourceFunc fn, gpointer data)
 {
     pcmk__assert(interval_ms != 0 && fn != NULL);
 
@@ -399,10 +399,11 @@ pcmk__create_timer(guint interval_ms, GSourceFunc fn, gpointer data)
  * \return If \p timeout_ms is 0, return 0.  Otherwise, return the number of
  *         seconds, rounded to the nearest integer, with a minimum of 1.
  */
-guint
-pcmk__timeout_ms2s(guint timeout_ms)
+unsigned int
+pcmk__timeout_ms2s(unsigned int timeout_ms)
 {
-    guint quot, rem;
+    unsigned int quot = 0;
+    unsigned int rem = 0;
 
     if (timeout_ms == 0) {
         return 0;

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1138,9 +1138,10 @@ pcmk__xe_get_flags(const xmlNode *xml, const char *name, uint32_t *dest,
 
 /*!
  * \internal
- * \brief Retrieve a \c guint value from an XML attribute
+ * \brief Retrieve an <tt>unsigned int</tt> value from an XML attribute
  *
- * This is like \c pcmk__xe_get() but returns the value as a \c guint.
+ * This is like \c pcmk__xe_get() but returns the value as an
+ * <tt>unsigned int</tt>.
  *
  * \param[in]  xml   XML element whose attribute to get
  * \param[in]  attr  Attribute name
@@ -1149,7 +1150,7 @@ pcmk__xe_get_flags(const xmlNode *xml, const char *name, uint32_t *dest,
  * \return Standard Pacemaker return code
  */
 int
-pcmk__xe_get_guint(const xmlNode *xml, const char *attr, guint *dest)
+pcmk__xe_get_guint(const xmlNode *xml, const char *attr, unsigned int *dest)
 {
     long long value_ll = 0;
     int rc = pcmk_rc_ok;
@@ -1164,22 +1165,22 @@ pcmk__xe_get_guint(const xmlNode *xml, const char *attr, guint *dest)
     if ((value_ll < 0) || (value_ll > UINT_MAX)) {
         return ERANGE;
     }
-    *dest = (guint) value_ll;
+    *dest = (unsigned int) value_ll;
     return pcmk_rc_ok;
 }
 
 /*!
  * \internal
- * \brief Set an XML attribute using a \c guint value
+ * \brief Set an XML attribute using an <tt>unsigned int</tt> value
  *
- * This is like \c pcmk__xe_set() but takes a \c guint.
+ * This is like \c pcmk__xe_set() but takes an <tt>unsigned int</tt>.
  *
  * \param[in,out] xml    XML node to modify
  * \param[in]     attr   Attribute name
  * \param[in]     value  Attribute value to set
  */
 void
-pcmk__xe_set_guint(xmlNode *xml, const char *attr, guint value)
+pcmk__xe_set_guint(xmlNode *xml, const char *attr, unsigned int value)
 {
     char *value_s = NULL;
 
@@ -1742,7 +1743,7 @@ crm_element_value_epoch(const xmlNode *xml, const char *name, time_t *dest)
 }
 
 int
-crm_element_value_ms(const xmlNode *data, const char *name, guint *dest)
+crm_element_value_ms(const xmlNode *data, const char *name, unsigned int *dest)
 {
     const char *value = NULL;
     long long value_ll;
@@ -1763,7 +1764,7 @@ crm_element_value_ms(const xmlNode *data, const char *name, guint *dest)
                    value);
         return -1;
     }
-    *dest = (guint) value_ll;
+    *dest = (unsigned int) value_ll;
     return pcmk_ok;
 }
 
@@ -1828,7 +1829,7 @@ crm_xml_add_timeval(xmlNode *xml, const char *name_sec, const char *name_usec,
 }
 
 const char *
-crm_xml_add_ms(xmlNode *node, const char *name, guint ms)
+crm_xml_add_ms(xmlNode *node, const char *name, unsigned int ms)
 {
     char *number = pcmk__assert_asprintf("%u", ms);
     const char *added = crm_xml_add(node, name, number);

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1180,7 +1180,7 @@ pcmk__xe_get_uint(const xmlNode *xml, const char *attr, unsigned int *dest)
  * \param[in]     value  Attribute value to set
  */
 void
-pcmk__xe_set_guint(xmlNode *xml, const char *attr, unsigned int value)
+pcmk__xe_set_uint(xmlNode *xml, const char *attr, unsigned int value)
 {
     char *value_s = NULL;
 

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -287,7 +287,7 @@ pcmk__xe_copy_attrs(xmlNode *target, const xmlNode *src, uint32_t flags)
  *                   lexicographically
  */
 static int
-compare_xml_attr(gconstpointer a, gconstpointer b)
+compare_xml_attr(const void *a, const void *b)
 {
     const xmlAttr *attr_a = a;
     const xmlAttr *attr_b = b;

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -286,7 +286,7 @@ pcmk__xe_copy_attrs(xmlNode *target, const xmlNode *src, uint32_t flags)
  * \retval  positive \c b->name is \c NULL or comes before \c a->name
  *                   lexicographically
  */
-static gint
+static int
 compare_xml_attr(gconstpointer a, gconstpointer b)
 {
     const xmlAttr *attr_a = a;

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1150,7 +1150,7 @@ pcmk__xe_get_flags(const xmlNode *xml, const char *name, uint32_t *dest,
  * \return Standard Pacemaker return code
  */
 int
-pcmk__xe_get_guint(const xmlNode *xml, const char *attr, unsigned int *dest)
+pcmk__xe_get_uint(const xmlNode *xml, const char *attr, unsigned int *dest)
 {
     long long value_ll = 0;
     int rc = pcmk_rc_ok;

--- a/lib/common/xml_element.c
+++ b/lib/common/xml_element.c
@@ -1161,7 +1161,7 @@ pcmk__xe_get_guint(const xmlNode *xml, const char *attr, guint *dest)
         return rc;
     }
 
-    if ((value_ll < 0) || (value_ll > G_MAXUINT)) {
+    if ((value_ll < 0) || (value_ll > UINT_MAX)) {
         return ERANGE;
     }
     *dest = (guint) value_ll;
@@ -1758,7 +1758,7 @@ crm_element_value_ms(const xmlNode *data, const char *name, guint *dest)
                    name, value, pcmk_rc_str(rc));
         return -1;
     }
-    if ((value_ll < 0) || (value_ll > G_MAXUINT)) {
+    if ((value_ll < 0) || (value_ll > UINT_MAX)) {
         pcmk__warn("Using default for %s because '%s' is out of range", name,
                    value);
         return -1;

--- a/lib/common/xml_idref.c
+++ b/lib/common/xml_idref.c
@@ -58,7 +58,7 @@ pcmk__add_idref(GHashTable *table, const char *id, const char *referrer)
  * \param[in,out] data  pcmk__idref_t to free
  */
 void
-pcmk__free_idref(gpointer data)
+pcmk__free_idref(void *data)
 {
     pcmk__idref_t *idref = data;
 

--- a/lib/common/xpath.c
+++ b/lib/common/xpath.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -298,7 +298,7 @@ pcmk__element_xpath(const xmlNode *xml)
     if (parent == NULL) {
         g_string_append_c(xpath, '/');
     } else if (parent->parent == NULL) {
-        g_string_append(xpath, (const gchar *) xml->name);
+        g_string_append(xpath, (const char *) xml->name);
     } else {
         pcmk__g_strcat(xpath, "/", (const char *) xml->name, NULL);
     }

--- a/lib/fencing/st_actions.c
+++ b/lib/fencing/st_actions.c
@@ -88,7 +88,7 @@ log_action(stonith_action_t *action, pid_t pid)
 }
 
 static void
-append_config_arg(gpointer key, gpointer value, gpointer user_data)
+append_config_arg(void *key, void *value, void *user_data)
 {
     /* Filter out parameters handled directly by Pacemaker.
      *

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -89,8 +89,8 @@ static int stonith_send_command(stonith_t *stonith, const char *op,
                                 xmlNode *data, xmlNode **output_data,
                                 int call_options, int timeout);
 
-static void stonith_connection_destroy(gpointer user_data);
-static void stonith_send_notification(gpointer data, gpointer user_data);
+static void stonith_connection_destroy(void *user_data);
+static void stonith_send_notification(void *data, void *user_data);
 static int stonith_api_del_notification(stonith_t *stonith,
                                         const char *event);
 
@@ -248,9 +248,7 @@ stonith__watchdog_fencing_enabled_for_node(const char *node)
    loop over it to remove the marked items
  */
 static void
-foreach_notify_entry (stonith_private_t *private,
-                GFunc func,
-                gpointer user_data)
+foreach_notify_entry(stonith_private_t *private, GFunc func, void *user_data)
 {
     private->notify_refcnt++;
     g_list_foreach(private->notify_list, func, user_data);
@@ -276,7 +274,7 @@ foreach_notify_entry (stonith_private_t *private,
 }
 
 static void
-stonith_connection_destroy(gpointer user_data)
+stonith_connection_destroy(void *user_data)
 {
     stonith_t *stonith = user_data;
     stonith_private_t *native = NULL;
@@ -313,7 +311,7 @@ create_device_registration_xml(const char *id, enum stonith_namespace standard,
         standard = get_namespace_from_agent(agent);
     }
     if (standard == st_namespace_lha) {
-        hash2field((gpointer) "plugin", (gpointer) agent, args);
+        hash2field((void *) "plugin", (void *) agent, args);
         agent = "fence_legacy";
     }
 #endif
@@ -329,7 +327,7 @@ create_device_registration_xml(const char *id, enum stonith_namespace standard,
     }
 
     for (; params; params = params->next) {
-        hash2field((gpointer) params->key, (gpointer) params->value, args);
+        hash2field((void *) params->key, (void *) params->value, args);
     }
 
     return data;
@@ -853,7 +851,7 @@ stonith_create_op(int call_id, const char *token, const char *op, xmlNode * data
 }
 
 static void
-stonith_destroy_op_callback(gpointer data)
+stonith_destroy_op_callback(void *data)
 {
     stonith_callback_client_t *blob = data;
 
@@ -1010,7 +1008,7 @@ invoke_registered_callbacks(stonith_t *stonith, const xmlNode *msg, int call_id)
 }
 
 static gboolean
-stonith_async_timeout_handler(gpointer data)
+stonith_async_timeout_handler(void *data)
 {
     struct timer_rec_s *timer = data;
 
@@ -1069,7 +1067,7 @@ update_callback_timeout(int call_id, int timeout, stonith_t * st)
 }
 
 static int
-stonith_dispatch_internal(const char *buffer, ssize_t length, gpointer userdata)
+stonith_dispatch_internal(const char *buffer, ssize_t length, void *userdata)
 {
     const char *type = NULL;
     struct notify_blob_s blob;
@@ -1317,7 +1315,7 @@ stonith_api_add_notification(stonith_t * stonith, const char *event,
 }
 
 static void
-del_notify_entry(gpointer data, gpointer user_data)
+del_notify_entry(void *data, void *user_data)
 {
     stonith_notify_client_t *entry = data;
     stonith_t * stonith = user_data;
@@ -1531,7 +1529,7 @@ event_free(stonith_event_t * event)
 }
 
 static void
-stonith_send_notification(gpointer data, gpointer user_data)
+stonith_send_notification(void *data, void *user_data)
 {
     struct notify_blob_s *blob = user_data;
     stonith_notify_client_t *entry = data;
@@ -1786,7 +1784,7 @@ free_stonith_api(stonith_t *stonith)
 }
 
 static gboolean
-is_fencing_param(gpointer key, gpointer value, gpointer user_data)
+is_fencing_param(void *key, void *value, void *user_data)
 {
     return pcmk_stonith_param(key);
 }
@@ -2887,7 +2885,7 @@ stonith_api_delete(stonith_t *stonith)
 }
 
 static void
-stonith_dump_pending_op(gpointer key, gpointer value, gpointer user_data)
+stonith_dump_pending_op(void *key, void *value, void *user_data)
 {
     int call = GPOINTER_TO_INT(key);
     stonith_callback_client_t *blob = value;

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -795,7 +795,7 @@ stonith__history_free(stonith_history_t *head)
 }
 
 static int
-stonithlib_GCompareFunc(gconstpointer a, gconstpointer b)
+stonithlib_GCompareFunc(const void *a, const void *b)
 {
     int rc = 0;
     const stonith_notify_client_t *a_client = a;

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -796,7 +796,7 @@ stonith__history_free(stonith_history_t *head)
     }
 }
 
-static gint
+static int
 stonithlib_GCompareFunc(gconstpointer a, gconstpointer b)
 {
     int rc = 0;

--- a/lib/fencing/st_client.c
+++ b/lib/fencing/st_client.c
@@ -76,7 +76,7 @@ struct notify_blob_s {
 struct timer_rec_s {
     int call_id;
     int timeout;
-    guint ref;
+    unsigned int ref;
     stonith_t *stonith;
 };
 

--- a/lib/fencing/st_output.c
+++ b/lib/fencing/st_output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -8,17 +8,25 @@
  */
 
 #include <crm_internal.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
 
-#include <crm/stonith-ng.h>
-#include <crm/common/iso8601.h>
-#include <crm/common/util.h>
-#include <crm/common/xml.h>
-#include <crm/common/output.h>
-#include <crm/fencing/internal.h>
-#include <crm/pengine/internal.h>
+#include <stdarg.h>                     // va_arg, va_list
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdlib.h>                     // free
+#include <time.h>                       // ctime, time_t, timespec
+
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+
+#include <crm/common/actions.h>         // PCMK_ACTION_{OFF,ON}
+#include <crm/common/iso8601.h>         // crm_time_*
+#include <crm/common/options.h>         // PCMK_VALUE_*
+#include <crm/common/output.h>          // pcmk_section_*, pcmk_show_*
+#include <crm/common/results.h>         // crm_exit_t, pcmk_ok, pcmk_rc_*
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*
+#include <crm/fencing/internal.h>       // stonith__*
+#include <crm/stonith-ng.h>             // st_*, stonith_history_t
 
 /*!
  * \internal
@@ -478,14 +486,12 @@ stonith_event_xml(pcmk__output_t *out, va_list args)
     const char *succeeded G_GNUC_UNUSED = va_arg(args, const char *);
     uint32_t show_opts G_GNUC_UNUSED = va_arg(args, uint32_t);
 
-    xmlNodePtr node = NULL;
-
-    node = pcmk__output_create_xml_node(out, PCMK_XE_FENCE_EVENT,
-                                        PCMK_XA_ACTION, event->action,
-                                        PCMK_XA_TARGET, event->target,
-                                        PCMK_XA_CLIENT, event->client,
-                                        PCMK_XA_ORIGIN, event->origin,
-                                        NULL);
+    xmlNode *node = pcmk__output_create_xml_node(out, PCMK_XE_FENCE_EVENT,
+                                                 PCMK_XA_ACTION, event->action,
+                                                 PCMK_XA_TARGET, event->target,
+                                                 PCMK_XA_CLIENT, event->client,
+                                                 PCMK_XA_ORIGIN, event->origin,
+                                                 NULL);
 
     switch (event->state) {
         case st_failed:
@@ -586,10 +592,10 @@ validate_agent_xml(pcmk__output_t *out, va_list args) {
     int rc = va_arg(args, int);
 
     const char *valid = pcmk__btoa(rc == pcmk_ok);
-    xmlNodePtr node = pcmk__output_create_xml_node(out, PCMK_XE_VALIDATE,
-                                                   PCMK_XA_AGENT, agent,
-                                                   PCMK_XA_VALID, valid,
-                                                   NULL);
+    xmlNode *node = pcmk__output_create_xml_node(out, PCMK_XE_VALIDATE,
+                                                 PCMK_XA_AGENT, agent,
+                                                 PCMK_XA_VALID, valid,
+                                                 NULL);
 
     if (device != NULL) {
         pcmk__xe_set(node, PCMK_XA_DEVICE, device);

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -57,7 +57,7 @@ alert_key2param_ms(lrmd_key_value_t *head, enum pcmk__alert_keys_e name,
 }
 
 static void
-set_ev_kv(gpointer key, gpointer value, gpointer user_data)
+set_ev_kv(void *key, void *value, void *user_data)
 {
     lrmd_key_value_t **head = (lrmd_key_value_t **) user_data;
 

--- a/lib/lrmd/lrmd_alerts.c
+++ b/lib/lrmd/lrmd_alerts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2025 the Pacemaker project contributors
+ * Copyright 2015-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -47,7 +47,7 @@ alert_key2param_int(lrmd_key_value_t *head, enum pcmk__alert_keys_e name,
 
 static lrmd_key_value_t *
 alert_key2param_ms(lrmd_key_value_t *head, enum pcmk__alert_keys_e name,
-                   guint value)
+                   unsigned int value)
 {
     char *value_s = pcmk__assert_asprintf("%u", value);
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -314,7 +314,7 @@ lrmd_dispatch_internal(gpointer data, gpointer user_data)
         int queue_time = 0;
 
         pcmk__xe_get_int(msg, PCMK__XA_LRMD_TIMEOUT, &event.timeout);
-        pcmk__xe_get_guint(msg, PCMK__XA_LRMD_RSC_INTERVAL, &event.interval_ms);
+        pcmk__xe_get_uint(msg, PCMK__XA_LRMD_RSC_INTERVAL, &event.interval_ms);
         pcmk__xe_get_int(msg, PCMK__XA_LRMD_RSC_START_DELAY,
                          &event.start_delay);
 

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -18,7 +18,7 @@
 #include <time.h>                   // time
 #include <unistd.h>                 // close
 
-#include <glib.h>                   // g_list_free_full, gpointer
+#include <glib.h>                   // g_list_free_full
 #include <gnutls/gnutls.h>          // gnutls_deinit, gnutls_bye
 #include <libxml/parser.h>          // xmlNode
 #include <qb/qbdefs.h>              // QB_MAX
@@ -274,7 +274,7 @@ lrmd_poll(lrmd_t * lrmd, int timeout)
 }
 
 static void
-lrmd_dispatch_internal(gpointer data, gpointer user_data)
+lrmd_dispatch_internal(void *data, void *user_data)
 {
     xmlNode *msg = data;
     lrmd_t *lrmd = user_data;
@@ -361,7 +361,7 @@ lrmd_dispatch_internal(gpointer data, gpointer user_data)
 
 // \return Always 0, to indicate that IPC mainloop source should be kept
 static int
-lrmd_ipc_dispatch(const char *buffer, ssize_t length, gpointer userdata)
+lrmd_ipc_dispatch(const char *buffer, ssize_t length, void *userdata)
 {
     lrmd_t *lrmd = userdata;
     lrmd_private_t *native = lrmd->lrmd_private;
@@ -533,7 +533,7 @@ handle_remote_msg(xmlNode *xml, lrmd_t *lrmd)
  *         to leave it in the mainloop
  */
 static int
-lrmd_tls_dispatch(gpointer userdata)
+lrmd_tls_dispatch(void *userdata)
 {
     lrmd_t *lrmd = userdata;
     lrmd_private_t *native = lrmd->lrmd_private;
@@ -635,7 +635,7 @@ lrmd_create_op(const char *token, const char *op, xmlNode *data, int timeout,
 }
 
 static void
-lrmd_ipc_connection_destroy(gpointer userdata)
+lrmd_ipc_connection_destroy(void *userdata)
 {
     lrmd_t *lrmd = userdata;
     lrmd_private_t *native = lrmd->lrmd_private;
@@ -1084,7 +1084,7 @@ lrmd_ipc_connect(lrmd_t *lrmd, int *fd)
 }
 
 static void
-lrmd_tls_connection_destroy(gpointer userdata)
+lrmd_tls_connection_destroy(void *userdata)
 {
     lrmd_t *lrmd = userdata;
     lrmd_private_t *native = lrmd->lrmd_private;
@@ -1170,7 +1170,7 @@ tls_client_handshake(lrmd_t *lrmd)
  *         mainloop
  */
 static int
-process_pending_notifies(gpointer userdata)
+process_pending_notifies(void *userdata)
 {
     lrmd_t *lrmd = userdata;
     lrmd_private_t *native = lrmd->lrmd_private;
@@ -1417,7 +1417,7 @@ struct handshake_data_s {
 };
 
 static gboolean
-try_handshake_cb(gpointer user_data)
+try_handshake_cb(void *user_data)
 {
     struct handshake_data_s *hs = user_data;
     lrmd_t *lrmd = hs->lrmd;
@@ -1895,7 +1895,7 @@ lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
     pcmk__xe_set_int(data, PCMK__XA_LRMD_RSC_START_DELAY, start_delay);
 
     for (tmp = params; tmp; tmp = tmp->next) {
-        hash2smartfield((gpointer) tmp->key, (gpointer) tmp->value, args);
+        hash2smartfield((void *) tmp->key, (void *) tmp->value, args);
     }
 
     rc = lrmd_send_command(lrmd, LRMD_OP_RSC_EXEC, data, NULL, timeout, options, true);
@@ -2068,7 +2068,7 @@ lrmd_api_exec_alert(lrmd_t *lrmd, const char *alert_id, const char *alert_path,
     pcmk__xe_set_int(data, PCMK__XA_LRMD_TIMEOUT, timeout);
 
     for (tmp = params; tmp; tmp = tmp->next) {
-        hash2smartfield((gpointer) tmp->key, (gpointer) tmp->value, args);
+        hash2smartfield((void *) tmp->key, (void *) tmp->value, args);
     }
 
     rc = lrmd_send_command(lrmd, LRMD_OP_ALERT_EXEC, data, NULL, timeout,

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -175,7 +175,7 @@ lrmd_key_value_freeall(lrmd_key_value_t * head)
  *       result with lrmd_free_event().
  */
 lrmd_event_data_t *
-lrmd_new_event(const char *rsc_id, const char *task, guint interval_ms)
+lrmd_new_event(const char *rsc_id, const char *task, unsigned int interval_ms)
 {
     lrmd_event_data_t *event = pcmk__assert_alloc(1, sizeof(lrmd_event_data_t));
 
@@ -1876,7 +1876,7 @@ lrmd_api_get_metadata(lrmd_t *lrmd, const char *standard, const char *provider,
 
 static int
 lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
-              const char *userdata, guint interval_ms,
+              const char *userdata, unsigned int interval_ms,
               int timeout,      /* ms */
               int start_delay,  /* ms */
               enum lrmd_call_options options, lrmd_key_value_t * params)
@@ -1907,7 +1907,7 @@ lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
 
 static int
 lrmd_api_cancel(lrmd_t *lrmd, const char *rsc_id, const char *action,
-                guint interval_ms)
+                unsigned int interval_ms)
 {
     int rc = pcmk_ok;
     xmlNode *data = pcmk__xe_create(NULL, PCMK__XE_LRMD_RSC);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1874,12 +1874,37 @@ lrmd_api_get_metadata(lrmd_t *lrmd, const char *standard, const char *provider,
                                            output, options, NULL);
 }
 
+/*!
+ * \internal
+ * \brief Request execution of a resource action
+ *
+ * \param[in,out] lrmd         Executor connection object
+ * \param[in]     rsc_id       ID of resource
+ * \param[in]     action       Name of resource action to execute
+ * \param[in]     userdata     Arbitrary string to pass to event callback
+ * \param[in]     interval_ms  If 0, execute action once; otherwise, execute it
+ *                             on a recurring basis at this interval (in
+ *                             milliseconds)
+ * \param[in]     timeout      Error if not complete within this time (in
+ *                             milliseconds)
+ * \param[in]     start_delay  Wait this long before execution (in milliseconds)
+ * \param[in]     options      Group of <tt>enum lrmd_call_options</tt>
+ * \param[in,out] params       Parameters to pass to agent (will be freed)
+ *
+ * \return A call ID for the action on success (in which case the action is
+ *         queued in the executor, and the event callback will be called
+ *         later with the result); otherwise, a negative legacy Pacemaker return
+ *         code
+ * \note \c exec() and \c cancel() operations on an individual resource are
+ *       guaranteed to occur in the order the client API is called. However,
+ *       operations on different resources are not guaranteed to occur in any
+ *       specific order.
+ */
 static int
 lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
               const char *userdata, unsigned int interval_ms,
-              int timeout,      /* ms */
-              int start_delay,  /* ms */
-              enum lrmd_call_options options, lrmd_key_value_t * params)
+              int timeout, int start_delay, enum lrmd_call_options options,
+              lrmd_key_value_t * params)
 {
     int rc = pcmk_ok;
     xmlNode *data = pcmk__xe_create(NULL, PCMK__XE_LRMD_RSC);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1885,9 +1885,9 @@ lrmd_api_get_metadata(lrmd_t *lrmd, const char *standard, const char *provider,
  * \param[in]     interval_ms  If 0, execute action once; otherwise, execute it
  *                             on a recurring basis at this interval (in
  *                             milliseconds)
- * \param[in]     timeout      Error if not complete within this time (in
+ * \param[in]     timeout_ms   Error if not complete within this time (in
  *                             milliseconds)
- * \param[in]     start_delay  Wait this long before execution (in milliseconds)
+ * \param[in]     delay_ms     Wait this long before execution (in milliseconds)
  * \param[in]     options      Group of <tt>enum lrmd_call_options</tt>
  * \param[in,out] params       Parameters to pass to agent (will be freed)
  *
@@ -1903,8 +1903,8 @@ lrmd_api_get_metadata(lrmd_t *lrmd, const char *standard, const char *provider,
 static int
 lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
               const char *userdata, unsigned int interval_ms,
-              int timeout, int start_delay, enum lrmd_call_options options,
-              lrmd_key_value_t * params)
+              int timeout_ms, int delay_ms, enum lrmd_call_options options,
+              lrmd_key_value_t *params)
 {
     int rc = pcmk_ok;
     xmlNode *data = pcmk__xe_create(NULL, PCMK__XE_LRMD_RSC);
@@ -1916,14 +1916,15 @@ lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_ACTION, action);
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_USERDATA_STR, userdata);
     pcmk__xe_set_uint(data, PCMK__XA_LRMD_RSC_INTERVAL, interval_ms);
-    pcmk__xe_set_int(data, PCMK__XA_LRMD_TIMEOUT, timeout);
-    pcmk__xe_set_int(data, PCMK__XA_LRMD_RSC_START_DELAY, start_delay);
+    pcmk__xe_set_int(data, PCMK__XA_LRMD_TIMEOUT, timeout_ms);
+    pcmk__xe_set_int(data, PCMK__XA_LRMD_RSC_START_DELAY, delay_ms);
 
     for (tmp = params; tmp; tmp = tmp->next) {
         hash2smartfield((void *) tmp->key, (void *) tmp->value, args);
     }
 
-    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_EXEC, data, NULL, timeout, options, true);
+    rc = lrmd_send_command(lrmd, LRMD_OP_RSC_EXEC, data, NULL, timeout_ms,
+                           options, true);
     pcmk__xml_free(data);
 
     lrmd_key_value_freeall(params);

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1890,7 +1890,7 @@ lrmd_api_exec(lrmd_t *lrmd, const char *rsc_id, const char *action,
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_ID, rsc_id);
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_ACTION, action);
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_USERDATA_STR, userdata);
-    pcmk__xe_set_guint(data, PCMK__XA_LRMD_RSC_INTERVAL, interval_ms);
+    pcmk__xe_set_uint(data, PCMK__XA_LRMD_RSC_INTERVAL, interval_ms);
     pcmk__xe_set_int(data, PCMK__XA_LRMD_TIMEOUT, timeout);
     pcmk__xe_set_int(data, PCMK__XA_LRMD_RSC_START_DELAY, start_delay);
 
@@ -1915,7 +1915,7 @@ lrmd_api_cancel(lrmd_t *lrmd, const char *rsc_id, const char *action,
     pcmk__xe_set(data, PCMK__XA_LRMD_ORIGIN, __func__);
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_ACTION, action);
     pcmk__xe_set(data, PCMK__XA_LRMD_RSC_ID, rsc_id);
-    pcmk__xe_set_guint(data, PCMK__XA_LRMD_RSC_INTERVAL, interval_ms);
+    pcmk__xe_set_uint(data, PCMK__XA_LRMD_RSC_INTERVAL, interval_ms);
     rc = lrmd_send_command(lrmd, LRMD_OP_RSC_CANCEL, data, NULL, 0, 0, true);
     pcmk__xml_free(data);
     return rc;

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -17,7 +17,7 @@
 #include <stdio.h>                  // NULL
 #include <stdint.h>                 // uint32_t
 #include <stdbool.h>                // bool, false
-#include <glib.h>                   // gpointer, GList, GHashTable
+#include <glib.h>                   // GList, GHashTable
 #include <libxml/tree.h>            // xmlNode
 
 #include <crm/common/internal.h>    // pcmk__location_t, etc.
@@ -450,7 +450,7 @@ G_GNUC_INTERNAL
 bool pcmk__node_unfenced(const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
-void pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data);
+void pcmk__order_restart_vs_unfence(void *data, void *user_data);
 
 
 // Injected scheduler inputs (pcmk_sched_injections.c)
@@ -544,7 +544,7 @@ void pcmk__add_colocated_node_scores(pcmk_resource_t *source_rsc,
                                      float factor, uint32_t flags);
 
 G_GNUC_INTERNAL
-void pcmk__add_dependent_scores(gpointer data, gpointer user_data);
+void pcmk__add_dependent_scores(void *data, void *user_data);
 
 G_GNUC_INTERNAL
 void pcmk__colocation_intersect_nodes(pcmk_resource_t *dependent,

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -17,7 +17,7 @@
 #include <stdio.h>                  // NULL
 #include <stdint.h>                 // uint32_t
 #include <stdbool.h>                // bool, false
-#include <glib.h>                   // guint, gpointer, GList, GHashTable
+#include <glib.h>                   // gpointer, GList, GHashTable
 #include <libxml/tree.h>            // xmlNode
 
 #include <crm/common/internal.h>    // pcmk__location_t, etc.
@@ -377,7 +377,7 @@ void pcmk__log_action(const char *pre_text, const pcmk_action_t *action,
 
 G_GNUC_INTERNAL
 pcmk_action_t *pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *name,
-                                       guint interval_ms,
+                                       unsigned int interval_ms,
                                        const pcmk_node_t *node);
 
 G_GNUC_INTERNAL
@@ -407,12 +407,12 @@ void pcmk__create_recurring_actions(pcmk_resource_t *rsc);
 
 G_GNUC_INTERNAL
 void pcmk__schedule_cancel(pcmk_resource_t *rsc, const char *call_id,
-                           const char *task, guint interval_ms,
+                           const char *task, unsigned int interval_ms,
                            const pcmk_node_t *node, const char *reason);
 
 G_GNUC_INTERNAL
 void pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
-                                guint interval_ms, pcmk_node_t *node);
+                                unsigned int interval_ms, pcmk_node_t *node);
 
 G_GNUC_INTERNAL
 bool pcmk__action_is_recurring(const pcmk_action_t *action);
@@ -984,7 +984,7 @@ xmlNode *pcmk__inject_resource_history(pcmk__output_t *out, xmlNode *cib_node,
 G_GNUC_INTERNAL
 void pcmk__inject_failcount(pcmk__output_t *out, cib_t *cib_conn,
                             xmlNode *cib_node, const char *resource,
-                            const char *task, guint interval_ms, int rc,
+                            const char *task, unsigned int interval_ms, int rc,
                             bool infinity);
 
 G_GNUC_INTERNAL

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -1061,10 +1061,10 @@ G_GNUC_INTERNAL
 void pcmk__sort_resources(pcmk_scheduler_t *scheduler);
 
 G_GNUC_INTERNAL
-int pcmk__cmp_instance(gconstpointer a, gconstpointer b);
+int pcmk__cmp_instance(const void *a, const void *b);
 
 G_GNUC_INTERNAL
-int pcmk__cmp_instance_number(gconstpointer a, gconstpointer b);
+int pcmk__cmp_instance_number(const void *a, const void *b);
 
 
 // Functions related to probes (pcmk_sched_probes.c)

--- a/lib/pacemaker/libpacemaker_private.h
+++ b/lib/pacemaker/libpacemaker_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 the Pacemaker project contributors
+ * Copyright 2021-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1061,10 +1061,10 @@ G_GNUC_INTERNAL
 void pcmk__sort_resources(pcmk_scheduler_t *scheduler);
 
 G_GNUC_INTERNAL
-gint pcmk__cmp_instance(gconstpointer a, gconstpointer b);
+int pcmk__cmp_instance(gconstpointer a, gconstpointer b);
 
 G_GNUC_INTERNAL
-gint pcmk__cmp_instance_number(gconstpointer a, gconstpointer b);
+int pcmk__cmp_instance_number(gconstpointer a, gconstpointer b);
 
 
 // Functions related to probes (pcmk_sched_probes.c)

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2025 the Pacemaker project contributors
+ * Copyright 2009-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -158,7 +158,7 @@ fence_callback(stonith_t * stonith, stonith_callback_data_t * data)
 }
 
 static gboolean
-async_fence_helper(gpointer user_data)
+async_fence_helper(void *user_data)
 {
     stonith_t *st = async_fence_data.st;
     int call_id = 0;

--- a/lib/pacemaker/pcmk_fence.c
+++ b/lib/pacemaker/pcmk_fence.c
@@ -47,8 +47,8 @@ handle_level(stonith_t *st, const char *target, int fence_level, GList *devices,
     const char *pattern = NULL;
 
     gchar **name_value = NULL;
-    const gchar *name = NULL;
-    const gchar *value = NULL;
+    const char *name = NULL;
+    const char *value = NULL;
     int rc = pcmk_rc_ok;
 
     if (target == NULL) {

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -30,7 +30,7 @@
  * \param[in,out] user_data  Action to free
  */
 static void
-free_graph_action(gpointer user_data)
+free_graph_action(void *user_data)
 {
     pcmk__graph_action_t *action = user_data;
 
@@ -50,7 +50,7 @@ free_graph_action(gpointer user_data)
  * \param[in,out] user_data  Synapse to free
  */
 static void
-free_graph_synapse(gpointer user_data)
+free_graph_synapse(void *user_data)
 {
     pcmk__graph_synapse_t *synapse = user_data;
 
@@ -635,7 +635,7 @@ unpack_synapse(pcmk__graph_t *new_graph, const xmlNode *xml_synapse)
     pcmk__scan_min_int(value, &(new_synapse->priority), 0);
 
     CRM_CHECK(new_synapse->id >= 0,
-              free_graph_synapse((gpointer) new_synapse); return NULL);
+              free_graph_synapse((void *) new_synapse); return NULL);
 
     new_graph->num_synapses++;
 

--- a/lib/pacemaker/pcmk_graph_consumer.c
+++ b/lib/pacemaker/pcmk_graph_consumer.c
@@ -596,8 +596,8 @@ unpack_action(pcmk__graph_synapse_t *parent, xmlNode *xml_action)
         action->timeout += start_delay;
     }
 
-    if (pcmk__guint_from_hash(action->params, CRM_META "_" PCMK_META_INTERVAL,
-                              0, &(action->interval_ms)) != pcmk_rc_ok) {
+    if (pcmk__uint_from_hash(action->params, CRM_META "_" PCMK_META_INTERVAL,
+                             0, &(action->interval_ms)) != pcmk_rc_ok) {
         action->interval_ms = 0;
     }
 

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -205,7 +205,7 @@ add_downed_nodes(xmlNode *xml, const pcmk_action_t *action)
  * \return Newly allocated string with transition graph operation key
  */
 static char *
-clone_op_key(const pcmk_action_t *action, guint interval_ms)
+clone_op_key(const pcmk_action_t *action, unsigned int interval_ms)
 {
     if (pcmk__str_eq(action->task, PCMK_ACTION_NOTIFY, pcmk__str_none)) {
         const char *n_type = g_hash_table_lookup(action->meta, "notify_type");
@@ -438,7 +438,7 @@ create_graph_action(xmlNode *parent, pcmk_action_t *action, bool skip_details,
 
     if ((action->rsc != NULL) && (action->rsc->priv->history_id != NULL)) {
         char *clone_key = NULL;
-        guint interval_ms;
+        unsigned int interval_ms = 0;
 
         if (pcmk__guint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
                                   &interval_ms) != pcmk_rc_ok) {

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -873,7 +873,7 @@ create_graph_synapse(const pcmk_action_t *action, pcmk_scheduler_t *scheduler)
  *       pcmk__create_graph().)
  */
 static void
-add_action_to_graph(gpointer data, gpointer user_data)
+add_action_to_graph(void *data, void *user_data)
 {
     pcmk_action_t *action = (pcmk_action_t *) data;
     pcmk_scheduler_t *scheduler = (pcmk_scheduler_t *) user_data;
@@ -1088,7 +1088,7 @@ pcmk__create_graph(pcmk_scheduler_t *scheduler)
             }
         }
 
-        add_action_to_graph((gpointer) action, (gpointer) scheduler);
+        add_action_to_graph((void *) action, (void *) scheduler);
     }
 
     pcmk__log_xml_trace(scheduler->priv->graph, "graph");

--- a/lib/pacemaker/pcmk_graph_producer.c
+++ b/lib/pacemaker/pcmk_graph_producer.c
@@ -440,8 +440,8 @@ create_graph_action(xmlNode *parent, pcmk_action_t *action, bool skip_details,
         char *clone_key = NULL;
         unsigned int interval_ms = 0;
 
-        if (pcmk__guint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
-                                  &interval_ms) != pcmk_rc_ok) {
+        if (pcmk__uint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
+                                 &interval_ms) != pcmk_rc_ok) {
             interval_ms = 0;
         }
         clone_key = clone_op_key(action, interval_ms);

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -685,7 +685,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->node_up; iter != NULL; iter = iter->next) {
-        const char *node = (const char *) iter->data;
+        const char *node = iter->data;
 
         out->message(out, "inject-modify-node", "Online", node);
 
@@ -698,7 +698,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->node_down; iter != NULL; iter = iter->next) {
-        const char *node = (const char *) iter->data;
+        const char *node = iter->data;
         char *xpath = NULL;
 
         out->message(out, "inject-modify-node", "Offline", node);
@@ -726,7 +726,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->node_fail; iter != NULL; iter = iter->next) {
-        const char *node = (const char *) iter->data;
+        const char *node = iter->data;
 
         out->message(out, "inject-modify-node", "Failing", node);
 
@@ -740,7 +740,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->ticket_grant; iter != NULL; iter = iter->next) {
-        const char *ticket_id = (const char *) iter->data;
+        const char *ticket_id = iter->data;
 
         out->message(out, "inject-modify-ticket", "Granting", ticket_id);
 
@@ -749,7 +749,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->ticket_revoke; iter != NULL; iter = iter->next) {
-        const char *ticket_id = (const char *) iter->data;
+        const char *ticket_id = iter->data;
 
         out->message(out, "inject-modify-ticket", "Revoking", ticket_id);
 
@@ -759,7 +759,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->ticket_standby; iter != NULL; iter = iter->next) {
-        const char *ticket_id = (const char *) iter->data;
+        const char *ticket_id = iter->data;
 
         out->message(out, "inject-modify-ticket", "Standby", ticket_id);
 
@@ -768,7 +768,7 @@ pcmk__inject_scheduler_input(pcmk_scheduler_t *scheduler, cib_t *cib,
     }
 
     for (iter = injections->ticket_activate; iter != NULL; iter = iter->next) {
-        const char *ticket_id = (const char *) iter->data;
+        const char *ticket_id = iter->data;
 
         out->message(out, "inject-modify-ticket", "Activating", ticket_id);
 
@@ -792,15 +792,15 @@ pcmk_free_injections(pcmk_injections_t *injections)
         return;
     }
 
-    g_list_free_full(injections->node_up, g_free);
-    g_list_free_full(injections->node_down, g_free);
-    g_list_free_full(injections->node_fail, g_free);
-    g_list_free_full(injections->op_fail, g_free);
-    g_list_free_full(injections->op_inject, g_free);
-    g_list_free_full(injections->ticket_grant, g_free);
-    g_list_free_full(injections->ticket_revoke, g_free);
-    g_list_free_full(injections->ticket_standby, g_free);
-    g_list_free_full(injections->ticket_activate, g_free);
+    g_list_free_full(injections->node_up, free);
+    g_list_free_full(injections->node_down, free);
+    g_list_free_full(injections->node_fail, free);
+    g_list_free_full(injections->op_fail, free);
+    g_list_free_full(injections->op_inject, free);
+    g_list_free_full(injections->ticket_grant, free);
+    g_list_free_full(injections->ticket_revoke, free);
+    g_list_free_full(injections->ticket_standby, free);
+    g_list_free_full(injections->ticket_activate, free);
     free(injections->quorum);
     free(injections->watchdog);
 

--- a/lib/pacemaker/pcmk_injections.c
+++ b/lib/pacemaker/pcmk_injections.c
@@ -98,7 +98,7 @@ inject_transient_attr(pcmk__output_t *out, xmlNode *cib_node,
 void
 pcmk__inject_failcount(pcmk__output_t *out, cib_t *cib_conn, xmlNode *cib_node,
                        const char *resource, const char *task,
-                       guint interval_ms, int exit_status, bool infinity)
+                       unsigned int interval_ms, int exit_status, bool infinity)
 {
     char *name = NULL;
     char *value = NULL;
@@ -192,8 +192,8 @@ create_node_entry(cib_t *cib_conn, const char *node)
  *       lrmd_free_event().
  */
 static lrmd_event_data_t *
-create_op(const xmlNode *cib_resource, const char *task, guint interval_ms,
-          int outcome)
+create_op(const xmlNode *cib_resource, const char *task,
+          unsigned int interval_ms, int outcome)
 {
     lrmd_event_data_t *op = NULL;
     xmlNode *xop = NULL;
@@ -568,7 +568,7 @@ inject_action(pcmk__output_t *out, const char *spec, cib_t *cib,
 {
     int rc;
     int outcome = PCMK_OCF_OK;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
 
     char *key = NULL;
     char *node = NULL;

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,19 +9,38 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
+#include <inttypes.h>                   // PRIu32
+#include <stdarg.h>                     // va_arg, va_list
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdio.h>                      // snprintf
+#include <stdlib.h>                     // free
+#include <string.h>                     // strdup, strlen
+#include <time.h>                       // clock_t, CLOCKS_PER_SEC, time_t
 
-#include <crm/common/output.h>
-#include <crm/common/results.h>
-#include <crm/common/xml.h>
-#include <crm/stonith-ng.h>         // stonith_history_t
-#include <crm/fencing/internal.h>   // stonith__*
-#include <crm/pengine/internal.h>
-#include <libxml/tree.h>
-#include <pacemaker-internal.h>
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlGetNodePath, xmlNode
+#include <libxml/xmlstring.h>           // xmlChar
+#include <qb/qbdefs.h>                  // QB_MAX
 
-#include <inttypes.h>
-#include <stdint.h>
+#include <crm/common/actions.h>         // PCMK_ACTION_*
+#include <crm/common/ipc_pacemakerd.h>  // pcmk_pacemakerd_*
+#include <crm/common/iso8601.h>         // crm_time_*
+#include <crm/common/logging.h>         // CRM_CHECK, CRM_LOG_ASSERT
+#include <crm/common/options.h>         // PCMK_VALUE_NONE, PCMK_VALUE_TRUE
+#include <crm/common/output.h>          // pcmk_section_*, pcmk_show_*
+#include <crm/common/results.h>         // crm_exit_*, pcmk_rc_*, etc.
+#include <crm/common/roles.h>           // pcmk_role_*, rsc_role_e
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // pcmk_readable_score
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/crm.h>                    // CRM_SYSTEM_MCP
+#include <crm/fencing/internal.h>       // stonith__*
+#include <crm/pengine/complex.h>        // uber_parent
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/stonith-ng.h>             // st_*, stonith_history_t
+#include <pacemaker-internal.h>         // pcmk__colocation_t, etc.
 
 static char *
 colocations_header(pcmk_resource_t *rsc, pcmk__colocation_t *cons,
@@ -1042,7 +1061,7 @@ add_digest_xml(xmlNode *parent, const char *type, const char *digest,
                xmlNode *digest_source)
 {
     if (digest != NULL) {
-        xmlNodePtr digest_xml = pcmk__xe_create(parent, PCMK_XE_DIGEST);
+        xmlNode *digest_xml = pcmk__xe_create(parent, PCMK_XE_DIGEST);
 
         pcmk__xe_set(digest_xml, PCMK_XA_TYPE, pcmk__s(type, "unspecified"));
         pcmk__xe_set(digest_xml, PCMK_XA_HASH, digest);
@@ -1422,7 +1441,7 @@ inject_cluster_action(pcmk__output_t *out, va_list args)
 {
     const char *node = va_arg(args, const char *);
     const char *task = va_arg(args, const char *);
-    xmlNodePtr rsc = va_arg(args, xmlNodePtr);
+    xmlNode *rsc = va_arg(args, xmlNode *);
 
     if (out->is_quiet(out)) {
         return pcmk_rc_no_output;
@@ -1445,9 +1464,9 @@ inject_cluster_action_xml(pcmk__output_t *out, va_list args)
 {
     const char *node = va_arg(args, const char *);
     const char *task = va_arg(args, const char *);
-    xmlNodePtr rsc = va_arg(args, xmlNodePtr);
+    xmlNode *rsc = va_arg(args, xmlNode *);
 
-    xmlNodePtr xml_node = NULL;
+    xmlNode *xml_node = NULL;
 
     if (out->is_quiet(out)) {
         return pcmk_rc_no_output;
@@ -1504,7 +1523,7 @@ inject_attr(pcmk__output_t *out, va_list args)
 {
     const char *name = va_arg(args, const char *);
     const char *value = va_arg(args, const char *);
-    xmlNodePtr cib_node = va_arg(args, xmlNodePtr);
+    xmlNode *cib_node = va_arg(args, xmlNode *);
 
     xmlChar *node_path = NULL;
 
@@ -1527,7 +1546,7 @@ inject_attr_xml(pcmk__output_t *out, va_list args)
 {
     const char *name = va_arg(args, const char *);
     const char *value = va_arg(args, const char *);
-    xmlNodePtr cib_node = va_arg(args, xmlNodePtr);
+    xmlNode *cib_node = va_arg(args, xmlNode *);
 
     xmlChar *node_path = NULL;
 
@@ -1608,7 +1627,7 @@ inject_modify_config_xml(pcmk__output_t *out, va_list args)
     const char *quorum = va_arg(args, const char *);
     const char *watchdog = va_arg(args, const char *);
 
-    xmlNodePtr node = NULL;
+    xmlNode *node = NULL;
 
     if (out->is_quiet(out)) {
         return pcmk_rc_no_output;
@@ -1732,7 +1751,7 @@ inject_pseudo_action_xml(pcmk__output_t *out, va_list args)
     const char *node = va_arg(args, const char *);
     const char *task = va_arg(args, const char *);
 
-    xmlNodePtr xml_node = NULL;
+    xmlNode *xml_node = NULL;
 
     if (out->is_quiet(out)) {
         return pcmk_rc_no_output;
@@ -1783,7 +1802,7 @@ inject_rsc_action_xml(pcmk__output_t *out, va_list args)
     const char *node = va_arg(args, const char *);
     guint interval_ms = va_arg(args, guint);
 
-    xmlNodePtr xml_node = NULL;
+    xmlNode *xml_node = NULL;
 
     if (out->is_quiet(out)) {
         return pcmk_rc_no_output;
@@ -2253,7 +2272,7 @@ attribute_xml(pcmk__output_t *out, va_list args)
     bool quiet G_GNUC_UNUSED = va_arg(args, int);
     bool legacy G_GNUC_UNUSED = va_arg(args, int);
 
-    xmlNodePtr node = NULL;
+    xmlNode *node = NULL;
 
     node = pcmk__output_create_xml_node(out, PCMK_XE_ATTRIBUTE,
                                         PCMK_XA_NAME, name,

--- a/lib/pacemaker/pcmk_output.c
+++ b/lib/pacemaker/pcmk_output.c
@@ -1001,14 +1001,14 @@ crmadmin_node_xml(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("digests", "const pcmk_resource_t *", "const pcmk_node_t *",
-                  "const char *", "guint", "const pcmk__op_digest_t *")
+                  "const char *", "unsigned int", "const pcmk__op_digest_t *")
 static int
 digests_text(pcmk__output_t *out, va_list args)
 {
     const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     const pcmk_node_t *node = va_arg(args, const pcmk_node_t *);
     const char *task = va_arg(args, const char *);
-    guint interval_ms = va_arg(args, guint);
+    unsigned int interval_ms = va_arg(args, unsigned int);
     const pcmk__op_digest_t *digests = va_arg(args, const pcmk__op_digest_t *);
 
     char *action_desc = NULL;
@@ -1070,14 +1070,14 @@ add_digest_xml(xmlNode *parent, const char *type, const char *digest,
 }
 
 PCMK__OUTPUT_ARGS("digests", "const pcmk_resource_t *", "const pcmk_node_t *",
-                  "const char *", "guint", "const pcmk__op_digest_t *")
+                  "const char *", "unsigned int", "const pcmk__op_digest_t *")
 static int
 digests_xml(pcmk__output_t *out, va_list args)
 {
     const pcmk_resource_t *rsc = va_arg(args, const pcmk_resource_t *);
     const pcmk_node_t *node = va_arg(args, const pcmk_node_t *);
     const char *task = va_arg(args, const char *);
-    guint interval_ms = va_arg(args, guint);
+    unsigned int interval_ms = va_arg(args, unsigned int);
     const pcmk__op_digest_t *digests = va_arg(args, const pcmk__op_digest_t *);
 
     char *interval_s = pcmk__assert_asprintf("%ums", interval_ms);
@@ -1768,14 +1768,14 @@ inject_pseudo_action_xml(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("inject-rsc-action", "const char *", "const char *",
-                  "const char *", "guint")
+                  "const char *", "unsigned int")
 static int
 inject_rsc_action(pcmk__output_t *out, va_list args)
 {
     const char *rsc = va_arg(args, const char *);
     const char *operation = va_arg(args, const char *);
     const char *node = va_arg(args, const char *);
-    guint interval_ms = va_arg(args, guint);
+    unsigned int interval_ms = va_arg(args, unsigned int);
 
     if (out->is_quiet(out)) {
         return pcmk_rc_no_output;
@@ -1793,14 +1793,14 @@ inject_rsc_action(pcmk__output_t *out, va_list args)
 }
 
 PCMK__OUTPUT_ARGS("inject-rsc-action", "const char *", "const char *",
-                  "const char *", "guint")
+                  "const char *", "unsigned int")
 static int
 inject_rsc_action_xml(pcmk__output_t *out, va_list args)
 {
     const char *rsc = va_arg(args, const char *);
     const char *operation = va_arg(args, const char *);
     const char *node = va_arg(args, const char *);
-    guint interval_ms = va_arg(args, guint);
+    unsigned int interval_ms = va_arg(args, unsigned int);
 
     xmlNode *xml_node = NULL;
 

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 the Pacemaker project contributors
+ * Copyright 2021-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,19 +9,27 @@
 
 #include <crm_internal.h>
 
-#include <errno.h>
-#include <stdbool.h>
+#include <errno.h>                      // EINVAL, ENOTCONN, EOPNOTSUPP
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdlib.h>                     // free
 
-#include <glib.h>
+#include <glib.h>                       // g_str_has_suffix, GHashTable, guint
 #include <libxml/tree.h>                // xmlNode
 
-#include <crm/cib/internal.h>
-#include <crm/common/mainloop.h>
-#include <crm/common/results.h>
-#include <crm/pengine/internal.h>
+#include <crm/cib.h>                    // cib_new, cib_t, etc.
+#include <crm/cib/internal.h>           // cib__clean_up_connection
+#include <crm/common/actions.h>         // PCMK_ACTION_*
+#include <crm/common/options.h>         // PCMK_META_INTERVAL
+#include <crm/common/results.h>         // pcmk_legacy2rc, pcmk_rc_*, etc.
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/crm.h>                    // crm_system_name
+#include <crm/pengine/internal.h>       // pe__*
 
-#include <pacemaker.h>
-#include <pacemaker-internal.h>
+#include <pacemaker.h>                  // pcmk_resource_{delete,digests}
+#include <pacemaker-internal.h>         // pcmk__register_*, pcmk__resource_*
 
 // Search path for resource operation history (takes node name and resource ID)
 #define XPATH_OP_HISTORY "//" PCMK_XE_STATUS                            \
@@ -148,7 +156,7 @@ pcmk__resource_delete(cib_t *cib, uint32_t cib_opts, const char *rsc_id,
 }
 
 int
-pcmk_resource_delete(xmlNodePtr *xml, const char *rsc_id, const char *rsc_type)
+pcmk_resource_delete(xmlNode **xml, const char *rsc_id, const char *rsc_type)
 {
     pcmk__output_t *out = NULL;
     int rc = pcmk_rc_ok;
@@ -237,7 +245,7 @@ pcmk__resource_digests(pcmk__output_t *out, pcmk_resource_t *rsc,
 }
 
 int
-pcmk_resource_digests(xmlNodePtr *xml, pcmk_resource_t *rsc,
+pcmk_resource_digests(xmlNode **xml, pcmk_resource_t *rsc,
                       const pcmk_node_t *node, GHashTable *overrides)
 {
     pcmk__output_t *out = NULL;

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -15,7 +15,7 @@
 #include <stdint.h>                     // uint32_t
 #include <stdlib.h>                     // free
 
-#include <glib.h>                       // g_str_has_suffix, GHashTable, guint
+#include <glib.h>                       // g_str_has_suffix, GHashTable
 #include <libxml/tree.h>                // xmlNode
 
 #include <crm/cib.h>                    // cib_new, cib_t, etc.
@@ -45,7 +45,7 @@ best_op(const pcmk_resource_t *rsc, const pcmk_node_t *node)
     xmlNode *history = NULL;
     xmlNode *best = NULL;
     bool best_effective_op = false;
-    guint best_interval = 0;
+    unsigned int best_interval = 0;
     bool best_failure = false;
     const char *best_digest = NULL;
 
@@ -64,7 +64,7 @@ best_op(const pcmk_resource_t *rsc, const pcmk_node_t *node)
 
         const char *digest = pcmk__xe_get(lrm_rsc_op,
                                           PCMK__XA_OP_RESTART_DIGEST);
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
         const char *task = pcmk__xe_get(lrm_rsc_op, PCMK_XA_OPERATION);
         bool effective_op = false;
         const char *id = pcmk__xe_id(lrm_rsc_op);
@@ -210,7 +210,7 @@ pcmk__resource_digests(pcmk__output_t *out, pcmk_resource_t *rsc,
     const char *task = NULL;
     xmlNode *xml_op = NULL;
     pcmk__op_digest_t *digests = NULL;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
     int rc = pcmk_rc_ok;
 
     if ((out == NULL) || (rsc == NULL) || (node == NULL)) {

--- a/lib/pacemaker/pcmk_resource.c
+++ b/lib/pacemaker/pcmk_resource.c
@@ -71,7 +71,7 @@ best_op(const pcmk_resource_t *rsc, const pcmk_node_t *node)
         bool failure = (id != NULL) && g_str_has_suffix(id, "_last_failure_0");
 
 
-        pcmk__xe_get_guint(lrm_rsc_op, PCMK_META_INTERVAL, &interval_ms);
+        pcmk__xe_get_uint(lrm_rsc_op, PCMK_META_INTERVAL, &interval_ms);
         effective_op = interval_ms == 0
                        && pcmk__strcase_any_of(task, PCMK_ACTION_MONITOR,
                                                PCMK_ACTION_START,
@@ -228,7 +228,7 @@ pcmk__resource_digests(pcmk__output_t *out, pcmk_resource_t *rsc,
     // Generate an operation key
     if (xml_op != NULL) {
         task = pcmk__xe_get(xml_op, PCMK_XA_OPERATION);
-        pcmk__xe_get_guint(xml_op, PCMK_META_INTERVAL, &interval_ms);
+        pcmk__xe_get_uint(xml_op, PCMK_META_INTERVAL, &interval_ms);
     }
     if (task == NULL) { // Assume start if no history is available
         task = PCMK_ACTION_START;

--- a/lib/pacemaker/pcmk_rule.c
+++ b/lib/pacemaker/pcmk_rule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,13 +9,21 @@
 
 #include <crm_internal.h>
 
-#include <libxml/xpath.h>           // xmlXPathObject, etc.
+#include <errno.h>                      // ENXIO, EOPNOTSUPP
+#include <stddef.h>                     // NULL
+#include <stdlib.h>                     // free
 
-#include <crm/cib/internal.h>
-#include <crm/common/cib.h>
-#include <crm/common/iso8601.h>
-#include <crm/common/xml.h>
-#include <crm/pengine/internal.h>
+#include <libxml/tree.h>                // xmlNode
+#include <libxml/xpath.h>               // xmlXPathObject, xmlXPathFreeObject
+
+#include <crm/common/cib.h>             // pcmk_find_cib_element
+#include <crm/common/iso8601.h>         // crm_time_t
+#include <crm/common/options.h>         // PCMK_VALUE_DATE_SPEC
+#include <crm/common/results.h>         // pcmk_rc_*, pcmk_rc2exitc
+#include <crm/common/rules.h>           // expression_type
+#include <crm/common/scheduler.h>       // pcmk_free_scheduler, pcmk_scheduler_t
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <pacemaker.h>                  // pcmk_check_rules
 #include <pacemaker-internal.h>
 
 #include "libpacemaker_private.h"
@@ -35,8 +43,8 @@
 static int
 eval_rule(pcmk_scheduler_t *scheduler, const char *rule_id, const char **error)
 {
-    xmlNodePtr cib_constraints = NULL;
-    xmlNodePtr match = NULL;
+    xmlNode *cib_constraints = NULL;
+    xmlNode *match = NULL;
     xmlXPathObject *xpath_obj = NULL;
     char *xpath = NULL;
     int rc = pcmk_rc_ok;
@@ -160,7 +168,7 @@ eval_rule(pcmk_scheduler_t *scheduler, const char *rule_id, const char **error)
  * \return Standard Pacemaker return code
  */
 int
-pcmk__check_rules(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
+pcmk__check_rules(pcmk__output_t *out, xmlNode *input, const crm_time_t *date,
                   const char **rule_ids)
 {
     pcmk_scheduler_t *scheduler = NULL;
@@ -195,7 +203,7 @@ pcmk__check_rules(pcmk__output_t *out, xmlNodePtr input, const crm_time_t *date,
 
 // Documented in pacemaker.h
 int
-pcmk_check_rules(xmlNodePtr *xml, xmlNodePtr input, const crm_time_t *date,
+pcmk_check_rules(xmlNode **xml, xmlNode *input, const crm_time_t *date,
                  const char **rule_ids)
 {
     pcmk__output_t *out = NULL;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1346,7 +1346,7 @@ pcmk__action_locks_rsc_to_node(const pcmk_action_t *action)
 
 /* lowest to highest */
 static int
-sort_action_id(gconstpointer a, gconstpointer b)
+sort_action_id(const void *a, const void *b)
 {
     const pcmk__related_action_t *action_wrapper2 = a;
     const pcmk__related_action_t *action_wrapper1 = b;

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1256,7 +1256,7 @@ pcmk__create_history_xml(xmlNode *parent, lrmd_event_data_t *op,
     pcmk__xe_set_int(xml_op, PCMK__XA_CALL_ID, op->call_id);
     pcmk__xe_set_int(xml_op, PCMK__XA_RC_CODE, op->rc);
     pcmk__xe_set_int(xml_op, PCMK__XA_OP_STATUS, op->op_status);
-    pcmk__xe_set_guint(xml_op, PCMK_META_INTERVAL, op->interval_ms);
+    pcmk__xe_set_uint(xml_op, PCMK_META_INTERVAL, op->interval_ms);
 
     if ((op->t_run > 0) || (op->t_rcchange > 0) || (op->exec_time > 0)
         || (op->queue_time > 0)) {

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -95,7 +95,7 @@ static char *
 action_uuid_for_ordering(const char *first_uuid,
                          const pcmk_resource_t *first_rsc)
 {
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
     char *uuid = NULL;
     char *rid = NULL;
     char *first_task_str = NULL;
@@ -1488,7 +1488,7 @@ pcmk__output_actions(pcmk_scheduler_t *scheduler)
  * \return Action name whose digest should be compared
  */
 static const char *
-task_for_digest(const char *task, guint interval_ms)
+task_for_digest(const char *task, unsigned int interval_ms)
 {
     /* Certain actions need to be compared against the parameters used to start
      * the resource.
@@ -1547,7 +1547,7 @@ only_sanitized_changed(const xmlNode *xml_op,
  * \param[in,out] node         Node where resource should be restarted
  */
 static void
-force_restart(pcmk_resource_t *rsc, const char *task, guint interval_ms,
+force_restart(pcmk_resource_t *rsc, const char *task, unsigned int interval_ms,
               pcmk_node_t *node)
 {
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
@@ -1639,7 +1639,7 @@ bool
 pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
                           const xmlNode *xml_op)
 {
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
     const char *task = NULL;
     const pcmk__op_digest_t *digest_data = NULL;
 
@@ -1831,7 +1831,7 @@ process_rsc_history(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
     for (GList *iter = sorted_op_list; iter != NULL; iter = iter->next) {
         xmlNode *rsc_op = (xmlNode *) iter->data;
         const char *task = NULL;
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
 
         if (++offset < start_index) {
             // Skip actions that happened before a start

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1567,7 +1567,7 @@ force_restart(pcmk_resource_t *rsc, const char *task, unsigned int interval_ms,
  * \param[in]     user_data  Where resource should be reloaded
  */
 static void
-schedule_reload(gpointer data, gpointer user_data)
+schedule_reload(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
     const pcmk_node_t *node = user_data;
@@ -1719,7 +1719,7 @@ pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
                                   "Device parameters changed (reload)", NULL,
                                   rsc->priv->scheduler);
                 pcmk__log_xml_debug(digest_data->params_all, "params:reload");
-                schedule_reload((gpointer) rsc, (gpointer) node);
+                schedule_reload((void *) rsc, (void *) node);
 
             } else {
                 pcmk__rsc_trace(rsc,

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1649,7 +1649,7 @@ pcmk__check_action_config(pcmk_resource_t *rsc, pcmk_node_t *node,
     task = pcmk__xe_get(xml_op, PCMK_XA_OPERATION);
     CRM_CHECK(task != NULL, return false);
 
-    pcmk__xe_get_guint(xml_op, PCMK_META_INTERVAL, &interval_ms);
+    pcmk__xe_get_uint(xml_op, PCMK_META_INTERVAL, &interval_ms);
 
     // If this is a recurring action, check whether it has been removed
     if (interval_ms > 0) {
@@ -1839,7 +1839,7 @@ process_rsc_history(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
         }
 
         task = pcmk__xe_get(rsc_op, PCMK_XA_OPERATION);
-        pcmk__xe_get_guint(rsc_op, PCMK_META_INTERVAL, &interval_ms);
+        pcmk__xe_get_uint(rsc_op, PCMK_META_INTERVAL, &interval_ms);
 
         if ((interval_ms > 0)
             && (pcmk__is_set(rsc->flags, pcmk__rsc_maintenance)

--- a/lib/pacemaker/pcmk_sched_actions.c
+++ b/lib/pacemaker/pcmk_sched_actions.c
@@ -1345,7 +1345,7 @@ pcmk__action_locks_rsc_to_node(const pcmk_action_t *action)
 }
 
 /* lowest to highest */
-static gint
+static int
 sort_action_id(gconstpointer a, gconstpointer b)
 {
     const pcmk__related_action_t *action_wrapper2 = a;

--- a/lib/pacemaker/pcmk_sched_bundle.c
+++ b/lib/pacemaker/pcmk_sched_bundle.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -73,7 +73,7 @@ assign_replica(pcmk__bundle_replica_t *replica, void *user_data)
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, replica->child->priv->allowed_nodes);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (!pcmk__same_node(node, replica->node)) {
                 node->assign->score = -PCMK_SCORE_INFINITY;
             } else if (!pcmk__threshold_reached(replica->child, node, NULL)) {
@@ -146,7 +146,7 @@ pcmk__bundle_assign(pcmk_resource_t *rsc, const pcmk_node_t *prefer,
         GHashTableIter iter;
 
         g_hash_table_iter_init(&iter, bundled_resource->priv->allowed_nodes);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) & node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
             if (pe__node_is_bundle_instance(rsc, node)) {
                 node->assign->score = 0;
             } else {

--- a/lib/pacemaker/pcmk_sched_clone.c
+++ b/lib/pacemaker/pcmk_sched_clone.c
@@ -448,7 +448,7 @@ pcmk__clone_apply_location(pcmk_resource_t *rsc, pcmk__location_t *location)
 
 // GFunc wrapper for calling the action_flags() resource method
 static void
-call_action_flags(gpointer data, gpointer user_data)
+call_action_flags(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = user_data;
 
@@ -512,7 +512,7 @@ rsc_probed_on(const pcmk_resource_t *rsc, const pcmk_node_t *node)
         pcmk_node_t *known_node = NULL;
 
         g_hash_table_iter_init(&iter, rsc->priv->probed_nodes);
-        while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &known_node)) {
+        while (g_hash_table_iter_next(&iter, NULL, (void **) &known_node)) {
             if (pcmk__same_node(node, known_node)) {
                 return true;
             }

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -159,7 +159,7 @@ cmp_colocation_priority(const pcmk__colocation_t *colocation1,
  *         or 0 if order doesn't matter
  */
 static int
-cmp_dependent_priority(gconstpointer a, gconstpointer b)
+cmp_dependent_priority(const void *a, const void *b)
 {
     return cmp_colocation_priority(a, b, true);
 }
@@ -185,7 +185,7 @@ cmp_dependent_priority(gconstpointer a, gconstpointer b)
  *         or 0 if order doesn't matter
  */
 static int
-cmp_primary_priority(gconstpointer a, gconstpointer b)
+cmp_primary_priority(const void *a, const void *b)
 {
     return cmp_colocation_priority(a, b, false);
 }

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -213,7 +213,7 @@ pcmk__add_this_with(GList **list, const pcmk__colocation_t *colocation,
                     colocation->id, colocation->dependent->id,
                     colocation->primary->id, colocation->node_attribute,
                     pcmk_readable_score(colocation->score), rsc->id);
-    *list = g_list_insert_sorted(*list, (gpointer) colocation,
+    *list = g_list_insert_sorted(*list, (void *) colocation,
                                  cmp_primary_priority);
 }
 
@@ -273,7 +273,7 @@ pcmk__add_with_this(GList **list, const pcmk__colocation_t *colocation,
                     colocation->id, colocation->dependent->id,
                     colocation->primary->id, colocation->node_attribute,
                     pcmk_readable_score(colocation->score), rsc->id);
-    *list = g_list_insert_sorted(*list, (gpointer) colocation,
+    *list = g_list_insert_sorted(*list, (void *) colocation,
                                  cmp_dependent_priority);
 }
 
@@ -1611,7 +1611,7 @@ allowed_on_one(const pcmk_resource_t *rsc)
     int allowed_nodes = 0;
 
     g_hash_table_iter_init(&iter, rsc->priv->allowed_nodes);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &allowed_node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &allowed_node)) {
         if ((allowed_node->assign->score >= 0) && (++allowed_nodes > 1)) {
             pcmk__rsc_trace(rsc, "%s is allowed on multiple nodes", rsc->id);
             return false;
@@ -1911,7 +1911,7 @@ pcmk__add_colocated_node_scores(pcmk_resource_t *source_rsc,
  * \param[in,out] user_data  Resource being assigned
  */
 void
-pcmk__add_dependent_scores(gpointer data, gpointer user_data)
+pcmk__add_dependent_scores(void *data, void *user_data)
 {
     pcmk__colocation_t *colocation = data;
     pcmk_resource_t *primary = user_data;
@@ -1966,7 +1966,7 @@ pcmk__colocation_intersect_nodes(pcmk_resource_t *dependent,
                  && (colocation != NULL));
 
     g_hash_table_iter_init(&iter, dependent->priv->allowed_nodes);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &dependent_node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &dependent_node)) {
         const pcmk_node_t *primary_node = NULL;
 
         primary_node = pe_find_node_id(primary_nodes,

--- a/lib/pacemaker/pcmk_sched_colocation.c
+++ b/lib/pacemaker/pcmk_sched_colocation.c
@@ -80,7 +80,7 @@ pcmk__colocation_node_attr(const pcmk_node_t *node, const char *attr,
  *         a positive number if \p colocation2 should be considered first,
  *         or 0 if order doesn't matter
  */
-static gint
+static int
 cmp_colocation_priority(const pcmk__colocation_t *colocation1,
                         const pcmk__colocation_t *colocation2, bool dependent)
 {
@@ -158,7 +158,7 @@ cmp_colocation_priority(const pcmk__colocation_t *colocation1,
  *         a positive number if \p b should be considered first,
  *         or 0 if order doesn't matter
  */
-static gint
+static int
 cmp_dependent_priority(gconstpointer a, gconstpointer b)
 {
     return cmp_colocation_priority(a, b, true);
@@ -184,7 +184,7 @@ cmp_dependent_priority(gconstpointer a, gconstpointer b)
  *         a positive number if \p b should be considered first,
  *         or 0 if order doesn't matter
  */
-static gint
+static int
 cmp_primary_priority(gconstpointer a, gconstpointer b)
 {
     return cmp_colocation_priority(a, b, false);

--- a/lib/pacemaker/pcmk_sched_constraints.c
+++ b/lib/pacemaker/pcmk_sched_constraints.c
@@ -117,7 +117,7 @@ find_constraint_tag(const pcmk_scheduler_t *scheduler, const char *id,
 
     // Check whether id refers to a resource set template
     if (g_hash_table_lookup_extended(scheduler->priv->templates, id,
-                                     NULL, (gpointer *) tag)) {
+                                     NULL, (void **) tag)) {
         if (*tag == NULL) {
             pcmk__notice("No resource is derived from template '%s'", id);
             return false;
@@ -127,7 +127,7 @@ find_constraint_tag(const pcmk_scheduler_t *scheduler, const char *id,
 
     // If not, check whether id refers to a tag
     if (g_hash_table_lookup_extended(scheduler->priv->tags, id,
-                                     NULL, (gpointer *) tag)) {
+                                     NULL, (void **) tag)) {
         if (*tag == NULL) {
             pcmk__notice("No resource is tagged with '%s'", id);
             return false;

--- a/lib/pacemaker/pcmk_sched_fencing.c
+++ b/lib/pacemaker/pcmk_sched_fencing.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -473,7 +473,7 @@ pcmk__node_unfenced(const pcmk_node_t *node)
  * \param[in,out] user_data  Resource to order
  */
 void
-pcmk__order_restart_vs_unfence(gpointer data, gpointer user_data)
+pcmk__order_restart_vs_unfence(void *data, void *user_data)
 {
     pcmk_node_t *node = (pcmk_node_t *) data;
     pcmk_resource_t *rsc = (pcmk_resource_t *) user_data;

--- a/lib/pacemaker/pcmk_sched_group.c
+++ b/lib/pacemaker/pcmk_sched_group.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -168,7 +168,7 @@ struct member_data {
  * \param[in,out] user_data  Member data (struct member_data *)
  */
 static void
-member_internal_constraints(gpointer data, gpointer user_data)
+member_internal_constraints(void *data, void *user_data)
 {
     pcmk_resource_t *member = (pcmk_resource_t *) data;
     struct member_data *member_data = (struct member_data *) user_data;
@@ -747,7 +747,7 @@ pcmk__group_colocated_resources(const pcmk_resource_t *rsc,
          * add every child's colocated resources to the list. The first and last
          * members will include the group's own colocations.
          */
-        colocated_rscs = g_list_prepend(colocated_rscs, (gpointer) rsc);
+        colocated_rscs = g_list_prepend(colocated_rscs, (void *) rsc);
 
         for (const GList *iter = rsc->priv->children;
              iter != NULL; iter = iter->next) {

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -308,7 +308,7 @@ node_is_allowed(const pcmk_resource_t *rsc, pcmk_node_t **node)
  *         a positive number if \p b's instance number is lower,
  *         or 0 if their instance numbers are the same
  */
-gint
+int
 pcmk__cmp_instance_number(gconstpointer a, gconstpointer b)
 {
     const pcmk_resource_t *instance1 = (const pcmk_resource_t *) a;
@@ -329,7 +329,7 @@ pcmk__cmp_instance_number(gconstpointer a, gconstpointer b)
     }
     pcmk__assert((div1 != NULL) && (div2 != NULL));
 
-    return (gint) (strtol(div1 + 1, NULL, 10) - strtol(div2 + 1, NULL, 10));
+    return (int) (strtol(div1 + 1, NULL, 10) - strtol(div2 + 1, NULL, 10));
 }
 
 /*!
@@ -357,7 +357,7 @@ pcmk__cmp_instance_number(gconstpointer a, gconstpointer b)
  *         a positive number if \p b should be assigned first,
  *         or 0 if assignment order doesn't matter
  */
-gint
+int
 pcmk__cmp_instance(gconstpointer a, gconstpointer b)
 {
     int rc = 0;

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -139,7 +139,7 @@ new_node_table(pcmk_node_t *node)
     GHashTable *table = pcmk__strkey_table(NULL, pcmk__free_node_copy);
 
     node = pe__copy_node(node);
-    g_hash_table_insert(table, (gpointer) node->priv->id, node);
+    g_hash_table_insert(table, (void *) node->priv->id, node);
     return table;
 }
 
@@ -733,7 +733,7 @@ reset_allowed_node_counts(pcmk_resource_t *rsc)
     GHashTableIter iter;
 
     g_hash_table_iter_init(&iter, rsc->priv->allowed_nodes);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         node->assign->count = 0;
         if (pcmk__node_available(node, false, false)) {
             available_nodes++;

--- a/lib/pacemaker/pcmk_sched_instances.c
+++ b/lib/pacemaker/pcmk_sched_instances.c
@@ -309,7 +309,7 @@ node_is_allowed(const pcmk_resource_t *rsc, pcmk_node_t **node)
  *         or 0 if their instance numbers are the same
  */
 int
-pcmk__cmp_instance_number(gconstpointer a, gconstpointer b)
+pcmk__cmp_instance_number(const void *a, const void *b)
 {
     const pcmk_resource_t *instance1 = (const pcmk_resource_t *) a;
     const pcmk_resource_t *instance2 = (const pcmk_resource_t *) b;
@@ -358,7 +358,7 @@ pcmk__cmp_instance_number(gconstpointer a, gconstpointer b)
  *         or 0 if assignment order doesn't matter
  */
 int
-pcmk__cmp_instance(gconstpointer a, gconstpointer b)
+pcmk__cmp_instance(const void *a, const void *b)
 {
     int rc = 0;
     pcmk_node_t *node1 = NULL;

--- a/lib/pacemaker/pcmk_sched_location.c
+++ b/lib/pacemaker/pcmk_sched_location.c
@@ -763,8 +763,7 @@ pcmk__apply_location(pcmk_resource_t *rsc, pcmk__location_t *location)
         if (allowed_node == NULL) {
             allowed_node = pe__copy_node(node);
             g_hash_table_insert(rsc->priv->allowed_nodes,
-                                (gpointer) allowed_node->priv->id,
-                                allowed_node);
+                                (void *) allowed_node->priv->id, allowed_node);
         } else {
             allowed_node->assign->score =
                 pcmk__add_scores(allowed_node->assign->score,

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -207,7 +207,7 @@ pcmk__copy_node_list(const GList *list, bool reset)
  * \return -1 if \p a is preferred, +1 if \p b is preferred, or 0 if they are
  *         equally preferred
  */
-static gint
+static int
 compare_nodes(gconstpointer a, gconstpointer b, gpointer data)
 {
     const pcmk_node_t *node1 = (const pcmk_node_t *) a;

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -77,10 +77,10 @@ pcmk__copy_node_table(GHashTable *nodes)
     }
     new_table = pcmk__strkey_table(NULL, pcmk__free_node_copy);
     g_hash_table_iter_init(&iter, nodes);
-    while (g_hash_table_iter_next(&iter, NULL, (gpointer *) &node)) {
+    while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
         pcmk_node_t *new_node = pe__copy_node(node);
 
-        g_hash_table_insert(new_table, (gpointer) new_node->priv->id,
+        g_hash_table_insert(new_table, (void *) new_node->priv->id,
                             new_node);
     }
     return new_table;
@@ -95,7 +95,7 @@ pcmk__copy_node_table(GHashTable *nodes)
  * \note This is a \c GDestroyNotify wrapper for \c g_hash_table_destroy().
  */
 static void
-destroy_node_tables(gpointer data)
+destroy_node_tables(void *data)
 {
     g_hash_table_destroy((GHashTable *) data);
 }
@@ -208,7 +208,7 @@ pcmk__copy_node_list(const GList *list, bool reset)
  *         equally preferred
  */
 static int
-compare_nodes(gconstpointer a, gconstpointer b, gpointer data)
+compare_nodes(gconstpointer a, gconstpointer b, void *data)
 {
     const pcmk_node_t *node1 = (const pcmk_node_t *) a;
     const pcmk_node_t *node2 = (const pcmk_node_t *) b;

--- a/lib/pacemaker/pcmk_sched_nodes.c
+++ b/lib/pacemaker/pcmk_sched_nodes.c
@@ -208,7 +208,7 @@ pcmk__copy_node_list(const GList *list, bool reset)
  *         equally preferred
  */
 static int
-compare_nodes(gconstpointer a, gconstpointer b, void *data)
+compare_nodes(const void *a, const void *b, void *data)
 {
     const pcmk_node_t *node1 = (const pcmk_node_t *) a;
     const pcmk_node_t *node2 = (const pcmk_node_t *) b;

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1365,14 +1365,14 @@ rsc_order_first(pcmk_resource_t *first_rsc, pcmk__action_relation_t *order)
 
 // GFunc to call pcmk__block_colocation_dependents()
 static void
-block_colocation_dependents(gpointer data, gpointer user_data)
+block_colocation_dependents(void *data, void *user_data)
 {
     pcmk__block_colocation_dependents(data);
 }
 
 // GFunc to call pcmk__update_action_for_orderings()
 static void
-update_action_for_orderings(gpointer data, gpointer user_data)
+update_action_for_orderings(void *data, void *user_data)
 {
     pcmk__update_action_for_orderings((pcmk_action_t *) data,
                                       (pcmk_scheduler_t *) user_data);

--- a/lib/pacemaker/pcmk_sched_ordering.c
+++ b/lib/pacemaker/pcmk_sched_ordering.c
@@ -1196,7 +1196,7 @@ find_actions_by_task(const pcmk_resource_t *rsc, const char *original_key)
         // Search again using this resource's ID
         char *key = NULL;
         char *task = NULL;
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
 
         CRM_CHECK(parse_op_key(original_key, NULL, &task, &interval_ms),
                   return NULL);
@@ -1305,7 +1305,7 @@ rsc_order_first(pcmk_resource_t *first_rsc, pcmk__action_relation_t *order)
     } else if (first_actions == NULL) {
         char *key = NULL;
         char *op_type = NULL;
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
         enum rsc_role_e first_role;
 
         parse_op_key(order->task1, NULL, &op_type, &interval_ms);

--- a/lib/pacemaker/pcmk_sched_primitive.c
+++ b/lib/pacemaker/pcmk_sched_primitive.c
@@ -1638,7 +1638,7 @@ shutdown_time(pcmk_node_t *node)
  * \param[in,out] user_data  Resource to check
  */
 static void
-ban_if_not_locked(gpointer data, gpointer user_data)
+ban_if_not_locked(void *data, void *user_data)
 {
     const pcmk_node_t *node = (const pcmk_node_t *) data;
     pcmk_resource_t *rsc = (pcmk_resource_t *) user_data;

--- a/lib/pacemaker/pcmk_sched_probes.c
+++ b/lib/pacemaker/pcmk_sched_probes.c
@@ -703,7 +703,7 @@ clear_actions_tracking_flag(pcmk_scheduler_t *scheduler)
  * \param[in]     user_data  Unused
  */
 static void
-add_start_restart_orderings_for_rsc(gpointer data, gpointer user_data)
+add_start_restart_orderings_for_rsc(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
     GList *probes = NULL;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -256,7 +256,7 @@ node_to_be_promoted_on(const pcmk_resource_t *rsc)
  *         or 0 if promotion priorities are equal
  */
 static int
-cmp_promotable_instance(gconstpointer a, gconstpointer b)
+cmp_promotable_instance(const void *a, const void *b)
 {
     const pcmk_resource_t *rsc1 = (const pcmk_resource_t *) a;
     const pcmk_resource_t *rsc2 = (const pcmk_resource_t *) b;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -255,7 +255,7 @@ node_to_be_promoted_on(const pcmk_resource_t *rsc)
  *         a positive number if \p b has higher promotion priority,
  *         or 0 if promotion priorities are equal
  */
-static gint
+static int
 cmp_promotable_instance(gconstpointer a, gconstpointer b)
 {
     const pcmk_resource_t *rsc1 = (const pcmk_resource_t *) a;

--- a/lib/pacemaker/pcmk_sched_promotable.c
+++ b/lib/pacemaker/pcmk_sched_promotable.c
@@ -318,7 +318,7 @@ cmp_promotable_instance(gconstpointer a, gconstpointer b)
  * \param[in,out] user_data  Clone parent of \p data
  */
 static void
-add_promotion_priority_to_node_score(gpointer data, gpointer user_data)
+add_promotion_priority_to_node_score(void *data, void *user_data)
 {
     const pcmk_resource_t *child = (const pcmk_resource_t *) data;
     pcmk_resource_t *clone = (pcmk_resource_t *) user_data;
@@ -362,7 +362,7 @@ add_promotion_priority_to_node_score(gpointer data, gpointer user_data)
  * \param[in,out] user_data  Promotable clone that is constraint's primary
  */
 static void
-apply_coloc_to_primary(gpointer data, gpointer user_data)
+apply_coloc_to_primary(void *data, void *user_data)
 {
     pcmk__colocation_t *colocation = data;
     pcmk_resource_t *clone = user_data;
@@ -394,7 +394,7 @@ apply_coloc_to_primary(gpointer data, gpointer user_data)
  * \param[in]     user_data  Parent clone of \p data
  */
 static void
-set_promotion_priority_to_node_score(gpointer data, gpointer user_data)
+set_promotion_priority_to_node_score(void *data, void *user_data)
 {
     pcmk_resource_t *child = (pcmk_resource_t *) data;
     const pcmk_resource_t *clone = (const pcmk_resource_t *) user_data;
@@ -887,7 +887,7 @@ set_next_role_unpromoted(void *data, void *user_data)
  * \param[in]     user_data  Ignored
  */
 static void
-set_next_role_promoted(void *data, gpointer user_data)
+set_next_role_promoted(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = (pcmk_resource_t *) data;
 
@@ -942,7 +942,7 @@ show_promotion_score(pcmk_resource_t *instance)
  * \param[in]     user_data  Instance's parent clone
  */
 static void
-set_instance_priority(gpointer data, gpointer user_data)
+set_instance_priority(void *data, void *user_data)
 {
     pcmk_resource_t *instance = (pcmk_resource_t *) data;
     const pcmk_resource_t *clone = (const pcmk_resource_t *) user_data;
@@ -1040,7 +1040,7 @@ set_instance_priority(gpointer data, gpointer user_data)
  * \param[in,out] user_data  Pointer to count of instances chosen for promotion
  */
 static void
-set_instance_role(gpointer data, gpointer user_data)
+set_instance_role(void *data, void *user_data)
 {
     pcmk_resource_t *instance = (pcmk_resource_t *) data;
     int *count = (int *) user_data;

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -748,8 +748,8 @@ pcmk__action_is_recurring(const pcmk_action_t *action)
 {
     unsigned int interval_ms = 0;
 
-    if (pcmk__guint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
-                              &interval_ms) != pcmk_rc_ok) {
+    if (pcmk__uint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
+                             &interval_ms) != pcmk_rc_ok) {
         return false;
     }
     return (interval_ms > 0);

--- a/lib/pacemaker/pcmk_sched_recurring.c
+++ b/lib/pacemaker/pcmk_sched_recurring.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,13 +19,13 @@
 // Information parsed from an operation history entry in the CIB
 struct op_history {
     // XML attributes
-    const char *id;         // ID of history entry
-    const char *name;       // Action name
+    const char *id;             // ID of history entry
+    const char *name;           // Action name
 
     // Parsed information
-    char *key;              // Operation key for action
-    enum rsc_role_e role;   // Action role (or pcmk_role_unknown for default)
-    guint interval_ms;      // Action interval
+    char *key;                  // Operation key for action
+    enum rsc_role_e role;       // Action role (pcmk_role_unknown for default)
+    unsigned int interval_ms;   // Action interval
 };
 
 /*!
@@ -36,10 +36,10 @@ struct op_history {
  *
  * \return Interval parsed from XML (or 0 as default)
  */
-static guint
+static unsigned int
 xe_interval(const xmlNode *xml)
 {
-    guint interval_ms = 0U;
+    unsigned int interval_ms = 0;
 
     pcmk_parse_interval_spec(pcmk__xe_get(xml, PCMK_META_INTERVAL),
                              &interval_ms);
@@ -58,7 +58,8 @@ xe_interval(const xmlNode *xml)
  *         once in the operation history of \p rsc, otherwise false
  */
 static bool
-is_op_dup(const pcmk_resource_t *rsc, const char *name, guint interval_ms)
+is_op_dup(const pcmk_resource_t *rsc, const char *name,
+          unsigned int interval_ms)
 {
     const char *id = NULL;
 
@@ -386,7 +387,7 @@ recurring_op_for_active(pcmk_resource_t *rsc, pcmk_action_t *start,
  */
 static void
 cancel_if_running(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                  const char *key, const char *name, guint interval_ms)
+                  const char *key, const char *name, unsigned int interval_ms)
 {
     GList *possible_matches = find_actions_exact(rsc->priv->actions, key,
                                                  node);
@@ -652,7 +653,7 @@ pcmk__create_recurring_actions(pcmk_resource_t *rsc)
  */
 pcmk_action_t *
 pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *task,
-                        guint interval_ms, const pcmk_node_t *node)
+                        unsigned int interval_ms, const pcmk_node_t *node)
 {
     pcmk_action_t *cancel_op = NULL;
     char *key = NULL;
@@ -692,7 +693,7 @@ pcmk__new_cancel_action(pcmk_resource_t *rsc, const char *task,
  */
 void
 pcmk__schedule_cancel(pcmk_resource_t *rsc, const char *call_id,
-                      const char *task, guint interval_ms,
+                      const char *task, unsigned int interval_ms,
                       const pcmk_node_t *node, const char *reason)
 {
     pcmk_action_t *cancel = NULL;
@@ -723,7 +724,7 @@ pcmk__schedule_cancel(pcmk_resource_t *rsc, const char *call_id,
  */
 void
 pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
-                           guint interval_ms, pcmk_node_t *node)
+                           unsigned int interval_ms, pcmk_node_t *node)
 {
     pcmk_action_t *op = NULL;
 
@@ -745,7 +746,7 @@ pcmk__reschedule_recurring(pcmk_resource_t *rsc, const char *task,
 bool
 pcmk__action_is_recurring(const pcmk_action_t *action)
 {
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
 
     if (pcmk__guint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
                               &interval_ms) != pcmk_rc_ok) {

--- a/lib/pacemaker/pcmk_sched_remote.c
+++ b/lib/pacemaker/pcmk_sched_remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -728,15 +728,13 @@ pcmk__add_guest_meta_to_xml(xmlNode *args_xml, const pcmk_action_t *action)
     }
 
     if (host != NULL) {
-        gpointer target =
+        void *target =
             g_hash_table_lookup(action->rsc->priv->meta,
                                 PCMK_META_CONTAINER_ATTRIBUTE_TARGET);
 
-        hash2metafield((gpointer) PCMK_META_CONTAINER_ATTRIBUTE_TARGET,
-                       target,
-                       (gpointer) args_xml);
-        hash2metafield((gpointer) PCMK__META_PHYSICAL_HOST,
-                       (gpointer) host->priv->name,
-                       (gpointer) args_xml);
+        hash2metafield((void *) PCMK_META_CONTAINER_ATTRIBUTE_TARGET,
+                       target, (void *) args_xml);
+        hash2metafield((void *) PCMK__META_PHYSICAL_HOST,
+                       (void *) host->priv->name, (void *) args_xml);
     }
 }

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -676,9 +676,9 @@ get_node_score(const pcmk_node_t *node, GHashTable *nodes)
  *         or +1 if \p a should be assigned after \b
  */
 static int
-cmp_resources(gconstpointer a, gconstpointer b, void *data)
+cmp_resources(const void *a, const void *b, void *data)
 {
-    /* GLib insists that this function require gconstpointer arguments, but we
+    /* GLib insists that this function require const void * arguments, but we
      * make a small, temporary change to each argument (setting the
      * pe_rsc_merging flag) during comparison
      */

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -207,7 +207,7 @@ pcmk__rscs_matching_id(const char *id, const pcmk_scheduler_t *scheduler)
  * \param[in]     user_data  Ignored
  */
 static void
-set_assignment_methods_for_rsc(gpointer data, gpointer user_data)
+set_assignment_methods_for_rsc(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
 
@@ -265,7 +265,7 @@ pcmk__colocated_resources(const pcmk_resource_t *rsc,
 
     pcmk__rsc_trace(orig_rsc, "%s is in colocation chain with %s",
                     rsc->id, orig_rsc->id);
-    colocated_rscs = g_list_prepend(colocated_rscs, (gpointer) rsc);
+    colocated_rscs = g_list_prepend(colocated_rscs, (void *) rsc);
 
     // Follow colocations where this resource is the dependent resource
     colocations = pcmk__this_with_colocations(rsc);
@@ -676,7 +676,7 @@ get_node_score(const pcmk_node_t *node, GHashTable *nodes)
  *         or +1 if \p a should be assigned after \b
  */
 static int
-cmp_resources(gconstpointer a, gconstpointer b, gpointer data)
+cmp_resources(gconstpointer a, gconstpointer b, void *data)
 {
     /* GLib insists that this function require gconstpointer arguments, but we
      * make a small, temporary change to each argument (setting the

--- a/lib/pacemaker/pcmk_sched_resource.c
+++ b/lib/pacemaker/pcmk_sched_resource.c
@@ -675,7 +675,7 @@ get_node_score(const pcmk_node_t *node, GHashTable *nodes)
  * \return -1 if \p a should be assigned before \b, 0 if they are equal,
  *         or +1 if \p a should be assigned after \b
  */
-static gint
+static int
 cmp_resources(gconstpointer a, gconstpointer b, gpointer data)
 {
     /* GLib insists that this function require gconstpointer arguments, but we

--- a/lib/pacemaker/pcmk_sched_utilization.c
+++ b/lib/pacemaker/pcmk_sched_utilization.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 the Pacemaker project contributors
+ * Copyright 2014-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -67,7 +67,7 @@ struct compare_data {
  * \param[in,out] user_data  Comparison data (as struct compare_data*)
  */
 static void
-compare_utilization_value(gpointer key, gpointer value, gpointer user_data)
+compare_utilization_value(void *key, void *value, void *user_data)
 {
     int node1_capacity = 0;
     int node2_capacity = 0;
@@ -145,7 +145,7 @@ struct calculate_data {
  * \param[in,out] user_data  Calculation data (as struct calculate_data *)
  */
 static void
-update_utilization_value(gpointer key, gpointer value, gpointer user_data)
+update_utilization_value(void *key, void *value, void *user_data)
 {
     struct calculate_data *data = user_data;
     const char *current = g_hash_table_lookup(data->current_utilization, key);
@@ -221,7 +221,7 @@ struct capacity_data {
  * \param[in,out] user_data  Capacity data (as struct capacity_data *)
  */
 static void
-check_capacity(gpointer key, gpointer value, gpointer user_data)
+check_capacity(void *key, void *value, void *user_data)
 {
     int required = 0;
     int remaining = 0;

--- a/lib/pacemaker/pcmk_scheduler.c
+++ b/lib/pacemaker/pcmk_scheduler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -107,7 +107,7 @@ failcount_clear_action_exists(const pcmk_node_t *node,
  * \param[in]     user_data  Node to check resource on
  */
 static void
-check_failure_threshold(gpointer data, gpointer user_data)
+check_failure_threshold(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
     const pcmk_node_t *node = user_data;
@@ -153,7 +153,7 @@ check_failure_threshold(gpointer data, gpointer user_data)
  * \param[in]     user_data  Node to check resource on
  */
 static void
-apply_exclusive_discovery(gpointer data, gpointer user_data)
+apply_exclusive_discovery(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
     const pcmk_node_t *node = user_data;
@@ -187,7 +187,7 @@ apply_exclusive_discovery(gpointer data, gpointer user_data)
  * \param[in]     user_data  Ignored
  */
 static void
-apply_stickiness(gpointer data, gpointer user_data)
+apply_stickiness(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
     pcmk_node_t *node = NULL;
@@ -340,7 +340,7 @@ assign_resources(pcmk_scheduler_t *scheduler)
  * \param[in]     user_data  Ignored
  */
 static void
-clear_failcounts_if_removed(gpointer data, gpointer user_data)
+clear_failcounts_if_removed(void *data, void *user_data)
 {
     pcmk_resource_t *rsc = data;
 
@@ -658,7 +658,7 @@ log_resource_details(pcmk_scheduler_t *scheduler)
      * resource-related messages expects a list of nodes that we are allowed to
      * output information for. Here, we create a wildcard to match all nodes.
      */
-    all = g_list_prepend(all, (gpointer) "*");
+    all = g_list_prepend(all, (void *) "*");
 
     for (GList *item = scheduler->priv->resources;
          item != NULL; item = item->next) {

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -72,8 +72,8 @@ create_action_name(const pcmk_action_t *action, bool verbose)
         char *key = NULL;
         unsigned int interval_ms = 0;
 
-        if (pcmk__guint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
-                                  &interval_ms) != pcmk_rc_ok) {
+        if (pcmk__uint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
+                                 &interval_ms) != pcmk_rc_ok) {
             interval_ms = 0;
         }
 

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -70,7 +70,7 @@ create_action_name(const pcmk_action_t *action, bool verbose)
 
     if (history_id != NULL) {
         char *key = NULL;
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
 
         if (pcmk__guint_from_hash(action->meta, PCMK_META_INTERVAL, 0,
                                   &interval_ms) != pcmk_rc_ok) {
@@ -618,8 +618,7 @@ simulate_resource_action(pcmk__graph_t *graph, pcmk__graph_action_t *action)
     // Certain actions need to be displayed but don't need history entries
     if (pcmk__strcase_any_of(operation, PCMK_ACTION_DELETE,
                              PCMK_ACTION_META_DATA, NULL)) {
-        out->message(out, "inject-rsc-action", resource, operation, node,
-                     (guint) 0);
+        out->message(out, "inject-rsc-action", resource, operation, node, 0);
         goto done; // Confirm action and update graph
     }
 

--- a/lib/pacemaker/pcmk_simulate.c
+++ b/lib/pacemaker/pcmk_simulate.c
@@ -152,7 +152,7 @@ print_cluster_status(pcmk_scheduler_t *scheduler, uint32_t show_opts,
     section_opts |= pcmk_section_nodes | pcmk_section_resources;
     show_opts |= pcmk_show_inactive_rscs | pcmk_show_failed_detail;
 
-    all = g_list_prepend(all, (gpointer) "*");
+    all = g_list_prepend(all, (void *) "*");
 
     PCMK__OUTPUT_SPACER_IF(out, print_spacer);
     out->begin_list(out, NULL, NULL, "%s", title);

--- a/lib/pacemaker/pcmk_status.c
+++ b/lib/pacemaker/pcmk_status.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,17 +9,29 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
-#include <stdint.h>
+#include <errno.h>                      // EINVAL, ENOTCONN
+#include <stdbool.h>                    // false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdlib.h>                     // free
+#include <time.h>                       // time, time_t
 
-#include <crm/cib/internal.h>
-#include <crm/common/output.h>
-#include <crm/common/results.h>
-#include <crm/fencing/internal.h>
-#include <crm/pengine/internal.h>
-#include <crm/stonith-ng.h>         // stonith_t
-#include <pacemaker.h>
-#include <pacemaker-internal.h>
+#include <glib.h>                       // g_list_free_full, GList
+#include <libxml/tree.h>                // xmlNode
+
+#include <crm/cib.h>                    // cib_*
+#include <crm/cib/internal.h>           // cib__*
+#include <crm/common/ipc_pacemakerd.h>  // pcmk_pacemakerd_state
+#include <crm/common/output.h>          // pcmk_section_*, pcmk_show_*
+#include <crm/common/results.h>         // pcmk_rc_*, pcmk_rc2exitc
+#include <crm/common/scheduler.h>       // pcmk_new_scheduler, pcmk_scheduler_t
+#include <crm/crm.h>                    // crm_system_name
+#include <crm/fencing/internal.h>       // stonith__*
+#include <crm/pengine/internal.h>       // pe__*
+#include <crm/pengine/status.h>         // cluster_status
+#include <crm/stonith-ng.h>             // stonith_history_t, stonith_t
+#include <pacemaker.h>                  // pcmk__status
+#include <pacemaker-internal.h>         // pcmk__fence_history, etc.
 
 static stonith_t *
 fencing_connect(void)
@@ -134,7 +146,7 @@ pcmk__output_cluster_status(pcmk_scheduler_t *scheduler, stonith_t *stonith,
 }
 
 int
-pcmk_status(xmlNodePtr *xml)
+pcmk_status(xmlNode **xml)
 {
     cib_t *cib = NULL;
     pcmk__output_t *out = NULL;

--- a/lib/pacemaker/pcmk_ticket.c
+++ b/lib/pacemaker/pcmk_ticket.c
@@ -72,7 +72,8 @@ add_attribute_xml(pcmk_scheduler_t *scheduler, const char *ticket_id,
     ticket = g_hash_table_lookup(scheduler->priv->ticket_constraints,
                                  ticket_id);
     g_hash_table_iter_init(&hash_iter, attr_set);
-    while (g_hash_table_iter_next(&hash_iter, (gpointer *) & key, (gpointer *) & value)) {
+    while (g_hash_table_iter_next(&hash_iter, (void **) &key,
+                                  (void **) &value)) {
         pcmk__xe_set(*ticket_state_xml, key, value);
 
         if (pcmk__str_eq(key, PCMK__XA_GRANTED, pcmk__str_none)

--- a/lib/pacemaker/pcmk_ticket.c
+++ b/lib/pacemaker/pcmk_ticket.c
@@ -16,7 +16,7 @@
 #include <string.h>                     // strdup
 #include <time.h>                       // time_t
 
-#include <glib.h>                       // g_str_has_suffix, GHashTable, guint
+#include <glib.h>                       // g_str_has_suffix, GHashTable
 #include <libxml/tree.h>                // xmlNode
 
 #include <crm/cib.h>                    // cib_*

--- a/lib/pacemaker/pcmk_ticket.c
+++ b/lib/pacemaker/pcmk_ticket.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 the Pacemaker project contributors
+ * Copyright 2024-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,15 +9,27 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
+#include <errno.h>                      // EACCES, EINVAL, ENXIO
+#include <stdbool.h>                    // bool, false
+#include <stddef.h>                     // NULL
+#include <stdlib.h>                     // free
+#include <string.h>                     // strdup
+#include <time.h>                       // time_t
 
-#include <crm/cib/internal.h>
-#include <crm/pengine/internal.h>
+#include <glib.h>                       // g_str_has_suffix, GHashTable, guint
+#include <libxml/tree.h>                // xmlNode
 
-#include <pacemaker.h>
-#include <pacemaker-internal.h>
+#include <crm/cib.h>                    // cib_*
+#include <crm/cib/internal.h>           // cib__clean_up_connection
+#include <crm/common/cib.h>             // pcmk_cib_xpath_for
+#include <crm/common/results.h>         // pcmk_legacy2rc, pcmk_rc_*, etc.
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/internal.h>       // pe__register_messages
+#include <pacemaker.h>                  // pcmk_ticket_*
+#include <pacemaker-internal.h>         // pcmk__ticket_*, etc.
 
-#include "libpacemaker_private.h"
+#include "libpacemaker_private.h"       // pcmk__setup_output_cib_sched
 
 static int
 build_ticket_modify_xml(cib_t *cib, const char *ticket_id, xmlNode **ticket_state_xml,
@@ -150,7 +162,7 @@ pcmk__ticket_constraints(pcmk__output_t *out, cib_t *cib, const char *ticket_id)
 }
 
 int
-pcmk_ticket_constraints(xmlNodePtr *xml, const char *ticket_id)
+pcmk_ticket_constraints(xmlNode **xml, const char *ticket_id)
 {
     pcmk__output_t *out = NULL;
     int rc = pcmk_rc_ok;
@@ -241,7 +253,7 @@ pcmk__ticket_delete(pcmk__output_t *out, cib_t *cib, pcmk_scheduler_t *scheduler
 }
 
 int
-pcmk_ticket_delete(xmlNodePtr *xml, const char *ticket_id, bool force)
+pcmk_ticket_delete(xmlNode **xml, const char *ticket_id, bool force)
 {
     pcmk_scheduler_t *scheduler = NULL;
     pcmk__output_t *out = NULL;
@@ -299,7 +311,7 @@ pcmk__ticket_get_attr(pcmk__output_t *out, pcmk_scheduler_t *scheduler,
 }
 
 int
-pcmk_ticket_get_attr(xmlNodePtr *xml, const char *ticket_id,
+pcmk_ticket_get_attr(xmlNode **xml, const char *ticket_id,
                      const char *attr_name, const char *attr_default)
 {
     pcmk_scheduler_t *scheduler = NULL;
@@ -354,7 +366,7 @@ pcmk__ticket_info(pcmk__output_t *out, pcmk_scheduler_t *scheduler,
 }
 
 int
-pcmk_ticket_info(xmlNodePtr *xml, const char *ticket_id)
+pcmk_ticket_info(xmlNode **xml, const char *ticket_id)
 {
     pcmk_scheduler_t *scheduler = NULL;
     pcmk__output_t *out = NULL;
@@ -427,7 +439,8 @@ pcmk__ticket_remove_attr(pcmk__output_t *out, cib_t *cib, pcmk_scheduler_t *sche
 }
 
 int
-pcmk_ticket_remove_attr(xmlNodePtr *xml, const char *ticket_id, GList *attr_delete, bool force)
+pcmk_ticket_remove_attr(xmlNode **xml, const char *ticket_id,
+                       GList *attr_delete, bool force)
 {
     pcmk_scheduler_t *scheduler = NULL;
     pcmk__output_t *out = NULL;
@@ -495,7 +508,7 @@ pcmk__ticket_set_attr(pcmk__output_t *out, cib_t *cib, pcmk_scheduler_t *schedul
 }
 
 int
-pcmk_ticket_set_attr(xmlNodePtr *xml, const char *ticket_id, GHashTable *attr_set,
+pcmk_ticket_set_attr(xmlNode **xml, const char *ticket_id, GHashTable *attr_set,
                      bool force)
 {
     pcmk_scheduler_t *scheduler = NULL;
@@ -544,7 +557,7 @@ pcmk__ticket_state(pcmk__output_t *out, cib_t *cib, const char *ticket_id)
 }
 
 int
-pcmk_ticket_state(xmlNodePtr *xml, const char *ticket_id)
+pcmk_ticket_state(xmlNode **xml, const char *ticket_id)
 {
     pcmk__output_t *out = NULL;
     int rc = pcmk_rc_ok;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -635,14 +635,13 @@ done:
 static void
 disallow_node(pcmk_resource_t *rsc, const char *uname)
 {
-    gpointer match = g_hash_table_lookup(rsc->priv->allowed_nodes, uname);
+    void *match = g_hash_table_lookup(rsc->priv->allowed_nodes, uname);
 
     if (match) {
         ((pcmk_node_t *) match)->assign->score = -PCMK_SCORE_INFINITY;
         ((pcmk_node_t *) match)->assign->probe_mode = pcmk__probe_never;
     }
-    g_list_foreach(rsc->priv->children, (GFunc) disallow_node,
-                   (gpointer) uname);
+    g_list_foreach(rsc->priv->children, (GFunc) disallow_node, (void *) uname);
 }
 
 static int
@@ -2092,8 +2091,8 @@ pe__bundle_active_node(const pcmk_resource_t *rsc, unsigned int *count_all,
             node = node_iter->data;
 
             // If insert returns true, we haven't counted this node yet
-            if (g_hash_table_insert(nodes, (gpointer) node->details,
-                                    (gpointer) node)
+            if (g_hash_table_insert(nodes, (void *) node->details,
+                                    (void *) node)
                 && !pe__count_active_node(rsc, node, &active, count_all,
                                           count_clean)) {
                 goto done;

--- a/lib/pengine/bundle.c
+++ b/lib/pengine/bundle.c
@@ -9,15 +9,36 @@
 
 #include <crm_internal.h>
 
-#include <ctype.h>
+#include <stdarg.h>                     // va_arg, va_list
 #include <stdbool.h>                    // bool, true, false
-#include <stdint.h>
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdio.h>                      // sscanf
+#include <stdlib.h>                     // free
+#include <string.h>                     // strcmp, strdup, strlen
 
-#include <crm/pengine/status.h>
-#include <crm/pengine/internal.h>
-#include <crm/common/xml.h>
-#include <crm/common/output.h>
-#include <pe_status_private.h>
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+#include <qb/qblog.h>                   // LOG_TRACE
+
+#include <crm/common/actions.h>         // crm_create_op_xml, PCMK_ACTION_*
+#include <crm/common/agents.h>          // PCMK_RESOURCE_CLASS_OCF
+#include <crm/common/logging.h>         // CRM_CHECK, CRM_LOG_ASSERT
+#include <crm/common/nvpair.h>          // crm_create_nvpair_xml
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*
+#include <crm/common/output.h>          // pcmk_show_implicit_rscs
+#include <crm/common/results.h>         // pcmk_rc_*
+#include <crm/common/roles.h>           // pcmk_role_unknown, rsc_role_e
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/crm.h>                    // CRM_ATTR_KIND
+#include <crm/lrmd.h>                   // DEFAULT_REMOTE_*
+#include <crm/pengine/complex.h>        // pe_rsc_params
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/pengine/status.h>         // pe_bundle_replicas, etc.
+
+#include "pe_status_private.h"          // pe__bundle_*, pe__unpack_resource
 
 enum pe__bundle_mount_flags {
     pe__bundle_mount_none       = 0x00,

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -132,7 +132,8 @@ sorted_hash_table_values(GHashTable *table)
 {
     GList *retval = NULL;
     GHashTableIter iter;
-    gpointer key, value;
+    void *key = NULL;
+    void *value = NULL;
 
     g_hash_table_iter_init(&iter, table);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
@@ -150,7 +151,8 @@ nodes_with_status(GHashTable *table, const char *status)
 {
     GList *retval = NULL;
     GHashTableIter iter;
-    gpointer key, value;
+    void *key = NULL;
+    void *value = NULL;
 
     g_hash_table_iter_init(&iter, table);
     while (g_hash_table_iter_next(&iter, &key, &value)) {
@@ -571,7 +573,7 @@ pe__clone_xml(pcmk__output_t *out, va_list args)
                            && pcmk__str_in_list(rsc->id, only_rsc,
                                                 pcmk__str_star_matches));
 
-    all = g_list_prepend(all, (gpointer) "*");
+    all = g_list_prepend(all, (void *) "*");
 
     for (GList *gIter = rsc->priv->children;
          gIter != NULL; gIter = gIter->next) {
@@ -762,7 +764,7 @@ pe__clone_default(pcmk__output_t *out, va_list args)
             clone_header(out, &rc, rsc, clone_data, desc);
 
             /* Print every resource that's a child of this clone. */
-            all = g_list_prepend(all, (gpointer) "*");
+            all = g_list_prepend(all, (void *) "*");
             out->message(out, (const char *) child_rsc->priv->xml->name,
                          show_opts, child_rsc, only_node, all);
             g_list_free(all);

--- a/lib/pengine/clone.c
+++ b/lib/pengine/clone.c
@@ -9,14 +9,31 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>                        // bool, true, false
-#include <stdint.h>
+#include <stdarg.h>                     // va_arg, va_list
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdlib.h>                     // free
+#include <string.h>                     // strcmp, strchr
 
-#include <crm/pengine/status.h>
-#include <crm/pengine/internal.h>
-#include <pe_status_private.h>
-#include <crm/common/xml.h>
-#include <crm/common/output.h>
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+#include <qb/qbdefs.h>                  // QB_MAX, QB_MIN
+#include <qb/qblog.h>                   // LOG_TRACE
+
+#include <crm/common/actions.h>         // PCMK_ACTION_*
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/options.h>         // PCMK_META_*
+#include <crm/common/output.h>          // pcmk_show_*
+#include <crm/common/results.h>         // crm_exit_str, pcmk_rc_*
+#include <crm/common/roles.h>           // pcmk_role_*, PCMK_ROLE_*, etc.
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/pengine/status.h>         // rsc_printable_id
+
+#include "pe_status_private.h"          // pe__action_notif_pseudo_ops, etc.
 
 typedef struct {
     int clone_max;

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -122,7 +122,7 @@ get_resource_type(const char *name)
  *       values.
  */
 static void
-dup_attr(gpointer key, gpointer value, gpointer user_data)
+dup_attr(void *key, void *value, void *user_data)
 {
     GHashTable *table = user_data;
 

--- a/lib/pengine/complex.c
+++ b/lib/pengine/complex.c
@@ -9,14 +9,30 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
+#include <errno.h>                      // EINVAL, ENOMEM
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdlib.h>                     // calloc, free
+#include <string.h>                     // strdup
 
-#include <libxml/tree.h>                    // xmlNode
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+#include <qb/qblog.h>                   // LOG_TRACE
 
-#include <crm/pengine/internal.h>
-#include <crm/common/xml.h>
+#include <crm/common/agents.h>          // PCMK_RESOURCE_CLASS_STONITH
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*, etc.
+#include <crm/common/results.h>         // pcmk_rc_*
+#include <crm/common/roles.h>           // pcmk_role_*, PCMK_ROLE_*, etc.
+#include <crm/common/rules.h>           // pcmk_rule_input_t
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // pcmk_parse_score, PCMK_SCORE_INFINITY
+#include <crm/common/strings.h>         // pcmk_parse_interval_spec
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/complex.h>        // pe_rsc_params, etc.
+#include <crm/pengine/internal.h>       // clone_*, native_*, pe__*, etc.
 
-#include "pe_status_private.h"
+#include "pe_status_private.h"          // pe__{bundle,group}_*, etc.
 
 void populate_hash(xmlNode * nvpair_list, GHashTable * hash, const char **attrs, int attrs_length);
 

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -40,8 +40,8 @@ is_matched_failure(const char *rsc_id, const xmlNode *conf_op_xml,
     const char *conf_op_name = NULL;
     const char *lrm_op_task = NULL;
     const char *conf_op_interval_spec = NULL;
-    guint conf_op_interval_ms = 0;
-    guint lrm_op_interval_ms = 0;
+    unsigned int conf_op_interval_ms = 0;
+    unsigned int lrm_op_interval_ms = 0;
     const char *lrm_op_id = NULL;
     char *last_failure_key = NULL;
 
@@ -133,7 +133,7 @@ block_failure(const pcmk_node_t *node, pcmk_resource_t *rsc,
             } else {
                 const char *conf_op_name = NULL;
                 const char *conf_op_interval_spec = NULL;
-                guint conf_op_interval_ms = 0;
+                unsigned int conf_op_interval_ms = 0;
                 pcmk_scheduler_t *scheduler = rsc->priv->scheduler;
                 char *lrm_op_xpath = NULL;
                 xmlXPathObject *lrm_op_xpathObj = NULL;
@@ -419,7 +419,8 @@ pe_get_failcount(const pcmk_node_t *node, pcmk_resource_t *rsc,
         && (rsc->priv->failure_expiration_ms > 0)) {
 
         time_t now = pcmk__scheduler_epoch_time(rsc->priv->scheduler);
-        const guint expiration = pcmk__timeout_ms2s(rsc->priv->failure_expiration_ms);
+        const unsigned int expiration =
+            pcmk__timeout_ms2s(rsc->priv->failure_expiration_ms);
 
         if (now > (fc_data.last_failure + expiration)) {
             pcmk__rsc_debug(rsc, "Failcount for %s on %s expired after %s",

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2025 the Pacemaker project contributors
+ * Copyright 2008-2026 the Pacemaker project contributors
  *
  * This source code is licensed under the GNU Lesser General Public License
  * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
@@ -7,17 +7,30 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
-#include <sys/types.h>
-#include <regex.h>
+#include <errno.h>                      // EINVAL
+#include <regex.h>                      // regex_t, REG_*, etc.
+#include <stdbool.h>                    // bool
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdlib.h>                     // free
+#include <string.h>                    // strdup
+#include <time.h>                       // time_t
 
-#include <glib.h>
-#include <libxml/xpath.h>           // xmlXPathObject, etc.
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+#include <libxml/xpath.h>               // xmlXPathObject, xmlXPathFreeObject
+#include <qb/qbdefs.h>                  // QB_MAX
+#include <qb/qblog.h>                   // QB_XS
 
-#include <crm/crm.h>
-#include <crm/common/xml.h>
-#include <crm/common/util.h>
-#include <crm/pengine/internal.h>
+#include <crm/common/actions.h>         // PCMK_ACTION_CLEAR_FAILCOUNT
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*
+#include <crm/common/results.h>         // pcmk_rc_*
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // pcmk_parse_score, pcmk_readable_score
+#include <crm/common/strings.h>         // pcmk_parse_interval_spec
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/internal.h>       // pe__*, etc.
 
 static gboolean
 is_matched_failure(const char *rsc_id, const xmlNode *conf_op_xml,

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -301,7 +301,7 @@ struct failcount_data {
  * \param[in] user_data  Fail count data to update
  */
 static void
-update_failcount_for_attr(gpointer key, gpointer value, gpointer user_data)
+update_failcount_for_attr(void *key, void *value, void *user_data)
 {
     struct failcount_data *fc_data = user_data;
 
@@ -349,7 +349,7 @@ update_failcount_for_attr(gpointer key, gpointer value, gpointer user_data)
  * \param[in] user_data  Fail count data to update
  */
 static void
-update_launched_failcount(gpointer data, gpointer user_data)
+update_launched_failcount(void *data, void *user_data)
 {
     pcmk_resource_t *launched = data;
     struct failcount_data *fc_data = user_data;

--- a/lib/pengine/failcounts.c
+++ b/lib/pengine/failcounts.c
@@ -56,7 +56,7 @@ is_matched_failure(const char *rsc_id, const xmlNode *conf_op_xml,
 
     // Get name and interval from op history entry
     lrm_op_task = pcmk__xe_get(lrm_op_xml, PCMK_XA_OPERATION);
-    pcmk__xe_get_guint(lrm_op_xml, PCMK_META_INTERVAL, &lrm_op_interval_ms);
+    pcmk__xe_get_uint(lrm_op_xml, PCMK_META_INTERVAL, &lrm_op_interval_ms);
 
     if ((conf_op_interval_ms != lrm_op_interval_ms)
         || !pcmk__str_eq(conf_op_name, lrm_op_task, pcmk__str_casei)) {

--- a/lib/pengine/group.c
+++ b/lib/pengine/group.c
@@ -9,14 +9,27 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>                        // bool, true, false
-#include <stdint.h>
+#include <stdarg.h>                     // va_arg, va_list
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdlib.h>                     // free
+#include <string.h>                     // strchr
 
-#include <crm/pengine/status.h>
-#include <crm/pengine/internal.h>
-#include <crm/common/xml.h>
-#include <crm/common/output.h>
-#include <pe_status_private.h>
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/options.h>         // PCMK_META_ORDERED
+#include <crm/common/output.h>          // pcmk_show_*
+#include <crm/common/results.h>         // pcmk_rc_*
+#include <crm/common/roles.h>           // pcmk_role_*, rsc_role_e
+#include <crm/common/scheduler.h>       // pcmk_resource_t
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/pengine/status.h>         // rsc_printable_id
+
+#include "pe_status_private.h"          // pe__group_max_per_node, etc.
 
 typedef struct {
     pcmk_resource_t *last_child;    // Last group member

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -213,7 +213,7 @@ native_add_running(pcmk_resource_t *rsc, pcmk_node_t *node,
 }
 
 static void
-recursive_clear_unique(pcmk_resource_t *rsc, gpointer user_data)
+recursive_clear_unique(pcmk_resource_t *rsc, void *user_data)
 {
     pcmk__clear_rsc_flags(rsc, pcmk__rsc_unique);
     pcmk__insert_meta(rsc->priv, PCMK_META_GLOBALLY_UNIQUE,
@@ -943,7 +943,7 @@ native_location(const pcmk_resource_t *rsc, GList **list, uint32_t target)
         if (pcmk__is_set(target, pcmk__rsc_node_pending)
             && (rsc->priv->pending_node != NULL)
             && !pe_find_node_id(result, rsc->priv->pending_node->priv->id)) {
-            result = g_list_append(result, (gpointer) rsc->priv->pending_node);
+            result = g_list_append(result, (void *) rsc->priv->pending_node);
         }
         if (pcmk__is_set(target, pcmk__rsc_node_assigned)
             && (rsc->priv->assigned_node != NULL)) {
@@ -1052,7 +1052,7 @@ get_rscs_brief(GList *rsc_list, GHashTable * rsc_table, GHashTable * active_tabl
 }
 
 static void
-destroy_node_table(gpointer data)
+destroy_node_table(void *data)
 {
     g_clear_pointer(&data, g_hash_table_destroy);
 }

--- a/lib/pengine/native.c
+++ b/lib/pengine/native.c
@@ -9,15 +9,33 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>                // bool, true, false
-#include <stdint.h>                 // uint32_t
+#include <stdarg.h>                     // va_arg, va_list
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t
+#include <stdio.h>                      // sscanf
+#include <stdlib.h>                     // free
+#include <string.h>                     // strcmp, strdup, strlen
 
-#include <crm/common/output.h>
-#include <crm/pengine/status.h>
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+
+#include <crm/common/actions.h>         // PCMK_ACTION_*
+#include <crm/common/agents.h>          // pcmk_get_ra_caps, pcmk_ra_caps
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*
+#include <crm/common/output.h>          // pcmk_show_*
+#include <crm/common/resources.h>       // pcmk_rsc_match_*
+#include <crm/common/results.h>         // crm_exit_str, pcmk_rc_*
+#include <crm/common/roles.h>           // pcmk_role_*, rsc_role_e, etc.
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
 #include <crm/pengine/complex.h>
 #include <crm/pengine/internal.h>
-#include <crm/common/xml.h>
-#include <pe_status_private.h>
+#include <crm/pengine/status.h>
+
+#include "pe_status_private.h"          // pe__force_anon, etc.
 
 /*!
  * \internal

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -9,13 +9,34 @@
 
 #include <crm_internal.h>
 
-#include <glib.h>
-#include <stdbool.h>
+#include <limits.h>                     // INT_MAX, UINT_MAX
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdlib.h>                     // free
+#include <string.h>                     // strdup, strstr
+#include <syslog.h>                     // LOG_WARNING
+#include <time.h>                       // time_t
 
-#include <crm/crm.h>
-#include <crm/common/xml.h>
-#include <crm/pengine/internal.h>
-#include "pe_status_private.h"
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode, xmlAttrPtr
+#include <qb/qbdefs.h>                  // QB_MAX, QB_MIN
+
+#include <crm/common/actions.h>         // PCMK_ACTION_*, etc.
+#include <crm/common/agents.h>          // pcmk_get_ra_caps, pcmk_ra_caps, etc.
+#include <crm/common/iso8601.h>         // crm_time_*
+#include <crm/common/logging.h>         // CRM_CHECK, CRM_LOG_ASSERT, do_crm_log
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*, etc.
+#include <crm/common/probes.h>          // pcmk_is_probe
+#include <crm/common/results.h>         // pcmk_rc_ok
+#include <crm/common/roles.h>           // pcmk_role_*, PCMK_ROLE_*, etc.
+#include <crm/common/rules.h>           // pcmk_rule_input_t
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/strings.h>         // pcmk_parse_interval_spec
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/complex.h>        // pe_rsc_params
+#include <crm/pengine/internal.h>       // pe__*, etc.
+
+#include "pe_status_private.h"          // pe__compare_fencing_digest
 
 static void unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
                              guint interval_ms);

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -623,7 +623,7 @@ unpack_start_delay(const char *value, GHashTable *meta)
 static xmlNode *
 most_frequent_monitor(const pcmk_resource_t *rsc)
 {
-    guint min_interval_ms = G_MAXUINT;
+    guint min_interval_ms = UINT_MAX;
     xmlNode *op = NULL;
 
     for (xmlNode *operation = pcmk__xe_first_child(rsc->priv->ops_xml,

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -39,7 +39,7 @@
 #include "pe_status_private.h"          // pe__compare_fencing_digest
 
 static void unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
-                             guint interval_ms);
+                             unsigned int interval_ms);
 
 static void
 add_singleton(pcmk_scheduler_t *scheduler, pcmk_action_t *action)
@@ -109,7 +109,7 @@ find_existing_action(const char *key, const pcmk_resource_t *rsc,
  */
 static xmlNode *
 find_exact_action_config(const pcmk_resource_t *rsc, const char *action_name,
-                         guint interval_ms, bool include_disabled)
+                         unsigned int interval_ms, bool include_disabled)
 {
     for (xmlNode *operation = pcmk__xe_first_child(rsc->priv->ops_xml,
                                                    PCMK_XE_OP, NULL, NULL);
@@ -118,7 +118,7 @@ find_exact_action_config(const pcmk_resource_t *rsc, const char *action_name,
         bool enabled = false;
         const char *config_name = NULL;
         const char *interval_spec = NULL;
-        guint tmp_ms = 0U;
+        unsigned int tmp_ms = 0;
 
         // @TODO This does not consider meta-attributes, rules, defaults, etc.
         if (!include_disabled
@@ -155,7 +155,7 @@ find_exact_action_config(const pcmk_resource_t *rsc, const char *action_name,
  */
 xmlNode *
 pcmk__find_action_config(const pcmk_resource_t *rsc, const char *action_name,
-                         guint interval_ms, bool include_disabled)
+                         unsigned int interval_ms, bool include_disabled)
 {
     xmlNode *action_config = NULL;
 
@@ -220,7 +220,7 @@ new_action(char *key, const char *task, pcmk_resource_t *rsc,
     if (rsc == NULL) {
         action->meta = pcmk__strkey_table(free, free);
     } else {
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
 
         parse_op_key(key, NULL, NULL, &interval_ms);
         action->op_entry = pcmk__find_action_config(rsc, task, interval_ms,
@@ -452,7 +452,7 @@ validate_on_fail(const pcmk_resource_t *rsc, const char *action_name,
     const char *role = NULL;
     const char *interval_spec = NULL;
     const char *value = g_hash_table_lookup(meta, PCMK_META_ON_FAIL);
-    guint interval_ms = 0U;
+    unsigned int interval_ms = 0;
 
     // Stop actions can only use certain on-fail values
     if (pcmk__str_eq(action_name, PCMK_ACTION_STOP, pcmk__str_none)
@@ -571,11 +571,11 @@ unpack_timeout(const char *value)
 // true if value contains valid, non-NULL interval origin for recurring op
 static bool
 unpack_interval_origin(const char *value, const xmlNode *xml_obj,
-                       guint interval_ms, const crm_time_t *now,
+                       unsigned int interval_ms, const crm_time_t *now,
                        long long *start_delay)
 {
     long long result = 0;
-    guint interval_sec = pcmk__timeout_ms2s(interval_ms);
+    unsigned int interval_sec = pcmk__timeout_ms2s(interval_ms);
     crm_time_t *origin = NULL;
 
     // Ignore unspecified values and non-recurring operations
@@ -644,7 +644,7 @@ unpack_start_delay(const char *value, GHashTable *meta)
 static xmlNode *
 most_frequent_monitor(const pcmk_resource_t *rsc)
 {
-    guint min_interval_ms = UINT_MAX;
+    unsigned int min_interval_ms = UINT_MAX;
     xmlNode *op = NULL;
 
     for (xmlNode *operation = pcmk__xe_first_child(rsc->priv->ops_xml,
@@ -652,7 +652,7 @@ most_frequent_monitor(const pcmk_resource_t *rsc)
          operation != NULL; operation = pcmk__xe_next(operation, PCMK_XE_OP)) {
 
         bool enabled = false;
-        guint interval_ms = 0U;
+        unsigned int interval_ms = 0;
         const char *interval_spec = pcmk__xe_get(operation, PCMK_META_INTERVAL);
 
         // We only care about enabled recurring monitors
@@ -699,7 +699,7 @@ most_frequent_monitor(const pcmk_resource_t *rsc)
  */
 GHashTable *
 pcmk__unpack_action_meta(pcmk_resource_t *rsc, const pcmk_node_t *node,
-                         const char *action_name, guint interval_ms,
+                         const char *action_name, unsigned int interval_ms,
                          const xmlNode *action_config)
 {
     GHashTable *meta = NULL;
@@ -877,7 +877,7 @@ pcmk__action_requires(const pcmk_resource_t *rsc, const char *action_name)
  */
 enum pcmk__on_fail
 pcmk__parse_on_fail(const pcmk_resource_t *rsc, const char *action_name,
-                    guint interval_ms, const char *value)
+                    unsigned int interval_ms, const char *value)
 {
     const char *desc = NULL;
     bool needs_remote_reset = false;
@@ -1070,7 +1070,7 @@ pcmk__role_after_failure(const pcmk_resource_t *rsc, const char *action_name,
  */
 static void
 unpack_operation(pcmk_action_t *action, const xmlNode *xml_obj,
-                 guint interval_ms)
+                 unsigned int interval_ms)
 {
     const char *value = NULL;
 

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1721,7 +1721,7 @@ pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b)
 }
 
 int
-sort_op_by_callid(gconstpointer a, gconstpointer b)
+sort_op_by_callid(const void *a, const void *b)
 {
     return pe__is_newer_op((const xmlNode *) a, (const xmlNode *) b);
 }

--- a/lib/pengine/pe_actions.c
+++ b/lib/pengine/pe_actions.c
@@ -1699,7 +1699,7 @@ pe__is_newer_op(const xmlNode *xml_a, const xmlNode *xml_b)
     CRM_CHECK(FALSE, sort_return(0, "default"));
 }
 
-gint
+int
 sort_op_by_callid(gconstpointer a, gconstpointer b)
 {
     return pe__is_newer_op((const xmlNode *) a, (const xmlNode *) b);

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -102,7 +102,7 @@ calculate_main_digest(pcmk__op_digest_t *data, pcmk_resource_t *rsc,
             long long value_ll;
 
             if ((pcmk__scan_ll(interval_s, &value_ll, 0LL) == pcmk_rc_ok)
-                && (value_ll >= 0) && (value_ll <= G_MAXUINT)) {
+                && (value_ll >= 0) && (value_ll <= UINT_MAX)) {
                 *interval_ms = (guint) value_ll;
             }
         }

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -412,7 +412,7 @@ rsc_action_digest_cmp(pcmk_resource_t *rsc, const xmlNode *xml_op,
     digest_all = pcmk__xe_get(xml_op, PCMK__XA_OP_DIGEST);
     digest_restart = pcmk__xe_get(xml_op, PCMK__XA_OP_RESTART_DIGEST);
 
-    pcmk__xe_get_guint(xml_op, PCMK_META_INTERVAL, &interval_ms);
+    pcmk__xe_get_uint(xml_op, PCMK_META_INTERVAL, &interval_ms);
     data = rsc_action_digest(rsc, task, interval_ms, node, xml_op,
                              pcmk__is_set(scheduler->flags,
                                           pcmk__sched_sanitized),

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -9,12 +9,26 @@
 
 #include <crm_internal.h>
 
-#include <glib.h>
-#include <stdbool.h>
+#include <limits.h>                     // UINT_MAX
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdio.h>                      // printf
+#include <stdlib.h>                     // calloc, free
+#include <string.h>                     // strcmp, strdup, strstr
 
-#include <crm/crm.h>
+#include <glib.h>                       // g_*, etc.
+
+#include <crm/common/agents.h>          // pcmk_get_ra_caps, pcmk_ra_caps, etc.
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/nvpair.h>          // hash2field, hash2metafield
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_REMOTE_RA_ADDR
+#include <crm/common/results.h>         // pcmk_rc_ok
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
 #include <crm/common/xml.h>
-#include <crm/pengine/internal.h>
+#include <crm/crm.h>                    // CRM_ATTR_*, CRM_FEATURE_SET, CRM_META
+#include <crm/pengine/complex.h>        // pe_rsc_params
+#include <crm/pengine/internal.h>       // pe__*, etc.
+
 #include "pe_status_private.h"
 
 /*!

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -93,7 +93,7 @@ attr_not_in_strv(xmlAttrPtr a, void *user_data)
 static void
 calculate_main_digest(pcmk__op_digest_t *data, pcmk_resource_t *rsc,
                       const pcmk_node_t *node, GHashTable *params,
-                      const char *task, guint *interval_ms,
+                      const char *task, unsigned int *interval_ms,
                       const xmlNode *xml_op, const char *op_version,
                       GHashTable *overrides, pcmk_scheduler_t *scheduler)
 {
@@ -117,7 +117,7 @@ calculate_main_digest(pcmk__op_digest_t *data, pcmk_resource_t *rsc,
 
             if ((pcmk__scan_ll(interval_s, &value_ll, 0LL) == pcmk_rc_ok)
                 && (value_ll >= 0) && (value_ll <= UINT_MAX)) {
-                *interval_ms = (guint) value_ll;
+                *interval_ms = (unsigned int) value_ll;
             }
         }
 
@@ -307,7 +307,7 @@ calculate_restart_digest(pcmk__op_digest_t *data, const xmlNode *xml_op,
  */
 pcmk__op_digest_t *
 pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
-                      guint *interval_ms, const pcmk_node_t *node,
+                      unsigned int *interval_ms, const pcmk_node_t *node,
                       const xmlNode *xml_op, GHashTable *overrides,
                       bool calc_secure, pcmk_scheduler_t *scheduler)
 {
@@ -364,9 +364,10 @@ pe__calculate_digests(pcmk_resource_t *rsc, const char *task,
  * \return Pointer to node's digest cache entry
  */
 static pcmk__op_digest_t *
-rsc_action_digest(pcmk_resource_t *rsc, const char *task, guint interval_ms,
-                  pcmk_node_t *node, const xmlNode *xml_op,
-                  bool calc_secure, pcmk_scheduler_t *scheduler)
+rsc_action_digest(pcmk_resource_t *rsc, const char *task,
+                  unsigned int interval_ms, pcmk_node_t *node,
+                  const xmlNode *xml_op, bool calc_secure,
+                  pcmk_scheduler_t *scheduler)
 {
     pcmk__op_digest_t *data = NULL;
     char *key = pcmk__op_key(rsc->id, task, interval_ms);
@@ -398,7 +399,7 @@ rsc_action_digest_cmp(pcmk_resource_t *rsc, const xmlNode *xml_op,
                       pcmk_node_t *node, pcmk_scheduler_t *scheduler)
 {
     pcmk__op_digest_t *data = NULL;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
 
     const char *op_version;
     const char *task = pcmk__xe_get(xml_op, PCMK_XA_OPERATION);

--- a/lib/pengine/pe_digest.c
+++ b/lib/pengine/pe_digest.c
@@ -37,11 +37,11 @@
  *
  * \param[in,out] ptr  Pointer to cache entry to free
  *
- * \note The argument is a gpointer so this can be used as a hash table
+ * \note The argument is a <tt>void *</tt> so this can be used as a hash table
  *       free function.
  */
 void
-pe__free_digests(gpointer ptr)
+pe__free_digests(void *ptr)
 {
     pcmk__op_digest_t *data = ptr;
 

--- a/lib/pengine/pe_health.c
+++ b/lib/pengine/pe_health.c
@@ -84,7 +84,7 @@ struct health_sum {
  *                           added if \p key is a node health attribute
  */
 static void
-add_node_health_value(gpointer key, gpointer value, gpointer user_data)
+add_node_health_value(void *key, void *value, void *user_data)
 {
     if (key == NULL) {
         return;
@@ -156,8 +156,7 @@ pe__node_health(pcmk_node_t *node)
     }
 
     g_hash_table_iter_init(&iter, node->priv->attrs);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &name,
-                                  (gpointer *) &value)) {
+    while (g_hash_table_iter_next(&iter, (void **) &name, (void **) &value)) {
         if ((name != NULL) && g_str_has_prefix(name, "#health")) {
             int parse_rc = pcmk_rc_ok;
 

--- a/lib/pengine/pe_health.c
+++ b/lib/pengine/pe_health.c
@@ -90,7 +90,7 @@ add_node_health_value(void *key, void *value, void *user_data)
         return;
     }
 
-    if (g_str_has_prefix((const gchar *) key, "#health")) {
+    if (g_str_has_prefix((const char *) key, "#health")) {
         struct health_sum *health_sum = user_data;
         int score = 0;
         int rc = pcmk_parse_score((const char *) value, &score, 0);

--- a/lib/pengine/pe_health.c
+++ b/lib/pengine/pe_health.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,9 +9,14 @@
 
 #include <crm_internal.h>
 
-#include <glib.h>                   // g_str_has_prefix()
+#include <stddef.h>                     // NULL
 
-#include <crm/pengine/status.h>
+#include <glib.h>                       // g_*, etc.
+
+#include <crm/common/options.h>         // PCMK_OPT_*, PCMK_VALUE_*
+#include <crm/common/results.h>         // pcmk_rc_*
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY, etc.
 #include <crm/pengine/internal.h>
 #include "pe_status_private.h"
 

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -262,7 +262,7 @@ notify_entries_to_strings(GList *list, GString **rsc_names,
  * \param[in,out] user_data  Notify action to copy into
  */
 static void
-copy_meta_to_notify(gpointer key, gpointer value, gpointer user_data)
+copy_meta_to_notify(void *key, void *value, void *user_data)
 {
     pcmk_action_t *notify = (pcmk_action_t *) user_data;
 

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -9,12 +9,22 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdlib.h>                     // free
+#include <string.h>                     // strcmp
 
-#include <crm/common/xml.h>
+#include <glib.h>                       // g_*, etc.
 
-#include <crm/pengine/internal.h>
-#include <pacemaker-internal.h>
+#include <crm/common/actions.h>         // PCMK_ACTION_*
+#include <crm/common/logging.h>         // CRM_CHECK, CRM_LOG_ASSERT
+#include <crm/common/nvpair.h>          // pcmk_nvpair_t, etc.
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*
+#include <crm/common/roles.h>           // pcmk_role_*
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY
+#include <crm/pengine/complex.h>        // uber_parent
+#include <crm/pengine/internal.h>       // pe__*, etc.
 
 #include "pe_status_private.h"
 

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -47,7 +47,7 @@ typedef struct {
  * \return -1 if \p a sorts before \p b, 0 if they are equal, otherwise 1
  */
 static int
-compare_notify_entries(gconstpointer a, gconstpointer b)
+compare_notify_entries(const void *a, const void *b)
 {
     int tmp;
     const notify_entry_t *entry_a = a;

--- a/lib/pengine/pe_notif.c
+++ b/lib/pengine/pe_notif.c
@@ -36,7 +36,7 @@ typedef struct {
  *
  * \return -1 if \p a sorts before \p b, 0 if they are equal, otherwise 1
  */
-static gint
+static int
 compare_notify_entries(gconstpointer a, gconstpointer b)
 {
     int tmp;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1453,7 +1453,7 @@ failed_action_friendly(pcmk__output_t *out, const xmlNode *xml_op,
 {
     char *rsc_id = NULL;
     char *task = NULL;
-    guint interval_ms = 0;
+    unsigned int interval_ms = 0;
     time_t last_change_epoch = 0;
     GString *str = NULL;
 
@@ -1666,7 +1666,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
         const char *queue_time = pcmk__xe_get(xml_op, PCMK_XA_QUEUE_TIME);
         const char *exec = pcmk__xe_get(xml_op, PCMK_XA_EXEC_TIME);
         const char *task = pcmk__xe_get(xml_op, PCMK_XA_OPERATION);
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
         char *interval_ms_s = NULL;
         char *rc_change = pcmk__epoch2str(&epoch,
                                           crm_time_log_date

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -198,7 +198,7 @@ get_operation_list(xmlNode *rsc_entry) {
 }
 
 static void
-add_dump_node(gpointer key, gpointer value, gpointer user_data)
+add_dump_node(void *key, void *value, void *user_data)
 {
     xmlNodePtr node = user_data;
 
@@ -207,7 +207,7 @@ add_dump_node(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
-append_dump_text(gpointer key, gpointer value, gpointer user_data)
+append_dump_text(void *key, void *value, void *user_data)
 {
     char **dump_text = user_data;
     char *new_text = pcmk__assert_asprintf("%s %s=%s",
@@ -2390,7 +2390,7 @@ node_attribute_list(pcmk__output_t *out, va_list args) {
 
         GList *attr_list = NULL;
         GHashTableIter iter;
-        gpointer key;
+        void *key = NULL;
 
         if (!node || !node->details || !node->details->online) {
             continue;
@@ -3430,7 +3430,7 @@ ticket_list(pcmk__output_t *out, va_list args) {
     bool details = va_arg(args, int);
 
     GHashTableIter iter;
-    gpointer value;
+    void *value = NULL;
 
     if (g_hash_table_size(tickets) == 0) {
         return pcmk_rc_no_output;

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -9,16 +9,37 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
-#include <stdint.h>
+#include <limits.h>                     // INT_MIN
+#include <stdarg.h>                     // va_arg, va_list, va_end, va_start
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t, uint64_t
+#include <stdlib.h>                     // free
+#include <string.h>                     // strcat, strlen, strcmp, strdup, etc.
+#include <syslog.h>                     // LOG_DEBUG
+#include <time.h>                       // time_t, ctime
 
-#include <glib.h>                           // g_strchomp()
-#include <libxml/tree.h>                    // xmlNode
+#include <glib.h>                       // g_*
+#include <libxml/tree.h>                // xmlNode
 
-#include <crm/common/output.h>
-#include <crm/cib/util.h>
-#include <crm/common/xml.h>
-#include <crm/pengine/internal.h>
+#include <crm/common/actions.h>         // parse_op_key, PCMK_ACTION_*
+#include <crm/common/agents.h>          // pcmk_get_ra_caps, pcmk_ra_caps, etc.
+#include <crm/common/cib.h>             // pcmk_find_cib_element
+#include <crm/common/ipc_pacemakerd.h>  // pcmk_pacemakerd_*
+#include <crm/common/iso8601.h>         // crm_time_*
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/nodes.h>           // PCMK_NODE_ATTR_*
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_OPT_*, PCMK_VALUE_*
+#include <crm/common/output.h>          // pcmk_show_*
+#include <crm/common/probes.h>          // pcmk_xe_mask_probe_failure
+#include <crm/common/results.h>         // crm_exit_str, pcmk_rc_*, etc.
+#include <crm/common/roles.h>           // PCMK_ROLE_PROMOTED, rsc_role_e
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/crm.h>                    // CRM_ATTR_FEATURE_SET
+#include <crm/pengine/complex.h>        // pe_rsc_params
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/pengine/status.h>         // pe_find_*, rsc_printable_id
 
 const char *
 pe__resource_description(const pcmk_resource_t *rsc, uint32_t show_opts)

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -1673,7 +1673,7 @@ failed_action_xml(pcmk__output_t *out, va_list args) {
                                           |crm_time_log_timeofday
                                           |crm_time_log_with_timezone);
 
-        pcmk__xe_get_guint(xml_op, PCMK_META_INTERVAL, &interval_ms);
+        pcmk__xe_get_uint(xml_op, PCMK_META_INTERVAL, &interval_ms);
         interval_ms_s = pcmk__assert_asprintf("%u", interval_ms);
 
         pcmk__xe_set_props(node,

--- a/lib/pengine/pe_output.c
+++ b/lib/pengine/pe_output.c
@@ -60,7 +60,7 @@ pe__resource_description(const pcmk_resource_t *rsc, uint32_t show_opts)
                      PCMK_NODE_ATTR_STANDBY, "#", NULL }
 
 static int
-compare_attribute(gconstpointer a, gconstpointer b)
+compare_attribute(const void *a, const void *b)
 {
     int rc;
 

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -72,7 +72,7 @@ void pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,
                     pcmk_scheduler_t *scheduler);
 
 G_GNUC_INTERNAL
-int pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
+int pe__cmp_rsc_priority(const void *a, const void *b);
 
 G_GNUC_INTERNAL
 gboolean pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,

--- a/lib/pengine/pe_status_private.h
+++ b/lib/pengine/pe_status_private.h
@@ -72,7 +72,7 @@ void pe__force_anon(const char *standard, pcmk_resource_t *rsc, const char *rid,
                     pcmk_scheduler_t *scheduler);
 
 G_GNUC_INTERNAL
-gint pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
+int pe__cmp_rsc_priority(gconstpointer a, gconstpointer b);
 
 G_GNUC_INTERNAL
 gboolean pe__unpack_resource(xmlNode *xml_obj, pcmk_resource_t **rsc,

--- a/lib/pengine/remote.c
+++ b/lib/pengine/remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 the Pacemaker project contributors
+ * Copyright 2013-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -9,11 +9,20 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
 
-#include <crm/common/xml.h>
-#include <crm/pengine/internal.h>
-#include <glib.h>
+#include <glib.h>                       // GList
+#include <libxml/tree.h>                // xmlNode
+
+#include <crm/common/actions.h>         // crm_create_op_xml, PCMK_ACTION_*
+#include <crm/common/agents.h>          // PCMK_RESOURCE_CLASS_OCF
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/nvpair.h>          // crm_create_nvpair_xml
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_REMOTE_*, etc.
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/internal.h>       // pe_create_remote_xml, etc.
 
 /*!
  * \internal

--- a/lib/pengine/status.c
+++ b/lib/pengine/status.c
@@ -9,17 +9,25 @@
 
 #include <crm_internal.h>
 
+#include <stddef.h>                     // NULL
 #include <stdint.h>                     // uint32_t
-#include <sys/param.h>
+#include <string.h>                     // memset
 
-#include <glib.h>
+#include <glib.h>                       // g_*
 #include <libxml/tree.h>                // xmlNode
+#include <qb/qblog.h>                   // LOG_TRACE
 
-#include <crm/crm.h>
-#include <crm/common/xml.h>
+#include <crm/common/iso8601.h>         // crm_time_*
+#include <crm/common/logging.h>         // CRM_LOG_ASSERT
+#include <crm/common/resources.h>       // pcmk_rsc_match_history
+#include <crm/common/results.h>         // pcmk_rc_ok
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/crm.h>                    // CRM_FEATURE_SET
+#include <crm/pengine/internal.h>       // pe_create_node
+#include <crm/pengine/status.h>         // pe_find_*
 
-#include <crm/pengine/internal.h>
-#include <pe_status_private.h>
+#include "pe_status_private.h"
 
 #define XPATH_DEPRECATED_RULES                          \
     "//" PCMK_XE_OP_DEFAULTS "//" PCMK_XE_EXPRESSION    \

--- a/lib/pengine/tags.c
+++ b/lib/pengine/tags.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 the Pacemaker project contributors
+ * Copyright 2020-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -19,7 +19,7 @@
 GList *
 pe__rscs_with_tag(pcmk_scheduler_t *scheduler, const char *tag_name)
 {
-    gpointer value;
+    void *value = NULL;
     GList *retval = NULL;
 
     if (scheduler->priv->tags == NULL) {
@@ -53,7 +53,7 @@ pe__rscs_with_tag(pcmk_scheduler_t *scheduler, const char *tag_name)
 GList *
 pe__unames_with_tag(pcmk_scheduler_t *scheduler, const char *tag_name)
 {
-    gpointer value;
+    void *value = NULL;
     GList *retval = NULL;
 
     if (scheduler->priv->tags == NULL) {

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -55,7 +55,7 @@ struct action_history {
     const char *key;          // Operation key of action
     const char *task;         // Action name
     const char *exit_reason;  // Exit reason given for result
-    guint interval_ms;        // Action interval
+    unsigned int interval_ms; // Action interval
     int call_id;              // Call ID of action
     int expected_exit_status; // Expected exit status of action
     int exit_status;          // Actual exit status of action
@@ -309,7 +309,7 @@ unpack_config(xmlNode *config, pcmk_scheduler_t *scheduler)
 
     value = pcmk__cluster_option(config_hash, PCMK_OPT_PRIORITY_FENCING_DELAY);
     if (value) {
-        guint *delay_ms = &(scheduler->priv->priority_fencing_ms);
+        unsigned int *delay_ms = &(scheduler->priv->priority_fencing_ms);
 
         pcmk_parse_interval_spec(value, delay_ms);
         pcmk__trace("Priority fencing delay is %s",
@@ -2654,7 +2654,7 @@ process_recurring(pcmk_node_t *node, pcmk_resource_t *rsc,
     for (; gIter != NULL; gIter = gIter->next) {
         xmlNode *rsc_op = (xmlNode *) gIter->data;
 
-        guint interval_ms = 0;
+        unsigned int interval_ms = 0;
         char *key = NULL;
         const char *id = pcmk__xe_id(rsc_op);
 
@@ -2757,7 +2757,7 @@ unpack_shutdown_lock(const xmlNode *rsc_entry, pcmk_resource_t *rsc,
 {
     time_t lock_time = 0;   // When lock started (i.e. node shutdown time)
     time_t sched_time = 0;
-    guint shutdown_lock_ms = scheduler->priv->shutdown_lock_ms;
+    unsigned int shutdown_lock_ms = scheduler->priv->shutdown_lock_ms;
 
     pcmk__xe_get_time(rsc_entry, PCMK_OPT_SHUTDOWN_LOCK, &lock_time);
     if (lock_time == 0) {
@@ -4045,7 +4045,7 @@ remap_operation(struct action_history *history,
 
         case PCMK_OCF_UNIMPLEMENT_FEATURE:
             {
-                guint interval_ms = 0;
+                unsigned int interval_ms = 0;
                 pcmk__xe_get_guint(history->xml, PCMK_META_INTERVAL,
                                    &interval_ms);
 
@@ -4150,7 +4150,7 @@ order_after_remote_fencing(pcmk_action_t *action, pcmk_resource_t *remote_conn,
 
 static bool
 should_ignore_failure_timeout(const pcmk_resource_t *rsc, const char *task,
-                              guint interval_ms, bool is_last_failure)
+                              unsigned int interval_ms, bool is_last_failure)
 {
     /* Clearing failures of recurring monitors has special concerns. The
      * executor reports only changes in the monitor result, so if the
@@ -4221,7 +4221,7 @@ check_operation_expiry(struct action_history *history)
     time_t last_run = 0;
     int unexpired_fail_count = 0;
     const char *clear_reason = NULL;
-    const guint expiration_sec =
+    const unsigned int expiration_sec =
         pcmk__timeout_ms2s(history->rsc->priv->failure_expiration_ms);
     pcmk_scheduler_t *scheduler = history->rsc->priv->scheduler;
 
@@ -4650,7 +4650,7 @@ static bool
 failure_is_newer(const struct action_history *history,
                  const xmlNode *last_failure)
 {
-    guint failure_interval_ms = 0U;
+    unsigned int failure_interval_ms = 0;
     long long failure_change = 0LL;
     long long this_change = 0LL;
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2382,7 +2382,7 @@ process_rsc_state(pcmk_resource_t *rsc, pcmk_node_t *node,
                                 pcmk__s(rsc->priv->history_id, "the same"),
                                 pcmk__node_name(n));
                 g_hash_table_insert(iter->priv->probed_nodes,
-                                    (gpointer) n->priv->id, n);
+                                    (void *) n->priv->id, n);
             }
             if (pcmk__is_set(iter->flags, pcmk__rsc_unique)) {
                 break;
@@ -2995,7 +2995,7 @@ set_active(pcmk_resource_t *rsc)
 }
 
 static void
-set_node_score(gpointer key, gpointer value, gpointer user_data)
+set_node_score(void *key, void *value, void *user_data)
 {
     pcmk_node_t *node = value;
     int *score = user_data;
@@ -3287,8 +3287,7 @@ add_dangling_migration(pcmk_resource_t *rsc, const pcmk_node_t *node)
                     rsc->id, pcmk__node_name(node));
     rsc->priv->orig_role = pcmk_role_stopped;
     rsc->priv->dangling_migration_sources =
-        g_list_prepend(rsc->priv->dangling_migration_sources,
-                       (gpointer) node);
+        g_list_prepend(rsc->priv->dangling_migration_sources, (void *) node);
 }
 
 /*!
@@ -3502,7 +3501,7 @@ unpack_migrate_to_failure(struct action_history *history)
         // Mark node as having dangling migration so we can force a stop later
         history->rsc->priv->dangling_migration_sources =
             g_list_prepend(history->rsc->priv->dangling_migration_sources,
-                           (gpointer) history->node);
+                           (void *) history->node);
     }
 }
 
@@ -4967,7 +4966,7 @@ done:
  * \param[in]     user_data  \c GHashTable to insert into
  */
 static gboolean
-insert_attr(gpointer key, gpointer value, gpointer user_data)
+insert_attr(void *key, void *value, void *user_data)
 {
     GHashTable *table = user_data;
 

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -2677,7 +2677,7 @@ process_recurring(pcmk_node_t *node, pcmk_resource_t *rsc,
             continue;
         }
 
-        pcmk__xe_get_guint(rsc_op, PCMK_META_INTERVAL, &interval_ms);
+        pcmk__xe_get_uint(rsc_op, PCMK_META_INTERVAL, &interval_ms);
         if (interval_ms == 0) {
             pcmk__rsc_trace(rsc, "Skipping %s on %s: non-recurring",
                             id, pcmk__node_name(node));
@@ -4046,8 +4046,8 @@ remap_operation(struct action_history *history,
         case PCMK_OCF_UNIMPLEMENT_FEATURE:
             {
                 unsigned int interval_ms = 0;
-                pcmk__xe_get_guint(history->xml, PCMK_META_INTERVAL,
-                                   &interval_ms);
+                pcmk__xe_get_uint(history->xml, PCMK_META_INTERVAL,
+                                  &interval_ms);
 
                 if (interval_ms == 0) {
                     if (!expired) {
@@ -4664,8 +4664,8 @@ failure_is_newer(const struct action_history *history,
         return false; // last_failure is for different action
     }
 
-    if ((pcmk__xe_get_guint(last_failure, PCMK_META_INTERVAL,
-                            &failure_interval_ms) != pcmk_rc_ok)
+    if ((pcmk__xe_get_uint(last_failure, PCMK_META_INTERVAL,
+                           &failure_interval_ms) != pcmk_rc_ok)
         || (history->interval_ms != failure_interval_ms)) {
         return false; // last_failure is for action with different interval
     }
@@ -4785,7 +4785,7 @@ unpack_rsc_op(pcmk_resource_t *rsc, pcmk_node_t *node, xmlNode *xml_op,
                          history.id, rsc->id, pcmk__node_name(node));
         return;
     }
-    pcmk__xe_get_guint(xml_op, PCMK_META_INTERVAL, &(history.interval_ms));
+    pcmk__xe_get_uint(xml_op, PCMK_META_INTERVAL, &(history.interval_ms));
     if (!can_affect_state(&history)) {
         pcmk__rsc_trace(rsc,
                         "Ignoring resource history entry %s for %s on %s "

--- a/lib/pengine/unpack.c
+++ b/lib/pengine/unpack.c
@@ -9,22 +9,40 @@
 
 #include <crm_internal.h>
 
-#include <stdbool.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <errno.h>                      // EAGAIN
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL, size_t
+#include <stdint.h>                     // uint8_t, uint64_t
+#include <stdlib.h>                     // calloc, free
+#include <string.h>                     // strcmp, strchr, memcpy, strdup, etc.
+#include <syslog.h>                     // LOG_DEBUG, LOG_ERR, LOG_NOTICE
+#include <time.h>                       // time_t
 
-#include <glib.h>
+#include <glib.h>                       // g_*
 #include <libxml/tree.h>                // xmlNode
-#include <libxml/xpath.h>               // xmlXPathObject, etc.
+#include <libxml/xpath.h>               // xmlXPathObject, xmlXPathFreeObject
+#include <qb/qblog.h>                   // LOG_TRACE, QB_XS
 
-#include <crm/crm.h>
-#include <crm/services.h>
-#include <crm/common/xml.h>
+#include <crm/common/actions.h>         // PCMK_ACTION_*
+#include <crm/common/agents.h>          // PCMK_FENCING_PROVIDES
+#include <crm/common/logging.h>         // CRM_CHECK, CRM_LOG_ASSERT, do_crm_log
+#include <crm/common/nodes.h>           // PCMK_NODE_ATTR_*
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_OPT_*, PCMK_VALUE_*
+#include <crm/common/probes.h>          // pcmk_is_probe, pcmk_xe_is_probe, etc.
+#include <crm/common/resources.h>       // pcmk_rsc_match_clone_only
+#include <crm/common/results.h>         // crm_exit_str, pcmk_rc_*, etc.
+#include <crm/common/roles.h>           // pcmk_role_*, rsc_role_e
+#include <crm/common/rules.h>           // pcmk_rule_input_t
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY
+#include <crm/common/strings.h>         // pcmk_parse_interval_spec
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/crm.h>                    // crm_system_name, CRMD_*
+#include <crm/pengine/complex.h>        // uber_parent
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/pengine/status.h>         // pe_find_*, etc.
 
-#include <crm/common/util.h>
-#include <crm/pengine/internal.h>
-#include <pe_status_private.h>
+#include "pe_status_private.h"
 
 // A (parsed) resource action history entry
 struct action_history {

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -196,7 +196,7 @@ pe__node_list2table(const GList *list)
  * \retval  1 \c a comes after \c b (or \c b is \c NULL and \c a is not)
  */
 int
-pe__cmp_node_name(gconstpointer a, gconstpointer b)
+pe__cmp_node_name(const void *a, const void *b)
 {
     const pcmk_node_t *node1 = (const pcmk_node_t *) a;
     const pcmk_node_t *node2 = (const pcmk_node_t *) b;
@@ -346,7 +346,7 @@ pe__show_node_scores_as(const char *file, const char *function, int line,
  * \retval  1 a's priority < b's priority (or \c a is \c NULL and \c b is not)
  */
 int
-pe__cmp_rsc_priority(gconstpointer a, gconstpointer b)
+pe__cmp_rsc_priority(const void *a, const void *b)
 {
     const pcmk_resource_t *resource1 = (const pcmk_resource_t *)a;
     const pcmk_resource_t *resource2 = (const pcmk_resource_t *)b;

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -36,7 +36,7 @@
 
 #include "pe_status_private.h"          // pe__cmp_rsc_priority
 
-gboolean ghash_free_str_str(gpointer key, gpointer value, gpointer user_data);
+gboolean ghash_free_str_str(void *key, void *value, void *user_data);
 
 /*!
  * \internal
@@ -175,7 +175,7 @@ pe__node_list2table(const GList *list)
         pcmk_node_t *new_node = NULL;
 
         new_node = pe__copy_node((const pcmk_node_t *) gIter->data);
-        g_hash_table_insert(result, (gpointer) new_node->priv->id, new_node);
+        g_hash_table_insert(result, (void *) new_node->priv->id, new_node);
     }
     return result;
 }
@@ -400,8 +400,8 @@ resource_node_score(pcmk_resource_t *rsc, const pcmk_node_t *node, int score,
     match = g_hash_table_lookup(rsc->priv->allowed_nodes, node->priv->id);
     if (match == NULL) {
         match = pe__copy_node(node);
-        g_hash_table_insert(rsc->priv->allowed_nodes,
-                            (gpointer) match->priv->id, match);
+        g_hash_table_insert(rsc->priv->allowed_nodes, (void *) match->priv->id,
+                            match);
     }
     match->assign->score = pcmk__add_scores(match->assign->score, score);
     pcmk__rsc_trace(rsc,
@@ -544,7 +544,7 @@ order_actions(pcmk_action_t *first, pcmk_action_t *then, uint32_t flags)
 }
 
 void
-destroy_ticket(gpointer data)
+destroy_ticket(void *data)
 {
     pcmk__ticket_t *ticket = data;
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -9,14 +9,32 @@
 
 #include <crm_internal.h>
 
-#include <glib.h>
-#include <stdbool.h>
+#include <stdbool.h>                    // bool, true, false
+#include <stddef.h>                     // NULL
+#include <stdint.h>                     // uint32_t, uint64_t
+#include <stdlib.h>                     // calloc, free
+#include <string.h>                     // strchr, strcmp, strdup
+#include <time.h>                       // time_t
 
-#include <crm/crm.h>
-#include <crm/common/xml.h>
-#include <crm/pengine/internal.h>
+#include <glib.h>                       // g_*, etc.
+#include <libxml/tree.h>                // xmlNode
+#include <qb/qblog.h>                   // LOG_TRACE, qb_log_*
 
-#include "pe_status_private.h"
+#include <crm/common/actions.h>         // parse_op_key, PCMK_ACTION_ON
+#include <crm/common/iso8601.h>         // crm_time_*
+#include <crm/common/logging.h>         // CRM_CHECK
+#include <crm/common/nvpair.h>          // pcmk_unpack_nvpair_blocks
+#include <crm/common/options.h>         // PCMK_META_*, PCMK_VALUE_*, etc.
+#include <crm/common/probes.h>          // pcmk_xe_mask_probe_failure
+#include <crm/common/roles.h>           // pcmk_role_*, PCMK_ROLE_*, etc.
+#include <crm/common/rules.h>           // pcmk_rule_input_t
+#include <crm/common/scheduler.h>       // pcmk_node_t, pcmk_scheduler_t, etc.
+#include <crm/common/scores.h>          // PCMK_SCORE_INFINITY, etc.
+#include <crm/common/xml.h>             // PCMK_XA_*, PCMK_XE_*, etc.
+#include <crm/pengine/internal.h>       // pe__*, etc.
+#include <crm/pengine/status.h>         // pe_find_*, rsc_printable_id
+
+#include "pe_status_private.h"          // pe__cmp_rsc_priority
 
 gboolean ghash_free_str_str(gpointer key, gpointer value, gpointer user_data);
 

--- a/lib/pengine/utils.c
+++ b/lib/pengine/utils.c
@@ -177,7 +177,7 @@ pe__node_list2table(const GList *list)
  * \retval  0 \c a and \c b are equal (or both are \c NULL)
  * \retval  1 \c a comes after \c b (or \c b is \c NULL and \c a is not)
  */
-gint
+int
 pe__cmp_node_name(gconstpointer a, gconstpointer b)
 {
     const pcmk_node_t *node1 = (const pcmk_node_t *) a;
@@ -327,7 +327,7 @@ pe__show_node_scores_as(const char *file, const char *function, int line,
  * \retval  0 a's priority == b's priority (or both \c a and \c b are \c NULL)
  * \retval  1 a's priority < b's priority (or \c a is \c NULL and \c b is not)
  */
-gint
+int
 pe__cmp_rsc_priority(gconstpointer a, gconstpointer b)
 {
     const pcmk_resource_t *resource1 = (const pcmk_resource_t *)a;

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -108,7 +108,7 @@ dbus_watch_flags_to_string(int flags)
  *       would indicate the file descriptor is no longer required).
  */
 static int
-dispatch_fd_data(gpointer userdata)
+dispatch_fd_data(void *userdata)
 {
     bool oom = FALSE;
     DBusWatch *watch = userdata;
@@ -143,7 +143,7 @@ dispatch_fd_data(gpointer userdata)
 }
 
 static void
-watch_fd_closed(gpointer userdata)
+watch_fd_closed(void *userdata)
 {
     pcmk__trace("DBus watch for file descriptor %d is now closed",
                 dbus_watch_get_unix_fd((DBusWatch *) userdata));
@@ -200,7 +200,7 @@ register_watch_functions(DBusConnection *connection)
  */
 
 static gboolean
-timer_popped(gpointer data)
+timer_popped(void *data)
 {
     pcmk__debug("%dms DBus timer expired",
                 dbus_timeout_get_interval((DBusTimeout *) data));

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -212,7 +212,7 @@ static dbus_bool_t
 add_dbus_timer(DBusTimeout *timeout, void *data)
 {
     int interval_ms = dbus_timeout_get_interval(timeout);
-    guint id = pcmk__create_timer(interval_ms, timer_popped, timeout);
+    unsigned int id = pcmk__create_timer(interval_ms, timer_popped, timeout);
 
     if (id) {
         dbus_timeout_set_data(timeout, GUINT_TO_POINTER(id), NULL);
@@ -225,7 +225,7 @@ static void
 remove_dbus_timer(DBusTimeout *timeout, void *data)
 {
     void *vid = dbus_timeout_get_data(timeout);
-    guint id = GPOINTER_TO_UINT(vid);
+    unsigned int id = GPOINTER_TO_UINT(vid);
 
     pcmk__trace("Removing %dms DBus timer", dbus_timeout_get_interval(timeout));
     if (id) {

--- a/lib/services/dbus.c
+++ b/lib/services/dbus.c
@@ -703,7 +703,7 @@ async_query_result_cb(DBusPendingCall *pending, void *user_data)
  */
 char *
 pcmk_dbus_get_property(DBusConnection *connection, const char *target,
-                       const char *obj, const gchar * iface, const char *name,
+                       const char *obj, const char *iface, const char *name,
                        property_callback_func callback, void *userdata,
                        DBusPendingCall **pending, int timeout)
 {

--- a/lib/services/pcmk-dbus.h
+++ b/lib/services/pcmk-dbus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the Pacemaker project contributors
+ * Copyright 2014-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -40,10 +40,14 @@ G_GNUC_INTERNAL
 bool pcmk_dbus_type_check(DBusMessage *msg, DBusMessageIter *field, int expected, const char *function, int line);
 
 G_GNUC_INTERNAL
-char *pcmk_dbus_get_property(
-    DBusConnection *connection, const char *target, const char *obj, const gchar * iface, const char *name,
-    void (*callback)(const char *name, const char *value, void *userdata), void *userdata,
-    DBusPendingCall **pending, int timeout);
+char *pcmk_dbus_get_property(DBusConnection *connection, const char *target,
+                             const char *obj, const char *iface,
+                             const char *name,
+                             void (*callback)(const char *name,
+                                              const char *value,
+                                              void *userdata),
+                             void *userdata, DBusPendingCall **pending,
+                             int timeout);
 
 G_GNUC_INTERNAL
 bool pcmk_dbus_find_error(const DBusPendingCall *pending, DBusMessage *reply,

--- a/lib/services/services.c
+++ b/lib/services/services.c
@@ -257,8 +257,9 @@ copy_action_arguments(svc_action_t *op, uint32_t ra_caps, const char *name,
 svc_action_t *
 services__create_resource_action(const char *name, const char *standard,
                         const char *provider, const char *agent,
-                        const char *action, guint interval_ms, int timeout,
-                        GHashTable *params, enum svc_action_flags flags)
+                        const char *action, unsigned int interval_ms,
+                        int timeout, GHashTable *params,
+                        enum svc_action_flags flags)
 {
     svc_action_t *op = NULL;
     uint32_t ra_caps = pcmk_get_ra_caps(standard);
@@ -329,8 +330,9 @@ services__create_resource_action(const char *name, const char *standard,
 svc_action_t *
 resources_action_create(const char *name, const char *standard,
                         const char *provider, const char *agent,
-                        const char *action, guint interval_ms, int timeout,
-                        GHashTable *params, enum svc_action_flags flags)
+                        const char *action, unsigned int interval_ms,
+                        int timeout, GHashTable *params,
+                        enum svc_action_flags flags)
 {
     svc_action_t *op = services__create_resource_action(name, standard,
                             provider, agent, action, interval_ms, timeout,
@@ -651,7 +653,8 @@ cancel_recurring_action(svc_action_t * op)
  * \return TRUE if action was successfully cancelled, FALSE otherwise
  */
 gboolean
-services_action_cancel(const char *name, const char *action, guint interval_ms)
+services_action_cancel(const char *name, const char *action,
+                       unsigned int interval_ms)
 {
     gboolean cancelled = FALSE;
     char *id = pcmk__op_key(name, action, interval_ms);
@@ -720,7 +723,8 @@ done:
 }
 
 gboolean
-services_action_kick(const char *name, const char *action, guint interval_ms)
+services_action_kick(const char *name, const char *action,
+                     unsigned int interval_ms)
 {
     svc_action_t * op = NULL;
     char *id = pcmk__op_key(name, action, interval_ms);

--- a/lib/services/services_linux.c
+++ b/lib/services/services_linux.c
@@ -357,7 +357,7 @@ svc_read_output(int fd, svc_action_t * op, bool is_stderr)
 }
 
 static int
-dispatch_stdout(gpointer userdata)
+dispatch_stdout(void *userdata)
 {
     svc_action_t *op = (svc_action_t *) userdata;
 
@@ -365,7 +365,7 @@ dispatch_stdout(gpointer userdata)
 }
 
 static int
-dispatch_stderr(gpointer userdata)
+dispatch_stderr(void *userdata)
 {
     svc_action_t *op = (svc_action_t *) userdata;
 
@@ -373,7 +373,7 @@ dispatch_stderr(gpointer userdata)
 }
 
 static void
-pipe_out_done(gpointer user_data)
+pipe_out_done(void *user_data)
 {
     svc_action_t *op = (svc_action_t *) user_data;
 
@@ -387,7 +387,7 @@ pipe_out_done(gpointer user_data)
 }
 
 static void
-pipe_err_done(gpointer user_data)
+pipe_err_done(void *user_data)
 {
     svc_action_t *op = (svc_action_t *) user_data;
 
@@ -409,7 +409,7 @@ static struct mainloop_fd_callbacks stderr_callbacks = {
 };
 
 static void
-set_ocf_env(const char *key, const char *value, gpointer user_data)
+set_ocf_env(const char *key, const char *value, void *user_data)
 {
     // @FIXME @COMPAT This seems like it should be a fatal error
     if (setenv(key, value, 1) != 0) {
@@ -421,7 +421,7 @@ set_ocf_env(const char *key, const char *value, gpointer user_data)
 }
 
 static void
-set_ocf_env_with_prefix(gpointer key, gpointer value, gpointer user_data)
+set_ocf_env_with_prefix(void *key, void *value, void *user_data)
 {
     const char *ckey = key;
 
@@ -437,7 +437,7 @@ set_ocf_env_with_prefix(gpointer key, gpointer value, gpointer user_data)
 }
 
 static void
-set_alert_env(gpointer key, gpointer value, gpointer user_data)
+set_alert_env(void *key, void *value, void *user_data)
 {
     int rc;
 
@@ -478,7 +478,7 @@ set_alert_env(gpointer key, gpointer value, gpointer user_data)
 static void
 add_action_env_vars(const svc_action_t *op)
 {
-    void (*env_setter)(gpointer, gpointer, gpointer) = NULL;
+    void (*env_setter)(void *, void *, void *) = NULL;
     if (op->agent == NULL) {
         env_setter = set_alert_env;  /* we deal with alert handler */
 
@@ -514,7 +514,7 @@ add_action_env_vars(const svc_action_t *op)
 }
 
 static void
-pipe_in_single_parameter(gpointer key, gpointer value, gpointer user_data)
+pipe_in_single_parameter(void *key, void *value, void *user_data)
 {
     svc_action_t *op = user_data;
     char *buffer = pcmk__assert_asprintf("%s=%s\n", (const char *) key,
@@ -543,12 +543,12 @@ static void
 pipe_in_action_stdin_parameters(const svc_action_t *op)
 {
     if (op->params) {
-        g_hash_table_foreach(op->params, pipe_in_single_parameter, (gpointer) op);
+        g_hash_table_foreach(op->params, pipe_in_single_parameter, (void *) op);
     }
 }
 
 gboolean
-recurring_action_timer(gpointer data)
+recurring_action_timer(void *data)
 {
     svc_action_t *op = data;
 

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2011 Red Hat, Inc.
- * Later changes copyright 2012-2025 the Pacemaker project contributors
+ * Later changes copyright 2012-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
 #include <stdbool.h>                // bool
 #include <unistd.h>                 // uid_t, gid_t
 
-#include <glib.h>                   // G_GNUC_INTERNAL, gboolean, guint, etc.
+#include <glib.h>                   // G_GNUC_INTERNAL, gboolean, etc.
 #if HAVE_DBUS
 #include <dbus/dbus.h>              // DBusPendingCall
 #endif
@@ -35,7 +35,7 @@ struct svc_action_private_s {
     uid_t uid;
     gid_t gid;
 
-    guint repeat_timer;
+    unsigned int repeat_timer;
     void (*callback) (svc_action_t * op);
     void (*fork_callback) (svc_action_t * op);
 

--- a/lib/services/services_private.h
+++ b/lib/services/services_private.h
@@ -69,7 +69,7 @@ G_GNUC_INTERNAL
 gboolean cancel_recurring_action(svc_action_t * op);
 
 G_GNUC_INTERNAL
-gboolean recurring_action_timer(gpointer data);
+gboolean recurring_action_timer(void *data);
 
 G_GNUC_INTERNAL
 int services__finalize_async_op(svc_action_t *op);

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -601,7 +601,7 @@ invoke_unit_by_name(const char *arg_name, svc_action_t *op, char **path)
  *       NULL is considered less than non-NULL.
  */
 static int
-sort_str(gconstpointer a, gconstpointer b)
+sort_str(const void *a, const void *b)
 {
     if (!a && !b) {
         return 0;

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -1352,7 +1352,7 @@ invoke_unit_by_path(svc_action_t *op, const char *unit)
 }
 
 static gboolean
-systemd_timeout_callback(gpointer p)
+systemd_timeout_callback(void *p)
 {
     svc_action_t * op = p;
 

--- a/lib/services/systemd.c
+++ b/lib/services/systemd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the Pacemaker project contributors
+ * Copyright 2012-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -600,7 +600,7 @@ invoke_unit_by_name(const char *arg_name, svc_action_t *op, char **path)
  * \note Usable as a GCompareFunc with g_list_sort().
  *       NULL is considered less than non-NULL.
  */
-static gint
+static int
 sort_str(gconstpointer a, gconstpointer b)
 {
     if (!a && !b) {

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -52,7 +52,7 @@ struct {
 };
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **err)
 {
     pcmk__str_update(&options.attr_value, optarg);
@@ -75,7 +75,7 @@ command_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-private_cb(const gchar *option_name, const gchar *optarg, void *data,
+private_cb(const char *option_name, const char *optarg, void *data,
            GError **err)
 {
     pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_private);
@@ -83,7 +83,7 @@ private_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-section_cb(const gchar *option_name, const gchar *optarg, void *data,
+section_cb(const char *option_name, const char *optarg, void *data,
            GError **err)
 {
     if (pcmk__str_any_of(optarg, PCMK_XE_NODES, "forever", NULL)) {
@@ -101,7 +101,7 @@ section_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-attr_set_type_cb(const gchar *option_name, const gchar *optarg, void *data,
+attr_set_type_cb(const char *option_name, const char *optarg, void *data,
                  GError **error)
 {
     if (pcmk__str_any_of(option_name, "-z", "--utilization", NULL)) {
@@ -112,7 +112,7 @@ attr_set_type_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-wait_cb(const gchar *option_name, const gchar *optarg, void *data, GError **err)
+wait_cb(const char *option_name, const char *optarg, void *data, GError **err)
 {
     if (pcmk__str_eq(optarg, "no", pcmk__str_none)) {
         pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);

--- a/tools/attrd_updater.c
+++ b/tools/attrd_updater.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -52,7 +52,9 @@ struct {
 };
 
 static gboolean
-command_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **err)
+{
     pcmk__str_update(&options.attr_value, optarg);
 
     if (pcmk__str_any_of(option_name, "--update-both", "-B", NULL)) {
@@ -73,13 +75,17 @@ command_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError
 }
 
 static gboolean
-private_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+private_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **err)
+{
     pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_private);
     return TRUE;
 }
 
 static gboolean
-section_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+section_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **err)
+{
     if (pcmk__str_any_of(optarg, PCMK_XE_NODES, "forever", NULL)) {
         pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_perm);
     } else if (pcmk__str_any_of(optarg, PCMK_XE_STATUS, PCMK_VALUE_REBOOT,
@@ -95,7 +101,9 @@ section_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError
 }
 
 static gboolean
-attr_set_type_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+attr_set_type_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **error)
+{
     if (pcmk__str_any_of(option_name, "-z", "--utilization", NULL)) {
         pcmk__set_node_attr_flags(options.attr_options, pcmk__node_attr_utilization);
     }
@@ -104,7 +112,8 @@ attr_set_type_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 }
 
 static gboolean
-wait_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+wait_cb(const gchar *option_name, const gchar *optarg, void *data, GError **err)
+{
     if (pcmk__str_eq(optarg, "no", pcmk__str_none)) {
         pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);
         return TRUE;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -551,7 +551,7 @@ static const cibadmin_cmd_info_t cibadmin_command_info[] = {
 };
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-u", "--upgrade", NULL)) {
@@ -604,7 +604,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-show_access_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+show_access_cb(const gchar *option_name, const gchar *optarg, void *data,
                GError **error)
 {
     if (pcmk__str_eq(optarg, "auto", pcmk__str_null_matches)) {
@@ -629,7 +629,7 @@ show_access_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-section_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+section_cb(const gchar *option_name, const gchar *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-o", "--scope", NULL)) {

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -551,7 +551,7 @@ static const cibadmin_cmd_info_t cibadmin_command_info[] = {
 };
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-u", "--upgrade", NULL)) {
@@ -604,7 +604,7 @@ command_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-show_access_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_access_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     if (pcmk__str_eq(optarg, "auto", pcmk__str_null_matches)) {
@@ -629,7 +629,7 @@ show_access_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-section_cb(const gchar *option_name, const gchar *optarg, void *data,
+section_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-o", "--scope", NULL)) {

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -129,7 +129,7 @@ static struct {
     enum cibadmin_section_type section_type;
     char *cib_section;
     char *validate_with;
-    gint timeout_sec;
+    int timeout_sec;
     enum pcmk__acl_render_how acl_render_mode;
     gchar *cib_user;
     gchar *input_file;

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -359,8 +359,7 @@ cibadmin_post_default(pcmk__output_t *out, cib_t *cib_conn, int call_options,
 
 static void
 cibadmin_output_xml(pcmk__output_t *out, xmlNode *xml, int call_options,
-                    const gchar *acl_user, crm_exit_t *exit_code,
-                    GError **error)
+                    const char *acl_user, crm_exit_t *exit_code, GError **error)
 {
     if ((options.acl_render_mode != pcmk__acl_render_none)
         && (*exit_code == CRM_EX_OK)
@@ -406,7 +405,7 @@ cibadmin_output_xml(pcmk__output_t *out, xmlNode *xml, int call_options,
 static crm_exit_t
 cibadmin_handle_command(pcmk__output_t *out,
                         const cibadmin_cmd_info_t *cmd_info, int call_options,
-                        const gchar *acl_user, xmlNode *input, GError **error)
+                        const char *acl_user, xmlNode *input, GError **error)
 {
     int rc = pcmk_rc_ok;
     crm_exit_t exit_code = CRM_EX_OK;

--- a/tools/cibsecret.c
+++ b/tools/cibsecret.c
@@ -62,7 +62,7 @@ static GOptionEntry entries[] = {
  *
  * \note On error, \p out->err() will be called to record stderr of the process
  */
-typedef int (*rsh_fn_t)(pcmk__output_t *out, gchar **nodes, const char *cmdline);
+typedef int (*rsh_fn_t)(pcmk__output_t *out, char **nodes, const char *cmdline);
 
 /*!
  * \internal
@@ -82,7 +82,7 @@ typedef int (*rsh_fn_t)(pcmk__output_t *out, gchar **nodes, const char *cmdline)
  *
  * \note On error, \p out->err() will be called to record stderr of the process
  */
-typedef int (*rcp_fn_t)(pcmk__output_t *out, gchar **nodes, const char *to,
+typedef int (*rcp_fn_t)(pcmk__output_t *out, char **nodes, const char *to,
                         const char *from);
 
 struct subcommand_entry {
@@ -150,7 +150,7 @@ done:
 }
 
 static int
-pssh(pcmk__output_t *out, gchar **nodes, const char *cmdline)
+pssh(pcmk__output_t *out, char **nodes, const char *cmdline)
 {
     int rc = pcmk_rc_ok;
     char *s = NULL;
@@ -166,7 +166,7 @@ pssh(pcmk__output_t *out, gchar **nodes, const char *cmdline)
 }
 
 static int
-pdsh(pcmk__output_t *out, gchar **nodes, const char *cmdline)
+pdsh(pcmk__output_t *out, char **nodes, const char *cmdline)
 {
     int rc = pcmk_rc_ok;
     char *s = NULL;
@@ -183,11 +183,11 @@ pdsh(pcmk__output_t *out, gchar **nodes, const char *cmdline)
 }
 
 static int
-ssh(pcmk__output_t *out, gchar **nodes, const char *cmdline)
+ssh(pcmk__output_t *out, char **nodes, const char *cmdline)
 {
     int rc = pcmk_rc_ok;
 
-    for (gchar **node = nodes; *node != NULL; node++) {
+    for (char **node = nodes; *node != NULL; node++) {
         char *s = pcmk__assert_asprintf("ssh " SSH_OPTS " \"%s\" -- \"%s\"",
                                         *node, cmdline);
 
@@ -204,7 +204,7 @@ ssh(pcmk__output_t *out, gchar **nodes, const char *cmdline)
 }
 
 static int
-pscp(pcmk__output_t *out, gchar **nodes, const char *to, const char *from)
+pscp(pcmk__output_t *out, char **nodes, const char *to, const char *from)
 {
     int rc = pcmk_rc_ok;
     char *s = NULL;
@@ -221,7 +221,7 @@ pscp(pcmk__output_t *out, gchar **nodes, const char *to, const char *from)
 }
 
 static int
-pdcp(pcmk__output_t *out, gchar **nodes, const char *to, const char *from)
+pdcp(pcmk__output_t *out, char **nodes, const char *to, const char *from)
 {
     int rc = pcmk_rc_ok;
     char *s = NULL;
@@ -239,11 +239,11 @@ pdcp(pcmk__output_t *out, gchar **nodes, const char *to, const char *from)
 }
 
 static int
-scp(pcmk__output_t *out, gchar **nodes, const char *to, const char *from)
+scp(pcmk__output_t *out, char **nodes, const char *to, const char *from)
 {
     int rc = pcmk_rc_ok;
 
-    for (gchar **node = nodes; *node != NULL; node++) {
+    for (char **node = nodes; *node != NULL; node++) {
         char *s = pcmk__assert_asprintf("scp -pqr " SSH_OPTS " \"%s\" "
                                         "\"%s:%s\"",
                                         from, *node, to);

--- a/tools/cibsecret.c
+++ b/tools/cibsecret.c
@@ -113,7 +113,7 @@ run_cmdline(pcmk__output_t *out, const char *cmdline, char **standard_out)
     GError *error = NULL;
     gchar *sout = NULL;
     gchar *serr = NULL;
-    gint status;
+    int status;
 
     /* A failure here is a failure starting the program (for example, it doesn't
      * exist on the $PATH), not that it ran but exited with an error code.

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -80,22 +80,25 @@ struct {
 #define INDENT "                               "
 
 static gboolean
-list_cb(const gchar *option_name, const gchar *optarg, gpointer data,
-        GError **error) {
+list_cb(const gchar *option_name, const gchar *optarg, void *data,
+        GError **error)
+{
     options.command = attr_cmd_list;
     pcmk__str_update(&options.opt_list, optarg);
     return TRUE;
 }
 
 static gboolean
-delete_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+delete_cb(const gchar *option_name, const gchar *optarg, void *data,
+          GError **error)
+{
     options.command = attr_cmd_delete;
     g_clear_pointer(&options.attr_value, free);
     return TRUE;
 }
 
 static gboolean
-attr_name_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+attr_name_cb(const gchar *option_name, const gchar *optarg, void *data,
              GError **error)
 {
     options.promotion_score = false;
@@ -108,7 +111,9 @@ attr_name_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-promotion_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+promotion_cb(const gchar *option_name, const gchar *optarg, void *data,
+             GError **error)
+{
     char *score_name = NULL;
 
     options.promotion_score = true;
@@ -129,14 +134,18 @@ promotion_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 }
 
 static gboolean
-update_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+update_cb(const gchar *option_name, const gchar *optarg, void *data,
+          GError **error)
+{
     options.command = attr_cmd_update;
     pcmk__str_update(&options.attr_value, optarg);
     return TRUE;
 }
 
 static gboolean
-utilization_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+utilization_cb(const gchar *option_name, const gchar *optarg, void *data,
+               GError **error)
+{
     if (options.type) {
         g_free(options.type);
     }
@@ -147,14 +156,17 @@ utilization_cb(const gchar *option_name, const gchar *optarg, gpointer data, GEr
 }
 
 static gboolean
-value_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+value_cb(const gchar *option_name, const gchar *optarg, void *data,
+         GError **error)
+{
     options.command = attr_cmd_query;
     g_clear_pointer(&options.attr_value, free);
     return TRUE;
 }
 
 static gboolean
-wait_cb (const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+wait_cb(const gchar *option_name, const gchar *optarg, void *data, GError **err)
+{
     if (pcmk__str_eq(optarg, "no", pcmk__str_none)) {
         pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);
         return TRUE;

--- a/tools/crm_attribute.c
+++ b/tools/crm_attribute.c
@@ -80,8 +80,7 @@ struct {
 #define INDENT "                               "
 
 static gboolean
-list_cb(const gchar *option_name, const gchar *optarg, void *data,
-        GError **error)
+list_cb(const char *option_name, const char *optarg, void *data, GError **error)
 {
     options.command = attr_cmd_list;
     pcmk__str_update(&options.opt_list, optarg);
@@ -89,7 +88,7 @@ list_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-delete_cb(const gchar *option_name, const gchar *optarg, void *data,
+delete_cb(const char *option_name, const char *optarg, void *data,
           GError **error)
 {
     options.command = attr_cmd_delete;
@@ -98,7 +97,7 @@ delete_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-attr_name_cb(const gchar *option_name, const gchar *optarg, void *data,
+attr_name_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
     options.promotion_score = false;
@@ -111,7 +110,7 @@ attr_name_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-promotion_cb(const gchar *option_name, const gchar *optarg, void *data,
+promotion_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
     char *score_name = NULL;
@@ -134,7 +133,7 @@ promotion_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-update_cb(const gchar *option_name, const gchar *optarg, void *data,
+update_cb(const char *option_name, const char *optarg, void *data,
           GError **error)
 {
     options.command = attr_cmd_update;
@@ -143,7 +142,7 @@ update_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-utilization_cb(const gchar *option_name, const gchar *optarg, void *data,
+utilization_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     if (options.type) {
@@ -156,7 +155,7 @@ utilization_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-value_cb(const gchar *option_name, const gchar *optarg, void *data,
+value_cb(const char *option_name, const char *optarg, void *data,
          GError **error)
 {
     options.command = attr_cmd_query;
@@ -165,7 +164,7 @@ value_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-wait_cb(const gchar *option_name, const gchar *optarg, void *data, GError **err)
+wait_cb(const char *option_name, const char *optarg, void *data, GError **err)
 {
     if (pcmk__str_eq(optarg, "no", pcmk__str_none)) {
         pcmk__clear_node_attr_flags(options.attr_options, pcmk__node_attr_sync_local | pcmk__node_attr_sync_cluster);

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -35,7 +35,7 @@ struct {
 } options;
 
 static gboolean
-patch_cb(const gchar *option_name, const gchar *optarg, void *data,
+patch_cb(const char *option_name, const char *optarg, void *data,
          GError **error)
 {
     options.patch = true;

--- a/tools/crm_diff.c
+++ b/tools/crm_diff.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2025 the Pacemaker project contributors
+ * Copyright 2005-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -35,7 +35,7 @@ struct {
 } options;
 
 static gboolean
-patch_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+patch_cb(const gchar *option_name, const gchar *optarg, void *data,
          GError **error)
 {
     options.patch = true;

--- a/tools/crm_error.c
+++ b/tools/crm_error.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2025 the Pacemaker project contributors
+ * Copyright 2012-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -28,7 +28,7 @@ struct {
 };
 
 static gboolean
-result_type_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+result_type_cb(const gchar *option_name, const gchar *optarg, void *data,
                GError **error)
 {
     if (pcmk__str_any_of(option_name, "--exit", "-X", NULL)) {

--- a/tools/crm_error.c
+++ b/tools/crm_error.c
@@ -28,7 +28,7 @@ struct {
 };
 
 static gboolean
-result_type_cb(const gchar *option_name, const gchar *optarg, void *data,
+result_type_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     if (pcmk__str_any_of(option_name, "--exit", "-X", NULL)) {

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -66,7 +66,7 @@ static mon_output_format_t output_format = mon_output_unset;
 /* other globals */
 static GIOChannel *io_channel = NULL;
 static GMainLoop *mainloop = NULL;
-static guint reconnect_timer = 0;
+static unsigned int reconnect_timer = 0;
 static mainloop_timer_t *refresh_timer = NULL;
 
 static enum pcmk_pacemakerd_state pcmkd_state = pcmk_pacemakerd_state_invalid;
@@ -205,7 +205,7 @@ static pcmk__message_entry_t fmt_functions[] = {
 #define RECONNECT_MSECS 5000
 
 struct {
-    guint reconnect_ms;
+    unsigned int reconnect_ms;
     enum mon_exec_mode exec_mode;
     gboolean fence_connect;
     gboolean print_pending;
@@ -519,9 +519,9 @@ reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
     }
 
     /* @FIXME Why do we call this instead of just clipping the pcmk__parse_ms()
-     * result to guint range? This was added by e4aff648 so that we could accept
-     * more formats. However, if pcmk__parse_ms() would reject optarg, then
-     * we've already returned by now.
+     * result to unsigned int range? This was added by e4aff648 so that we could
+     * accept more formats. However, if pcmk__parse_ms() would reject optarg,
+     * then we've already returned by now.
      */
     pcmk_parse_interval_spec(optarg, &options.reconnect_ms);
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -227,7 +227,7 @@ struct {
 static crm_exit_t clean_up(crm_exit_t exit_code);
 static void crm_diff_update(const char *event, xmlNode * msg);
 static void clean_up_on_connection_failure(int rc);
-static int mon_refresh_display(gpointer user_data);
+static int mon_refresh_display(void *user_data);
 static int setup_cib_connection(void);
 static int setup_fencer_connection(void);
 static int setup_api_connections(void);
@@ -399,7 +399,9 @@ apply_include_exclude(GSList *lst, GError **error) {
 }
 
 static gboolean
-user_include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+user_include_exclude_cb(const gchar *option_name, const gchar *optarg,
+                        void *data, GError **err)
+{
     char *s = pcmk__assert_asprintf("%s=%s", option_name, optarg);
 
     options.user_includes_excludes = g_slist_append(options.user_includes_excludes, s);
@@ -407,7 +409,9 @@ user_include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer 
 }
 
 static gboolean
-include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+include_exclude_cb(const gchar *option_name, const gchar *optarg, void *data,
+                   GError **err)
+{
     char *s = pcmk__assert_asprintf("%s=%s", option_name, optarg);
 
     options.includes_excludes = g_slist_append(options.includes_excludes, s);
@@ -415,21 +419,25 @@ include_exclude_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-as_xml_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+as_xml_cb(const gchar *option_name, const gchar *optarg, void *data,
+          GError **err)
+{
     pcmk__str_update(&args->output_ty, "xml");
     output_format = mon_output_legacy_xml;
     return TRUE;
 }
 
 static gboolean
-pid_file_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+pid_file_cb(const gchar *option_name, const gchar *optarg, void *data,
             GError **err)
 {
     return TRUE;
 }
 
 static gboolean
-fence_history_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+fence_history_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **err)
+{
     if (optarg == NULL) {
         interactive_fence_level = 2;
     } else {
@@ -467,48 +475,64 @@ fence_history_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 }
 
 static gboolean
-group_by_node_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+group_by_node_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **err)
+{
     show_opts |= pcmk_show_rscs_by_node;
     return TRUE;
 }
 
 static gboolean
-hide_headers_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+hide_headers_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **err)
+{
     return user_include_exclude_cb("--exclude", "summary", data, err);
 }
 
 static gboolean
-inactive_resources_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+inactive_resources_cb(const gchar *option_name, const gchar *optarg, void *data,
+                      GError **err)
+{
     show_opts |= pcmk_show_inactive_rscs;
     return TRUE;
 }
 
 static gboolean
-print_brief_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+print_brief_cb(const gchar *option_name, const gchar *optarg, void *data,
+               GError **err)
+{
     show_opts |= pcmk_show_brief;
     return TRUE;
 }
 
 static gboolean
-print_detail_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+print_detail_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **err)
+{
     show_opts |= pcmk_show_details;
     return TRUE;
 }
 
 static gboolean
-print_description_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+print_description_cb(const gchar *option_name, const gchar *optarg, void *data,
+                     GError **err)
+{
     show_opts |= pcmk_show_description;
     return TRUE;
 }
 
 static gboolean
-print_timing_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+print_timing_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **err)
+{
     show_opts |= pcmk_show_timing;
     return user_include_exclude_cb("--include", "operations", data, err);
 }
 
 static gboolean
-reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+reconnect_cb(const gchar *option_name, const gchar *optarg, void *data,
+             GError **err)
+{
     long long reconnect_ms = 0;
 
     if ((pcmk__parse_ms(optarg, &reconnect_ms) != pcmk_rc_ok)
@@ -542,7 +566,7 @@ reconnect_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
  * \param[out] err          Where to store error (ignored)
  */
 static gboolean
-one_shot_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+one_shot_cb(const gchar *option_name, const gchar *optarg, void *data,
             GError **err)
 {
     options.exec_mode = mon_exec_one_shot;
@@ -559,7 +583,7 @@ one_shot_cb(const gchar *option_name, const gchar *optarg, gpointer data,
  * \param[out] err          Where to store error (ignored)
  */
 static gboolean
-daemonize_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+daemonize_cb(const gchar *option_name, const gchar *optarg, void *data,
              GError **err)
 {
     options.exec_mode = mon_exec_daemonized;
@@ -567,12 +591,16 @@ daemonize_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-show_attributes_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+show_attributes_cb(const gchar *option_name, const gchar *optarg, void *data,
+                   GError **err)
+{
     return user_include_exclude_cb("--include", "attributes", data, err);
 }
 
 static gboolean
-show_bans_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+show_bans_cb(const gchar *option_name, const gchar *optarg, void *data,
+             GError **err)
+{
     if (optarg != NULL) {
         char *s = pcmk__assert_asprintf("bans:%s", optarg);
         gboolean rc = user_include_exclude_cb("--include", s, data, err);
@@ -584,22 +612,30 @@ show_bans_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErro
 }
 
 static gboolean
-show_failcounts_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+show_failcounts_cb(const gchar *option_name, const gchar *optarg, void *data,
+                   GError **err)
+{
     return user_include_exclude_cb("--include", "failcounts", data, err);
 }
 
 static gboolean
-show_operations_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+show_operations_cb(const gchar *option_name, const gchar *optarg, void *data,
+                   GError **err)
+{
     return user_include_exclude_cb("--include", "failcounts,operations", data, err);
 }
 
 static gboolean
-show_tickets_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+show_tickets_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **err)
+{
     return user_include_exclude_cb("--include", "tickets", data, err);
 }
 
 static gboolean
-use_cib_file_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+use_cib_file_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **err)
+{
     setenv("CIB_file", optarg, 1);
     options.exec_mode = mon_exec_one_shot;
     return TRUE;
@@ -749,7 +785,7 @@ static GOptionEntry display_entries[] = {
  * mon_cib_connection_destroy.
  */
 static gboolean
-reconnect_after_timeout(gpointer data)
+reconnect_after_timeout(void *data)
 {
 #if PCMK__ENABLE_CURSES
     if (output_format == mon_output_console) {
@@ -779,7 +815,7 @@ reconnect_after_timeout(gpointer data)
  * attempt to sign off and reconnect.
  */
 static void
-mon_cib_connection_destroy(gpointer user_data)
+mon_cib_connection_destroy(void *user_data)
 {
     const char *msg = "Connection to the cluster lost";
 
@@ -1042,7 +1078,7 @@ get_option_desc(char c)
  * agent what would happen in mon_refresh_display.
  */
 static gboolean
-detect_user_input(GIOChannel *channel, GIOCondition condition, gpointer user_data)
+detect_user_input(GIOChannel *channel, GIOCondition condition, void *user_data)
 {
     int c;
     gboolean config_mode = FALSE;
@@ -1824,7 +1860,7 @@ handle_rsc_op(xmlNode *xml, void *userdata)
  * gets redrawn.
  */
 static gboolean
-mon_trigger_refresh(gpointer user_data)
+mon_trigger_refresh(void *user_data)
 {
     mainloop_set_trigger((crm_trigger_t *) refresh_trigger);
     return FALSE;
@@ -1995,7 +2031,7 @@ crm_diff_update(const char *event, xmlNode * msg)
 }
 
 static int
-mon_refresh_display(gpointer user_data)
+mon_refresh_display(void *user_data)
 {
     int rc = pcmk_rc_ok;
 

--- a/tools/crm_mon.c
+++ b/tools/crm_mon.c
@@ -301,7 +301,8 @@ find_section_bit(const char *name) {
 }
 
 static gboolean
-apply_exclude(const gchar *excludes, GError **error) {
+apply_exclude(const char *excludes, GError **error)
+{
     char **parts = NULL;
     gboolean result = TRUE;
 
@@ -331,7 +332,8 @@ apply_exclude(const gchar *excludes, GError **error) {
 }
 
 static gboolean
-apply_include(const gchar *includes, GError **error) {
+apply_include(const char *includes, GError **error)
+{
     char **parts = NULL;
     gboolean result = TRUE;
 
@@ -399,8 +401,8 @@ apply_include_exclude(GSList *lst, GError **error) {
 }
 
 static gboolean
-user_include_exclude_cb(const gchar *option_name, const gchar *optarg,
-                        void *data, GError **err)
+user_include_exclude_cb(const char *option_name, const char *optarg, void *data,
+                        GError **err)
 {
     char *s = pcmk__assert_asprintf("%s=%s", option_name, optarg);
 
@@ -409,7 +411,7 @@ user_include_exclude_cb(const gchar *option_name, const gchar *optarg,
 }
 
 static gboolean
-include_exclude_cb(const gchar *option_name, const gchar *optarg, void *data,
+include_exclude_cb(const char *option_name, const char *optarg, void *data,
                    GError **err)
 {
     char *s = pcmk__assert_asprintf("%s=%s", option_name, optarg);
@@ -419,8 +421,7 @@ include_exclude_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-as_xml_cb(const gchar *option_name, const gchar *optarg, void *data,
-          GError **err)
+as_xml_cb(const char *option_name, const char *optarg, void *data, GError **err)
 {
     pcmk__str_update(&args->output_ty, "xml");
     output_format = mon_output_legacy_xml;
@@ -428,14 +429,14 @@ as_xml_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-pid_file_cb(const gchar *option_name, const gchar *optarg, void *data,
+pid_file_cb(const char *option_name, const char *optarg, void *data,
             GError **err)
 {
     return TRUE;
 }
 
 static gboolean
-fence_history_cb(const gchar *option_name, const gchar *optarg, void *data,
+fence_history_cb(const char *option_name, const char *optarg, void *data,
                  GError **err)
 {
     if (optarg == NULL) {
@@ -475,7 +476,7 @@ fence_history_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-group_by_node_cb(const gchar *option_name, const gchar *optarg, void *data,
+group_by_node_cb(const char *option_name, const char *optarg, void *data,
                  GError **err)
 {
     show_opts |= pcmk_show_rscs_by_node;
@@ -483,14 +484,14 @@ group_by_node_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-hide_headers_cb(const gchar *option_name, const gchar *optarg, void *data,
+hide_headers_cb(const char *option_name, const char *optarg, void *data,
                 GError **err)
 {
     return user_include_exclude_cb("--exclude", "summary", data, err);
 }
 
 static gboolean
-inactive_resources_cb(const gchar *option_name, const gchar *optarg, void *data,
+inactive_resources_cb(const char *option_name, const char *optarg, void *data,
                       GError **err)
 {
     show_opts |= pcmk_show_inactive_rscs;
@@ -498,7 +499,7 @@ inactive_resources_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-print_brief_cb(const gchar *option_name, const gchar *optarg, void *data,
+print_brief_cb(const char *option_name, const char *optarg, void *data,
                GError **err)
 {
     show_opts |= pcmk_show_brief;
@@ -506,7 +507,7 @@ print_brief_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-print_detail_cb(const gchar *option_name, const gchar *optarg, void *data,
+print_detail_cb(const char *option_name, const char *optarg, void *data,
                 GError **err)
 {
     show_opts |= pcmk_show_details;
@@ -514,7 +515,7 @@ print_detail_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-print_description_cb(const gchar *option_name, const gchar *optarg, void *data,
+print_description_cb(const char *option_name, const char *optarg, void *data,
                      GError **err)
 {
     show_opts |= pcmk_show_description;
@@ -522,7 +523,7 @@ print_description_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-print_timing_cb(const gchar *option_name, const gchar *optarg, void *data,
+print_timing_cb(const char *option_name, const char *optarg, void *data,
                 GError **err)
 {
     show_opts |= pcmk_show_timing;
@@ -530,7 +531,7 @@ print_timing_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-reconnect_cb(const gchar *option_name, const gchar *optarg, void *data,
+reconnect_cb(const char *option_name, const char *optarg, void *data,
              GError **err)
 {
     long long reconnect_ms = 0;
@@ -566,7 +567,7 @@ reconnect_cb(const gchar *option_name, const gchar *optarg, void *data,
  * \param[out] err          Where to store error (ignored)
  */
 static gboolean
-one_shot_cb(const gchar *option_name, const gchar *optarg, void *data,
+one_shot_cb(const char *option_name, const char *optarg, void *data,
             GError **err)
 {
     options.exec_mode = mon_exec_one_shot;
@@ -583,7 +584,7 @@ one_shot_cb(const gchar *option_name, const gchar *optarg, void *data,
  * \param[out] err          Where to store error (ignored)
  */
 static gboolean
-daemonize_cb(const gchar *option_name, const gchar *optarg, void *data,
+daemonize_cb(const char *option_name, const char *optarg, void *data,
              GError **err)
 {
     options.exec_mode = mon_exec_daemonized;
@@ -591,14 +592,14 @@ daemonize_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-show_attributes_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_attributes_cb(const char *option_name, const char *optarg, void *data,
                    GError **err)
 {
     return user_include_exclude_cb("--include", "attributes", data, err);
 }
 
 static gboolean
-show_bans_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_bans_cb(const char *option_name, const char *optarg, void *data,
              GError **err)
 {
     if (optarg != NULL) {
@@ -612,28 +613,28 @@ show_bans_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-show_failcounts_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_failcounts_cb(const char *option_name, const char *optarg, void *data,
                    GError **err)
 {
     return user_include_exclude_cb("--include", "failcounts", data, err);
 }
 
 static gboolean
-show_operations_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_operations_cb(const char *option_name, const char *optarg, void *data,
                    GError **err)
 {
     return user_include_exclude_cb("--include", "failcounts,operations", data, err);
 }
 
 static gboolean
-show_tickets_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_tickets_cb(const char *option_name, const char *optarg, void *data,
                 GError **err)
 {
     return user_include_exclude_cb("--include", "tickets", data, err);
 }
 
 static gboolean
-use_cib_file_cb(const gchar *option_name, const gchar *optarg, void *data,
+use_cib_file_cb(const char *option_name, const char *optarg, void *data,
                 GError **err)
 {
     setenv("CIB_file", optarg, 1);

--- a/tools/crm_mon_curses.c
+++ b/tools/crm_mon_curses.c
@@ -37,7 +37,7 @@ typedef struct {
 } private_data_t;
 
 static void
-free_list_data(gpointer data) {
+free_list_data(void *data) {
     curses_list_data_t *list_data = data;
 
     free(list_data->singular_noun);
@@ -241,7 +241,7 @@ curses_list_item(pcmk__output_t *out, const char *id, const char *format, ...) {
 static void
 curses_increment_list(pcmk__output_t *out) {
     private_data_t *priv = NULL;
-    gpointer tail;
+    void *tail = NULL;
 
     pcmk__assert((out != NULL) && (out->priv != NULL));
     priv = out->priv;

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -322,7 +322,7 @@ static pcmk__message_entry_t fmt_functions[] = {
     { NULL, NULL, NULL }
 };
 
-static gint
+static int
 sort_node(gconstpointer a, gconstpointer b)
 {
     const pcmk_controld_api_node_t *node_a = a;

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -332,7 +332,7 @@ static pcmk__message_entry_t fmt_functions[] = {
 };
 
 static int
-sort_node(gconstpointer a, gconstpointer b)
+sort_node(const void *a, const void *b)
 {
     const pcmk_controld_api_node_t *node_a = a;
     const pcmk_controld_api_node_t *node_b = b;

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -39,9 +39,12 @@ struct {
     .force_flag = FALSE
 };
 
-gboolean command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
-gboolean name_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
-gboolean remove_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
+gboolean command_cb(const gchar *option_name, const gchar *optarg, void *data,
+                    GError **error);
+gboolean name_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **error);
+gboolean remove_cb(const gchar *option_name, const gchar *optarg, void *data,
+                   GError **error);
 
 static GError *error = NULL;
 static GMainLoop *mainloop = NULL;
@@ -102,7 +105,9 @@ static pcmk__supported_format_t formats[] = {
 };
 
 gboolean
-command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **error)
+{
     if (pcmk__str_eq("-i", option_name, pcmk__str_casei) || pcmk__str_eq("--cluster-id", option_name, pcmk__str_casei)) {
         options.command = 'i';
     } else if (pcmk__str_eq("-l", option_name, pcmk__str_casei) || pcmk__str_eq("--list", option_name, pcmk__str_casei)) {
@@ -122,14 +127,18 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 }
 
 gboolean
-name_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+name_cb(const gchar *option_name, const gchar *optarg, void *data,
+        GError **error)
+{
     options.command = 'N';
     pcmk__scan_min_int(optarg, &(options.nodeid), 0);
     return TRUE;
 }
 
 gboolean
-remove_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+remove_cb(const gchar *option_name, const gchar *optarg, void *data,
+          GError **error)
+{
     if (optarg == NULL) {
         g_set_error(error, PCMK__EXITC_ERROR, CRM_EX_INVALID_PARAM, "-R option requires an argument");
         return FALSE;

--- a/tools/crm_node.c
+++ b/tools/crm_node.c
@@ -39,11 +39,11 @@ struct {
     .force_flag = FALSE
 };
 
-gboolean command_cb(const gchar *option_name, const gchar *optarg, void *data,
+gboolean command_cb(const char *option_name, const char *optarg, void *data,
                     GError **error);
-gboolean name_cb(const gchar *option_name, const gchar *optarg, void *data,
+gboolean name_cb(const char *option_name, const char *optarg, void *data,
                  GError **error);
-gboolean remove_cb(const gchar *option_name, const gchar *optarg, void *data,
+gboolean remove_cb(const char *option_name, const char *optarg, void *data,
                    GError **error);
 
 static GError *error = NULL;
@@ -105,7 +105,7 @@ static pcmk__supported_format_t formats[] = {
 };
 
 gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_eq("-i", option_name, pcmk__str_casei) || pcmk__str_eq("--cluster-id", option_name, pcmk__str_casei)) {
@@ -127,8 +127,7 @@ command_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 gboolean
-name_cb(const gchar *option_name, const gchar *optarg, void *data,
-        GError **error)
+name_cb(const char *option_name, const char *optarg, void *data, GError **error)
 {
     options.command = 'N';
     pcmk__scan_min_int(optarg, &(options.nodeid), 0);
@@ -136,7 +135,7 @@ name_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 gboolean
-remove_cb(const gchar *option_name, const gchar *optarg, void *data,
+remove_cb(const char *option_name, const char *optarg, void *data,
           GError **error)
 {
     if (optarg == NULL) {

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -310,7 +310,7 @@ build_constraint_list(xmlNode *root)
 }
 
 static gboolean
-validate_opt_list(const gchar *optarg)
+validate_opt_list(const char *optarg)
 {
     if (pcmk__str_eq(optarg, PCMK_VALUE_FENCING, pcmk__str_none)) {
         options.opt_list = pcmk__opt_fencing;
@@ -328,7 +328,7 @@ validate_opt_list(const gchar *optarg)
 // GOptionArgFunc callback functions
 
 static gboolean
-attr_set_type_cb(const gchar *option_name, const gchar *optarg, void *data,
+attr_set_type_cb(const char *option_name, const char *optarg, void *data,
                  GError **error)
 {
     if (pcmk__str_any_of(option_name, "-m", "--meta", NULL)) {
@@ -356,7 +356,7 @@ attr_set_type_cb(const gchar *option_name, const gchar *optarg, void *data,
  *         error occurred, in which case \p *error is set
  */
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     // Sorted by enum rsc_command name
@@ -494,7 +494,7 @@ command_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-option_cb(const gchar *option_name, const gchar *optarg, void *data,
+option_cb(const char *option_name, const char *optarg, void *data,
           GError **error)
 {
     gchar *name = NULL;
@@ -519,7 +519,7 @@ option_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-timeout_cb(const gchar *option_name, const gchar *optarg, void *data,
+timeout_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     long long timeout_ms = 0;

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -148,7 +148,7 @@ struct {
     char *prop_name;              // Attribute name
     gchar *prop_set;              // --set-name (attribute block XML ID)
     gchar *prop_value;            // --parameter-value (attribute value)
-    guint timeout_ms;             // Parsed from --timeout value
+    unsigned int timeout_ms;      // Parsed from --timeout value
     char *agent_spec;             // Standard and/or provider and/or agent
     int check_level;              // Optional value of --validate or --force-check
 
@@ -527,7 +527,7 @@ timeout_cb(const gchar *option_name, const gchar *optarg, gpointer data,
         || (timeout_ms < 0)) {
         return FALSE;
     }
-    options.timeout_ms = (guint) QB_MIN(timeout_ms, UINT_MAX);
+    options.timeout_ms = (unsigned int) QB_MIN(timeout_ms, UINT_MAX);
     return TRUE;
 }
 
@@ -2104,7 +2104,7 @@ main(int argc, char **argv)
         // Commands that use positional arguments will create override_params
         if (options.override_params == NULL) {
             GString *msg = g_string_sized_new(128);
-            guint len = g_strv_length(options.remainder);
+            unsigned int len = g_strv_length(options.remainder);
 
             g_string_append(msg, "non-option ARGV-elements:");
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -200,7 +200,7 @@ quit_main_loop(crm_exit_t ec)
 }
 
 static gboolean
-resource_ipc_timeout(gpointer data)
+resource_ipc_timeout(void *data)
 {
     // Start with newline because "Waiting for ..." message doesn't have one
     if (error != NULL) {
@@ -328,8 +328,9 @@ validate_opt_list(const gchar *optarg)
 // GOptionArgFunc callback functions
 
 static gboolean
-attr_set_type_cb(const gchar *option_name, const gchar *optarg, gpointer data,
-                 GError **error) {
+attr_set_type_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **error)
+{
     if (pcmk__str_any_of(option_name, "-m", "--meta", NULL)) {
         options.attr_set_type = PCMK_XE_META_ATTRIBUTES;
     } else if (pcmk__str_any_of(option_name, "-z", "--utilization", NULL)) {
@@ -355,7 +356,7 @@ attr_set_type_cb(const gchar *option_name, const gchar *optarg, gpointer data,
  *         error occurred, in which case \p *error is set
  */
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
            GError **error)
 {
     // Sorted by enum rsc_command name
@@ -493,7 +494,7 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-option_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+option_cb(const gchar *option_name, const gchar *optarg, void *data,
           GError **error)
 {
     gchar *name = NULL;
@@ -518,7 +519,7 @@ option_cb(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 static gboolean
-timeout_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+timeout_cb(const gchar *option_name, const gchar *optarg, void *data,
            GError **error)
 {
     long long timeout_ms = 0;
@@ -1561,7 +1562,7 @@ handle_list_resources(pcmk_resource_t *rsc, pcmk_node_t *node, cib_t *cib_conn,
                       pcmk_scheduler_t *scheduler, pcmk_ipc_api_t *controld_api,
                       xmlNode *cib_xml_orig)
 {
-    GList *all = g_list_prepend(NULL, (gpointer) "*");
+    GList *all = g_list_prepend(NULL, (void *) "*");
     int rc = out->message(out, "resource-list", scheduler,
                           pcmk_show_inactive_rscs
                           |pcmk_show_rsc_only

--- a/tools/crm_resource.h
+++ b/tools/crm_resource.h
@@ -93,8 +93,8 @@ int cli_cleanup_all(pcmk_ipc_api_t *controld_api, pcmk_node_t *node,
                     pcmk_scheduler_t *scheduler);
 int cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                          const pcmk_node_t *node, const char *move_lifetime,
-                         guint timeout_ms, cib_t *cib, bool promoted_role_only,
-                         bool force);
+                         unsigned int timeout_ms, cib_t *cib,
+                         bool promoted_role_only, bool force);
 int cli_resource_move(pcmk_resource_t *rsc, const char *rsc_id,
                       const pcmk_node_t *node, const char *move_lifetime,
                       cib_t *cib, bool promoted_role_only, bool force);
@@ -102,14 +102,14 @@ crm_exit_t cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc
                                             const char *rsc_class, const char *rsc_prov,
                                             const char *rsc_type, const char *rsc_action,
                                             GHashTable *params, GHashTable *override_hash,
-                                            guint timeout_ms,
+                                            unsigned int timeout_ms,
                                             int resource_verbose,
                                             bool force, int check_level);
 crm_exit_t cli_resource_execute(pcmk_resource_t *rsc,
                                 const char *requested_name,
                                 const char *rsc_action,
                                 GHashTable *override_hash,
-                                guint timeout_ms, cib_t *cib,
+                                unsigned int timeout_ms, cib_t *cib,
                                 int resource_verbose, bool force,
                                 int check_level);
 
@@ -129,7 +129,7 @@ int cli_resource_delete_attribute(pcmk_resource_t *rsc,
 
 int update_scheduler_input(pcmk__output_t *out, pcmk_scheduler_t *scheduler,
                            cib_t *cib, xmlNode **cib_xml_orig);
-int wait_till_stable(pcmk__output_t *out, guint timeout_ms, cib_t * cib);
+int wait_till_stable(pcmk__output_t *out, unsigned int timeout_ms, cib_t *cib);
 
 bool resource_is_running_on(pcmk_resource_t *rsc, const char *host);
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -120,7 +120,7 @@ cli_resource_print(pcmk_resource_t *rsc, bool expanded)
 
     scheduler = rsc->priv->scheduler;
     out = scheduler->priv->out;
-    all = g_list_prepend(all, (gpointer) "*");
+    all = g_list_prepend(all, (void *) "*");
 
     out->begin_list(out, NULL, NULL, "Resource Config");
     out->message(out, (const char *) rsc->priv->xml->name, pcmk_show_pending,
@@ -392,7 +392,8 @@ resource_agent_action_default(pcmk__output_t *out, va_list args) {
         out->begin_list(out, NULL, NULL, PCMK_XE_OVERRIDES);
 
         g_hash_table_iter_init(&iter, overrides);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &name, (gpointer *) &value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &name,
+                                      (void **) &value)) {
             out->message(out, "override", rsc_name, name, value);
         }
 
@@ -467,7 +468,8 @@ resource_agent_action_xml(pcmk__output_t *out, va_list args) {
         out->begin_list(out, NULL, NULL, PCMK_XE_OVERRIDES);
 
         g_hash_table_iter_init(&iter, overrides);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &name, (gpointer *) &value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &name,
+                                      (void **) &value)) {
             out->message(out, "override", rsc_name, name, value);
         }
 

--- a/tools/crm_resource_print.c
+++ b/tools/crm_resource_print.c
@@ -578,12 +578,12 @@ resource_check_list_xml(pcmk__output_t *out, va_list args) {
     return pcmk_rc_ok;
 }
 
-PCMK__OUTPUT_ARGS("resource-search-list", "GList *", "const gchar *")
+PCMK__OUTPUT_ARGS("resource-search-list", "GList *", "const char *")
 static int
 resource_search_list_default(pcmk__output_t *out, va_list args)
 {
     GList *nodes = va_arg(args, GList *);
-    const gchar *requested_name = va_arg(args, const gchar *);
+    const char *requested_name = va_arg(args, const char *);
 
     bool printed = false;
     int rc = pcmk_rc_no_output;
@@ -622,12 +622,12 @@ resource_search_list_default(pcmk__output_t *out, va_list args)
     return rc;
 }
 
-PCMK__OUTPUT_ARGS("resource-search-list", "GList *", "const gchar *")
+PCMK__OUTPUT_ARGS("resource-search-list", "GList *", "const char *")
 static int
 resource_search_list_xml(pcmk__output_t *out, va_list args)
 {
     GList *nodes = va_arg(args, GList *);
-    const gchar *requested_name = va_arg(args, const gchar *);
+    const char *requested_name = va_arg(args, const char *);
 
     pcmk__output_xml_create_parent(out, PCMK_XE_NODES,
                                    PCMK_XA_RESOURCE, requested_name,

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -72,7 +72,7 @@ struct rsc_node_info {
  * \note This is suitable for use with \c g_list_foreach().
  */
 static void
-prepend_node_info(gpointer data, gpointer user_data)
+prepend_node_info(void *data, void *user_data)
 {
     const pcmk_node_t *node = data;
     struct rsc_node_info *rni = user_data;
@@ -410,7 +410,7 @@ resources_with_attr(pcmk__output_t *out, cib_t *cib, pcmk_resource_t *rsc,
 }
 
 static void
-free_attr_update_data(gpointer data)
+free_attr_update_data(void *data)
 {
     attr_update_data_t *ud = data;
 
@@ -945,13 +945,13 @@ clear_rsc_failures(pcmk__output_t *out, pcmk_ipc_api_t *controld_api,
             }
         }
 
-        g_hash_table_add(rscs, (gpointer) failed_id);
+        g_hash_table_add(rscs, (void *) failed_id);
     }
 
     free(interval_ms_s);
 
     g_hash_table_iter_init(&iter, rscs);
-    while (g_hash_table_iter_next(&iter, (gpointer *) &failed_id, NULL)) {
+    while (g_hash_table_iter_next(&iter, (void **) &failed_id, NULL)) {
         pcmk_resource_t *rsc = NULL;
 
         pcmk__debug("Erasing failures of %s on %s", failed_id,
@@ -1033,10 +1033,9 @@ cli_resource_delete(pcmk_ipc_api_t *controld_api, pcmk_resource_t *rsc,
                 GHashTableIter iter;
 
                 g_hash_table_iter_init(&iter, rsc->priv->allowed_nodes);
-                while (g_hash_table_iter_next(&iter, NULL,
-                                              (gpointer *) &node)) {
+                while (g_hash_table_iter_next(&iter, NULL, (void **) &node)) {
                     if ((node != NULL) && (node->assign->score >= 0)) {
-                        nodes = g_list_prepend(nodes, (gpointer *) node);
+                        nodes = g_list_prepend(nodes, (void **) node);
                     }
                 }
 
@@ -1319,7 +1318,8 @@ generate_resource_params(pcmk_resource_t *rsc)
     params = pe_rsc_params(rsc, NULL, rsc->priv->scheduler);
     if (params != NULL) {
         g_hash_table_iter_init(&iter, params);
-        while (g_hash_table_iter_next(&iter, (gpointer *) & key, (gpointer *) & value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &key,
+                                      (void **) &value)) {
             pcmk__insert_dup(combined, key, value);
         }
     }
@@ -2361,8 +2361,8 @@ apply_overrides(GHashTable *params, GHashTable *overrides)
         char *value = NULL;
 
         g_hash_table_iter_init(&iter, overrides);
-        while (g_hash_table_iter_next(&iter, (gpointer *) &name,
-                                      (gpointer *) &value)) {
+        while (g_hash_table_iter_next(&iter, (void **) &name,
+                                      (void **) &value)) {
             pcmk__insert_dup(params, name, value);
         }
     }

--- a/tools/crm_resource_runtime.c
+++ b/tools/crm_resource_runtime.c
@@ -895,7 +895,7 @@ clear_rsc_failures(pcmk__output_t *out, pcmk_ipc_api_t *controld_api,
 
     // Normalize interval to milliseconds for comparison to history entry
     if (operation) {
-        guint interval_ms = 0U;
+        unsigned int interval_ms = 0;
 
         pcmk_parse_interval_spec(interval_spec, &interval_ms);
         interval_ms_s = pcmk__assert_asprintf("%u", interval_ms);
@@ -1576,11 +1576,11 @@ update_dataset(cib_t *cib, pcmk_scheduler_t *scheduler, xmlNode **cib_xml_orig,
  *
  * \return Maximum stop timeout for \p rsc (in milliseconds)
  */
-static guint
+static unsigned int
 max_rsc_stop_timeout(pcmk_resource_t *rsc)
 {
     long long result_ll;
-    guint max_delay = 0;
+    unsigned int max_delay = 0;
     xmlNode *config = NULL;
     GHashTable *meta = NULL;
 
@@ -1595,7 +1595,7 @@ max_rsc_stop_timeout(pcmk_resource_t *rsc)
              iter != NULL; iter = iter->next) {
 
             pcmk_resource_t *child = iter->data;
-            guint delay = max_rsc_stop_timeout(child);
+            unsigned int delay = max_rsc_stop_timeout(child);
 
             if (delay > max_delay) {
                 pcmk__rsc_trace(rsc,
@@ -1619,7 +1619,7 @@ max_rsc_stop_timeout(pcmk_resource_t *rsc)
     meta = pcmk__unpack_action_meta(rsc, NULL, PCMK_ACTION_STOP, 0, config);
     if ((pcmk__scan_ll(g_hash_table_lookup(meta, PCMK_META_TIMEOUT),
                        &result_ll, -1LL) == pcmk_rc_ok) && (result_ll >= 0)) {
-        max_delay = (guint) QB_MIN(result_ll, UINT_MAX);
+        max_delay = (unsigned int) QB_MIN(result_ll, UINT_MAX);
     }
     g_hash_table_destroy(meta);
 
@@ -1641,16 +1641,16 @@ max_rsc_stop_timeout(pcmk_resource_t *rsc)
  *       throttling, or any demotions needed. It checks the stop timeout, even
  *       if the resources in question are actually being started.
  */
-static guint
+static unsigned int
 wait_time_estimate(pcmk_scheduler_t *scheduler, const GList *resources)
 {
-    guint max_delay = 0U;
+    unsigned int max_delay = 0;
 
     // Find maximum stop timeout in milliseconds
     for (const GList *item = resources; item != NULL; item = item->next) {
         pcmk_resource_t *rsc = pe_find_resource(scheduler->priv->resources,
                                                 (const char *) item->data);
-        guint delay = max_rsc_stop_timeout(rsc);
+        unsigned int delay = max_rsc_stop_timeout(rsc);
 
         if (delay > max_delay) {
             pcmk__rsc_trace(rsc,
@@ -1690,17 +1690,17 @@ wait_time_estimate(pcmk_scheduler_t *scheduler, const GList *resources)
 int
 cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
                      const pcmk_node_t *node, const char *move_lifetime,
-                     guint timeout_ms, cib_t *cib, bool promoted_role_only,
-                     bool force)
+                     unsigned int timeout_ms, cib_t *cib,
+                     bool promoted_role_only, bool force)
 {
     /* @TODO Due to this sleep interval, a timeout <2s will cause problems and
      * should be rejected
      */
-    static const guint sleep_interval = 2U;
+    static const unsigned int sleep_interval = 2;
 
     int rc = pcmk_rc_ok;
-    guint step_timeout_s = 0;
-    guint timeout = pcmk__timeout_ms2s(timeout_ms);
+    unsigned int step_timeout_s = 0;
+    unsigned int timeout = pcmk__timeout_ms2s(timeout_ms);
 
     bool stop_via_ban = false;
     char *rsc_id = NULL;
@@ -1869,7 +1869,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
 
     step_timeout_s = timeout / sleep_interval;
     while (list_delta != NULL) {
-        guint before = g_list_length(list_delta);
+        unsigned int before = g_list_length(list_delta);
 
         if(timeout_ms == 0) {
             step_timeout_s = wait_time_estimate(scheduler, list_delta)
@@ -1947,7 +1947,7 @@ cli_resource_restart(pcmk__output_t *out, pcmk_resource_t *rsc,
 
     step_timeout_s = timeout / sleep_interval;
     while (waiting_for_starts(list_delta, rsc, host)) {
-        guint before = g_list_length(list_delta);
+        unsigned int before = g_list_length(list_delta);
 
         if(timeout_ms == 0) {
             step_timeout_s = wait_time_estimate(scheduler, list_delta)
@@ -2212,7 +2212,7 @@ pending_actions_in_cib(pcmk_scheduler_t *scheduler)
  * \return Standard Pacemaker return code
  */
 int
-wait_till_stable(pcmk__output_t *out, guint timeout_ms, cib_t * cib)
+wait_till_stable(pcmk__output_t *out, unsigned int timeout_ms, cib_t *cib)
 {
     // @FIXME This should bail out when run with CIB_file
     pcmk_scheduler_t *scheduler = NULL;
@@ -2318,8 +2318,8 @@ get_action(const char *rsc_action) {
  * \param[in]     verbosity    Verbosity level
  */
 static void
-set_agent_environment(GHashTable *params, guint timeout_ms, int check_level,
-                      int verbosity)
+set_agent_environment(GHashTable *params, unsigned int timeout_ms,
+                      int check_level, int verbosity)
 {
     g_hash_table_insert(params, crm_meta_name(PCMK_META_TIMEOUT),
                         pcmk__assert_asprintf("%u", timeout_ms));
@@ -2376,7 +2376,7 @@ cli_resource_execute_from_params(pcmk__output_t *out, const char *rsc_name,
                                  const char *rsc_class, const char *rsc_prov,
                                  const char *rsc_type, const char *rsc_action,
                                  GHashTable *params, GHashTable *override_hash,
-                                 guint timeout_ms, int resource_verbose,
+                                 unsigned int timeout_ms, int resource_verbose,
                                  bool force, int check_level)
 {
     const char *class = rsc_class;
@@ -2448,7 +2448,7 @@ done:
  * \param[in] rsc     Resource that action is for
  * \param[in] action  Name of action
  */
-static guint
+static unsigned int
 get_action_timeout(pcmk_resource_t *rsc, const char *action)
 {
     long long timeout_ms = -1LL;
@@ -2461,14 +2461,14 @@ get_action_timeout(pcmk_resource_t *rsc, const char *action)
         timeout_ms = PCMK_DEFAULT_ACTION_TIMEOUT_MS;
     }
     g_hash_table_destroy(meta);
-    return (guint) QB_MIN(timeout_ms, UINT_MAX);
+    return (unsigned int) QB_MIN(timeout_ms, UINT_MAX);
 }
 
 // Does not modify override_hash or its contents
 crm_exit_t
 cli_resource_execute(pcmk_resource_t *rsc, const char *requested_name,
                      const char *rsc_action, GHashTable *override_hash,
-                     guint timeout_ms, cib_t *cib, int resource_verbose,
+                     unsigned int timeout_ms, cib_t *cib, int resource_verbose,
                      bool force, int check_level)
 {
     pcmk_scheduler_t *scheduler = NULL;

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2025 the Pacemaker project contributors
+ * Copyright 2019-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -41,7 +41,8 @@ struct {
     .mode = crm_rule_mode_none
 };
 
-static gboolean mode_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
+static gboolean mode_cb(const gchar *option_name, const gchar *optarg,
+                        void *data, GError **error);
 
 static GOptionEntry mode_entries[] = {
     { "check", 'c', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, mode_cb,
@@ -71,7 +72,9 @@ static GOptionEntry addl_entries[] = {
 };
 
 static gboolean
-mode_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+mode_cb(const gchar *option_name, const gchar *optarg, void *data,
+        GError **error)
+{
     if (strcmp(option_name, "c")) {
         options.mode = crm_rule_mode_check;
     }

--- a/tools/crm_rule.c
+++ b/tools/crm_rule.c
@@ -41,8 +41,8 @@ struct {
     .mode = crm_rule_mode_none
 };
 
-static gboolean mode_cb(const gchar *option_name, const gchar *optarg,
-                        void *data, GError **error);
+static gboolean mode_cb(const char *option_name, const char *optarg, void *data,
+                        GError **error);
 
 static GOptionEntry mode_entries[] = {
     { "check", 'c', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, mode_cb,
@@ -72,8 +72,7 @@ static GOptionEntry addl_entries[] = {
 };
 
 static gboolean
-mode_cb(const gchar *option_name, const gchar *optarg, void *data,
-        GError **error)
+mode_cb(const char *option_name, const char *optarg, void *data, GError **error)
 {
     if (strcmp(option_name, "c")) {
         options.mode = crm_rule_mode_check;

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -1033,7 +1033,7 @@ switch_shadow_instance(pcmk__output_t *out, GError **error)
 }
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-w", "--which", NULL)) {

--- a/tools/crm_shadow.c
+++ b/tools/crm_shadow.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -1033,7 +1033,7 @@ switch_shadow_instance(pcmk__output_t *out, GError **error)
 }
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, gpointer data,
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
            GError **error)
 {
     if (pcmk__str_any_of(option_name, "-w", "--which", NULL)) {

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -65,32 +65,42 @@ static pcmk__supported_format_t formats[] = {
 };
 
 static gboolean
-all_actions_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+all_actions_cb(const gchar *option_name, const gchar *optarg, void *data,
+               GError **error)
+{
     options.flags |= pcmk_sim_all_actions;
     return TRUE;
 }
 
 static gboolean
-attrs_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+attrs_cb(const gchar *option_name, const gchar *optarg, void *data,
+         GError **error)
+{
     section_opts |= pcmk_section_attributes;
     return TRUE;
 }
 
 static gboolean
-failcounts_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+failcounts_cb(const gchar *option_name, const gchar *optarg, void *data,
+              GError **error)
+{
     section_opts |= pcmk_section_failcounts | pcmk_section_failures;
     return TRUE;
 }
 
 static gboolean
-in_place_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+in_place_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     options.store = TRUE;
     options.flags |= pcmk_sim_process | pcmk_sim_simulate;
     return TRUE;
 }
 
 static gboolean
-live_check_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+live_check_cb(const gchar *option_name, const gchar *optarg, void *data,
+              GError **error)
+{
     if (options.xml_file) {
         free(options.xml_file);
     }
@@ -101,126 +111,166 @@ live_check_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErr
 }
 
 static gboolean
-node_down_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+node_down_cb(const gchar *option_name, const gchar *optarg, void *data,
+             GError **error)
+{
     options.injections->node_down = g_list_append(options.injections->node_down, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-node_fail_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+node_fail_cb(const gchar *option_name, const gchar *optarg, void *data,
+             GError **error)
+{
     options.injections->node_fail = g_list_append(options.injections->node_fail, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-node_up_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+node_up_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **error)
+{
     pcmk__simulate_node_config = true;
     options.injections->node_up = g_list_append(options.injections->node_up, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-op_fail_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+op_fail_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **error)
+{
     options.flags |= pcmk_sim_process | pcmk_sim_simulate;
     options.injections->op_fail = g_list_append(options.injections->op_fail, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-op_inject_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+op_inject_cb(const gchar *option_name, const gchar *optarg, void *data,
+             GError **error)
+{
     options.injections->op_inject = g_list_append(options.injections->op_inject, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-pending_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+pending_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **error)
+{
     options.flags |= pcmk_sim_show_pending;
     return TRUE;
 }
 
 static gboolean
-process_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+process_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **error)
+{
     options.flags |= pcmk_sim_process;
     return TRUE;
 }
 
 static gboolean
-quorum_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+quorum_cb(const gchar *option_name, const gchar *optarg, void *data,
+          GError **error)
+{
     pcmk__str_update(&options.injections->quorum, optarg);
     return TRUE;
 }
 
 static gboolean
-save_dotfile_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+save_dotfile_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **error)
+{
     options.flags |= pcmk_sim_process;
     pcmk__str_update(&options.dot_file, optarg);
     return TRUE;
 }
 
 static gboolean
-save_graph_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+save_graph_cb(const gchar *option_name, const gchar *optarg, void *data,
+              GError **error)
+{
     options.flags |= pcmk_sim_process;
     pcmk__str_update(&options.graph_file, optarg);
     return TRUE;
 }
 
 static gboolean
-show_scores_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+show_scores_cb(const gchar *option_name, const gchar *optarg, void *data,
+               GError **error)
+{
     options.flags |= pcmk_sim_process | pcmk_sim_show_scores;
     return TRUE;
 }
 
 static gboolean
-simulate_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+simulate_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     options.flags |= pcmk_sim_process | pcmk_sim_simulate;
     return TRUE;
 }
 
 static gboolean
-ticket_activate_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+ticket_activate_cb(const gchar *option_name, const gchar *optarg, void *data,
+                   GError **error)
+{
     options.injections->ticket_activate = g_list_append(options.injections->ticket_activate, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-ticket_grant_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+ticket_grant_cb(const gchar *option_name, const gchar *optarg, void *data,
+                GError **error)
+{
     options.injections->ticket_grant = g_list_append(options.injections->ticket_grant, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-ticket_revoke_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+ticket_revoke_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **error)
+{
     options.injections->ticket_revoke = g_list_append(options.injections->ticket_revoke, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-ticket_standby_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+ticket_standby_cb(const gchar *option_name, const gchar *optarg, void *data,
+                  GError **error)
+{
     options.injections->ticket_standby = g_list_append(options.injections->ticket_standby, g_strdup(optarg));
     return TRUE;
 }
 
 static gboolean
-utilization_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+utilization_cb(const gchar *option_name, const gchar *optarg, void *data,
+               GError **error)
+{
     options.flags |= pcmk_sim_process | pcmk_sim_show_utilization;
     return TRUE;
 }
 
 static gboolean
-watchdog_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+watchdog_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     pcmk__str_update(&options.injections->watchdog, optarg);
     return TRUE;
 }
 
 static gboolean
-xml_file_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+xml_file_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     pcmk__str_update(&options.xml_file, optarg);
     options.flags |= pcmk_sim_sanitized;
     return TRUE;
 }
 
 static gboolean
-xml_pipe_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+xml_pipe_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     pcmk__str_update(&options.xml_file, "-");
     options.flags |= pcmk_sim_sanitized;
     return TRUE;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -114,7 +114,8 @@ static gboolean
 node_down_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
-    options.injections->node_down = g_list_append(options.injections->node_down, g_strdup(optarg));
+    options.injections->node_down = g_list_append(options.injections->node_down,
+                                                  pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -122,7 +123,8 @@ static gboolean
 node_fail_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
-    options.injections->node_fail = g_list_append(options.injections->node_fail, g_strdup(optarg));
+    options.injections->node_fail = g_list_append(options.injections->node_fail,
+                                                  pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -131,7 +133,8 @@ node_up_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     pcmk__simulate_node_config = true;
-    options.injections->node_up = g_list_append(options.injections->node_up, g_strdup(optarg));
+    options.injections->node_up = g_list_append(options.injections->node_up,
+                                                pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -140,7 +143,8 @@ op_fail_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     options.flags |= pcmk_sim_process | pcmk_sim_simulate;
-    options.injections->op_fail = g_list_append(options.injections->op_fail, g_strdup(optarg));
+    options.injections->op_fail = g_list_append(options.injections->op_fail,
+                                                pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -148,7 +152,8 @@ static gboolean
 op_inject_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
-    options.injections->op_inject = g_list_append(options.injections->op_inject, g_strdup(optarg));
+    options.injections->op_inject = g_list_append(options.injections->op_inject,
+                                                  pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -214,7 +219,9 @@ static gboolean
 ticket_activate_cb(const char *option_name, const char *optarg, void *data,
                    GError **error)
 {
-    options.injections->ticket_activate = g_list_append(options.injections->ticket_activate, g_strdup(optarg));
+    options.injections->ticket_activate =
+        g_list_append(options.injections->ticket_activate,
+                      pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -222,7 +229,8 @@ static gboolean
 ticket_grant_cb(const char *option_name, const char *optarg, void *data,
                 GError **error)
 {
-    options.injections->ticket_grant = g_list_append(options.injections->ticket_grant, g_strdup(optarg));
+    options.injections->ticket_grant =
+        g_list_append(options.injections->ticket_grant, pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -230,7 +238,9 @@ static gboolean
 ticket_revoke_cb(const char *option_name, const char *optarg, void *data,
                  GError **error)
 {
-    options.injections->ticket_revoke = g_list_append(options.injections->ticket_revoke, g_strdup(optarg));
+    options.injections->ticket_revoke =
+        g_list_append(options.injections->ticket_revoke,
+                      pcmk__str_copy(optarg));
     return TRUE;
 }
 
@@ -238,7 +248,9 @@ static gboolean
 ticket_standby_cb(const char *option_name, const char *optarg, void *data,
                   GError **error)
 {
-    options.injections->ticket_standby = g_list_append(options.injections->ticket_standby, g_strdup(optarg));
+    options.injections->ticket_standby =
+        g_list_append(options.injections->ticket_standby,
+                      pcmk__str_copy(optarg));
     return TRUE;
 }
 

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -41,7 +41,7 @@ struct {
     pcmk_injections_t *injections;
     uint32_t flags;
     gchar *output_file;
-    gint repeat;
+    int repeat;
     gboolean store;
     gchar *test_dir;
     char *use_date;

--- a/tools/crm_simulate.c
+++ b/tools/crm_simulate.c
@@ -65,7 +65,7 @@ static pcmk__supported_format_t formats[] = {
 };
 
 static gboolean
-all_actions_cb(const gchar *option_name, const gchar *optarg, void *data,
+all_actions_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     options.flags |= pcmk_sim_all_actions;
@@ -73,7 +73,7 @@ all_actions_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-attrs_cb(const gchar *option_name, const gchar *optarg, void *data,
+attrs_cb(const char *option_name, const char *optarg, void *data,
          GError **error)
 {
     section_opts |= pcmk_section_attributes;
@@ -81,7 +81,7 @@ attrs_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-failcounts_cb(const gchar *option_name, const gchar *optarg, void *data,
+failcounts_cb(const char *option_name, const char *optarg, void *data,
               GError **error)
 {
     section_opts |= pcmk_section_failcounts | pcmk_section_failures;
@@ -89,7 +89,7 @@ failcounts_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-in_place_cb(const gchar *option_name, const gchar *optarg, void *data,
+in_place_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     options.store = TRUE;
@@ -98,7 +98,7 @@ in_place_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-live_check_cb(const gchar *option_name, const gchar *optarg, void *data,
+live_check_cb(const char *option_name, const char *optarg, void *data,
               GError **error)
 {
     if (options.xml_file) {
@@ -111,7 +111,7 @@ live_check_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-node_down_cb(const gchar *option_name, const gchar *optarg, void *data,
+node_down_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
     options.injections->node_down = g_list_append(options.injections->node_down, g_strdup(optarg));
@@ -119,7 +119,7 @@ node_down_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-node_fail_cb(const gchar *option_name, const gchar *optarg, void *data,
+node_fail_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
     options.injections->node_fail = g_list_append(options.injections->node_fail, g_strdup(optarg));
@@ -127,7 +127,7 @@ node_fail_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-node_up_cb(const gchar *option_name, const gchar *optarg, void *data,
+node_up_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     pcmk__simulate_node_config = true;
@@ -136,7 +136,7 @@ node_up_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-op_fail_cb(const gchar *option_name, const gchar *optarg, void *data,
+op_fail_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     options.flags |= pcmk_sim_process | pcmk_sim_simulate;
@@ -145,7 +145,7 @@ op_fail_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-op_inject_cb(const gchar *option_name, const gchar *optarg, void *data,
+op_inject_cb(const char *option_name, const char *optarg, void *data,
              GError **error)
 {
     options.injections->op_inject = g_list_append(options.injections->op_inject, g_strdup(optarg));
@@ -153,7 +153,7 @@ op_inject_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-pending_cb(const gchar *option_name, const gchar *optarg, void *data,
+pending_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     options.flags |= pcmk_sim_show_pending;
@@ -161,7 +161,7 @@ pending_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-process_cb(const gchar *option_name, const gchar *optarg, void *data,
+process_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     options.flags |= pcmk_sim_process;
@@ -169,7 +169,7 @@ process_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-quorum_cb(const gchar *option_name, const gchar *optarg, void *data,
+quorum_cb(const char *option_name, const char *optarg, void *data,
           GError **error)
 {
     pcmk__str_update(&options.injections->quorum, optarg);
@@ -177,7 +177,7 @@ quorum_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-save_dotfile_cb(const gchar *option_name, const gchar *optarg, void *data,
+save_dotfile_cb(const char *option_name, const char *optarg, void *data,
                 GError **error)
 {
     options.flags |= pcmk_sim_process;
@@ -186,7 +186,7 @@ save_dotfile_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-save_graph_cb(const gchar *option_name, const gchar *optarg, void *data,
+save_graph_cb(const char *option_name, const char *optarg, void *data,
               GError **error)
 {
     options.flags |= pcmk_sim_process;
@@ -195,7 +195,7 @@ save_graph_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-show_scores_cb(const gchar *option_name, const gchar *optarg, void *data,
+show_scores_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     options.flags |= pcmk_sim_process | pcmk_sim_show_scores;
@@ -203,7 +203,7 @@ show_scores_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-simulate_cb(const gchar *option_name, const gchar *optarg, void *data,
+simulate_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     options.flags |= pcmk_sim_process | pcmk_sim_simulate;
@@ -211,7 +211,7 @@ simulate_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-ticket_activate_cb(const gchar *option_name, const gchar *optarg, void *data,
+ticket_activate_cb(const char *option_name, const char *optarg, void *data,
                    GError **error)
 {
     options.injections->ticket_activate = g_list_append(options.injections->ticket_activate, g_strdup(optarg));
@@ -219,7 +219,7 @@ ticket_activate_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-ticket_grant_cb(const gchar *option_name, const gchar *optarg, void *data,
+ticket_grant_cb(const char *option_name, const char *optarg, void *data,
                 GError **error)
 {
     options.injections->ticket_grant = g_list_append(options.injections->ticket_grant, g_strdup(optarg));
@@ -227,7 +227,7 @@ ticket_grant_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-ticket_revoke_cb(const gchar *option_name, const gchar *optarg, void *data,
+ticket_revoke_cb(const char *option_name, const char *optarg, void *data,
                  GError **error)
 {
     options.injections->ticket_revoke = g_list_append(options.injections->ticket_revoke, g_strdup(optarg));
@@ -235,7 +235,7 @@ ticket_revoke_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-ticket_standby_cb(const gchar *option_name, const gchar *optarg, void *data,
+ticket_standby_cb(const char *option_name, const char *optarg, void *data,
                   GError **error)
 {
     options.injections->ticket_standby = g_list_append(options.injections->ticket_standby, g_strdup(optarg));
@@ -243,7 +243,7 @@ ticket_standby_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-utilization_cb(const gchar *option_name, const gchar *optarg, void *data,
+utilization_cb(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     options.flags |= pcmk_sim_process | pcmk_sim_show_utilization;
@@ -251,7 +251,7 @@ utilization_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-watchdog_cb(const gchar *option_name, const gchar *optarg, void *data,
+watchdog_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     pcmk__str_update(&options.injections->watchdog, optarg);
@@ -259,7 +259,7 @@ watchdog_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-xml_file_cb(const gchar *option_name, const gchar *optarg, void *data,
+xml_file_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     pcmk__str_update(&options.xml_file, optarg);
@@ -268,7 +268,7 @@ xml_file_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-xml_pipe_cb(const gchar *option_name, const gchar *optarg, void *data,
+xml_pipe_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     pcmk__str_update(&options.xml_file, "-");

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -70,7 +70,9 @@ static pcmk__supported_format_t formats[] = {
 };
 
 static gboolean
-attr_value_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+attr_value_cb(const gchar *option_name, const gchar *optarg, void *data,
+              GError **err)
+{
     pcmk__str_update(&options.attr_value, optarg);
 
     if (!options.attr_name || !options.attr_value) {
@@ -87,7 +89,9 @@ attr_value_cb(const gchar *option_name, const gchar *optarg, gpointer data, GErr
 }
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **err)
+{
     if (pcmk__str_any_of(option_name, "--info", "-l", NULL)) {
         options.ticket_cmd = 'l';
     } else if (pcmk__str_any_of(option_name, "--details", "-L", NULL)) {
@@ -106,21 +110,27 @@ command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError 
 }
 
 static gboolean
-delete_attr_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+delete_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
+               GError **err)
+{
     attr_delete = g_list_append(attr_delete, strdup(optarg));
     modified = true;
     return TRUE;
 }
 
 static gboolean
-get_attr_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+get_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **err)
+{
     pcmk__str_update(&options.get_attr_name, optarg);
     options.ticket_cmd = 'G';
     return TRUE;
 }
 
 static gboolean
-grant_standby_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+grant_standby_cb(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **err)
+{
     if (pcmk__str_any_of(option_name, "--grant", "-g", NULL)) {
         pcmk__insert_dup(attr_set, PCMK__XA_GRANTED, PCMK_VALUE_TRUE);
         modified = true;
@@ -139,7 +149,9 @@ grant_standby_cb(const gchar *option_name, const gchar *optarg, gpointer data, G
 }
 
 static gboolean
-set_attr_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **err) {
+set_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **err)
+{
     pcmk__str_update(&options.attr_name, optarg);
 
     if (!options.attr_name || !options.attr_value) {

--- a/tools/crm_ticket.c
+++ b/tools/crm_ticket.c
@@ -70,7 +70,7 @@ static pcmk__supported_format_t formats[] = {
 };
 
 static gboolean
-attr_value_cb(const gchar *option_name, const gchar *optarg, void *data,
+attr_value_cb(const char *option_name, const char *optarg, void *data,
               GError **err)
 {
     pcmk__str_update(&options.attr_value, optarg);
@@ -89,7 +89,7 @@ attr_value_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **err)
 {
     if (pcmk__str_any_of(option_name, "--info", "-l", NULL)) {
@@ -110,7 +110,7 @@ command_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-delete_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
+delete_attr_cb(const char *option_name, const char *optarg, void *data,
                GError **err)
 {
     attr_delete = g_list_append(attr_delete, strdup(optarg));
@@ -119,7 +119,7 @@ delete_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-get_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
+get_attr_cb(const char *option_name, const char *optarg, void *data,
             GError **err)
 {
     pcmk__str_update(&options.get_attr_name, optarg);
@@ -128,7 +128,7 @@ get_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-grant_standby_cb(const gchar *option_name, const gchar *optarg, void *data,
+grant_standby_cb(const char *option_name, const char *optarg, void *data,
                  GError **err)
 {
     if (pcmk__str_any_of(option_name, "--grant", "-g", NULL)) {
@@ -149,7 +149,7 @@ grant_standby_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-set_attr_cb(const gchar *option_name, const gchar *optarg, void *data,
+set_attr_cb(const char *option_name, const char *optarg, void *data,
             GError **err)
 {
     pcmk__str_update(&options.attr_name, optarg);
@@ -273,7 +273,7 @@ static GOptionEntry deprecated_entries[] = {
 };
 
 static void
-ticket_grant_warning(gchar *ticket_id)
+ticket_grant_warning(char *ticket_id)
 {
     out->err(out, "This command cannot help you verify whether '%s' has "
                   "been already granted elsewhere.\n"
@@ -284,7 +284,7 @@ ticket_grant_warning(gchar *ticket_id)
 }
 
 static void
-ticket_revoke_warning(gchar *ticket_id)
+ticket_revoke_warning(char *ticket_id)
 {
     out->err(out, "Revoking '%s' can trigger the specified '" PCMK_XA_LOSS_POLICY
               "'(s) relating to '%s'.\n\n"

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -41,7 +41,7 @@ struct {
     .bash_export = FALSE
 };
 
-gboolean command_cb(const gchar *option_name, const gchar *optarg, void *data,
+gboolean command_cb(const char *option_name, const char *optarg, void *data,
                     GError **error);
 
 static GOptionEntry command_options[] = {
@@ -97,7 +97,7 @@ static GOptionEntry additional_options[] = {
 };
 
 gboolean
-command_cb(const gchar *option_name, const gchar *optarg, void *data,
+command_cb(const char *option_name, const char *optarg, void *data,
            GError **error)
 {
     if (!strcmp(option_name, "--status") || !strcmp(option_name, "-S")) {

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -41,7 +41,8 @@ struct {
     .bash_export = FALSE
 };
 
-gboolean command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
+gboolean command_cb(const gchar *option_name, const gchar *optarg, void *data,
+                    GError **error);
 
 static GOptionEntry command_options[] = {
     { "status", 'S', 0, G_OPTION_ARG_CALLBACK, command_cb,
@@ -96,7 +97,8 @@ static GOptionEntry additional_options[] = {
 };
 
 gboolean
-command_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error)
+command_cb(const gchar *option_name, const gchar *optarg, void *data,
+           GError **error)
 {
     if (!strcmp(option_name, "--status") || !strcmp(option_name, "-S")) {
         command = cmd_health;

--- a/tools/crmadmin.c
+++ b/tools/crmadmin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -30,7 +30,7 @@ static enum {
 
 struct {
     gboolean health;
-    guint timeout;
+    unsigned int timeout;
     char *optarg;
     char *ipc_name;
     gboolean bash_export;

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -36,7 +36,7 @@ struct {
 #define INDENT "                              "
 
 static gboolean
-date_now_cb(const gchar *option_name, const gchar *optarg, void *data,
+date_now_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     if (pcmk__str_any_of(option_name, "--now", "-n", NULL)) {
@@ -49,7 +49,7 @@ date_now_cb(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 static gboolean
-modifier_cb(const gchar *option_name, const gchar *optarg, void *data,
+modifier_cb(const char *option_name, const char *optarg, void *data,
             GError **error)
 {
     if (pcmk__str_any_of(option_name, "--seconds", "-s", NULL)) {

--- a/tools/iso8601.c
+++ b/tools/iso8601.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2025 the Pacemaker project contributors
+ * Copyright 2005-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -36,7 +36,9 @@ struct {
 #define INDENT "                              "
 
 static gboolean
-date_now_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+date_now_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     if (pcmk__str_any_of(option_name, "--now", "-n", NULL)) {
         pcmk__str_update(&options.date_time_s, "now");
     } else if (pcmk__str_any_of(option_name, "--date", "-d", NULL)) {
@@ -47,7 +49,9 @@ date_now_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError
 }
 
 static gboolean
-modifier_cb(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+modifier_cb(const gchar *option_name, const gchar *optarg, void *data,
+            GError **error)
+{
     if (pcmk__str_any_of(option_name, "--seconds", "-s", NULL)) {
         options.print_options |= crm_time_seconds;
     } else if (pcmk__str_any_of(option_name, "--epoch", "-S", NULL)) {

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -73,11 +73,16 @@ struct {
     .delay = 0
 };
 
-gboolean add_env_params(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
-gboolean add_fencing_device(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
-gboolean add_fencing_params(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
-gboolean add_tolerance(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
-gboolean set_tag(const gchar *option_name, const gchar *optarg, gpointer data, GError **error);
+gboolean add_env_params(const gchar *option_name, const gchar *optarg,
+                        void *data, GError **error);
+gboolean add_fencing_device(const gchar *option_name, const gchar *optarg,
+                            void *data, GError **error);
+gboolean add_fencing_params(const gchar *option_name, const gchar *optarg,
+                            void *data, GError **error);
+gboolean add_tolerance(const gchar *option_name, const gchar *optarg,
+                       void *data, GError **error);
+gboolean set_tag(const gchar *option_name, const gchar *optarg, void *data,
+                 GError **error);
 
 #define INDENT "                                    "
 
@@ -239,7 +244,9 @@ static const int st_opts = st_opt_sync_call|st_opt_allow_self_fencing;
 static char *name = NULL;
 
 gboolean
-add_env_params(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+add_env_params(const gchar *option_name, const gchar *optarg, void *data,
+               GError **error)
+{
     char *key = pcmk__assert_asprintf("OCF_RESKEY_%s", optarg);
     const char *env = getenv(key);
     gboolean retval = TRUE;
@@ -262,7 +269,7 @@ add_env_params(const gchar *option_name, const gchar *optarg, gpointer data, GEr
 }
 
 gboolean
-add_fencing_device(const gchar *option_name, const gchar *optarg, gpointer data,
+add_fencing_device(const gchar *option_name, const gchar *optarg, void *data,
                    GError **error)
 {
     options.devices = g_list_append(options.devices, pcmk__str_copy(optarg));
@@ -270,7 +277,9 @@ add_fencing_device(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 gboolean
-add_tolerance(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+add_tolerance(const gchar *option_name, const gchar *optarg, void *data,
+              GError **error)
+{
     // pcmk__request_fencing() expects an unsigned int
     long long tolerance_ms = 0;
 
@@ -286,7 +295,7 @@ add_tolerance(const gchar *option_name, const gchar *optarg, gpointer data, GErr
 }
 
 gboolean
-add_fencing_params(const gchar *option_name, const gchar *optarg, gpointer data,
+add_fencing_params(const gchar *option_name, const gchar *optarg, void *data,
                    GError **error)
 {
     gchar *name = NULL;
@@ -317,7 +326,9 @@ add_fencing_params(const gchar *option_name, const gchar *optarg, gpointer data,
 }
 
 gboolean
-set_tag(const gchar *option_name, const gchar *optarg, gpointer data, GError **error) {
+set_tag(const gchar *option_name, const gchar *optarg, void *data,
+        GError **error)
+{
     free(name);
     name = pcmk__assert_asprintf("%s.%s", crm_system_name, optarg);
     return TRUE;
@@ -608,7 +619,8 @@ main(int argc, char **argv)
             /* register_device wants a stonith_key_value_t instead of a GHashTable */
             stonith_key_value_t *params = NULL;
             GHashTableIter iter;
-            gpointer key, val;
+            void *key = NULL;
+            void *val = NULL;
 
             if (options.params != NULL) {
                 g_hash_table_iter_init(&iter, options.params);

--- a/tools/stonith_admin.c
+++ b/tools/stonith_admin.c
@@ -73,15 +73,15 @@ struct {
     .delay = 0
 };
 
-gboolean add_env_params(const gchar *option_name, const gchar *optarg,
-                        void *data, GError **error);
-gboolean add_fencing_device(const gchar *option_name, const gchar *optarg,
+gboolean add_env_params(const char *option_name, const char *optarg, void *data,
+                        GError **error);
+gboolean add_fencing_device(const char *option_name, const char *optarg,
                             void *data, GError **error);
-gboolean add_fencing_params(const gchar *option_name, const gchar *optarg,
+gboolean add_fencing_params(const char *option_name, const char *optarg,
                             void *data, GError **error);
-gboolean add_tolerance(const gchar *option_name, const gchar *optarg,
-                       void *data, GError **error);
-gboolean set_tag(const gchar *option_name, const gchar *optarg, void *data,
+gboolean add_tolerance(const char *option_name, const char *optarg, void *data,
+                       GError **error);
+gboolean set_tag(const char *option_name, const char *optarg, void *data,
                  GError **error);
 
 #define INDENT "                                    "
@@ -244,7 +244,7 @@ static const int st_opts = st_opt_sync_call|st_opt_allow_self_fencing;
 static char *name = NULL;
 
 gboolean
-add_env_params(const gchar *option_name, const gchar *optarg, void *data,
+add_env_params(const char *option_name, const char *optarg, void *data,
                GError **error)
 {
     char *key = pcmk__assert_asprintf("OCF_RESKEY_%s", optarg);
@@ -269,7 +269,7 @@ add_env_params(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 gboolean
-add_fencing_device(const gchar *option_name, const gchar *optarg, void *data,
+add_fencing_device(const char *option_name, const char *optarg, void *data,
                    GError **error)
 {
     options.devices = g_list_append(options.devices, pcmk__str_copy(optarg));
@@ -277,7 +277,7 @@ add_fencing_device(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 gboolean
-add_tolerance(const gchar *option_name, const gchar *optarg, void *data,
+add_tolerance(const char *option_name, const char *optarg, void *data,
               GError **error)
 {
     // pcmk__request_fencing() expects an unsigned int
@@ -295,7 +295,7 @@ add_tolerance(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 gboolean
-add_fencing_params(const gchar *option_name, const gchar *optarg, void *data,
+add_fencing_params(const char *option_name, const char *optarg, void *data,
                    GError **error)
 {
     gchar *name = NULL;
@@ -326,8 +326,7 @@ add_fencing_params(const gchar *option_name, const gchar *optarg, void *data,
 }
 
 gboolean
-set_tag(const gchar *option_name, const gchar *optarg, void *data,
-        GError **error)
+set_tag(const char *option_name, const char *optarg, void *data, GError **error)
 {
     free(name);
     name = pcmk__assert_asprintf("%s.%s", crm_system_name, optarg);


### PR DESCRIPTION
The GLib documentation says the standard types should be preferred in new code. See, for example, https://docs.gtk.org/glib/types.html#gint.

I'm opening this as a draft because it's so invasive and is likely to conflict with other ongoing work.