### PR TITLE
libcrmcommon: Use pcmk__assert_alloc() for IPC event copies.

### DIFF
--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -771,11 +771,11 @@ pcmk__ipc_send_iov(pcmk__client_t *c, struct iovec *iov, uint32_t flags)
 
             pcmk__trace("Sending a copy to %p[%d]", c->ipcs, c->pid);
             iov_copy[0].iov_len = iov[0].iov_len;
-            iov_copy[0].iov_base = malloc(iov[0].iov_len);
+            iov_copy[0].iov_base = pcmk__assert_alloc(1, iov[0].iov_len);
             memcpy(iov_copy[0].iov_base, iov[0].iov_base, iov[0].iov_len);
 
             iov_copy[1].iov_len = iov[1].iov_len;
-            iov_copy[1].iov_base = malloc(iov[1].iov_len);
+            iov_copy[1].iov_base = pcmk__assert_alloc(1, iov[1].iov_len);
             memcpy(iov_copy[1].iov_base, iov[1].iov_base, iov[1].iov_len);
 
             add_event(c, iov_copy);


### PR DESCRIPTION
The two malloc() calls in pcmk__ipc_send_iov() for copying iovec buffers did not check for allocation failure, risking a NULL pointer
dereference on OOM. Replace them with pcmk__assert_alloc() to match the project convention used by pcmk__new_ipc_event() in the same function.