### PR TITLE
Fix: Check for watchdog-based self-fencing device only if "fencing-watchdog-timeout" is enabled

### DIFF
--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -997,12 +997,8 @@ controld_validate_fencing_watchdog_timeout(const char *value)
     const char *our_nodename = controld_globals.cluster->priv->node_name;
     long long timeout_ms = 0;
 
-    if (value == NULL) {
-        return;
-    }
-
-    if ((pcmk__parse_ms(value, &timeout_ms) == pcmk_rc_ok)
-        && (timeout_ms == 0)) {
+    timeout_ms = pcmk__parse_fencing_watchdog_timeout(value);
+    if (timeout_ms == 0) {
         return;
     }
 
@@ -1011,7 +1007,7 @@ controld_validate_fencing_watchdog_timeout(const char *value)
         && stonith__watchdog_fencing_enabled_for_node_api(fencer_api,
                                                           our_nodename)) {
 
-        pcmk__valid_fencing_watchdog_timeout(value);
+        pcmk__valid_fencing_watchdog_timeout(timeout_ms);
     }
 }
 

--- a/daemons/controld/controld_fencing.c
+++ b/daemons/controld/controld_fencing.c
@@ -995,6 +995,16 @@ void
 controld_validate_fencing_watchdog_timeout(const char *value)
 {
     const char *our_nodename = controld_globals.cluster->priv->node_name;
+    long long timeout_ms = 0;
+
+    if (value == NULL) {
+        return;
+    }
+
+    if ((pcmk__parse_ms(value, &timeout_ms) == pcmk_rc_ok)
+        && (timeout_ms == 0)) {
+        return;
+    }
 
     // Validate only if the timeout will be used
     if ((fencer_api != NULL) && (fencer_api->state != stonith_disconnected)

--- a/daemons/execd/execd_messages.c
+++ b/daemons/execd/execd_messages.c
@@ -133,7 +133,7 @@ handle_check_request(pcmk__request_t *request)
                                 pcmk__client_privileged);
     xmlNode *wrapper = NULL;
     xmlNode *data = NULL;
-    const char *timeout = NULL;
+    long long timeout_ms = 0;
 
     if (!allowed) {
         pcmk__set_result(&request->result, CRM_EX_INSUFFICIENT_PRIV,
@@ -154,11 +154,11 @@ handle_check_request(pcmk__request_t *request)
         return NULL;
     }
 
-    timeout = pcmk__xe_get(data, PCMK__XA_LRMD_WATCHDOG);
+    pcmk__xe_get_ll(data, PCMK__XA_LRMD_WATCHDOG, &timeout_ms);
     /* FIXME: This just exits on certain conditions, which seems like a pretty
      * extreme reaction for a daemon to take.
      */
-    pcmk__valid_fencing_watchdog_timeout(timeout);
+    pcmk__valid_fencing_watchdog_timeout(timeout_ms);
 
     pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
     return NULL;

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -159,8 +159,6 @@ get_fencing_watchdog_timeout(xmlNode *cib)
 {
     xmlNode *stonith_watchdog_xml = NULL;
     const char *value = NULL;
-    int rc = pcmk_rc_ok;
-    long long timeout_ms = 0;
 
     // @TODO An XPath search can't handle multiple instances or rules
     stonith_watchdog_xml = pcmk__xpath_find_one(cib->doc,
@@ -182,16 +180,8 @@ get_fencing_watchdog_timeout(xmlNode *cib)
     }
 
     value = pcmk__xe_get(stonith_watchdog_xml, PCMK_XA_VALUE);
-    if (value == NULL) {
-        return 0;
-    }
 
-    rc = pcmk__parse_ms(value, &timeout_ms);
-    if ((rc == pcmk_rc_ok) && (timeout_ms >= 0)) {
-        return timeout_ms;
-    }
-
-    return pcmk__auto_fencing_watchdog_timeout();
+    return pcmk__parse_fencing_watchdog_timeout(value);
 }
 
 /*!

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -134,7 +134,8 @@ bool pcmk__valid_placement_strategy(const char *value);
 long pcmk__get_sbd_watchdog_timeout(void);
 bool pcmk__get_sbd_sync_resource_startup(void);
 long pcmk__auto_fencing_watchdog_timeout(void);
-bool pcmk__valid_fencing_watchdog_timeout(const char *value);
+long long pcmk__parse_fencing_watchdog_timeout(const char *value);
+bool pcmk__valid_fencing_watchdog_timeout(long long st_timeout);
 
 // @COMPAT Deprecated cluster options
 #define PCMK__OPT_CANCEL_REMOVED_ACTIONS    "cancel-removed-actions"

--- a/include/crm/common/options_internal.h
+++ b/include/crm/common/options_internal.h
@@ -133,7 +133,6 @@ bool pcmk__valid_placement_strategy(const char *value);
 // from watchdog.c
 long pcmk__get_sbd_watchdog_timeout(void);
 bool pcmk__get_sbd_sync_resource_startup(void);
-long pcmk__auto_fencing_watchdog_timeout(void);
 long long pcmk__parse_fencing_watchdog_timeout(const char *value);
 bool pcmk__valid_fencing_watchdog_timeout(long long st_timeout);
 

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -262,8 +262,8 @@ pcmk__get_sbd_sync_resource_startup(void)
 }
 
 // 0 <= return value <= min(LONG_MAX, (2 * SBD timeout))
-long
-pcmk__auto_fencing_watchdog_timeout(void)
+static long
+auto_fencing_watchdog_timeout(void)
 {
     long sbd_timeout = pcmk__get_sbd_watchdog_timeout();
     long long st_timeout = 2 * (long long) sbd_timeout;
@@ -285,7 +285,7 @@ pcmk__parse_fencing_watchdog_timeout(const char *value)
     }
 
     if (st_timeout < 0) {
-        st_timeout = pcmk__auto_fencing_watchdog_timeout();
+        st_timeout = auto_fencing_watchdog_timeout();
 
         // At this point, 0 <= sbd_timeout <= st_timeout
         pcmk__debug("Using calculated value %lld for "

--- a/lib/common/watchdog.c
+++ b/lib/common/watchdog.c
@@ -271,8 +271,8 @@ pcmk__auto_fencing_watchdog_timeout(void)
     return (long) QB_MIN(st_timeout, LONG_MAX);
 }
 
-bool
-pcmk__valid_fencing_watchdog_timeout(const char *value)
+long long
+pcmk__parse_fencing_watchdog_timeout(const char *value)
 {
     /* @COMPAT At a compatibility break, accept either negative values or a
      * specific string like "auto" (but not both) to mean "auto-calculate the
@@ -293,15 +293,19 @@ pcmk__valid_fencing_watchdog_timeout(const char *value)
                     st_timeout, value);
     }
 
+    return st_timeout;
+}
+
+bool
+pcmk__valid_fencing_watchdog_timeout(long long st_timeout)
+{
     if (st_timeout == 0) {
         pcmk__debug("Watchdog may be enabled but "
-                    PCMK_OPT_FENCING_WATCHDOG_TIMEOUT " is disabled (%s)",
-                    pcmk__s(value, "default"));
+                    PCMK_OPT_FENCING_WATCHDOG_TIMEOUT " is disabled (0ms)");
 
     } else if (pcmk__locate_sbd() == 0) {
         pcmk__emerg("Shutting down: " PCMK_OPT_FENCING_WATCHDOG_TIMEOUT
-                    " configured (%s) but SBD not active",
-                    pcmk__s(value, "auto"));
+                    " configured (%lldms) but SBD not active", st_timeout);
         crm_exit(CRM_EX_FATAL);
         return false;
 
@@ -313,14 +317,13 @@ pcmk__valid_fencing_watchdog_timeout(const char *value)
              * parsable, positive, and less than the SBD_WATCHDOG_TIMEOUT
              */
             pcmk__emerg("Shutting down: " PCMK_OPT_FENCING_WATCHDOG_TIMEOUT
-                        " (%s) too short (must be >%ldms)",
-                        value, sbd_timeout);
+                        " (%lldms) too short (must be >%ldms)",
+                        st_timeout, sbd_timeout);
             crm_exit(CRM_EX_FATAL);
             return false;
         }
         pcmk__info("Watchdog configured with " PCMK_OPT_FENCING_WATCHDOG_TIMEOUT
-                   " %s and SBD timeout %ldms",
-                   value, sbd_timeout);
+                   " %lldms and SBD timeout %ldms", st_timeout, sbd_timeout);
     }
     return true;
 }

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1034,11 +1034,10 @@ lrmd__validate_remote_settings(lrmd_t *lrmd, GHashTable *hash)
     pcmk__xe_set(data, PCMK__XA_LRMD_ORIGIN, __func__);
 
     value = pcmk__cluster_option(hash, PCMK_OPT_FENCING_WATCHDOG_TIMEOUT);
