### PR TITLE
Revert "API: libraries: Update version numbers in so names"

### DIFF
--- a/include/crm/cib.h
+++ b/include/crm/cib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2026 the Pacemaker project contributors
+ * Copyright 2004-2025 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -52,7 +52,7 @@ void cib_dump_pending_callbacks(void);
 int num_cib_op_callbacks(void);
 void remove_cib_op_callback(int call_id, gboolean all_callbacks);
 
-#define CIB_LIBRARY "libcib.so.55"
+#define CIB_LIBRARY "libcib.so.54"
 
 #ifdef __cplusplus
 }

--- a/include/crm/stonith-ng.h
+++ b/include/crm/stonith-ng.h
@@ -712,7 +712,7 @@ time_t stonith_api_time(uint32_t nodeid, const char *uname, bool in_progress);
 
  */
 
-#define STONITH_LIBRARY "libstonithd.so.57"
+#define STONITH_LIBRARY "libstonithd.so.56"
 
 // NOTE: dlm (as of at least 4.3.0) uses these (via the helper functions below)
 typedef int (*st_api_kick_fn) (int nodeid, const char *uname, int timeout, bool off);


### PR DESCRIPTION
This reverts commit 7cbdc274963638a1e66d5b73cd953ce76366f426.  The version numbers don't need to be updated because the major version number hasn't changed.