### PR TITLE
Low: Build: Use -std=c99 with cov-build

### DIFF
--- a/devel/Makefile.am
+++ b/devel/Makefile.am
@@ -49,8 +49,9 @@ COVHTML		= $(COVERITY_DIR)/output/errors
 .PHONY: $(COVERITY_DIR)
 $(COVERITY_DIR): coverity-clean
 	$(MAKE) $(AM_MAKEFLAGS) -C $(top_builddir) init core-clean
-	$(AM_V_GEN)cd $(top_builddir)	\
-		&& cov-build --dir "$@" $(MAKE) $(AM_MAKEFLAGS) core
+	$(AM_V_GEN)cd $(top_builddir)					\
+		&& cov-build --dir "$@" $(MAKE) $(AM_MAKEFLAGS) 	\
+			CFLAGS="-std=c99 $(CFLAGS)" core
 
 # Public coverity instance
 


### PR DESCRIPTION
This fixes the "recoverable" Coverity build errors and makes a bunch of UNINIT false positives go away.