### PR TITLE
Low: libcrmcommon, tools: Fix NULL dereference in crm_resource.c

### DIFF
--- a/lib/common/ipc_controld.c
+++ b/lib/common/ipc_controld.c
@@ -623,8 +623,11 @@ pcmk_controld_api_refresh(pcmk_ipc_api_t *api, const char *target_node,
 unsigned int
 pcmk_controld_api_replies_expected(const pcmk_ipc_api_t *api)
 {
-    struct controld_api_private_s *private = api->api_data;
+    struct controld_api_private_s *private = NULL;
 
+    CRM_CHECK(api != NULL, return 0);
+
+    private = api->api_data;
     return private->replies_expected;
 }
 

--- a/tools/crm_resource.c
+++ b/tools/crm_resource.c
@@ -268,16 +268,24 @@ static void
 start_mainloop(pcmk_ipc_api_t *capi)
 {
     // @TODO See if we can avoid setting exit_code as a global variable
-    unsigned int count = pcmk_controld_api_replies_expected(capi);
+    unsigned int count = 0;
 
-    if (count > 0) {
-        out->info(out, "Waiting for %u %s from the controller",
-                  count, pcmk__plural_alt(count, "reply", "replies"));
-        exit_code = CRM_EX_DISCONNECT; // For unexpected disconnects
-        mainloop = g_main_loop_new(NULL, FALSE);
-        pcmk__create_timer(MESSAGE_TIMEOUT_S * 1000, resource_ipc_timeout, NULL);
-        g_main_loop_run(mainloop);
+    if (capi == NULL) {
+        // Should happen only during a dry run due to CIB_file being set
+        return;
     }
+
+    count = pcmk_controld_api_replies_expected(capi);
+    if (count == 0) {
+        return;
+    }
+
+    out->info(out, "Waiting for %u %s from the controller", count,
+              pcmk__plural_alt(count, "reply", "replies"));
+    exit_code = CRM_EX_DISCONNECT;  // For unexpected disconnects
+    mainloop = g_main_loop_new(NULL, false);
+    pcmk__create_timer((MESSAGE_TIMEOUT_S * 1000), resource_ipc_timeout, NULL);
+    g_main_loop_run(mainloop);
 }
 
 static GList *


### PR DESCRIPTION
Found by Coverity with `--enable-fnptr` option. `pcmk_controld_api_replies_expected()` dereferences its argument.