-    if ((value) &&
-        (pcmk__parse_ms(value, &timeout_ms) == pcmk_rc_ok) &&
-        (timeout_ms != 0) &&
+    timeout_ms = pcmk__parse_fencing_watchdog_timeout(value);
+    if ((timeout_ms != 0) &&
         (stonith__watchdog_fencing_enabled_for_node(native->remote_nodename))) {
-       pcmk__xe_set(data, PCMK__XA_LRMD_WATCHDOG, value);
+        pcmk__xe_set_ll(data, PCMK__XA_LRMD_WATCHDOG, timeout_ms);
     }
 
     rc = lrmd_send_command(lrmd, LRMD_OP_CHECK, data, NULL, 0, 0,

--- a/lib/lrmd/lrmd_client.c
+++ b/lib/lrmd/lrmd_client.c
@@ -1029,11 +1029,14 @@ lrmd__validate_remote_settings(lrmd_t *lrmd, GHashTable *hash)
     const char *value;
     lrmd_private_t *native = lrmd->lrmd_private;
     xmlNode *data = pcmk__xe_create(NULL, PCMK__XA_LRMD_OP);
+    long long timeout_ms = 0;
 
     pcmk__xe_set(data, PCMK__XA_LRMD_ORIGIN, __func__);
 
     value = pcmk__cluster_option(hash, PCMK_OPT_FENCING_WATCHDOG_TIMEOUT);
     if ((value) &&
+        (pcmk__parse_ms(value, &timeout_ms) == pcmk_rc_ok) &&
+        (timeout_ms != 0) &&
         (stonith__watchdog_fencing_enabled_for_node(native->remote_nodename))) {
        pcmk__xe_set(data, PCMK__XA_LRMD_WATCHDOG, value);
     }


### PR DESCRIPTION
With 14e9b3e1b5, stonith__watchdog_fencing_enabled_for_node_api() was
called only if "stonith-watchdog-timeout" was enabled (non-zero). But
with a4f2db39c8, the function is again always called even if the cluster
option is not enabled, so that it again keeps logging the confusing
notice "Cluster does not have watchdog fencing".

Besides, in liblrmd, stonith__watchdog_fencing_enabled_for_node_api()
has always been called for remote nodes even if "fencing-watchdog-timeout"
is disabled.

This PR fixes the issues  by ensuring the watchdog-based self-fencing device
is only checked when "fencing-watchdog-timeout" is actually enabled.