### PR TITLE
report.collector:fix wrong DC name fetching

### DIFF
--- a/tools/report.collector.in
+++ b/tools/report.collector.in
@@ -813,7 +813,7 @@ case $cluster in
 	;;
 esac
 
-dc=`crm_mon -1 2>/dev/null | awk '/Current DC/ {print $3}'`
+dc=`crm_mon -1 2>/dev/null | awk '/Current DC/ {print $4}'`
 if [ "$REPORT_TARGET" = "$dc" ]; then
     echo "$REPORT_TARGET" > DC
 fi


### PR DESCRIPTION
When running dc=$(crm_mon -1 2>/dev/null | awk '/Current DC/ {print $3}'), the variable captures the literal string "DC:" instead of the actual datacenter name; the correct target field is $4