### PR TITLE
allow the status-section to be updated on a crm_shadow commit with an explicit switch

### DIFF
--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -178,6 +178,7 @@ cib__client_triggers_refresh(const char *name)
     return (pcmk__parse_server(name) == pcmk_ipc_unknown)
            && !pcmk__str_any_of(name,
                                 "attrd_updater",
+                                "cibadmin_status",
                                 "crm_attribute",
                                 "crm_node",
                                 "crm_resource",

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -137,6 +137,7 @@ static struct {
     gboolean input_stdin;
     gboolean allow_create;
     gboolean force;
+    gboolean update_status;
     gboolean get_node_path;
     gboolean no_children;
     gboolean score_update;
@@ -807,6 +808,11 @@ static GOptionEntry addl_entries[] = {
       "result",
       NULL },
 
+    { "update-status", 'u', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+      &options.update_status,
+      "(Advanced) Apply CIB update without triggering a controller refresh",
+      NULL },
+
     // @COMPAT Deprecated since 3.0.0
     { "local", 'l', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &options.local,
       "(deprecated)", NULL },
@@ -1087,7 +1093,8 @@ main(int argc, char **argv)
      * In cibadmin we explicitly output the XML portion without the prefixes. So
      * we default to LOG_CRIT.
      */
-    pcmk__cli_init_logging("cibadmin", 0);
+    pcmk__cli_init_logging(
+        options.update_status? "cibadmin_status" : "cibadmin", 0);
     set_crm_log_level(LOG_CRIT);
 
     if (args->verbosity > 0) {


### PR DESCRIPTION
Investigating why with Pacemaker 2.1.7 the high-level-tooling approach to prevent a resource restart as a result of a parameter change in the config by in parallel changing the digests in the status section wouldn't work anymore  ...
Was barking at the wrong tree investigating the commit that changes how digests are calculated.
In parallel there was as well a commit in Pacemaker 2.1.7 ( ec65417cc7) that removes the special handling of replacing the full cib and now triggers an election + join refresh whenever an “unsafe” client modifies the status section, overwriting the manually pushed digest before the scheduler can see it.
Added a ‘--commit-status’ option to cibadmin that prevents this behavior (client will claim to be cibadmin_status and this is added to the safe clients list).