### PR TITLE
Fix: libcrmcommon: Clear remaining attrs' flags in commit_attr_deletions

### DIFF
--- a/lib/common/crmcommon_private.h
+++ b/lib/common/crmcommon_private.h
@@ -117,9 +117,6 @@ G_GNUC_INTERNAL
 void pcmk__xml_tree_foreach_remove(xmlNode *xml, bool (*fn)(xmlNode *));
 
 G_GNUC_INTERNAL
-bool pcmk__xml_reset_node_flags(xmlNode *xml, void *user_data);
-
-G_GNUC_INTERNAL
 void pcmk__xml_set_parent_flags(xmlNode *xml, uint64_t flags);
 
 G_GNUC_INTERNAL

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -601,9 +601,30 @@ marked_as_deleted(const xmlAttr *attr, void *user_data)
 
 /*!
  * \internal
- * \brief Remove all attributes marked as deleted from an XML node
+ * \brief Clear flags on an XML attribute
  *
- * \param[in,out] xml        XML node whose deleted attributes to remove
+ * \param[in,out] xml        XML attribute whose flags to reset
+ * \param[in,out] user_data  Ignored
+ *
+ * \return \c true (to continue iterating)
+ *
+ * \note This is compatible with \c pcmk__xe_foreach_attr().
+ */
+static bool
+reset_attr_flags(xmlAttr *attr, void *user_data)
+{
+    reset_node_flags((xmlNode *) attr, user_data);
+    return true;
+}
+
+/*!
+ * \internal
+ * \brief Commit an XML node's attribute deletions
+ *
+ * This clears the node's flags, deletes any of its attributes that have the
+ * \c pcmk__xf_deleted flag set, and clears the remaining attributes' flags.
+ *
+ * \param[in,out] xml        XML node whose attribute deletions to commit
  * \param[in,out] user_data  Ignored
  *
  * \return \c true (to continue traversing the tree)
@@ -615,6 +636,7 @@ commit_attr_deletions(xmlNode *xml, void *user_data)
 {
     reset_node_flags(xml, NULL);
     pcmk__xe_remove_matching_attrs(xml, true, marked_as_deleted, NULL);
+    pcmk__xe_foreach_attr(xml, reset_attr_flags, NULL);
     return true;
 }
 
@@ -623,8 +645,8 @@ commit_attr_deletions(xmlNode *xml, void *user_data)
  * \brief Finalize all pending changes to an XML document and reset private data
  *
  * Clear the ACL user and all flags, unpacked ACLs, and deleted node records for
- * the document; clear all flags on each node in the tree; and delete any
- * attributes that are marked for deletion.
+ * the document; clear all flags on each node in the tree; delete any attributes
+ * that are marked for deletion; and clear flags for the remaining attributes.
  *
  * \param[in,out] doc  XML document
  *

--- a/lib/common/xml.c
+++ b/lib/common/xml.c
@@ -225,8 +225,8 @@ pcmk__mark_xml_node_dirty(xmlNode *xml)
  *
  * \note This is compatible with \c pcmk__xml_tree_foreach().
  */
-bool
-pcmk__xml_reset_node_flags(xmlNode *xml, void *user_data)
+static bool
+reset_node_flags(xmlNode *xml, void *user_data)
 {
     xml_node_private_t *nodepriv = xml->_private;
 
@@ -613,7 +613,7 @@ marked_as_deleted(const xmlAttr *attr, void *user_data)
 static bool
 commit_attr_deletions(xmlNode *xml, void *user_data)
 {
-    pcmk__xml_reset_node_flags(xml, NULL);
+    reset_node_flags(xml, NULL);
     pcmk__xe_remove_matching_attrs(xml, true, marked_as_deleted, NULL);
     return true;
 }
@@ -1071,7 +1071,7 @@ pcmk__xml_replace_with_copy(xmlNode *old, xmlNode *new)
     pcmk__assert(old != NULL);
 
     // May be unnecessary but avoids slight changes to some test outputs
-    pcmk__xml_tree_foreach(new_copy, pcmk__xml_reset_node_flags, NULL);
+    pcmk__xml_tree_foreach(new_copy, reset_node_flags, NULL);
 
     if (pcmk__xml_doc_all_flags_set(new_copy->doc, pcmk__xf_tracking)) {
         // Replaced sections may have included relevant ACLs
@@ -1583,7 +1583,7 @@ mark_child_deleted(xmlNode *old_child, xmlNode *new_parent)
     xmlNode *candidate = pcmk__xml_copy(new_parent, old_child);
 
     // Clear flags on new child and its children
-    pcmk__xml_tree_foreach(candidate, pcmk__xml_reset_node_flags, NULL);
+    pcmk__xml_tree_foreach(candidate, reset_node_flags, NULL);
 
     // free_xml_with_position() will check whether ACLs allow the deletion
     pcmk__apply_acls(candidate->doc);


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/ClusterLabs/pacemaker/commit/917a568c81b64d04c8794b8897669e8b3ee6e8d7. This has not made it into any release.

Commit https://github.com/ClusterLabs/pacemaker/commit/917a568c81b64d04c8794b8897669e8b3ee6e8d7 dropped a side effect from `marked_as_deleted()`: it no longer resets flags for an attribute that is not marked as deleted. Somehow this causes the `Reattach` cts-lab test to fail.

This commit fixes the regression by putting the flag clearing in the caller (`commit_attr_deletions()`).