### PR TITLE
[3.0] Fix: libcib: Full-CIB replace op no longer segfaults with cib_xpath

### DIFF
--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -738,50 +738,6 @@ cib__process_query(const char *op, int options, const char *section,
     return process_query_section(options, section, *cib, answer);
 }
 
-static int
-process_replace_xpath(const char *op, int options, const char *xpath,
-                      xmlNode *input, xmlNode *cib)
-{
-    int num_results = 0;
-    int rc = pcmk_rc_ok;
-    xmlXPathObject *xpath_obj = pcmk__xpath_search(cib->doc, xpath);
-
-    num_results = pcmk__xpath_num_results(xpath_obj);
-    if (num_results == 0) {
-        pcmk__debug("%s: %s does not exist", op, xpath);
-        rc = ENXIO;
-        goto done;
-    }
-
-    for (int i = 0; i < num_results; i++) {
-        xmlNode *match = NULL;
-        xmlNode *parent = NULL;
-        xmlChar *path = NULL;
-
-        match = pcmk__xpath_result(xpath_obj, i);
-        if (match == NULL) {
-            continue;
-        }
-
-        path = xmlGetNodePath(match);
-        pcmk__debug("Processing %s op for %s with %s", op, xpath, path);
-        free(path);
-
-        parent = match->parent;
-
-        pcmk__xml_free(match);
-        pcmk__xml_copy(parent, input);
-
-        if (!pcmk__is_set(options, cib_multiple)) {
-            break;
-        }
-    }
-
-done:
-    xmlXPathFreeObject(xpath_obj);
-    return rc;
-}
-
 static bool
 replace_cib_digest_matches(xmlNode *request, xmlNode *input)
 {
@@ -865,6 +821,50 @@ replace_cib(xmlNode *request, xmlNode *input, xmlNode **cib)
                updates, replace_admin_epoch, replace_epoch, replace_updates,
                peer);
     return pcmk_rc_ok;
+}
+
+static int
+process_replace_xpath(const char *op, int options, const char *xpath,
+                      xmlNode *input, xmlNode *cib)
+{
+    int num_results = 0;
+    int rc = pcmk_rc_ok;
+    xmlXPathObject *xpath_obj = pcmk__xpath_search(cib->doc, xpath);
+
+    num_results = pcmk__xpath_num_results(xpath_obj);
+    if (num_results == 0) {
+        pcmk__debug("%s: %s does not exist", op, xpath);
+        rc = ENXIO;
+        goto done;
+    }
+
+    for (int i = 0; i < num_results; i++) {
+        xmlNode *match = NULL;
+        xmlNode *parent = NULL;
+        xmlChar *path = NULL;
+
+        match = pcmk__xpath_result(xpath_obj, i);
+        if (match == NULL) {
+            continue;
+        }
+
+        path = xmlGetNodePath(match);
+        pcmk__debug("Processing %s op for %s with %s", op, xpath, path);
+        free(path);
+
+        parent = match->parent;
+
+        pcmk__xml_free(match);
+        pcmk__xml_copy(parent, input);
+
+        if (!pcmk__is_set(options, cib_multiple)) {
+            break;
+        }
+    }
+
+done:
+    xmlXPathFreeObject(xpath_obj);
+    return rc;
 }
 
 static int

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -825,11 +825,11 @@ replace_cib(xmlNode *request, xmlNode *input, xmlNode **cib)
 
 static int
 process_replace_xpath(const char *op, int options, const char *xpath,
-                      xmlNode *input, xmlNode *cib)
+                      xmlNode *request, xmlNode *input, xmlNode **cib)
 {
     int num_results = 0;
     int rc = pcmk_rc_ok;
-    xmlXPathObject *xpath_obj = pcmk__xpath_search(cib->doc, xpath);
+    xmlXPathObject *xpath_obj = pcmk__xpath_search((*cib)->doc, xpath);
 
     num_results = pcmk__xpath_num_results(xpath_obj);
     if (num_results == 0) {
@@ -851,6 +851,11 @@ process_replace_xpath(const char *op, int options, const char *xpath,
         path = xmlGetNodePath(match);
         pcmk__debug("Processing %s op for %s with %s", op, xpath, path);
         free(path);
+
+        if (match == *cib) {
+            rc = replace_cib(request, input, cib);
+            break;
+        }
 
         parent = match->parent;
 
@@ -905,7 +910,7 @@ cib__process_replace(const char *op, int options, const char *section,
                      xmlNode **answer)
 {
     if (pcmk__is_set(options, cib_xpath)) {
-        return process_replace_xpath(op, options, section, input, *cib);
+        return process_replace_xpath(op, options, section, req, input, cib);
     }
 
     return process_replace_section(section, req, input, cib);


### PR DESCRIPTION
Previously, a CIB replace operation targeting the full CIB would fail with a segmentation fault if the `cib_xpath` flag were set (or if `--xpath` were used with `cibadmin`). Presumably this is because `process_replace_xpath()` was freeing the CIB, leaving no reference to it, and possibly dereferencing more nodes in the document as it continued processing any remaining XPath search results.

Now, a full CIB replacement with XPath succeeds if the replacement CIB is well-formed and is of a newer version, and it appears to fail sanely otherwise.

This backports commit bcc47c8153dde6da78151a3101bdc14f5acc5d05 from main.