### PR TITLE
Low: based: Fix a segfault in cib_process_command.

### DIFF
--- a/daemons/based/based_callbacks.c
+++ b/daemons/based/based_callbacks.c
@@ -571,12 +571,13 @@ cib_process_command(xmlNode *request, const cib__operation_t *operation,
                              || pcmk__is_set(operation->flags,
                                              cib__op_attr_writes_through);
 
-        const char *feature_set = pcmk__xe_get(the_cib,
-                                               PCMK_XA_CRM_FEATURE_SET);
+        const char *feature_set = NULL;
 
         if (result_cib != the_cib) {
             rc = based_activate_cib(result_cib, to_disk, op);
         }
+
+        feature_set = pcmk__xe_get(the_cib, PCMK_XA_CRM_FEATURE_SET);
 
         /* @COMPAT Nodes older than feature set 3.19.0 don't support
          * transactions. In a mixed-version cluster with nodes <3.19.0, we must


### PR DESCRIPTION
Calling based_activate_cib will cause the_cib to be freed, which means that feature_set (which was grabbed by pcmk__xe_get earlier) will now be pointing at invalid memory.  This will result in a segfault when pcmk__compare_versions is called later.

Instead, grab feature_set after calling based_activate_cib.  This was introduced by 38cfbabfab8.