### PR TITLE
Refactor: daemons: Drop redundant NULL checks

### DIFF
--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -639,10 +639,8 @@ static struct qb_ipcs_service_handlers ipc_callbacks = {
 void
 attrd_ipc_cleanup(void)
 {
-    if (ipcs != NULL) {
-        pcmk__drop_all_clients(ipcs);
-        g_clear_pointer(&ipcs, qb_ipcs_destroy);
-    }
+    pcmk__drop_all_clients(ipcs);
+    g_clear_pointer(&ipcs, qb_ipcs_destroy);
 
     pcmk__client_cleanup();
 }

--- a/daemons/execd/execd_ipc.c
+++ b/daemons/execd/execd_ipc.c
@@ -208,10 +208,8 @@ static struct qb_ipcs_service_handlers ipc_callbacks = {
 void
 execd_ipc_cleanup(void)
 {
-    if (ipcs != NULL) {
-        pcmk__drop_all_clients(ipcs);
-        g_clear_pointer(&ipcs, qb_ipcs_destroy);
-    }
+    pcmk__drop_all_clients(ipcs);
+    g_clear_pointer(&ipcs, qb_ipcs_destroy);
 
     pcmk__client_cleanup();
 }

--- a/daemons/fenced/fenced_ipc.c
+++ b/daemons/fenced/fenced_ipc.c
@@ -266,10 +266,8 @@ static struct qb_ipcs_service_handlers ipc_callbacks = {
 void
 fenced_ipc_cleanup(void)
 {
-    if (ipcs != NULL) {
-        pcmk__drop_all_clients(ipcs);
-        g_clear_pointer(&ipcs, qb_ipcs_destroy);
-    }
+    pcmk__drop_all_clients(ipcs);
+    g_clear_pointer(&ipcs, qb_ipcs_destroy);
 
     pcmk__client_cleanup();
 }

--- a/daemons/pacemakerd/pcmkd_ipc.c
+++ b/daemons/pacemakerd/pcmkd_ipc.c
@@ -189,10 +189,8 @@ static struct qb_ipcs_service_handlers ipc_callbacks = {
 void
 pacemakerd_ipc_cleanup(void)
 {
-    if (ipcs != NULL) {
-        pcmk__drop_all_clients(ipcs);
-        g_clear_pointer(&ipcs, qb_ipcs_destroy);
-    }
+    pcmk__drop_all_clients(ipcs);
+    g_clear_pointer(&ipcs, qb_ipcs_destroy);
 
     pcmk__client_cleanup();
 }

--- a/daemons/schedulerd/schedulerd_ipc.c
+++ b/daemons/schedulerd/schedulerd_ipc.c
@@ -196,10 +196,8 @@ static struct qb_ipcs_service_handlers ipc_callbacks = {
 void
 schedulerd_ipc_cleanup(void)
 {
-    if (ipcs != NULL) {
-        pcmk__drop_all_clients(ipcs);
-        g_clear_pointer(&ipcs, qb_ipcs_destroy);
-    }
+    pcmk__drop_all_clients(ipcs);
+    g_clear_pointer(&ipcs, qb_ipcs_destroy);
 
     pcmk__client_cleanup();
 }


### PR DESCRIPTION
pcmk__drop_all_clients() returns immediately if its argument is NULL, and g_clear_pointer() is NULL-safe.