### PR TITLE
Enable compression on remote messages

### DIFF
--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -47,8 +47,8 @@ int pcmk__uint_from_hash(GHashTable *table, const char *key,
                          unsigned int default_val, unsigned int *result);
 void pcmk__add_separated_word(GString **list, size_t init_size,
                               const char *word, const char *separator);
-int pcmk__compress(const char *data, unsigned int length, unsigned int max,
-                   char **result, unsigned int *result_len);
+int pcmk__compress(const char *data, unsigned int length, char **result,
+                   unsigned int *result_len);
 
 int pcmk__scan_ll(const char *text, long long *result, long long default_value);
 int pcmk__scan_min_int(const char *text, int *result, int minimum);

--- a/include/crm/common/strings_internal.h
+++ b/include/crm/common/strings_internal.h
@@ -47,8 +47,8 @@ int pcmk__uint_from_hash(GHashTable *table, const char *key,
                          unsigned int default_val, unsigned int *result);
 void pcmk__add_separated_word(GString **list, size_t init_size,
                               const char *word, const char *separator);
-int pcmk__compress(const char *data, unsigned int length, char **result,
-                   unsigned int *result_len);
+int pcmk__compress(const char *data, size_t length, char **result,
+                   size_t *result_len);
 
 int pcmk__scan_ll(const char *text, long long *result, long long default_value);
 int pcmk__scan_min_int(const char *text, int *result, int minimum);

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -984,7 +984,7 @@ send_cpg_text(const char *data, const pcmk__node_status_t *node,
         char *compressed = NULL;
         unsigned int new_size = 0;
 
-        if (pcmk__compress(data, (unsigned int) msg->size, 0, &compressed,
+        if (pcmk__compress(data, (unsigned int) msg->size, &compressed,
                            &new_size) == pcmk_rc_ok) {
 
             msg->header.size = sizeof(pcmk__cpg_msg_t) + new_size;

--- a/lib/cluster/cpg.c
+++ b/lib/cluster/cpg.c
@@ -982,11 +982,9 @@ send_cpg_text(const char *data, const pcmk__node_status_t *node,
 
     } else {
         char *compressed = NULL;
-        unsigned int new_size = 0;
+        size_t new_size = 0;
 
-        if (pcmk__compress(data, (unsigned int) msg->size, &compressed,
-                           &new_size) == pcmk_rc_ok) {
-
+        if (pcmk__compress(data, msg->size, &compressed, &new_size) == pcmk_rc_ok) {
             msg->header.size = sizeof(pcmk__cpg_msg_t) + new_size;
             msg = pcmk__realloc(msg, msg->header.size);
             memcpy(msg->data, compressed, new_size);

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -240,8 +240,7 @@ send_plaintext(int sock, struct iovec *iov)
             unsent_len -= write_rc;
 
         } else {
-            pcmk__trace("Sent all %zd bytes remaining: %.100s", write_rc,
-                        (const char *) iov->iov_base);
+            pcmk__trace("Sent all %zd bytes", write_rc);
             return pcmk_rc_ok;
         }
     }

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -38,17 +38,44 @@
 #define ENDIAN_LOCAL 0xBADADBBD
 
 struct remote_header_v0 {
-    uint32_t endian;    /* Detect messages from hosts with different endian-ness */
+    /*!
+     * Magic number used to detect whether the message came from a host with
+     * different endianness than ours
+     */
+    uint32_t endian;
+
+    //! Remote protocol version
     uint32_t version;
+
+    //! Message ID number
     uint64_t id;
+
+    //! Currently unused
     uint64_t flags;
+
+    /*!
+     * Amount that will be transmitted:
+     * - Header size plus payload_compressed if the payload is compressed
+     * - Header size plus payload_uncompressed otherwise
+     */
     uint32_t size_total;
+
+    /*!
+     * Where the payload starts - should be immediately after this header,
+     * so sizeof(struct remote_header_v0)
+     */
     uint32_t payload_offset;
+
+    //! If non-zero, the payload is compressed and this is its compressed size
     uint32_t payload_compressed;
+
+    /*!
+     * The payload's size including a terminating null byte.  If the payload
+     * is compressed, this is its size after being decompressed.
+     */
     uint32_t payload_uncompressed;
 
-        /* New fields get added here */
-
+    /* New fields get added here */
 } __attribute__ ((packed));
 
 /*!

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -931,7 +931,7 @@ connect_socket_once(int sock, const struct sockaddr *addr, socklen_t addrlen)
         return rc;
     }
 
-    return pcmk_ok;
+    return pcmk_rc_ok;
 }
 
 /*!

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -330,6 +330,105 @@ done:
 
 /*!
  * \internal
+ * \brief Sanity check the message header and uncompress the payload
+ *
+ * \param[in]     header  The received message's header
+ * \param[in,out] remote  Pacemaker Remote connection to use
+ *
+ * \note This function invalidates the \p header parameter.  The caller needs
+ *       to reassign the start of the remote buffer to it after this function
+ *       has been called.
+ *
+ * \return Standard Pacemaker return code
+ */
+static int
+handle_compressed_payload(const struct remote_header_v0 *header,
+                          pcmk__remote_t *remote)
+{
+    int rc = 0;
+    unsigned int size_u = 0;
+    char *uncompressed = NULL;
+    size_t buffer_size = 0;
+
+#if (UINT32_MAX < UINT_MAX)
+    if (header->payload_uncompressed >= UINT_MAX) {
+        pcmk__err("Couldn't decompress message because uncompressed "
+                  "payload size (%" PRIu32 ") is greater than UINT_MAX "
+                  "(%u)", header->payload_uncompressed, UINT_MAX);
+        return EMSGSIZE;
+    }
+#endif
+
+    /* @TODO Is the extra byte for the null terminator?
+     * pcmk__remote_send_xml() also adds one byte to the iov length.
+     * (However, we do need to account for the possibility of receiving a
+     * message from an untrusted sender.)
+     */
+    size_u = 1 + header->payload_uncompressed;
+
+    /* Header and uncompressed payload must fit in the destination buffer.
+     * We do not need to separately check the header size here since
+     * localized_remote_header will return NULL if it's incorrect.
+     */
+#if (UINT_MAX >= SIZE_MAX)
+    if ((size_u >= SIZE_MAX)
+        || (header->payload_offset > (SIZE_MAX - size_u))) {
+#else
+    if (header->payload_offset > (SIZE_MAX - size_u)) {
+#endif
+        pcmk__err("Couldn't decompress message because the required buffer "
+                  "size (%" PRIu32 " + %u) is greater than SIZE_MAX (%zu)",
+                  header->payload_offset, size_u, SIZE_MAX);
+        return EMSGSIZE;
+    }
+
+    buffer_size = (size_t) header->payload_offset + size_u;
+    if (buffer_size > PCMK__REMOTE_MSG_MAX_SIZE) {
+        pcmk__err("Message size %zu is larger than max allowed %u bytes",
+                  buffer_size, PCMK__REMOTE_MSG_MAX_SIZE);
+        return EMSGSIZE;
+    }
+
+    pcmk__trace("Decompressing message data %" PRIu32 " bytes into %u "
+                "bytes", header->payload_compressed, size_u);
+
+    uncompressed = pcmk__assert_alloc(buffer_size, sizeof(char));
+
+    rc = BZ2_bzBuffToBuffDecompress(uncompressed + header->payload_offset,
+                                    &size_u,
+                                    remote->buffer + header->payload_offset,
+                                    header->payload_compressed, 1, 0);
+    rc = pcmk__bzlib2rc(rc);
+
+    if (rc != pcmk_rc_ok && header->version > REMOTE_MSG_VERSION) {
+        pcmk__warn("Couldn't decompress v%d message, we only understand "
+                   "v%d",
+                   header->version, REMOTE_MSG_VERSION);
+        free(uncompressed);
+        return EPROTO;
+
+    } else if (rc != pcmk_rc_ok) {
+        pcmk__err("Decompression failed: %s " QB_XS " rc=%d",
+                  pcmk_rc_str(rc), rc);
+        free(uncompressed);
+        return rc;
+    }
+
+    pcmk__assert(size_u == header->payload_uncompressed);
+
+    /* Copy the original, localized (as in, we've dealt with the endianness)
+     * header to the front of the remote buffer.
+     */
+    memcpy(uncompressed, remote->buffer, header->payload_offset);
+    remote->buffer_size = header->payload_offset + size_u;
+
+    free(remote->buffer);
+    remote->buffer = uncompressed;
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
  * \brief Obtain the XML from the currently buffered remote connection message
  *
  * \param[in,out] remote  Remote connection possibly with message available
@@ -351,83 +450,16 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
 
     /* Support compression on the receiving end now, in case we ever want to add it later */
     if (header->payload_compressed != 0) {
-        int rc = 0;
-        unsigned int size_u = 0;
-        char *uncompressed = NULL;
-        size_t buffer_size = 0;
+        int rc = handle_compressed_payload(header, remote);
 
-#if (UINT32_MAX < UINT_MAX)
-        if (header->payload_uncompressed >= UINT_MAX) {
-            pcmk__err("Couldn't decompress message because uncompressed "
-                      "payload size (%" PRIu32 ") is greater than UINT_MAX "
-                      "(%u)", header->payload_uncompressed, UINT_MAX);
+        if (rc != pcmk_rc_ok) {
             return NULL;
         }
-#endif
 
-        /* @TODO Is the extra byte for the null terminator?
-         * pcmk__remote_send_xml() also adds one byte to the iov length.
-         * (However, we do need to account for the possibility of receiving a
-         * message from an untrusted sender.)
+        /* handle_compressed_payload copies the header to the front of the
+         * uncompressed buffer, so update the pointer here.
          */
-        size_u = 1 + header->payload_uncompressed;
-
-        /* Header and uncompressed payload must fit in the destination buffer.
-         * We do not need to separately check the header size here since
-         * localized_remote_header will return NULL if it's incorrect.
-         */
-#if (UINT_MAX >= SIZE_MAX)
-        if ((size_u >= SIZE_MAX)
-            || (header->payload_offset > (SIZE_MAX - size_u))) {
-#else
-        if (header->payload_offset > (SIZE_MAX - size_u)) {
-#endif
-            pcmk__err("Couldn't decompress message because the required buffer "
-                      "size (%" PRIu32 " + %u) is greater than SIZE_MAX (%zu)",
-                      header->payload_offset, size_u, SIZE_MAX);
-            return NULL;
-        }
-
-        buffer_size = (size_t) header->payload_offset + size_u;
-        if (buffer_size > PCMK__REMOTE_MSG_MAX_SIZE) {
-            pcmk__err("Message size %zu is larger than max allowed %u bytes",
-                      buffer_size, PCMK__REMOTE_MSG_MAX_SIZE);
-            return NULL;
-        }
-
-        pcmk__trace("Decompressing message data %" PRIu32 " bytes into %u "
-                    "bytes", header->payload_compressed, size_u);
-
-        uncompressed = pcmk__assert_alloc(buffer_size, sizeof(char));
-
-        rc = BZ2_bzBuffToBuffDecompress(uncompressed + header->payload_offset,
-                                        &size_u,
-                                        remote->buffer + header->payload_offset,
-                                        header->payload_compressed, 1, 0);
-        rc = pcmk__bzlib2rc(rc);
-
-        if (rc != pcmk_rc_ok && header->version > REMOTE_MSG_VERSION) {
-            pcmk__warn("Couldn't decompress v%d message, we only understand "
-                       "v%d",
-                       header->version, REMOTE_MSG_VERSION);
-            free(uncompressed);
-            return NULL;
-
-        } else if (rc != pcmk_rc_ok) {
-            pcmk__err("Decompression failed: %s " QB_XS " rc=%d",
-                      pcmk_rc_str(rc), rc);
-            free(uncompressed);
-            return NULL;
-        }
-
-        pcmk__assert(size_u == header->payload_uncompressed);
-
-        memcpy(uncompressed, remote->buffer, header->payload_offset);       /* Preserve the header */
-        remote->buffer_size = header->payload_offset + size_u;
-
-        free(remote->buffer);
-        remote->buffer = uncompressed;
-        header = localized_remote_header(remote);
+        header = (struct remote_header_v0 *) remote->buffer;
     }
 
     /* take ownership of the buffer */

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -400,14 +400,7 @@ handle_compressed_payload(const struct remote_header_v0 *header,
                                     header->payload_compressed, 1, 0);
     rc = pcmk__bzlib2rc(rc);
 
-    if (rc != pcmk_rc_ok && header->version > REMOTE_MSG_VERSION) {
-        pcmk__warn("Couldn't decompress v%d message, we only understand "
-                   "v%d",
-                   header->version, REMOTE_MSG_VERSION);
-        free(uncompressed);
-        return EPROTO;
-
-    } else if (rc != pcmk_rc_ok) {
+    if (rc != pcmk_rc_ok) {
         pcmk__err("Decompression failed: %s " QB_XS " rc=%d",
                   pcmk_rc_str(rc), rc);
         free(uncompressed);
@@ -448,6 +441,12 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
         return NULL;
     }
 
+    if (header->version > REMOTE_MSG_VERSION) {
+        pcmk__err("Header version %" PRIu32 " does not match expected version %d",
+                  header->version, REMOTE_MSG_VERSION);
+        return NULL;
+    }
+
     /* Support compression on the receiving end now, in case we ever want to add it later */
     if (header->payload_compressed != 0) {
         int rc = handle_compressed_payload(header, remote);
@@ -482,13 +481,7 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
 
     xml = pcmk__xml_parse(payload);
     if (xml == NULL) {
-        if (header->version > REMOTE_MSG_VERSION) {
-            pcmk__warn("Couldn't parse v%d message, we only understand v%d",
-                       header->version, REMOTE_MSG_VERSION);
-        } else {
-            pcmk__err("Couldn't parse: '%.120s'", payload);
-        }
-
+        pcmk__err("Couldn't parse: '%.120s'", payload);
     } else {
         pcmk__log_xml_trace(xml, "[remote msg]");
     }

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -288,6 +288,8 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
 
     struct iovec iov[2];
     struct remote_header_v0 *header;
+    bool did_compress = false;
+    size_t payload_len = 0;
 
     CRM_CHECK((remote != NULL) && (msg != NULL), return EINVAL);
 
@@ -300,21 +302,71 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
 
     iov[0].iov_base = header;
     iov[0].iov_len = sizeof(struct remote_header_v0);
-
-    iov[1].iov_len = 1 + xml_text->len;
-    iov[1].iov_base = g_string_free(xml_text, FALSE);
+    iov[1].iov_base = NULL;
+    iov[1].iov_len = 0;
 
     id++;
     header->id = id;
     header->endian = ENDIAN_LOCAL;
     header->version = REMOTE_MSG_VERSION;
     header->payload_offset = iov[0].iov_len;
-    header->payload_uncompressed = iov[1].iov_len;
 
-    if ((UINT32_MAX - iov[0].iov_len) < iov[1].iov_len) {
+    payload_len = 1 + xml_text->len;
+
+    /* Check that:
+     * - the above addition calculating payload_len did not overflow
+     * - payload_len + header size fits in a uint32_t (therefore, payload_len
+     *   will also fit into a uint32_t when we assign it to payload_uncompressed
+     *   later)
+     */
+    if ((payload_len < xml_text->len) || (UINT32_MAX - iov[0].iov_len) < payload_len) {
         pcmk__err("Remote message size %zu + %zu exceeds maximum of %" PRIu32,
-                  iov[0].iov_len, iov[1].iov_len, UINT32_MAX);
+                  iov[0].iov_len, payload_len, UINT32_MAX);
         goto done;
+    }
+
+    if (payload_len >= PCMK__BZ2_THRESHOLD) {
+        char *compressed = NULL;
+        size_t new_size = 0;
+
+        if (pcmk__compress(xml_text->str, payload_len, &compressed,
+                           &new_size) == pcmk_rc_ok) {
+
+            /* The above call might have given us a new_size value that's
+             * different from the original payload_len, so we need to repeat the
+             * overflow check.
+             */
+#if (SIZE_MAX > UINT32_MAX)
+            if ((new_size > UINT32_MAX)
+                || ((UINT32_MAX - iov[0].iov_len) < new_size)) {
+#else
+            if ((UINT32_MAX - iov[0].iov_len) < new_size) {
+#endif
+                pcmk__err("Compressed message size %zu exceeds maximum of %" PRIu32,
+                          new_size, UINT32_MAX);
+                rc = EMSGSIZE;
+
+                g_string_free(xml_text, TRUE);
+                free(compressed);
+                goto done;
+            }
+
+            iov[1].iov_len = new_size;
+            iov[1].iov_base = compressed;
+
+            header->payload_compressed = new_size;
+            header->payload_uncompressed = payload_len;
+            g_string_free(xml_text, TRUE);
+
+            did_compress = true;
+        }
+    }
+
+    if (!did_compress) {
+        iov[1].iov_len = payload_len;
+        iov[1].iov_base = g_string_free(xml_text, FALSE);
+
+        header->payload_uncompressed = iov[1].iov_len;
     }
 
     header->size_total = iov[0].iov_len + iov[1].iov_len;
@@ -327,7 +379,13 @@ pcmk__remote_send_xml(pcmk__remote_t *remote, const xmlNode *msg)
 
 done:
     free(iov[0].iov_base);
-    g_free((gchar *) iov[1].iov_base);
+
+    if (did_compress) {
+        free(iov[1].iov_base);
+    } else {
+        g_free(iov[1].iov_base);
+    }
+
     return rc;
 }
 
@@ -392,8 +450,8 @@ handle_compressed_payload(const struct remote_header_v0 *header,
         return EMSGSIZE;
     }
 
-    pcmk__trace("Decompressing message data %" PRIu32 " bytes into %u "
-                "bytes", header->payload_compressed, size_u);
+    pcmk__trace("Decompressing message data %" PRIu32 " bytes into %" PRIu32
+                " bytes", header->payload_compressed, header->payload_uncompressed);
 
     uncompressed = pcmk__assert_alloc(buffer_size, sizeof(char));
 
@@ -450,7 +508,6 @@ pcmk__remote_message_xml(pcmk__remote_t *remote)
         return NULL;
     }
 
-    /* Support compression on the receiving end now, in case we ever want to add it later */
     if (header->payload_compressed != 0) {
         int rc = handle_compressed_payload(header, remote);
 

--- a/lib/common/remote.c
+++ b/lib/common/remote.c
@@ -8,31 +8,35 @@
  */
 
 #include <crm_internal.h>
-#include <crm/crm.h>
 
-#include <sys/param.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/tcp.h>
-#include <netdb.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <inttypes.h>   // PRIu32, PRIx32
+#include <arpa/inet.h>              // htons, inet_ntop
+#include <errno.h>                  // errno, EAGAIN, EINTR, EINVAL
+#include <inttypes.h>               // PRIu32, uint32_t, SIZE_MAX
+#include <limits.h>                 // UINT_MAX
+#include <netdb.h>                  // addrinfo, freeaddrinfo, getaddrinfo
+#include <netinet/in.h>             // INET6_ADDRSTRLEN, sockaddr_in
+#include <netinet/tcp.h>            // TCP_USER_TIMEOUT, SOL_TCP
+#include <poll.h>                   // pollfd, poll, POLLIN
+#include <stdbool.h>                // true, bool, false
+#include <stdlib.h>                 // NULL, free, size_t, strtol
+#include <string.h>                 // memset, memcpy, strcpy
+#include <sys/select.h>             // FD_ISSET, fd_set, select
+#include <sys/socket.h>             // connect, socklen_t, AF_INET6
+#include <sys/time.h>               // timeval
+#include <sys/types.h>              // ssize_t, time_t
+#include <sys/uio.h>                // iovec
+#include <time.h>                   // time
+#include <unistd.h>                 // close, read, write
 
-#include <glib.h>
-#include <bzlib.h>
+#include <bzlib.h>                  // BZ2_bzBuffToBuffDecompress
+#include <glib.h>                   // GUINT32_SWAP_LE_BE, g_string_*
+#include <gnutls/gnutls.h>          // gnutls_strerror, GNUTLS_E_AGAIN
+#include <libxml/tree.h>            // xmlNode
+#include <qb/qblog.h>               // QB_XS
 
-#include <crm/common/xml.h>
-#include <crm/common/mainloop.h>
-
-#include <gnutls/gnutls.h>
+#include <crm/common/logging.h>     // CRM_CHECK
+#include <crm/common/results.h>     // pcmk_rc_*
+#include <crm/common/util.h>        // crm_default_remote_port
 
 #define REMOTE_MSG_VERSION 1
 #define ENDIAN_LOCAL 0xBADADBBD

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -585,16 +585,16 @@ pcmk__add_separated_word(GString **list, size_t init_size, const char *word,
  *
  * \param[in]  data        Data to compress
  * \param[in]  length      Number of characters of data to compress
- * \param[in]  max         Maximum size of compressed data (or 0 to estimate)
  * \param[out] result      Where to store newly allocated compressed result
  * \param[out] result_len  Where to store actual compressed length of result
  *
  * \return Standard Pacemaker return code
  */
 int
-pcmk__compress(const char *data, unsigned int length, unsigned int max,
-               char **result, unsigned int *result_len)
+pcmk__compress(const char *data, unsigned int length, char **result,
+               unsigned int *result_len)
 {
+    unsigned int max = (length * 1.01) + 601;   // Size guaranteed to hold result
     int rc;
     char *compressed = NULL;
     char *uncompressed = strdup(data);
@@ -602,10 +602,6 @@ pcmk__compress(const char *data, unsigned int length, unsigned int max,
     struct timespec after_t;
     struct timespec before_t;
 #endif
-
-    if (max == 0) {
-        max = (length * 1.01) + 601; // Size guaranteed to hold result
-    }
 
 #ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &before_t);

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -591,10 +591,10 @@ pcmk__add_separated_word(GString **list, size_t init_size, const char *word,
  * \return Standard Pacemaker return code
  */
 int
-pcmk__compress(const char *data, unsigned int length, char **result,
-               unsigned int *result_len)
+pcmk__compress(const char *data, size_t length, char **result, size_t *result_len)
 {
-    unsigned int max = (length * 1.01) + 601;   // Size guaranteed to hold result
+    size_t max = (length * 1.01) + 601;     // Max size of the compressed result
+    unsigned int dest_len = 0;              // Where bz2 should store the actual size
     int rc = pcmk_rc_ok;
     char *compressed = NULL;
     char *uncompressed = NULL;
@@ -603,16 +603,33 @@ pcmk__compress(const char *data, unsigned int length, char **result,
     struct timespec before_t;
 #endif
 
+    /* Did the max calculation overflow? */
+    if (max < length) {
+        return EINVAL;
+    }
+
+    /* BZ2_bzBuffToBuffCompress wants unsigned ints, not size_t.  This function
+     * takes size_t arguments to simplify checking in its callers.  Make sure
+     * we're not passing BZ2_bzBuffToBuffCompress something that's too large.
+     */
+#if (SIZE_MAX > UINT_MAX)
+    if (max > UINT_MAX) {
+        return EINVAL;
+    }
+#endif
+
 #ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &before_t);
 #endif
 
-    compressed = pcmk__assert_alloc((size_t) max, sizeof(char));
+    compressed = pcmk__assert_alloc(max, sizeof(char));
     uncompressed = pcmk__str_copy(data);
 
-    *result_len = max;
-    rc = BZ2_bzBuffToBuffCompress(compressed, result_len, uncompressed, length,
+    dest_len = max;
+    rc = BZ2_bzBuffToBuffCompress(compressed, &dest_len, uncompressed, length,
                                   PCMK__BZ2_BLOCKS, 0, PCMK__BZ2_WORK);
+    *result_len = dest_len;
+
     rc = pcmk__bzlib2rc(rc);
 
     free(uncompressed);
@@ -627,13 +644,11 @@ pcmk__compress(const char *data, unsigned int length, char **result,
 #ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &after_t);
 
-    pcmk__trace("Compressed %d bytes into %d (ratio %d:1) in %.0fms", length,
-                *result_len, (length / *result_len),
+    pcmk__trace("Compressed %zu bytes into %zu in %.0fms", length, *result_len,
                 (((after_t.tv_sec - before_t.tv_sec) * 1000)
                  + ((after_t.tv_nsec - before_t.tv_nsec) / 1e6)));
 #else
-    pcmk__trace("Compressed %d bytes into %d (ratio %d:1)", length, *result_len,
-                (length / *result_len));
+    pcmk__trace("Compressed %zu bytes into %zu", length, *result_len);
 #endif
 
     *result = compressed;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -598,10 +598,6 @@ pcmk__compress(const char *data, size_t length, char **result, size_t *result_le
     int rc = pcmk_rc_ok;
     char *compressed = NULL;
     char *uncompressed = NULL;
-#ifdef CLOCK_MONOTONIC
-    struct timespec after_t;
-    struct timespec before_t;
-#endif
 
     /* Did the max calculation overflow? */
     if (max < length) {
@@ -618,10 +614,6 @@ pcmk__compress(const char *data, size_t length, char **result, size_t *result_le
     }
 #endif
 
-#ifdef CLOCK_MONOTONIC
-    clock_gettime(CLOCK_MONOTONIC, &before_t);
-#endif
-
     compressed = pcmk__assert_alloc(max, sizeof(char));
     uncompressed = pcmk__str_copy(data);
 
@@ -635,21 +627,13 @@ pcmk__compress(const char *data, size_t length, char **result, size_t *result_le
     free(uncompressed);
 
     if (rc != pcmk_rc_ok) {
-        pcmk__err("Compression of %d bytes failed: %s " QB_XS " rc=%d", length,
+        pcmk__err("Compression of %zu bytes failed: %s " QB_XS " rc=%d", length,
                   pcmk_rc_str(rc), rc);
         free(compressed);
         return rc;
     }
 
-#ifdef CLOCK_MONOTONIC
-    clock_gettime(CLOCK_MONOTONIC, &after_t);
-
-    pcmk__trace("Compressed %zu bytes into %zu in %.0fms", length, *result_len,
-                (((after_t.tv_sec - before_t.tv_sec) * 1000)
-                 + ((after_t.tv_nsec - before_t.tv_nsec) / 1e6)));
-#else
     pcmk__trace("Compressed %zu bytes into %zu", length, *result_len);
-#endif
 
     *result = compressed;
     return pcmk_rc_ok;

--- a/lib/common/strings.c
+++ b/lib/common/strings.c
@@ -595,9 +595,9 @@ pcmk__compress(const char *data, unsigned int length, char **result,
                unsigned int *result_len)
 {
     unsigned int max = (length * 1.01) + 601;   // Size guaranteed to hold result
-    int rc;
+    int rc = pcmk_rc_ok;
     char *compressed = NULL;
-    char *uncompressed = strdup(data);
+    char *uncompressed = NULL;
 #ifdef CLOCK_MONOTONIC
     struct timespec after_t;
     struct timespec before_t;
@@ -608,6 +608,7 @@ pcmk__compress(const char *data, unsigned int length, char **result,
 #endif
 
     compressed = pcmk__assert_alloc((size_t) max, sizeof(char));
+    uncompressed = pcmk__str_copy(data);
 
     *result_len = max;
     rc = BZ2_bzBuffToBuffCompress(compressed, result_len, uncompressed, length,

--- a/lib/common/tests/strings/pcmk__compress_test.c
+++ b/lib/common/tests/strings/pcmk__compress_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 the Pacemaker project contributors
+ * Copyright 2022-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -25,17 +25,8 @@ simple_compress(void **state)
     char *result = pcmk__assert_alloc(1024, sizeof(char));
     unsigned int len;
 
-    assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, 0, &result, &len), pcmk_rc_ok);
+    assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, &result, &len), pcmk_rc_ok);
     assert_memory_equal(result, SIMPLE_COMPRESSED, 13);
-}
-
-static void
-max_too_small(void **state)
-{
-    char *result = pcmk__assert_alloc(1024, sizeof(char));
-    unsigned int len;
-
-    assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, 10, &result, &len), EFBIG);
 }
 
 static void
@@ -50,7 +41,7 @@ calloc_fails(void **state) {
             expect_uint_value(__wrap_calloc, nmemb,
                               (size_t) ((40 * 1.01) + 601));
             expect_uint_value(__wrap_calloc, size, sizeof(char));
-            pcmk__compress(SIMPLE_DATA, 40, 0, &result, &len);
+            pcmk__compress(SIMPLE_DATA, 40, &result, &len);
             pcmk__mock_calloc = false;  // Use the real calloc()
         }
     );
@@ -58,5 +49,4 @@ calloc_fails(void **state) {
 
 PCMK__UNIT_TEST(NULL, NULL,
                 cmocka_unit_test(simple_compress),
-                cmocka_unit_test(max_too_small),
                 cmocka_unit_test(calloc_fails))

--- a/lib/common/tests/strings/pcmk__compress_test.c
+++ b/lib/common/tests/strings/pcmk__compress_test.c
@@ -23,7 +23,7 @@ static void
 simple_compress(void **state)
 {
     char *result = pcmk__assert_alloc(1024, sizeof(char));
-    unsigned int len;
+    size_t len;
 
     assert_int_equal(pcmk__compress(SIMPLE_DATA, 40, &result, &len), pcmk_rc_ok);
     assert_memory_equal(result, SIMPLE_COMPRESSED, 13);
@@ -32,7 +32,7 @@ simple_compress(void **state)
 static void
 calloc_fails(void **state) {
     char *result = pcmk__assert_alloc(1024, sizeof(char));
-    unsigned int len;
+    size_t len;
 
     pcmk__assert_exits(
         CRM_EX_OSERR,


### PR DESCRIPTION
Decompression on the receive side has been supported forever in a "just in case we ever want this..." basis.  However, the fact that it was unused meant there were bugs in it, for instance the recent integer overflow stuff.  So, I'm enabling it here both to ensure it gets used and therefore is less buggy and to continue improving our scalability.

I've tested the following combinations to try to make sure there's no backwards compatibility problems here:

✓ old cluster, new remote CIB, no compression
✓ old cluster, new remote CIB, force compression
✓ old cluster, new remote node, no compression
✓ old cluster, new remote node, force compression
✓ new cluster, old remote CIB, no compression
✓ new cluster, old remote CIB, force compression
✓ new cluster, new remote node, no compression
✓ new cluster, new remote node, force compression
✓ new cluster, old remote node, no compression
✓ new cluster, old remote node, force compression
