### PR TITLE
Deprecate allowing specifying your own DH parameters

### DIFF
--- a/doc/sphinx/Pacemaker_Explained/local-options.rst
+++ b/doc/sphinx/Pacemaker_Explained/local-options.rst
@@ -663,6 +663,8 @@ whose location varies by OS (most commonly ``/etc/sysconfig/pacemaker`` or
 
        Clients do not use ``PCMK_dh_max_bits``.
 
+       *(Deprecated since 3.0.2)*
+
    * - .. _pcmk_ipc_type:
 
        .. index::

--- a/etc/sysconfig/pacemaker.in
+++ b/etc/sysconfig/pacemaker.in
@@ -317,7 +317,7 @@
 # Default: PCMK_tls_priorities="@PCMK__GNUTLS_PRIORITIES@"
 # Example: PCMK_tls_priorities="SECURE128:+SECURE192:-VERS-ALL:+VERS-TLS1.2"
 
-# PCMK_dh_max_bits (Advanced Use Only)
+# PCMK_dh_max_bits (DEPRECATED; Advanced Use Only)
 #
 # Set an upper bound on the bit length of the prime number generated for
 # Diffie-Hellman parameters needed by TLS connections. The default is no
@@ -331,6 +331,8 @@
 # versions.
 #
 # Clients do not use PCMK_dh_max_bits.
+#
+# This variable is deprecated as of Pacemaker 3.0.2.
 #
 # Default: PCMK_dh_max_bits="0" (no maximum)
 

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -151,7 +151,6 @@ bool pcmk__valid_fencing_watchdog_timeout(const char *value);
 #define PCMK__ENV_CLUSTER_TYPE              "cluster_type"
 #define PCMK__ENV_CRL_FILE                  "crl_file"
 #define PCMK__ENV_DEBUG                     "debug"
-#define PCMK__ENV_DH_MAX_BITS               "dh_max_bits"
 #define PCMK__ENV_FAIL_FAST                 "fail_fast"
 #define PCMK__ENV_IPC_TYPE                  "ipc_type"
 #define PCMK__ENV_KEY_FILE                  "key_file"
@@ -177,6 +176,9 @@ bool pcmk__valid_fencing_watchdog_timeout(const char *value);
 #define PCMK__ENV_TRACE_FUNCTIONS           "trace_functions"
 #define PCMK__ENV_TRACE_TAGS                "trace_tags"
 #define PCMK__ENV_VALGRIND_ENABLED          "valgrind_enabled"
+
+// @COMPAT Deprecated since 3.0.2
+#define PCMK__ENV_DH_MAX_BITS               "dh_max_bits"
 
 // Constants for meta-attribute names
 #define PCMK__META_CLONE                    "clone"

--- a/include/crm/common/tls_internal.h
+++ b/include/crm/common/tls_internal.h
@@ -83,23 +83,6 @@ int pcmk__init_tls(pcmk__tls_t **tls, bool server, bool have_psk);
 
 /*!
  * \internal
- * \brief Initialize Diffie-Hellman parameters for a TLS server
- *
- * \param[out] dh_params  Parameter object to initialize
- *
- * \return Standard Pacemaker return code
- * \todo The current best practice is to allow the client and server to
- *       negotiate the Diffie-Hellman parameters via a TLS extension (RFC 7919).
- *       However, we have to support both older versions of GnuTLS (<3.6) that
- *       don't support the extension on our side, and older Pacemaker versions
- *       that don't support the extension on the other side. The next best
- *       practice would be to use a known good prime (see RFC 5114 section 2.2),
- *       possibly stored in a file distributed with Pacemaker.
- */
-int pcmk__init_tls_dh(gnutls_dh_params_t *dh_params);
-
-/*!
- * \internal
  * \brief Initialize a new TLS session
  *
  * \param[in] tls    TLS environment object

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -31,8 +31,23 @@
 #include <crm/common/logging.h>     // CRM_CHECK
 #include <crm/common/results.h>     // pcmk_rc_*
 
-int
-pcmk__init_tls_dh(gnutls_dh_params_t *dh_params)
+/*!
+ * \internal
+ * \brief Initialize Diffie-Hellman parameters for a TLS server
+ *
+ * \param[out] dh_params  Parameter object to initialize
+ *
+ * \return Standard Pacemaker return code
+ * \todo The current best practice is to allow the client and server to
+ *       negotiate the Diffie-Hellman parameters via a TLS extension (RFC 7919).
+ *       However, we have to support both older versions of GnuTLS (<3.6) that
+ *       don't support the extension on our side, and older Pacemaker versions
+ *       that don't support the extension on the other side. The next best
+ *       practice would be to use a known good prime (see RFC 5114 section 2.2),
+ *       possibly stored in a file distributed with Pacemaker.
+ */
+static int
+init_tls_dh(gnutls_dh_params_t *dh_params)
 {
     int rc = GNUTLS_E_SUCCESS;
     unsigned int dh_bits = 0;
@@ -206,7 +221,7 @@ pcmk__init_tls(pcmk__tls_t **tls, bool server, bool have_psk)
     gnutls_global_set_log_function(_gnutls_log_func);
 
     if (server) {
-        rc = pcmk__init_tls_dh(&(*tls)->dh_params);
+        rc = init_tls_dh(&(*tls)->dh_params);
         if (rc != pcmk_rc_ok) {
             g_clear_pointer(tls, pcmk__free_tls);
             return rc;

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -31,6 +31,46 @@
 #include <crm/common/logging.h>     // CRM_CHECK
 #include <crm/common/results.h>     // pcmk_rc_*
 
+int
+pcmk__init_tls_dh(gnutls_dh_params_t *dh_params)
+{
+    int rc = GNUTLS_E_SUCCESS;
+    unsigned int dh_bits = 0;
+    int dh_max_bits = 0;
+
+    rc = gnutls_dh_params_init(dh_params);
+    if (rc != GNUTLS_E_SUCCESS) {
+        goto error;
+    }
+
+    dh_bits = gnutls_sec_param_to_pk_bits(GNUTLS_PK_DH,
+                                          GNUTLS_SEC_PARAM_NORMAL);
+    if (dh_bits == 0) {
+        rc = GNUTLS_E_DH_PRIME_UNACCEPTABLE;
+        goto error;
+    }
+
+    pcmk__scan_min_int(pcmk__env_option(PCMK__ENV_DH_MAX_BITS), &dh_max_bits, 0);
+    if ((dh_max_bits > 0) && (dh_bits > dh_max_bits)) {
+        dh_bits = dh_max_bits;
+    }
+
+    pcmk__info("Generating Diffie-Hellman parameters with %u-bit prime for TLS",
+               dh_bits);
+    rc = gnutls_dh_params_generate2(*dh_params, dh_bits);
+    if (rc != GNUTLS_E_SUCCESS) {
+        goto error;
+    }
+
+    return pcmk_rc_ok;
+
+error:
+    pcmk__err("Could not initialize Diffie-Hellman parameters for TLS: %s "
+              QB_XS " rc=%d",
+              gnutls_strerror(rc), rc);
+    return EPROTO;
+}
+
 static char *
 get_gnutls_priorities(gnutls_credentials_type_t cred_type)
 {
@@ -246,46 +286,6 @@ pcmk__init_tls(pcmk__tls_t **tls, bool server, bool have_psk)
     }
 
     return rc;
-}
-
-int
-pcmk__init_tls_dh(gnutls_dh_params_t *dh_params)
-{
-    int rc = GNUTLS_E_SUCCESS;
-    unsigned int dh_bits = 0;
-    int dh_max_bits = 0;
-
-    rc = gnutls_dh_params_init(dh_params);
-    if (rc != GNUTLS_E_SUCCESS) {
-        goto error;
-    }
-
-    dh_bits = gnutls_sec_param_to_pk_bits(GNUTLS_PK_DH,
-                                          GNUTLS_SEC_PARAM_NORMAL);
-    if (dh_bits == 0) {
-        rc = GNUTLS_E_DH_PRIME_UNACCEPTABLE;
-        goto error;
-    }
-
-    pcmk__scan_min_int(pcmk__env_option(PCMK__ENV_DH_MAX_BITS), &dh_max_bits, 0);
-    if ((dh_max_bits > 0) && (dh_bits > dh_max_bits)) {
-        dh_bits = dh_max_bits;
-    }
-
-    pcmk__info("Generating Diffie-Hellman parameters with %u-bit prime for TLS",
-               dh_bits);
-    rc = gnutls_dh_params_generate2(*dh_params, dh_bits);
-    if (rc != GNUTLS_E_SUCCESS) {
-        goto error;
-    }
-
-    return pcmk_rc_ok;
-
-error:
-    pcmk__err("Could not initialize Diffie-Hellman parameters for TLS: %s "
-              QB_XS " rc=%d",
-              gnutls_strerror(rc), rc);
-    return EPROTO;
 }
 
 gnutls_session_t

--- a/lib/common/tls.c
+++ b/lib/common/tls.c
@@ -67,6 +67,9 @@ init_tls_dh(gnutls_dh_params_t *dh_params)
 
     pcmk__scan_min_int(pcmk__env_option(PCMK__ENV_DH_MAX_BITS), &dh_max_bits, 0);
     if ((dh_max_bits > 0) && (dh_bits > dh_max_bits)) {
+        pcmk__warn("Support for the " PCMK__ENV_DH_MAX_BITS " "
+                   "environment variable is deprecated and will be removed "
+                   "in a future release");
         dh_bits = dh_max_bits;
     }
 


### PR DESCRIPTION
As part of working on PQC readiness, I'm trying to deal with various other TLS-related problems along the way.  Here's another patch along these lines.

DH parameters are only supported being set on the server side of a connection.  As far as I can tell, the point of this functionality in pacemaker is to be able to support newer clients talking to older servers.  Also worth noting is that as of gnutls 3.6, specifying your own DH parameters is deprecated and the library will negotiate the parameters for you instead.  gnutls 3.6 was released in 2017, and you have to go all the way back to RHEL 7 to find a release that included an older version.

In pacemaker, the only places the TLS code comes up are in remote CIB administration and remote nodes.

For remote CIB administration, I don't think there's any problems with eventually removing the DH code.  For remote nodes, it's more complicated.  In that case, the remote node is the server, so the only case we need to consider is remote nodes on OSes that have gnutls < 3.6 (which is RHEL 7 or similar, which is pacemaker 1.x) talking to pacemaker >= 3.1 (which is the earliest I would actually remove this code) clusters.

I've tested a 3.x remote node that allows specifying DH parameters with a 3.x cluster that doesn't, and a 2.x remote node that allows specifying DH parameters with a 3.x cluster that doesn't.  In each case, however, gnutls >= 3.6 was in use.  Testing the one concerning case doesn't seem to be especially worth it to me, given the age of all the parts involved.