### PR TITLE
High: pacemakerd: Properly find and track all existing sub-daemons

### DIFF
--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -796,11 +796,11 @@ find_and_track_existing_processes(void)
             int rc = find_and_track_child(&pcmk_children[i], rounds,
                                           &wait_in_progress);
 
-            if (rc == pcmk_rc_ok) {
-                break;
-            } else if (rc != EAGAIN) {
-                return rc;
+            if ((rc == pcmk_rc_ok) || (rc == EAGAIN)) {
+                continue;
             }
+
+            return rc;
         }
 
         if (!wait_in_progress) {


### PR DESCRIPTION
This fixes a regression introduced by be3103910c. With that commit, by killing pacemakerd, the respawned pacemakerd would only find and track the existing pacemaker-based and start forking all the other sub-daemons again. Eventually it would run into an unrecoverable internal error and shut down itself.

This fixes the issue by continuing the loop to as well find and track the other sub-daemons.