### PR TITLE
Feature: cibadmin: allow altering status section without triggering r…

### DIFF
--- a/include/crm/cib/internal.h
+++ b/include/crm/cib/internal.h
@@ -169,6 +169,7 @@ cib__client_triggers_refresh(const char *name)
     return (pcmk__parse_server(name) == pcmk_ipc_unknown)
            && !pcmk__str_any_of(name,
                                 "attrd_updater",
+                                "cibadmin_status",
                                 "crm_attribute",
                                 "crm_node",
                                 "crm_resource",

--- a/tools/cibadmin.c
+++ b/tools/cibadmin.c
@@ -137,6 +137,7 @@ static struct {
     gboolean input_stdin;
     gboolean allow_create;
     gboolean force;
+    gboolean update_status;
     gboolean get_node_path;
     gboolean no_children;
     gboolean score_update;
@@ -808,6 +809,11 @@ static GOptionEntry addl_entries[] = {
       "result",
       NULL },
 
+    { "update-status", 'u', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+      &options.update_status,
+      "(Advanced) Apply CIB update without triggering a controller refresh",
+      NULL },
+
     // @COMPAT Deprecated since 3.0.0
     { "local", 'l', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &options.local,
       "(deprecated)", NULL },
@@ -1088,7 +1094,8 @@ main(int argc, char **argv)
      * In cibadmin we explicitly output the XML portion without the prefixes. So
      * we default to LOG_CRIT.
      */
-    pcmk__cli_init_logging("cibadmin", 0);
+    pcmk__cli_init_logging(
+        options.update_status? "cibadmin_status" : "cibadmin", 0);
     set_crm_log_level(LOG_CRIT);
 
     if (args->verbosity > 0) {


### PR DESCRIPTION
…efresh

As since ec65417cc769d7930a1e4c2751909e5f545f42ff there is no tool available anymore to modify the status section adding the switch --update-status.
Instead of reverting to behavior before the commit above this approach doesn't introduce potentially unintentional behavioral changes.
When used, cibadmin registers with the CIB as
"cibadmin_status" (a safe client name), so the controller does not trigger an election and join refresh that would overwrite the status changes.
This was triggered by pcs feature that allows altering fence_scsi devices without resource restart by updating the digests in already recorded actions in the status section. (Jira Issue RHEL-70283)