### PR TITLE
[3.0] Fix: libcib: Prevent based or cibadmin from crashing when handling an XPath query for an attribute

### DIFF
--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -636,7 +636,18 @@ process_query_xpath(const char *op, int options, const char *xpath,
         pcmk__debug("Processing %s op for %s with %s", op, xpath, path);
         free(path);
 
-        if (match->type != XML_ELEMENT_NODE) {
+        if (match->type != XML_ELEMENT_NODE
+            && pcmk__is_set(options, cib_xpath_address)) {
+            /* @COMPAT cib_xpath_address is deprecated since 3.0.2
+             * For a non-element, handle cib_xpath_address with its
+             * corresponding element.
+             */
+            match = pcmk__xpath_match_element(match);
+            if (match == NULL) {
+                continue;
+            }
+
+        } else if (match->type != XML_ELEMENT_NODE) {
             // Create an element for a single match of a non-element
             if (*answer == NULL) {
                 *answer = pcmk__xe_create(NULL, PCMK__XE_XPATH_QUERY);

--- a/lib/cib/cib_ops.c
+++ b/lib/cib/cib_ops.c
@@ -636,6 +636,16 @@ process_query_xpath(const char *op, int options, const char *xpath,
         pcmk__debug("Processing %s op for %s with %s", op, xpath, path);
         free(path);
 
+        if (match->type != XML_ELEMENT_NODE) {
+            // Create an element for a single match of a non-element
+            if (*answer == NULL) {
+                *answer = pcmk__xe_create(NULL, PCMK__XE_XPATH_QUERY);
+            }
+
+            pcmk__xml_copy(*answer, match);
+            continue;
+        }
+
         if (pcmk__is_set(options, cib_no_children)) {
             xmlNode *shallow = pcmk__xe_create(*answer,
                                                (const char *) match->name);


### PR DESCRIPTION
Backport https://github.com/ClusterLabs/pacemaker/pull/3980 to 3.0