### PR TITLE
[3.0] Low: tools: Use the VERSION variable instead of invoking `crm_attribute --version`

### DIFF
--- a/tools/crm_failcount.in
+++ b/tools/crm_failcount.in
@@ -223,7 +223,8 @@ while true ; do
 			exit $CRM_EX_OK
 			;;
 		--version)
-			crm_attribute --version
+			echo "Pacemaker @VERSION@"
+			echo "Written by Andrew Beekhof and the Pacemaker project contributors"
 			exit $?
 			;;
 		-q|-Q|--quiet)

--- a/tools/crm_master.in
+++ b/tools/crm_master.in
@@ -49,7 +49,8 @@ while true ; do
 			exit 0
 			;;
 		--version)
-			crm_attribute --version
+			echo "Pacemaker @VERSION@"
+			echo "Written by Andrew Beekhof and the Pacemaker project contributors"
 			exit 0
 			;;
 		--verbose|-V|--quiet|-q|--query|-G|--delete|-D)

--- a/tools/crm_standby.in
+++ b/tools/crm_standby.in
@@ -69,7 +69,8 @@ while true ; do
             exit 0
             ;;
         --version)
-            crm_attribute --version
+            echo "Pacemaker @VERSION@"
+            echo "Written by Andrew Beekhof and the Pacemaker project contributors"
             exit 0
             ;;
         -q|--quiet|-V|--verbose|-Q)


### PR DESCRIPTION
Backport https://github.com/ClusterLabs/pacemaker/pull/4112 to 3.0 branch.

As a matter of fact, `help2man` generates a man page out of `--help` and `--version` output. The tools `crm_failcount`, `crm_master` and `crm_standby` invoke `crm_attribute --version` for their `--version` option. It means, when generating their man pages using `help2man`, `crm_attribute` has to be existing already.

The commit af996cdfe5 dropped the MAN8DEPS on crm_attribute. It doesn't seem to be an issue with `-j1` build option. But with a build option like `-j4`, an error message like the following may result into the generated man page:

```
-.TH CRM_FAILCOUNT: "8" "uq2000-02-02" "crm_failcount: line 226: crm_attribute: command not found" "System Administration Utilities"
```

This fixes it by outputting the version and author information by themselves using the VERSION variable instead of invoking `crm_attribute --version`.