### PR TITLE
Fix integer overflows in remote message code

### DIFF
--- a/include/crm/common/remote_internal.h
+++ b/include/crm/common/remote_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2024 the Pacemaker project contributors
+ * Copyright 2008-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,6 +14,9 @@
 
 #include <crm/common/nodes.h>           // pcmk_node_variant_remote
 #include <crm/common/scheduler_types.h> // pcmk_node_t
+
+// The maximum payload size for a remote message (in bytes)
+#define PCMK__REMOTE_MSG_MAX_SIZE (20 * 1024 * 1024)
 
 // internal functions from remote.c
 

--- a/lib/cib/cib_remote.c
+++ b/lib/cib/cib_remote.c
@@ -243,7 +243,6 @@ cib_remote_callback_dispatch(gpointer user_data)
             return -1;
     }
 
-    // coverity[tainted_data] This can't easily be changed right now
     msg = pcmk__remote_message_xml(&private->callback);
     if (msg == NULL) {
         private->start_time = 0;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -620,6 +620,7 @@ xmlNode *
 pcmk__remote_message_xml(pcmk__remote_t *remote)
 {
     xmlNode *xml = NULL;
+    size_t data_size = 0;
     struct remote_header_v0 *header = localized_remote_header(remote);
 
     if (header == NULL) {
@@ -709,7 +710,18 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
     /* take ownership of the buffer */
     remote->buffer_offset = 0;
 
-    CRM_LOG_ASSERT(remote->buffer[sizeof(struct remote_header_v0) + header->payload_uncompressed - 1] == 0);
+    data_size = (size_t) header->payload_offset + header->payload_uncompressed;
+
+    // Ensure the buffer is as big as it should be
+    CRM_CHECK(remote->buffer_size >= data_size, return NULL);
+
+    /* Ensure the buffer is null-terminated (see
+     * pcmk__read_available_remote_data()).
+     *
+     * Note that payload_uncompressed contains the payload size including the
+     * null byte (see pcmk__remote_send_xml()).
+     */
+    CRM_CHECK(remote->buffer[data_size] == '\0', return NULL);
 
     xml = pcmk__xml_parse(remote->buffer + header->payload_offset);
     if (xml == NULL && header->version > REMOTE_MSG_VERSION) {

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -623,6 +623,7 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
         int rc = 0;
         unsigned int size_u = 0;
         char *uncompressed = NULL;
+        size_t buffer_size = 0;
 
 #if (UINT32_MAX < UINT_MAX)
         if (header->payload_uncompressed >= UINT_MAX) {
@@ -656,11 +657,17 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
             return NULL;
         }
 
+        buffer_size = (size_t) header->payload_offset + size_u;
+        if (buffer_size > PCMK__REMOTE_MSG_MAX_SIZE) {
+            crm_err("Message size %zu is larger than max allowed %u bytes",
+                    buffer_size, PCMK__REMOTE_MSG_MAX_SIZE);
+            return NULL;
+        }
+
         crm_trace("Decompressing message data %" PRIu32 " bytes into %u "
                   "bytes", header->payload_compressed, size_u);
 
-        uncompressed = pcmk__assert_alloc(header->payload_offset + size_u,
-                                          sizeof(char));
+        uncompressed = pcmk__assert_alloc(buffer_size, sizeof(char));
 
         rc = BZ2_bzBuffToBuffDecompress(uncompressed + header->payload_offset,
                                         &size_u,
@@ -803,6 +810,12 @@ pcmk__read_available_remote_data(pcmk__remote_t *remote)
     if(header) {
         /* Stop at the end of the current message */
         read_len = header->size_total;
+    }
+
+    if (read_len > PCMK__REMOTE_MSG_MAX_SIZE) {
+        crm_err("Message size %zu is larger than max allowed %u bytes",
+                read_len, PCMK__REMOTE_MSG_MAX_SIZE);
+        return EINVAL;
     }
 
     /* automatically grow the buffer when needed */

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2024 the Pacemaker project contributors
+ * Copyright 2008-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -23,7 +23,7 @@
 #include <netdb.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <inttypes.h>   // PRIx32
+#include <inttypes.h>   // PRIu32, PRIx32
 
 #include <glib.h>
 #include <bzlib.h>
@@ -97,11 +97,18 @@ struct remote_header_v0 {
 static struct remote_header_v0 *
 localized_remote_header(pcmk__remote_t *remote)
 {
-    struct remote_header_v0 *header = (struct remote_header_v0 *)remote->buffer;
-    if(remote->buffer_offset < sizeof(struct remote_header_v0)) {
-        return NULL;
+    struct remote_header_v0 *header = NULL;
+    size_t expected_size = 0;
 
-    } else if(header->endian != ENDIAN_LOCAL) {
+    if ((remote == NULL) || (remote->buffer == NULL)
+        || (remote->buffer_offset < sizeof(struct remote_header_v0))) {
+
+        // Caller error or we haven't received the full header yet
+        return NULL;
+    }
+
+    header = (struct remote_header_v0 *) remote->buffer;
+    if (header->endian != ENDIAN_LOCAL) {
         uint32_t endian = __swab32(header->endian);
 
         CRM_LOG_ASSERT(endian == ENDIAN_LOCAL);
@@ -121,6 +128,41 @@ localized_remote_header(pcmk__remote_t *remote)
         header->payload_offset = __swab32(header->payload_offset);
         header->payload_compressed = __swab32(header->payload_compressed);
         header->payload_uncompressed = __swab32(header->payload_uncompressed);
+    }
+
+    // Sanity checks
+    if (header->payload_offset != sizeof(struct remote_header_v0)) {
+        crm_err("Header payload offset %" PRIu32 " does not have expected "
+                "size %zu", header->payload_offset,
+                sizeof(struct remote_header_v0));
+        return NULL;
+    }
+
+    if (header->payload_compressed != 0) {
+        if (header->payload_compressed > (SIZE_MAX - header->payload_offset)) {
+            crm_err("Header compressed size %" PRIu32 " is too large",
+                    header->payload_compressed);
+            return NULL;
+        }
+
+        expected_size = (size_t) header->payload_offset
+                        + header->payload_compressed;
+
+    } else {
+        if (header->payload_uncompressed > (SIZE_MAX - header->payload_offset)) {
+            crm_err("Header uncompressed size %" PRIu32 " is too large",
+                    header->payload_uncompressed);
+            return NULL;
+        }
+
+        expected_size = (size_t) header->payload_offset
+                        + header->payload_uncompressed;
+    }
+
+    if (expected_size != header->size_total) {
+        crm_err("Header total size %" PRIu32 " does not match calculated "
+                "size %zu", header->size_total, expected_size);
+        return NULL;
     }
 
     return header;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -586,6 +586,13 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
     header->version = REMOTE_MSG_VERSION;
     header->payload_offset = iov[0].iov_len;
     header->payload_uncompressed = iov[1].iov_len;
+
+    if ((UINT32_MAX - iov[0].iov_len) < iov[1].iov_len) {
+        crm_err("Remote message size %zu + %zu exceeds maximum of %" PRIu32,
+                iov[0].iov_len, iov[1].iov_len, UINT32_MAX);
+        goto done;
+    }
+
     header->size_total = iov[0].iov_len + iov[1].iov_len;
 
     rc = remote_send_iovs(remote, iov, 2);
@@ -594,6 +601,7 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
                 pcmk_rc_str(rc), rc);
     }
 
+done:
     free(iov[0].iov_base);
     g_free((gchar *) iov[1].iov_base);
     return rc;

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -619,16 +619,51 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
     }
 
     /* Support compression on the receiving end now, in case we ever want to add it later */
-    if (header->payload_compressed) {
+    if (header->payload_compressed != 0) {
         int rc = 0;
-        unsigned int size_u = 1 + header->payload_uncompressed;
-        char *uncompressed =
-            pcmk__assert_alloc(1, header->payload_offset + size_u);
+        unsigned int size_u = 0;
+        char *uncompressed = NULL;
 
-        crm_trace("Decompressing message data %d bytes into %d bytes",
-                 header->payload_compressed, size_u);
+#if (UINT32_MAX < UINT_MAX)
+        if (header->payload_uncompressed >= UINT_MAX) {
+            crm_err("Couldn't decompress message because uncompressed "
+                    "payload size (%" PRIu32 ") is greater than UINT_MAX "
+                    "(%u)", header->payload_uncompressed, UINT_MAX);
+            return NULL;
+        }
+#endif
 
-        rc = BZ2_bzBuffToBuffDecompress(uncompressed + header->payload_offset, &size_u,
+        /* @TODO Is the extra byte for the null terminator?
+         * pcmk__remote_send_xml() also adds one byte to the iov length.
+         * (However, we do need to account for the possibility of receiving a
+         * message from an untrusted sender.)
+         */
+        size_u = 1 + header->payload_uncompressed;
+
+        /* Header and uncompressed payload must fit in the destination buffer.
+         * We do not need to separately check the header size here since
+         * localized_remote_header will return NULL if it's incorrect.
+         */
+#if (UINT_MAX >= SIZE_MAX)
+        if ((size_u >= SIZE_MAX)
+            || (header->payload_offset > (SIZE_MAX - size_u))) {
+#else
+        if (header->payload_offset > (SIZE_MAX - size_u)) {
+#endif
+            crm_err("Couldn't decompress message because the required buffer "
+                    "size (%" PRIu32 " + %u) is greater than SIZE_MAX (%zu)",
+                    header->payload_offset, size_u, SIZE_MAX);
+            return NULL;
+        }
+
+        crm_trace("Decompressing message data %" PRIu32 " bytes into %u "
+                  "bytes", header->payload_compressed, size_u);
+
+        uncompressed = pcmk__assert_alloc(header->payload_offset + size_u,
+                                          sizeof(char));
+
+        rc = BZ2_bzBuffToBuffDecompress(uncompressed + header->payload_offset,
+                                        &size_u,
                                         remote->buffer + header->payload_offset,
                                         header->payload_compressed, 1, 0);
         rc = pcmk__bzlib2rc(rc);


### PR DESCRIPTION
@nrwahl2 It would be worth taking a look at these more carefully since there's a fair number of refactoring differences between 2.1 and 3.0.  The logic of the code doesn't appear to have changed much at all, however.  I've looked at the log for lib/common/remote.c between these two branches and nothing stands.  I've run this through ctslab but not yet double checked that it fixes the actual issue.