### PR TITLE
Fix: fenced: Prevent segfault by not merging with in-flight fencing actions

### DIFF
--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -2816,6 +2816,12 @@ reply_to_duplicates(async_command_t *cmd, const pcmk__action_result_t *result,
             continue;
         }
 
+        // Do not merge with an in-flight fencing action
+        if (cmd_other->activating_on != NULL
+            || cmd_other->active_on != NULL) {
+            continue;
+        }
+
         /* A pending operation matches if:
          * 1. The client connections are different.
          * 2. The target is the same.


### PR DESCRIPTION
With "pcmk_action_limit" configured to be -1 or > 1 for the fencing resource, it's possible that when reply_to_duplicates() is called, some matching commands in cmd_list are already in-flight. Previously such in-flight commands would be merged and freed. Then when a command eventually returned and st_child_done() was called, it would segfault due to use-after-free of cmd.

This commit fixes the issue by not merging with any in-flight fencing actions.