### PR TITLE
Introduce a pcmk__daemon_t object and use it for mainloop/shutdown

### DIFF
--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -154,7 +154,10 @@ cleanup:
 void
 attrd_cib_disconnect(void)
 {
-    CRM_CHECK(the_cib != NULL, return);
+    if (the_cib == NULL) {
+        return;
+    }
+
     the_cib->cmds->del_notify_callback(the_cib, PCMK__VALUE_CIB_DIFF_NOTIFY,
                                        attrd_cib_updated_cb);
     cib__clean_up_connection(&the_cib);

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -35,13 +35,12 @@ attrd_cib_destroy_cb(void *user_data)
 
     if (attrd_shutting_down()) {
         pcmk__info("Disconnected from the CIB manager");
-
-    } else {
-        // @TODO This should trigger a reconnect, not a shutdown
-        pcmk__crit("Lost connection to the CIB manager, shutting down");
-        attrd_exit_status = CRM_EX_DISCONNECT;
-        attrd_shutdown(0);
+        return;
     }
+
+    // @TODO This should trigger a reconnect, not a shutdown
+    pcmk__crit("Lost connection to the CIB manager, shutting down");
+    attrd_quit_main_loop(CRM_EX_DISCONNECT);
 }
 
 static void

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -33,7 +33,7 @@ attrd_cib_destroy_cb(void *user_data)
 
     cib->cmds->signoff(cib);
 
-    if (attrd_shutting_down()) {
+    if (attrd.shutting_down) {
         pcmk__info("Disconnected from the CIB manager");
         return;
     }
@@ -55,7 +55,7 @@ attrd_cib_updated_cb(const char *event, xmlNode *msg)
     }
 
     if (pcmk__cib_element_in_patchset(patchset, PCMK_XE_ALERTS)) {
-        if (attrd_shutting_down()) {
+        if (attrd.shutting_down) {
             pcmk__debug("Ignoring alerts change in CIB during shutdown");
         } else {
             mainloop_set_trigger(attrd_config_read);
@@ -80,7 +80,7 @@ attrd_cib_updated_cb(const char *event, xmlNode *msg)
     if (status_changed
         || pcmk__cib_element_in_patchset(patchset, PCMK_XE_NODES)) {
 
-        if (attrd_shutting_down()) {
+        if (attrd.shutting_down) {
             pcmk__debug("Ignoring node change in CIB during shutdown");
             return;
         }

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -40,7 +40,7 @@ attrd_cib_destroy_cb(void *user_data)
 
     // @TODO This should trigger a reconnect, not a shutdown
     pcmk__crit("Lost connection to the CIB manager, shutting down");
-    attrd_quit_main_loop(CRM_EX_DISCONNECT);
+    pcmk__daemon_quit(&attrd, CRM_EX_DISCONNECT);
 }
 
 static void

--- a/daemons/attrd/attrd_cib.c
+++ b/daemons/attrd/attrd_cib.c
@@ -520,7 +520,7 @@ write_attribute(attribute_t *a, bool ignore_delay)
     }
 
     // Private attributes (or any in standalone mode) are not written to the CIB
-    if (attrd_stand_alone() || pcmk__is_set(a->flags, attrd_attr_is_private)) {
+    if (attrd.stand_alone || pcmk__is_set(a->flags, attrd_attr_is_private)) {
         should_write = false;
     }
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -181,12 +181,11 @@ attrd_cpg_destroy(void *unused)
 {
     if (attrd_shutting_down()) {
         pcmk__info("Disconnected from Corosync process group");
-
-    } else {
-        pcmk__crit("Lost connection to Corosync process group, shutting down");
-        attrd_exit_status = CRM_EX_DISCONNECT;
-        attrd_shutdown(0);
+        return;
     }
+
+    pcmk__crit("Lost connection to Corosync process group, shutting down");
+    attrd_quit_main_loop(CRM_EX_DISCONNECT);
 }
 #endif // SUPPORT_COROSYNC
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -185,7 +185,7 @@ attrd_cpg_destroy(void *unused)
     }
 
     pcmk__crit("Lost connection to Corosync process group, shutting down");
-    attrd_quit_main_loop(CRM_EX_DISCONNECT);
+    pcmk__daemon_quit(&attrd, CRM_EX_DISCONNECT);
 }
 #endif // SUPPORT_COROSYNC
 

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -82,7 +82,7 @@ attrd_peer_message(pcmk__node_status_t *peer, xmlNode *xml)
         return;
     }
 
-    if (attrd_shutting_down()) {
+    if (attrd.shutting_down) {
         /* If we're shutting down, we want to continue responding to election
          * ops as long as we're a cluster member (because our vote may be
          * needed). Ignore all other messages.
@@ -179,7 +179,7 @@ attrd_cpg_dispatch(cpg_handle_t handle, const struct cpg_name *group_name,
 static void
 attrd_cpg_destroy(void *unused)
 {
-    if (attrd_shutting_down()) {
+    if (attrd.shutting_down) {
         pcmk__info("Disconnected from Corosync process group");
         return;
     }

--- a/daemons/attrd/attrd_corosync.c
+++ b/daemons/attrd/attrd_corosync.c
@@ -510,7 +510,10 @@ attrd_cluster_connect(void)
     pcmk__cluster_set_status_callback(&attrd_peer_change_cb);
 
     rc = pcmk_cluster_connect(attrd_cluster);
-    if (rc != pcmk_rc_ok) {
+
+    if (rc == pcmk_rc_ok) {
+        pcmk__info("Cluster connection active");
+    } else {
         pcmk__err("Cluster connection failed");
     }
 

--- a/daemons/attrd/attrd_elections.c
+++ b/daemons/attrd/attrd_elections.c
@@ -46,7 +46,7 @@ attrd_start_election_if_needed(void)
 {
     if ((peer_writer == NULL)
         && (election_state(attrd_cluster) != election_in_progress)
-        && !attrd_shutting_down()) {
+        && !attrd.shutting_down) {
 
         pcmk__info("Starting an election to determine the writer");
         election_vote(attrd_cluster);
@@ -68,7 +68,7 @@ attrd_handle_election_op(const pcmk__node_status_t *peer, xmlNode *xml)
     pcmk__xe_set(xml, PCMK__XA_SRC, peer->name);
 
     // Don't become writer if we're shutting down
-    rc = election_count_vote(attrd_cluster, xml, !attrd_shutting_down());
+    rc = election_count_vote(attrd_cluster, xml, !attrd.shutting_down);
 
     switch(rc) {
         case election_start:

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -492,7 +492,7 @@ static int32_t
 attrd_ipc_accept(qb_ipcs_connection_t *c, uid_t uid, gid_t gid)
 {
     pcmk__trace("New client connection %p", c);
-    if (attrd_shutting_down()) {
+    if (attrd.shutting_down) {
         pcmk__info("Ignoring new connection from pid %d during shutdown",
                    pcmk__client_pid(c));
         return -ECONNREFUSED;

--- a/daemons/attrd/attrd_ipc.c
+++ b/daemons/attrd/attrd_ipc.c
@@ -649,8 +649,9 @@ attrd_ipc_cleanup(void)
  * \internal
  * \brief Set up attrd IPC communication
  */
-void
+bool
 attrd_ipc_init(void)
 {
     pcmk__serve_attrd_ipc(&ipcs, &ipc_callbacks);
+    return ipcs != NULL;
 }

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -41,7 +41,7 @@ attrd_quit_main_loop(crm_exit_t ec)
     // Tell various functions not to do anything
     attrd.shutting_down = true;
 
-    attrd_exit_status = ec;
+    attrd.ec = ec;
 
     // Don't respond to signals while shutting down
     mainloop_destroy_signal(SIGTERM);

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -45,17 +45,19 @@ attrd_shutting_down(void)
     return shutting_down;
 }
 
-/*!
- * \internal
- * \brief  Exit (using mainloop or not, as appropriate)
- *
- * \param[in] nsig  Ignored
- */
 void
-attrd_shutdown(int nsig)
+attrd_quit_main_loop(crm_exit_t ec)
 {
-    // Tell various functions not to do anthing
+    if (attrd_shutting_down()) {
+        return;
+    }
+
+    pcmk__info("Shutting down attribute manager");
+
+    // Tell various functions not to do anything
     shutting_down = true;
+
+    attrd_exit_status = ec;
 
     // Don't respond to signals while shutting down
     mainloop_destroy_signal(SIGTERM);
@@ -65,15 +67,27 @@ attrd_shutdown(int nsig)
     mainloop_destroy_signal(SIGUSR2);
     mainloop_destroy_signal(SIGTRAP);
 
-    if ((mloop == NULL) || !g_main_loop_is_running(mloop)) {
-        /* If there's no main loop active, just exit. This should be possible
-         * only if we get SIGTERM in brief windows at start-up and shutdown.
-         */
-        crm_exit(CRM_EX_OK);
-    } else {
-        g_main_loop_quit(mloop);
-        g_main_loop_unref(mloop);
-    }
+    /* There's no way to get to this function without the main loop running,
+     * but check just in case someone adds one in the future
+     */
+    CRM_CHECK((mloop != NULL) && g_main_loop_is_running(mloop), return);
+
+    g_main_loop_quit(mloop);
+    g_main_loop_unref(mloop);
+}
+
+/*!
+ * \internal
+ * \brief  Quit the main loop and set the exit code to \c CRM_EX_OK
+ *
+ * \param[in] nsig  Ignored
+ *
+ * \note This is a main loop signal handler function.
+ */
+void
+attrd_shutdown(int nsig)
+{
+    attrd_quit_main_loop(CRM_EX_OK);
 }
 
 /*!

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -24,37 +24,22 @@
 
 cib_t *the_cib = NULL;
 
-static bool shutting_down = false;
-
 /* A hash table storing information on the protocol version of each peer attrd.
  * The key is the peer's uname, and the value is the protocol version number.
  */
 GHashTable *peer_protocol_vers = NULL;
 
-/*!
- * \internal
- * \brief Check whether local attribute manager is shutting down
- *
- * \return \c true if local attribute manager has begun shutdown sequence,
- *         otherwise \c false
- */
-bool
-attrd_shutting_down(void)
-{
-    return shutting_down;
-}
-
 void
 attrd_quit_main_loop(crm_exit_t ec)
 {
-    if (attrd_shutting_down()) {
+    if (attrd.shutting_down) {
         return;
     }
 
     pcmk__info("Shutting down attribute manager");
 
     // Tell various functions not to do anything
-    shutting_down = true;
+    attrd.shutting_down = true;
 
     attrd_exit_status = ec;
 

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -65,11 +65,6 @@ attrd_shutdown(int nsig)
     mainloop_destroy_signal(SIGUSR2);
     mainloop_destroy_signal(SIGTRAP);
 
-    attrd_free_waitlist();
-    attrd_free_confirmations();
-
-    g_clear_pointer(&peer_protocol_vers, g_hash_table_destroy);
-
     if ((mloop == NULL) || !g_main_loop_is_running(mloop)) {
         /* If there's no main loop active, just exit. This should be possible
          * only if we get SIGTERM in brief windows at start-up and shutdown.

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -78,20 +78,6 @@ attrd_quit_main_loop(crm_exit_t ec)
 
 /*!
  * \internal
- * \brief  Quit the main loop and set the exit code to \c CRM_EX_OK
- *
- * \param[in] nsig  Ignored
- *
- * \note This is a main loop signal handler function.
- */
-void
-attrd_shutdown(int nsig)
-{
-    attrd_quit_main_loop(CRM_EX_OK);
-}
-
-/*!
- * \internal
  * \brief Create a main loop for attrd
  */
 void

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -25,7 +25,6 @@
 cib_t *the_cib = NULL;
 
 static bool shutting_down = false;
-static GMainLoop *mloop = NULL;
 
 /* A hash table storing information on the protocol version of each peer attrd.
  * The key is the peer's uname, and the value is the protocol version number.
@@ -67,33 +66,7 @@ attrd_quit_main_loop(crm_exit_t ec)
     mainloop_destroy_signal(SIGUSR2);
     mainloop_destroy_signal(SIGTRAP);
 
-    /* There's no way to get to this function without the main loop running,
-     * but check just in case someone adds one in the future
-     */
-    CRM_CHECK((mloop != NULL) && g_main_loop_is_running(mloop), return);
-
-    g_main_loop_quit(mloop);
-    g_main_loop_unref(mloop);
-}
-
-/*!
- * \internal
- * \brief Create a main loop for attrd
- */
-void
-attrd_init_mainloop(void)
-{
-    mloop = g_main_loop_new(NULL, FALSE);
-}
-
-/*!
- * \internal
- * \brief Run attrd main loop
- */
-void
-attrd_run_mainloop(void)
-{
-    g_main_loop_run(mloop);
+    pcmk__daemon_quit(&attrd);
 }
 
 /* strlen("value") */

--- a/daemons/attrd/attrd_utils.c
+++ b/daemons/attrd/attrd_utils.c
@@ -29,31 +29,6 @@ cib_t *the_cib = NULL;
  */
 GHashTable *peer_protocol_vers = NULL;
 
-void
-attrd_quit_main_loop(crm_exit_t ec)
-{
-    if (attrd.shutting_down) {
-        return;
-    }
-
-    pcmk__info("Shutting down attribute manager");
-
-    // Tell various functions not to do anything
-    attrd.shutting_down = true;
-
-    attrd.ec = ec;
-
-    // Don't respond to signals while shutting down
-    mainloop_destroy_signal(SIGTERM);
-    mainloop_destroy_signal(SIGCHLD);
-    mainloop_destroy_signal(SIGPIPE);
-    mainloop_destroy_signal(SIGUSR1);
-    mainloop_destroy_signal(SIGUSR2);
-    mainloop_destroy_signal(SIGTRAP);
-
-    pcmk__daemon_quit(&attrd);
-}
-
 /* strlen("value") */
 #define plus_plus_len (5)
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -193,8 +193,6 @@ main(int argc, char **argv)
         goto done;
     }
 
-    pcmk__info("Cluster connection active");
-
     // Initialization that requires the cluster to be connected
     attrd_election_init();
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -34,14 +34,13 @@ pcmk__daemon_t attrd = {
     .type = pcmk_ipc_attrd,
 };
 
-static gboolean stand_alone = false;
-
 static gchar **log_files = NULL;
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
 
 static GOptionEntry entries[] = {
-    { "stand-alone", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &stand_alone,
+    { "stand-alone", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+      &attrd.stand_alone,
       "(Advanced use only) Run in stand-alone mode", NULL },
 
     { "logfile", 'l', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME_ARRAY,
@@ -62,19 +61,6 @@ static pcmk__supported_format_t formats[] = {
 lrmd_t *the_lrmd = NULL;
 crm_trigger_t *attrd_config_read = NULL;
 crm_exit_t attrd_exit_status = CRM_EX_OK;
-
-/*!
- * \internal
- * \brief Check whether local attribute manager is running in stand-alone mode
- *
- * \return \c true if local attribute manager is in stand-alone mode, or
- *         \c false otherwise
- */
-bool
-attrd_stand_alone(void)
-{
-    return stand_alone;
-}
 
 static bool
 ipc_already_running(void)
@@ -191,7 +177,7 @@ main(int argc, char **argv)
 
     crm_log_init(PCMK__VALUE_ATTRD, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
     pcmk__notice("Starting Pacemaker node attribute manager%s",
-                 (attrd_stand_alone() ? " in standalone mode" : ""));
+                 (attrd.stand_alone ? " in standalone mode" : ""));
 
     if (ipc_already_running()) {
         attrd_exit_status = CRM_EX_OK;
@@ -208,7 +194,7 @@ main(int argc, char **argv)
      * This allows us to assume the CIB is connected whenever we process a
      * cluster or IPC message (which also avoids start-up race conditions).
      */
-    if (!attrd_stand_alone()) {
+    if (!attrd.stand_alone) {
         if (attrd_cib_connect(30) != pcmk_ok) {
             attrd_exit_status = CRM_EX_FATAL;
             g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
@@ -230,7 +216,7 @@ main(int argc, char **argv)
     // Initialization that requires the cluster to be connected
     attrd_election_init();
 
-    if (!attrd_stand_alone()) {
+    if (!attrd.stand_alone) {
         attrd_cib_init();
     }
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -30,6 +30,10 @@
 
 #define SUMMARY "daemon for managing Pacemaker node attributes"
 
+pcmk__daemon_t attrd = {
+    .type = pcmk_ipc_attrd,
+};
+
 static gboolean stand_alone = false;
 
 static gchar **log_files = NULL;
@@ -160,9 +164,7 @@ main(int argc, char **argv)
     processed_args = pcmk__cmdline_preproc(argv, NULL);
     context = build_arg_context(args, &output_group);
 
-    attrd_init_mainloop();
     crm_log_preinit(NULL, argc, argv);
-    mainloop_add_signal(SIGTERM, attrd_shutdown);
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
@@ -240,9 +242,19 @@ main(int argc, char **argv)
     attrd_send_protocol(NULL);
 
     attrd_ipc_init();
-    pcmk__notice("Pacemaker node attribute manager successfully started and "
-                 "accepting connections");
-    attrd_run_mainloop();
+
+    rc = pcmk__daemon_init(&attrd);
+    if (rc != pcmk_rc_ok) {
+        attrd_exit_status = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
+                    "Error initializing daemon object: %s",
+                    pcmk_rc_str(rc));
+        goto done;
+    }
+
+    mainloop_add_signal(SIGTERM, attrd_shutdown);
+
+    pcmk__daemon_run(&attrd);
 
   done:
     attrd_cleanup();

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -231,8 +231,6 @@ main(int argc, char **argv)
     attrd_run_mainloop();
 
   done:
-    pcmk__info("Shutting down attribute manager");
-
     attrd_cleanup();
 
     pcmk__output_and_clear_error(&error, out);

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -223,9 +223,11 @@ main(int argc, char **argv)
 
     attrd_free_removed_peers();
     attrd_free_waitlist();
+    attrd_free_confirmations();
     attrd_cleanup_xml_ids();
 
     g_clear_pointer(&attributes, g_hash_table_destroy);
+    g_clear_pointer(&peer_protocol_vers, g_hash_table_destroy);
 
     pcmk__output_and_clear_error(&error, out);
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -32,6 +32,7 @@
 
 pcmk__daemon_t attrd = {
     .type = pcmk_ipc_attrd,
+    .ec = CRM_EX_OK,
 };
 
 static gchar **log_files = NULL;
@@ -60,7 +61,6 @@ static pcmk__supported_format_t formats[] = {
 
 lrmd_t *the_lrmd = NULL;
 crm_trigger_t *attrd_config_read = NULL;
-crm_exit_t attrd_exit_status = CRM_EX_OK;
 
 static bool
 ipc_already_running(void)
@@ -154,14 +154,14 @@ main(int argc, char **argv)
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
-        attrd_exit_status = CRM_EX_USAGE;
+        attrd.ec = CRM_EX_USAGE;
         goto done;
     }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if ((rc != pcmk_rc_ok) || (out == NULL)) {
-        attrd_exit_status = CRM_EX_ERROR;
-        g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
+        attrd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, attrd.ec,
                     "Error creating output format %s: %s",
                     args->output_ty, pcmk_rc_str(rc));
         goto done;
@@ -180,8 +180,8 @@ main(int argc, char **argv)
                  (attrd.stand_alone ? " in standalone mode" : ""));
 
     if (ipc_already_running()) {
-        attrd_exit_status = CRM_EX_OK;
-        g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
+        attrd.ec = CRM_EX_OK;
+        g_set_error(&error, PCMK__EXITC_ERROR, attrd.ec,
                     "Aborting start-up because an attribute manager "
                     "instance is already active");
         pcmk__crit("%s", error->message);
@@ -196,8 +196,8 @@ main(int argc, char **argv)
      */
     if (!attrd.stand_alone) {
         if (attrd_cib_connect(30) != pcmk_ok) {
-            attrd_exit_status = CRM_EX_FATAL;
-            g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
+            attrd.ec = CRM_EX_FATAL;
+            g_set_error(&error, PCMK__EXITC_ERROR, attrd.ec,
                         "Could not connect to the CIB");
             goto done;
         }
@@ -205,8 +205,8 @@ main(int argc, char **argv)
     }
 
     if (attrd_cluster_connect() != pcmk_rc_ok) {
-        attrd_exit_status = CRM_EX_FATAL;
-        g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
+        attrd.ec = CRM_EX_FATAL;
+        g_set_error(&error, PCMK__EXITC_ERROR, attrd.ec,
                     "Could not connect to the cluster");
         goto done;
     }
@@ -231,8 +231,8 @@ main(int argc, char **argv)
 
     rc = pcmk__daemon_init(&attrd);
     if (rc != pcmk_rc_ok) {
-        attrd_exit_status = CRM_EX_ERROR;
-        g_set_error(&error, PCMK__EXITC_ERROR, attrd_exit_status,
+        attrd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, attrd.ec,
                     "Error initializing daemon object: %s",
                     pcmk_rc_str(rc));
         goto done;
@@ -255,9 +255,9 @@ main(int argc, char **argv)
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
-        out->finish(out, attrd_exit_status, true, NULL);
+        out->finish(out, attrd.ec, true, NULL);
         pcmk__output_free(out);
     }
     pcmk__unregister_formats();
-    crm_exit(attrd_exit_status);
+    crm_exit(attrd.ec);
 }

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -113,6 +113,24 @@ attrd_cleanup_cmdline(void)
     g_clear_pointer(&log_files, g_strfreev);
 }
 
+static void
+attrd_cleanup(void)
+{
+    attrd_ipc_cleanup();
+    attrd_lrmd_disconnect();
+    attrd_unregister_handlers();
+    attrd_cib_disconnect();
+    attrd_cluster_disconnect();
+
+    attrd_free_removed_peers();
+    attrd_free_waitlist();
+    attrd_free_confirmations();
+    attrd_cleanup_xml_ids();
+
+    g_clear_pointer(&attributes, g_hash_table_destroy);
+    g_clear_pointer(&peer_protocol_vers, g_hash_table_destroy);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -215,19 +233,7 @@ main(int argc, char **argv)
   done:
     pcmk__info("Shutting down attribute manager");
 
-    attrd_ipc_cleanup();
-    attrd_lrmd_disconnect();
-    attrd_unregister_handlers();
-    attrd_cib_disconnect();
-    attrd_cluster_disconnect();
-
-    attrd_free_removed_peers();
-    attrd_free_waitlist();
-    attrd_free_confirmations();
-    attrd_cleanup_xml_ids();
-
-    g_clear_pointer(&attributes, g_hash_table_destroy);
-    g_clear_pointer(&peer_protocol_vers, g_hash_table_destroy);
+    attrd_cleanup();
 
     pcmk__output_and_clear_error(&error, out);
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -108,7 +108,6 @@ main(int argc, char **argv)
     int rc = pcmk_rc_ok;
 
     GError *error = NULL;
-    bool initialized = false;
 
     GOptionGroup *output_group = NULL;
     pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
@@ -155,8 +154,6 @@ main(int argc, char **argv)
         goto done;
     }
 
-    initialized = true;
-
     attributes = pcmk__strkey_table(NULL, attrd_free_attribute);
 
     /* Connect to the CIB before connecting to the cluster or listening for IPC.
@@ -202,28 +199,22 @@ main(int argc, char **argv)
     attrd_run_mainloop();
 
   done:
-    if (initialized) {
-        pcmk__info("Shutting down attribute manager");
+    pcmk__info("Shutting down attribute manager");
 
-        attrd_ipc_cleanup();
-        attrd_lrmd_disconnect();
+    attrd_ipc_cleanup();
+    attrd_lrmd_disconnect();
+    attrd_unregister_handlers();
+    attrd_cib_disconnect();
+    attrd_cluster_disconnect();
 
-        if (!attrd_stand_alone()) {
-            attrd_cib_disconnect();
-        }
-
-        attrd_free_removed_peers();
-        attrd_free_waitlist();
-        attrd_cluster_disconnect();
-        attrd_unregister_handlers();
-        g_hash_table_destroy(attributes);
-    }
-
+    attrd_free_removed_peers();
+    attrd_free_waitlist();
     attrd_cleanup_xml_ids();
+
+    g_clear_pointer(&attributes, g_hash_table_destroy);
 
     g_strfreev(processed_args);
     pcmk__free_arg_context(context);
-
     g_strfreev(log_files);
 
     pcmk__output_and_clear_error(&error, out);

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -132,7 +132,7 @@ attrd_cleanup(void)
 static void
 attrd_shutdown(int nsig)
 {
-    attrd_quit_main_loop(CRM_EX_OK);
+    pcmk__daemon_quit(&attrd, CRM_EX_OK);
 }
 
 int

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -131,6 +131,20 @@ attrd_cleanup(void)
     g_clear_pointer(&peer_protocol_vers, g_hash_table_destroy);
 }
 
+/*!
+ * \internal
+ * \brief  Quit the main loop and set the exit code to \c CRM_EX_OK
+ *
+ * \param[in] nsig  Ignored
+ *
+ * \note This is a main loop signal handler function.
+ */
+static void
+attrd_shutdown(int nsig)
+{
+    attrd_quit_main_loop(CRM_EX_OK);
+}
+
 int
 main(int argc, char **argv)
 {

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -209,7 +209,10 @@ main(int argc, char **argv)
      */
     attrd_send_protocol(NULL);
 
-    attrd_ipc_init();
+    if (!attrd_ipc_init()) {
+        attrd.ec = CRM_EX_FATAL;
+        goto done;
+    }
 
     rc = pcmk__daemon_init(&attrd);
     if (rc != pcmk_rc_ok) {

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -31,7 +31,10 @@
 #define SUMMARY "daemon for managing Pacemaker node attributes"
 
 static gboolean stand_alone = false;
-gchar **log_files = NULL;
+
+static gchar **log_files = NULL;
+static gchar **processed_args = NULL;
+static GOptionContext *context = NULL;
 
 static GOptionEntry entries[] = {
     { "stand-alone", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &stand_alone,
@@ -102,17 +105,28 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     return context;
 }
 
+static void
+attrd_cleanup_cmdline(void)
+{
+    g_clear_pointer(&processed_args, g_strfreev);
+    g_clear_pointer(&context, g_option_context_free);
+    g_clear_pointer(&log_files, g_strfreev);
+}
+
 int
 main(int argc, char **argv)
 {
     int rc = pcmk_rc_ok;
 
     GError *error = NULL;
-
     GOptionGroup *output_group = NULL;
-    pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
-    gchar **processed_args = pcmk__cmdline_preproc(argv, NULL);
-    GOptionContext *context = build_arg_context(args, &output_group);
+    pcmk__common_args_t *args = NULL;
+
+    atexit(attrd_cleanup_cmdline);
+
+    args = pcmk__new_common_args(SUMMARY);
+    processed_args = pcmk__cmdline_preproc(argv, NULL);
+    context = build_arg_context(args, &output_group);
 
     attrd_init_mainloop();
     crm_log_preinit(NULL, argc, argv);
@@ -212,10 +226,6 @@ main(int argc, char **argv)
     attrd_cleanup_xml_ids();
 
     g_clear_pointer(&attributes, g_hash_table_destroy);
-
-    g_strfreev(processed_args);
-    pcmk__free_arg_context(context);
-    g_strfreev(log_files);
 
     pcmk__output_and_clear_error(&error, out);
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -30,9 +30,14 @@
 
 #define SUMMARY "daemon for managing Pacemaker node attributes"
 
+static pcmk__daemon_ipc_fns_t ipc_fns = {
+    .already_running = pcmk__daemon_ipc_running,
+};
+
 pcmk__daemon_t attrd = {
     .type = pcmk_ipc_attrd,
     .ec = CRM_EX_OK,
+    .ipc_fns = &ipc_fns,
 };
 
 static gchar **log_files = NULL;
@@ -61,30 +66,6 @@ static pcmk__supported_format_t formats[] = {
 
 lrmd_t *the_lrmd = NULL;
 crm_trigger_t *attrd_config_read = NULL;
-
-static bool
-ipc_already_running(void)
-{
-    pcmk_ipc_api_t *old_instance = NULL;
-    int rc = pcmk_rc_ok;
-
-    rc = pcmk_new_ipc_api(&old_instance, pcmk_ipc_attrd);
-    if (rc != pcmk_rc_ok) {
-        return false;
-    }
-
-    rc = pcmk__connect_ipc(old_instance, pcmk_ipc_dispatch_sync, 2);
-    if (rc != pcmk_rc_ok) {
-        pcmk__debug("No existing %s instance found: %s",
-                    pcmk_ipc_name(old_instance, true), pcmk_rc_str(rc));
-        pcmk_free_ipc_api(old_instance);
-        return false;
-    }
-
-    pcmk_disconnect_ipc(old_instance);
-    pcmk_free_ipc_api(old_instance);
-    return true;
-}
 
 static GOptionContext *
 build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
@@ -176,10 +157,8 @@ main(int argc, char **argv)
     pcmk__add_logfiles(log_files, out);
 
     crm_log_init(PCMK__VALUE_ATTRD, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
-    pcmk__notice("Starting Pacemaker node attribute manager%s",
-                 (attrd.stand_alone ? " in standalone mode" : ""));
 
-    if (ipc_already_running()) {
+    if (attrd.ipc_fns->already_running(&attrd)) {
         attrd.ec = CRM_EX_OK;
         g_set_error(&error, PCMK__EXITC_ERROR, attrd.ec,
                     "Aborting start-up because an attribute manager "
@@ -187,6 +166,9 @@ main(int argc, char **argv)
         pcmk__crit("%s", error->message);
         goto done;
     }
+
+    pcmk__notice("Starting Pacemaker node attribute manager%s",
+                 (attrd.stand_alone ? " in standalone mode" : ""));
 
     attributes = pcmk__strkey_table(NULL, attrd_free_attribute);
 

--- a/daemons/attrd/pacemaker-attrd.c
+++ b/daemons/attrd/pacemaker-attrd.c
@@ -257,6 +257,13 @@ main(int argc, char **argv)
     pcmk__daemon_run(&attrd);
 
   done:
+    /* If we got here through any of the "goto done" calls instead of by the
+     * main loop quitting on SIGTERM, shutting_down will still be false.  Set
+     * it here so attrd_cleanup -> attrd_cib_disconnect -> attrd_cib_destroy_cb
+     * doesn't call pcmk__daemon_quit with no main loop.
+     */
+    attrd.shutting_down = true;
+
     attrd_cleanup();
 
     pcmk__output_and_clear_error(&error, out);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -57,9 +57,6 @@
     pcmk__ipc_send_ack((client), (id), (flags), ATTRD_PROTOCOL_VERSION, \
                        CRM_EX_INDETERMINATE)
 
-void attrd_init_mainloop(void);
-void attrd_run_mainloop(void);
-
 void attrd_free_waitlist(void);
 void attrd_quit_main_loop(crm_exit_t ec);
 bool attrd_shutting_down(void);
@@ -188,6 +185,7 @@ typedef struct {
 extern pcmk_cluster_t *attrd_cluster;
 extern GHashTable *attributes;
 extern GHashTable *peer_protocol_vers;
+extern pcmk__daemon_t attrd;
 
 #define CIB_OP_TIMEOUT_S 120
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -61,7 +61,6 @@ void attrd_init_mainloop(void);
 void attrd_run_mainloop(void);
 
 void attrd_free_waitlist(void);
-void attrd_shutdown(int nsig);
 void attrd_quit_main_loop(crm_exit_t ec);
 bool attrd_shutting_down(void);
 bool attrd_stand_alone(void);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -59,7 +59,6 @@
 
 void attrd_free_waitlist(void);
 void attrd_quit_main_loop(crm_exit_t ec);
-bool attrd_stand_alone(void);
 void attrd_ipc_init(void);
 void attrd_ipc_cleanup(void);
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -58,7 +58,7 @@
                        CRM_EX_INDETERMINATE)
 
 void attrd_free_waitlist(void);
-void attrd_ipc_init(void);
+bool attrd_ipc_init(void);
 void attrd_ipc_cleanup(void);
 
 int attrd_cib_connect(int max_retry);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -59,7 +59,6 @@
 
 void attrd_free_waitlist(void);
 void attrd_quit_main_loop(crm_exit_t ec);
-bool attrd_shutting_down(void);
 bool attrd_stand_alone(void);
 void attrd_ipc_init(void);
 void attrd_ipc_cleanup(void);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -88,7 +88,6 @@ int attrd_failure_regex(regex_t *regex, const char *rsc, const char *op,
                         unsigned int interval_ms);
 
 extern cib_t *the_cib;
-extern crm_exit_t attrd_exit_status;
 
 /* Alerts */
 

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -62,6 +62,7 @@ void attrd_run_mainloop(void);
 
 void attrd_free_waitlist(void);
 void attrd_shutdown(int nsig);
+void attrd_quit_main_loop(crm_exit_t ec);
 bool attrd_shutting_down(void);
 bool attrd_stand_alone(void);
 void attrd_ipc_init(void);

--- a/daemons/attrd/pacemaker-attrd.h
+++ b/daemons/attrd/pacemaker-attrd.h
@@ -58,7 +58,6 @@
                        CRM_EX_INDETERMINATE)
 
 void attrd_free_waitlist(void);
-void attrd_quit_main_loop(crm_exit_t ec);
 void attrd_ipc_init(void);
 void attrd_ipc_cleanup(void);
 

--- a/daemons/based/based_corosync.c
+++ b/daemons/based/based_corosync.c
@@ -115,7 +115,10 @@ based_cluster_connect(void)
 #endif // SUPPORT_COROSYNC
 
     rc = pcmk_cluster_connect(cluster);
-    if (rc != pcmk_rc_ok) {
+
+    if (rc == pcmk_rc_ok) {
+        pcmk__info("Cluster connection active");
+    } else {
         pcmk__err("Cluster connection failed");
     }
 

--- a/daemons/based/based_ipc.c
+++ b/daemons/based/based_ipc.c
@@ -306,6 +306,10 @@ based_ipc_init(void)
 {
     pcmk__serve_based_ipc(&ipcs_ro, &ipcs_rw, &ipc_ro_callbacks,
                           &ipc_rw_callbacks);
+
+    if ((ipcs_ro == NULL) || (ipcs_rw == NULL)) {
+        crm_exit(CRM_EX_FATAL);
+    }
 }
 
 /*!

--- a/daemons/based/pacemaker-based.c
+++ b/daemons/based/pacemaker-based.c
@@ -405,8 +405,6 @@ main(int argc, char **argv)
                         "Could not connect to the cluster");
             goto done;
         }
-
-        pcmk__info("Cluster connection active");
     }
 
     // Run the main loop

--- a/daemons/execd/execd_alerts.c
+++ b/daemons/execd/execd_alerts.c
@@ -168,28 +168,40 @@ err:
 static bool
 drain_check(unsigned int remaining_timeout_ms)
 {
-    if (inflight_alerts != NULL) {
-        unsigned int count = g_hash_table_size(inflight_alerts);
+    unsigned int count = 0;
 
-        if (count > 0) {
-            pcmk__trace("%d alerts pending (%.3fs timeout remaining)",
-                        count, (remaining_timeout_ms / 1000.0));
-            return TRUE;
-        }
+    if (inflight_alerts == NULL) {
+        return false;
     }
-    return FALSE;
+
+    count = g_hash_table_size(inflight_alerts);
+    if (count > 0) {
+        pcmk__trace("%d alerts pending (%.3fs timeout remaining)",
+                    count, (remaining_timeout_ms / 1000.0));
+        return true;
+    }
+
+    return false;
 }
 
 void
 lrmd_drain_alerts(GMainLoop *mloop)
 {
-    if (inflight_alerts != NULL) {
-        unsigned int timer_ms = max_inflight_timeout() + 5000;
+    unsigned int timer_ms = 0;
 
-        pcmk__trace("Draining in-flight alerts (timeout %.3fs)",
-                    (timer_ms / 1000.0));
-        draining_alerts = TRUE;
-        pcmk_drain_main_loop(mloop, timer_ms, drain_check);
-        g_clear_pointer(&inflight_alerts, g_hash_table_destroy);
+    if (mloop == NULL) {
+        return;
     }
+
+    if (inflight_alerts == NULL) {
+        return;
+    }
+
+    timer_ms = max_inflight_timeout() + 5000;
+
+    pcmk__trace("Draining in-flight alerts (timeout %.3fs)",
+                (timer_ms / 1000.0));
+    draining_alerts = TRUE;
+    pcmk_drain_main_loop(mloop, timer_ms, drain_check);
+    g_clear_pointer(&inflight_alerts, g_hash_table_destroy);
 }

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -1580,7 +1580,7 @@ execd_process_signon(pcmk__client_t *client, xmlNode *request, int call_id,
     pcmk__xe_set(*reply, PCMK__XA_LRMD_OP, CRM_OP_REGISTER);
     pcmk__xe_set(*reply, PCMK__XA_LRMD_CLIENTID, client->id);
     pcmk__xe_set(*reply, PCMK__XA_LRMD_PROTOCOL_VERSION, LRMD_PROTOCOL_VERSION);
-    pcmk__xe_set_time(*reply, PCMK__XA_UPTIME, now - start_time);
+    pcmk__xe_set_time(*reply, PCMK__XA_UPTIME, now - execd.start_time);
 
     if (start_state) {
         pcmk__xe_set(*reply, PCMK__XA_NODE_START_STATE, start_state);

--- a/daemons/execd/execd_commands.c
+++ b/daemons/execd/execd_commands.c
@@ -101,7 +101,6 @@ typedef struct {
     GHashTable *params;
 } lrmd_cmd_t;
 
-static void cmd_finalize(lrmd_cmd_t * cmd, lrmd_rsc_t * rsc);
 static gboolean execute_resource_action(void *user_data);
 static void cancel_all_recurring(lrmd_rsc_t * rsc, const char *client_id);
 

--- a/daemons/execd/execd_ipc.c
+++ b/daemons/execd/execd_ipc.c
@@ -218,8 +218,9 @@ execd_ipc_cleanup(void)
  * \internal
  * \brief Set up executor IPC communication
  */
-void
+bool
 execd_ipc_init(void)
 {
     pcmk__serve_execd_ipc(&ipcs, &ipc_callbacks);
+    return ipcs != NULL;
 }

--- a/daemons/execd/execd_messages.c
+++ b/daemons/execd/execd_messages.c
@@ -50,8 +50,16 @@ handle_ipc_fwd_request(pcmk__request_t *request)
 
     rc = ipc_proxy_forward_client(request->ipc_client, request->xml);
 
-    if (rc == pcmk_rc_ok) {
+    if ((rc == pcmk_rc_ok) || (rc == ESHUTDOWN)) {
         pcmk__set_result(&request->result, CRM_EX_OK, PCMK_EXEC_DONE, NULL);
+
+        if (rc == ESHUTDOWN) {
+            /* We're shutting down so return NULL for the reply, but
+             * execd_handle_request will still want to process a result which
+             * is why we set one above.
+             */
+            return NULL;
+        }
 
     } else {
         pcmk__set_result(&request->result, pcmk_rc2exitc(rc), PCMK_EXEC_ERROR,

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -203,57 +203,6 @@ execd_cleanup(void)
 
 /*!
  * \internal
- * \brief Request cluster shutdown if appropriate, otherwise exit immediately
- *
- * \param[in] nsig  Signal that caused invocation (ignored)
- */
-static void
-lrmd_shutdown(int nsig)
-{
-#ifdef PCMK__COMPILE_REMOTE
-    pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
-
-    if (ipc_proxy == NULL) {
-        goto done;
-    }
-
-    /* If there are active proxied IPC providers, then we may be running
-     * resources, so notify the cluster that we wish to shut down.
-     */
-    if (shutting_down) {
-        pcmk__notice("Waiting for cluster to stop resources before exiting");
-        return;
-    }
-
-    pcmk__info("Sending shutdown request to cluster");
-    if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
-        pcmk__crit("Shutdown request failed, exiting immediately");
-        goto done;
-    }
-
-    /* We requested a shutdown. Now, we need to wait for an acknowledgement
-     * from the proxy host, then wait for all proxy hosts to disconnect (which
-     * ensures that all resources have been stopped).
-     */
-    shutting_down = TRUE;
-
-    /* Stop accepting new proxy connections */
-    execd_stop_tls_server();
-
-    /* Currently, we let the OS kill us if the clients don't disconnect in a
-     * reasonable time. We could instead set a long timer here (shorter than
-     * what the OS is likely to use) and exit immediately if it pops.
-     */
-    return;
-
-done:
-#endif
-
-    execd_quit_main_loop(CRM_EX_OK);
-}
-
-/*!
- * \internal
  * \brief Log a shutdown acknowledgment
  */
 void
@@ -335,12 +284,65 @@ execd_cleanup_cmdline(void)
 static void
 execd_quit_main_loop(crm_exit_t ec)
 {
+#ifdef PCMK__COMPILE_REMOTE
+    pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
+
+    if (ipc_proxy == NULL) {
+        goto done;
+    }
+
+    /* If there are active proxied IPC providers, then we may be running
+     * resources, so notify the cluster that we wish to shut down.
+     */
+    if (shutting_down) {
+        pcmk__notice("Waiting for cluster to stop resources before exiting");
+        return;
+    }
+
+    pcmk__info("Sending shutdown request to cluster");
+    if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
+        pcmk__crit("Shutdown request failed, exiting immediately");
+        goto done;
+    }
+
+    /* We requested a shutdown. Now, we need to wait for an acknowledgement
+     * from the proxy host, then wait for all proxy hosts to disconnect (which
+     * ensures that all resources have been stopped).
+     */
+    shutting_down = TRUE;
+
+    /* Stop accepting new proxy connections */
+    execd_stop_tls_server();
+
+    /* Currently, we let the OS kill us if the clients don't disconnect in a
+     * reasonable time. We could instead set a long timer here (shorter than
+     * what the OS is likely to use) and exit immediately if it pops.
+     */
+    return;
+
+done:
+#endif
+
     /* There's no way to get to this function without the main loop running,
      * but check just in case someone adds one in the future
      */
     CRM_CHECK((mainloop != NULL) && g_main_loop_is_running(mainloop), return);
 
     g_main_loop_quit(mainloop);
+}
+
+/*!
+ * \internal
+ * \brief  Quit the main loop and set the exit code to \c CRM_EX_OK
+ *
+ * \param[in] nsig  Ignored
+ *
+ * \note This is a main loop signal handler function.
+ */
+static void
+execd_shutdown(int nsig)
+{
+    execd_quit_main_loop(CRM_EX_OK);
 }
 
 int
@@ -463,7 +465,7 @@ main(int argc, char **argv)
     }
 #endif
 
-    mainloop_add_signal(SIGTERM, lrmd_shutdown);
+    mainloop_add_signal(SIGTERM, execd_shutdown);
     mainloop = g_main_loop_new(NULL, FALSE);
     pcmk__notice("Pacemaker " EXECD_TYPE " executor successfully started and "
                  "accepting connections");

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -53,7 +53,6 @@ pcmk__daemon_t execd = {
 };
 
 static stonith_t *fencer_api = NULL;
-time_t start_time;
 
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
@@ -425,8 +424,6 @@ main(int argc, char **argv)
         pcmk__set_env_option(PCMK__ENV_REMOTE_PORT, options.port, false);
     }
 #endif  // PCMK__COMPILE_REMOTE
-
-    start_time = time(NULL);
 
     pcmk__notice("Starting Pacemaker " EXECD_TYPE " executor");
 

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -193,10 +193,7 @@ exit_executor(void)
     ipc_proxy_cleanup();
 #endif
 
-    if (mainloop) {
-        lrmd_drain_alerts(mainloop);
-    }
-
+    lrmd_drain_alerts(mainloop);
     execd_unregister_handlers();
     g_hash_table_destroy(rsc_list);
 
@@ -216,40 +213,40 @@ lrmd_shutdown(int nsig)
 #ifdef PCMK__COMPILE_REMOTE
     pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
 
+    if (ipc_proxy == NULL) {
+        exit_executor();
+    }
+
     /* If there are active proxied IPC providers, then we may be running
      * resources, so notify the cluster that we wish to shut down.
      */
-    if (ipc_proxy) {
-        if (shutting_down) {
-            pcmk__notice("Waiting for cluster to stop resources before "
-                         "exiting");
-            return;
-        }
-
-        pcmk__info("Sending shutdown request to cluster");
-        if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
-            pcmk__crit("Shutdown request failed, exiting immediately");
-
-        } else {
-            /* We requested a shutdown. Now, we need to wait for an
-             * acknowledgement from the proxy host, then wait for all proxy
-             * hosts to disconnect (which ensures that all resources have been
-             * stopped).
-             */
-            shutting_down = TRUE;
-
-            /* Stop accepting new proxy connections */
-            execd_stop_tls_server();
-
-            /* Currently, we let the OS kill us if the clients don't disconnect
-             * in a reasonable time. We could instead set a long timer here
-             * (shorter than what the OS is likely to use) and exit immediately
-             * if it pops.
-             */
-            return;
-        }
+    if (shutting_down) {
+        pcmk__notice("Waiting for cluster to stop resources before exiting");
+        return;
     }
+
+    pcmk__info("Sending shutdown request to cluster");
+    if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
+        pcmk__crit("Shutdown request failed, exiting immediately");
+        exit_executor();
+    }
+
+    /* We requested a shutdown. Now, we need to wait for an acknowledgement
+     * from the proxy host, then wait for all proxy hosts to disconnect (which
+     * ensures that all resources have been stopped).
+     */
+    shutting_down = TRUE;
+
+    /* Stop accepting new proxy connections */
+    execd_stop_tls_server();
+
+    /* Currently, we let the OS kill us if the clients don't disconnect in a
+     * reasonable time. We could instead set a long timer here (shorter than
+     * what the OS is likely to use) and exit immediately if it pops.
+     */
+    return;
 #endif
+
     exit_executor();
 }
 

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -60,7 +60,7 @@ static struct {
 static gboolean shutting_down = FALSE;
 #endif
 
-static void exit_executor(void);
+static void execd_cleanup(void);
 
 static void
 fencer_connection_destroy_cb(stonith_t *st, stonith_event_t *e)
@@ -120,7 +120,7 @@ lrmd_client_destroy(pcmk__client_t *client)
      * if there are no more proxied IPC providers
      */
     if (shutting_down && (ipc_proxy_get_provider() == NULL)) {
-        exit_executor();
+        execd_cleanup();
     }
 #endif
 }
@@ -174,12 +174,8 @@ lrmd_server_send_notify(pcmk__client_t *client, xmlNode *msg)
     return ENOTCONN;
 }
 
-/*!
- * \internal
- * \brief Clean up and exit immediately
- */
 static void
-exit_executor(void)
+execd_cleanup(void)
 {
     const unsigned int nclients = pcmk__ipc_client_count();
 
@@ -195,7 +191,7 @@ exit_executor(void)
 
     lrmd_drain_alerts(mainloop);
     execd_unregister_handlers();
-    g_hash_table_destroy(rsc_list);
+    g_clear_pointer(&rsc_list, g_hash_table_destroy);
 
     // @TODO End mainloop instead so all cleanup is done
     crm_exit(CRM_EX_OK);
@@ -214,7 +210,7 @@ lrmd_shutdown(int nsig)
     pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
 
     if (ipc_proxy == NULL) {
-        exit_executor();
+        execd_cleanup();
     }
 
     /* If there are active proxied IPC providers, then we may be running
@@ -228,7 +224,7 @@ lrmd_shutdown(int nsig)
     pcmk__info("Sending shutdown request to cluster");
     if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
         pcmk__crit("Shutdown request failed, exiting immediately");
-        exit_executor();
+        execd_cleanup();
     }
 
     /* We requested a shutdown. Now, we need to wait for an acknowledgement
@@ -247,7 +243,7 @@ lrmd_shutdown(int nsig)
     return;
 #endif
 
-    exit_executor();
+    execd_cleanup();
 }
 
 /*!
@@ -278,7 +274,7 @@ handle_shutdown_nack(void)
     if (shutting_down) {
         pcmk__info("Exiting immediately after IPC proxy provider indicated no "
                    "resources will be stopped");
-        exit_executor();
+        execd_cleanup();
         return;
     }
 #endif
@@ -455,7 +451,7 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
     /* should never get here */
-    exit_executor();
+    execd_cleanup();
 
 done:
     pcmk__output_and_clear_error(&error, out);

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -59,11 +59,6 @@ static struct {
 #endif  // PCMK__COMPILE_REMOTE
 } options;
 
-#ifdef PCMK__COMPILE_REMOTE
-/* whether shutdown request has been sent */
-static gboolean shutting_down = FALSE;
-#endif
-
 static void execd_cleanup(void);
 static void execd_quit_main_loop(crm_exit_t ec);
 
@@ -130,7 +125,7 @@ lrmd_client_destroy(pcmk__client_t *client)
      * After that, we'll return to the done label in main() and finish
      * shutting down.
      */
-    if (shutting_down && (ipc_proxy_get_provider() == NULL)) {
+    if (execd.shutting_down && (ipc_proxy_get_provider() == NULL)) {
         execd_quit_main_loop(CRM_EX_OK);
     }
 #endif
@@ -213,7 +208,7 @@ void
 handle_shutdown_ack(void)
 {
 #ifdef PCMK__COMPILE_REMOTE
-    if (shutting_down) {
+    if (execd.shutting_down) {
         pcmk__info("IPC proxy provider acknowledged shutdown request");
         return;
     }
@@ -232,7 +227,7 @@ int
 handle_shutdown_nack(void)
 {
 #ifdef PCMK__COMPILE_REMOTE
-    if (shutting_down) {
+    if (execd.shutting_down) {
         pcmk__info("Exiting immediately after IPC proxy provider indicated no "
                    "resources will be stopped");
         return ESHUTDOWN;
@@ -298,7 +293,7 @@ execd_quit_main_loop(crm_exit_t ec)
     /* If there are active proxied IPC providers, then we may be running
      * resources, so notify the cluster that we wish to shut down.
      */
-    if (shutting_down) {
+    if (execd.shutting_down) {
         pcmk__notice("Waiting for cluster to stop resources before exiting");
         return;
     }
@@ -313,7 +308,7 @@ execd_quit_main_loop(crm_exit_t ec)
      * from the proxy host, then wait for all proxy hosts to disconnect (which
      * ensures that all resources have been stopped).
      */
-    shutting_down = TRUE;
+    execd.shutting_down = true;
 
     /* Stop accepting new proxy connections */
     execd_stop_tls_server();

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -117,11 +117,17 @@ lrmd_client_destroy(pcmk__client_t *client)
     pcmk__free_client(client);
 
 #ifdef PCMK__COMPILE_REMOTE
-    /* If we were waiting to shut down, we can now safely do so
-     * if there are no more proxied IPC providers
+    /* If we were waiting to shut down, we can now safely do so if there are
+     * no more proxied IPC providers
+     *
+     * This kills the main loop and cleans everything up.  Control flow will
+     * eventually make it back up to lrmd_remote_client_destroy or
+     * execd_ipc_closed, which were both called directly from the main loop.
+     * After that, we'll return to the done label in main() and finish
+     * shutting down.
      */
     if (shutting_down && (ipc_proxy_get_provider() == NULL)) {
-        execd_cleanup();
+        execd_quit_main_loop(CRM_EX_OK);
     }
 #endif
 }
@@ -193,11 +199,6 @@ execd_cleanup(void)
     lrmd_drain_alerts(mainloop);
     execd_unregister_handlers();
     g_clear_pointer(&rsc_list, g_hash_table_destroy);
-
-#ifdef PCMK__COMPILE_REMOTE
-    // @TODO End mainloop instead so all cleanup is done
-    crm_exit(CRM_EX_OK);
-#endif
 }
 
 /*!
@@ -213,7 +214,7 @@ lrmd_shutdown(int nsig)
     pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
 
     if (ipc_proxy == NULL) {
-        execd_cleanup();
+        goto done;
     }
 
     /* If there are active proxied IPC providers, then we may be running
@@ -227,7 +228,7 @@ lrmd_shutdown(int nsig)
     pcmk__info("Sending shutdown request to cluster");
     if (ipc_proxy_shutdown_req(ipc_proxy) < 0) {
         pcmk__crit("Shutdown request failed, exiting immediately");
-        execd_cleanup();
+        goto done;
     }
 
     /* We requested a shutdown. Now, we need to wait for an acknowledgement
@@ -244,6 +245,8 @@ lrmd_shutdown(int nsig)
      * what the OS is likely to use) and exit immediately if it pops.
      */
     return;
+
+done:
 #endif
 
     execd_quit_main_loop(CRM_EX_OK);
@@ -278,7 +281,7 @@ handle_shutdown_nack(void)
         pcmk__info("Exiting immediately after IPC proxy provider indicated no "
                    "resources will be stopped");
         execd_cleanup();
-        return;
+        crm_exit(CRM_EX_OK);
     }
 #endif
     pcmk__debug("Ignoring unexpected shutdown rejection from IPC proxy "

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -272,20 +272,23 @@ handle_shutdown_ack(void)
 /*!
  * \internal
  * \brief Handle rejection of shutdown request
+ *
+ * \return Standard Pacemaker return code
  */
-void
+int
 handle_shutdown_nack(void)
 {
 #ifdef PCMK__COMPILE_REMOTE
     if (shutting_down) {
         pcmk__info("Exiting immediately after IPC proxy provider indicated no "
                    "resources will be stopped");
-        execd_cleanup();
-        crm_exit(CRM_EX_OK);
+        return ESHUTDOWN;
     }
 #endif
+
     pcmk__debug("Ignoring unexpected shutdown rejection from IPC proxy "
                 "provider");
+    return pcmk_rc_ok;
 }
 
 static GOptionEntry entries[] = {

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -43,6 +43,7 @@
 static GMainLoop *mainloop = NULL;
 static stonith_t *fencer_api = NULL;
 time_t start_time;
+crm_exit_t exit_code = CRM_EX_OK;
 
 static struct {
     gchar **log_files;
@@ -319,7 +320,6 @@ int
 main(int argc, char **argv)
 {
     int rc = pcmk_rc_ok;
-    crm_exit_t exit_code = CRM_EX_OK;
 
     const char *option = NULL;
 
@@ -430,7 +430,10 @@ main(int argc, char **argv)
         exit_code = CRM_EX_FATAL;
         goto done;
     }
-    ipc_proxy_init();
+
+    if (!ipc_proxy_init()) {
+        goto done;
+    }
 #endif
 
     mainloop_add_signal(SIGTERM, lrmd_shutdown);

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -40,10 +40,14 @@
 #  define SUMMARY "resource agent executor daemon for Pacemaker cluster nodes"
 #endif
 
+pcmk__daemon_t execd = {
+    .type = pcmk_ipc_execd,
+    .ec = CRM_EX_OK,
+};
+
 static GMainLoop *mainloop = NULL;
 static stonith_t *fencer_api = NULL;
 time_t start_time;
-crm_exit_t exit_code = CRM_EX_OK;
 
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
@@ -378,14 +382,14 @@ main(int argc, char **argv)
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
-        exit_code = CRM_EX_USAGE;
+        execd.ec = CRM_EX_USAGE;
         goto done;
     }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if (rc != pcmk_rc_ok) {
-        exit_code = CRM_EX_ERROR;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+        execd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, execd.ec,
                     "Error creating output format %s: %s",
                     args->output_ty, pcmk_rc_str(rc));
         goto done;
@@ -456,7 +460,7 @@ main(int argc, char **argv)
     if (lrmd_init_remote_tls_server() < 0) {
         pcmk__err("Failed to create TLS listener: shutting down and staying "
                   "down");
-        exit_code = CRM_EX_FATAL;
+        execd.ec = CRM_EX_FATAL;
         goto done;
     }
 
@@ -479,9 +483,9 @@ done:
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
-        out->finish(out, exit_code, true, NULL);
+        out->finish(out, execd.ec, true, NULL);
         pcmk__output_free(out);
     }
     pcmk__unregister_formats();
-    crm_exit(exit_code);
+    crm_exit(execd.ec);
 }

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -40,12 +40,18 @@
 #  define SUMMARY "resource agent executor daemon for Pacemaker cluster nodes"
 #endif
 
+static bool execd_quit(pcmk__daemon_t *d);
+
+static pcmk__daemon_fns_t fns = {
+    .quit = execd_quit,
+};
+
 pcmk__daemon_t execd = {
     .type = pcmk_ipc_execd,
     .ec = CRM_EX_OK,
+    .fns = &fns,
 };
 
-static GMainLoop *mainloop = NULL;
 static stonith_t *fencer_api = NULL;
 time_t start_time;
 
@@ -58,9 +64,6 @@ static struct {
     gchar *port;
 #endif  // PCMK__COMPILE_REMOTE
 } options;
-
-static void execd_cleanup(void);
-static void execd_quit_main_loop(crm_exit_t ec);
 
 static void
 fencer_connection_destroy_cb(stonith_t *st, stonith_event_t *e)
@@ -126,7 +129,9 @@ lrmd_client_destroy(pcmk__client_t *client)
      * shutting down.
      */
     if (execd.shutting_down && (ipc_proxy_get_provider() == NULL)) {
-        execd_quit_main_loop(CRM_EX_OK);
+        // Unset shutting_down so pcmk__daemon_quit does something
+        execd.shutting_down = false;
+        pcmk__daemon_quit(&execd, CRM_EX_OK);
     }
 #endif
 }
@@ -195,7 +200,6 @@ execd_cleanup(void)
     ipc_proxy_cleanup();
 #endif
 
-    lrmd_drain_alerts(mainloop);
     execd_unregister_handlers();
     g_clear_pointer(&rsc_list, g_hash_table_destroy);
 }
@@ -280,8 +284,8 @@ execd_cleanup_cmdline(void)
 #endif
 }
 
-static void
-execd_quit_main_loop(crm_exit_t ec)
+static bool
+execd_quit(pcmk__daemon_t *d)
 {
 #ifdef PCMK__COMPILE_REMOTE
     pcmk__client_t *ipc_proxy = ipc_proxy_get_provider();
@@ -295,7 +299,7 @@ execd_quit_main_loop(crm_exit_t ec)
      */
     if (execd.shutting_down) {
         pcmk__notice("Waiting for cluster to stop resources before exiting");
-        return;
+        return false;
     }
 
     pcmk__info("Sending shutdown request to cluster");
@@ -317,17 +321,13 @@ execd_quit_main_loop(crm_exit_t ec)
      * reasonable time. We could instead set a long timer here (shorter than
      * what the OS is likely to use) and exit immediately if it pops.
      */
-    return;
+    return false;
 
 done:
 #endif
 
-    /* There's no way to get to this function without the main loop running,
-     * but check just in case someone adds one in the future
-     */
-    CRM_CHECK((mainloop != NULL) && g_main_loop_is_running(mainloop), return);
-
-    g_main_loop_quit(mainloop);
+    lrmd_drain_alerts(execd.mainloop);
+    return true;
 }
 
 /*!
@@ -341,7 +341,7 @@ done:
 static void
 execd_shutdown(int nsig)
 {
-    execd_quit_main_loop(CRM_EX_OK);
+    pcmk__daemon_quit(&execd, CRM_EX_OK);
 }
 
 int
@@ -464,13 +464,18 @@ main(int argc, char **argv)
     }
 #endif
 
+    rc = pcmk__daemon_init(&execd);
+    if (rc != pcmk_rc_ok) {
+        execd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, execd.ec,
+                    "Error initializing daemon object: %s",
+                    pcmk_rc_str(rc));
+        goto done;
+    }
+
     mainloop_add_signal(SIGTERM, execd_shutdown);
-    mainloop = g_main_loop_new(NULL, FALSE);
-    pcmk__notice("Pacemaker " EXECD_TYPE " executor successfully started and "
-                 "accepting connections");
-    pcmk__notice("OCF resource agent search path is %s", PCMK__OCF_RA_PATH);
-    g_main_loop_run(mainloop);
-    g_clear_pointer(&mainloop, g_main_loop_unref);
+
+    pcmk__daemon_run(&execd);
 
 done:
     execd_cleanup();

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -45,6 +45,9 @@ static stonith_t *fencer_api = NULL;
 time_t start_time;
 crm_exit_t exit_code = CRM_EX_OK;
 
+static gchar **processed_args = NULL;
+static GOptionContext *context = NULL;
+
 static struct {
     gchar **log_files;
 #ifdef PCMK__COMPILE_REMOTE
@@ -316,6 +319,17 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group)
     return context;
 }
 
+static void
+execd_cleanup_cmdline(void)
+{
+    g_clear_pointer(&processed_args, g_strfreev);
+    g_clear_pointer(&context, g_option_context_free);
+    g_clear_pointer(&options.log_files, g_strfreev);
+#ifdef PCMK__COMPILE_REMOTE
+    g_clear_pointer(&options.port, g_free);
+#endif
+}
+
 int
 main(int argc, char **argv)
 {
@@ -329,8 +343,8 @@ main(int argc, char **argv)
 
     GOptionGroup *output_group = NULL;
     pcmk__common_args_t *args = NULL;
-    gchar **processed_args = NULL;
-    GOptionContext *context = NULL;
+
+    atexit(execd_cleanup_cmdline);
 
 #ifdef PCMK__COMPILE_REMOTE
     // If necessary, create PID 1 now before any file descriptors are opened
@@ -447,14 +461,6 @@ main(int argc, char **argv)
     exit_executor();
 
 done:
-    g_strfreev(options.log_files);
-#ifdef PCMK__COMPILE_REMOTE
-    g_free(options.port);
-#endif  // PCMK__COMPILE_REMOTE
-
-    g_strfreev(processed_args);
-    pcmk__free_arg_context(context);
-
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -61,6 +61,7 @@ static gboolean shutting_down = FALSE;
 #endif
 
 static void execd_cleanup(void);
+static void execd_quit_main_loop(crm_exit_t ec);
 
 static void
 fencer_connection_destroy_cb(stonith_t *st, stonith_event_t *e)
@@ -193,8 +194,10 @@ execd_cleanup(void)
     execd_unregister_handlers();
     g_clear_pointer(&rsc_list, g_hash_table_destroy);
 
+#ifdef PCMK__COMPILE_REMOTE
     // @TODO End mainloop instead so all cleanup is done
     crm_exit(CRM_EX_OK);
+#endif
 }
 
 /*!
@@ -243,7 +246,7 @@ lrmd_shutdown(int nsig)
     return;
 #endif
 
-    execd_cleanup();
+    execd_quit_main_loop(CRM_EX_OK);
 }
 
 /*!
@@ -321,6 +324,17 @@ execd_cleanup_cmdline(void)
 #ifdef PCMK__COMPILE_REMOTE
     g_clear_pointer(&options.port, g_free);
 #endif
+}
+
+static void
+execd_quit_main_loop(crm_exit_t ec)
+{
+    /* There's no way to get to this function without the main loop running,
+     * but check just in case someone adds one in the future
+     */
+    CRM_CHECK((mainloop != NULL) && g_main_loop_is_running(mainloop), return);
+
+    g_main_loop_quit(mainloop);
 }
 
 int
@@ -449,11 +463,11 @@ main(int argc, char **argv)
                  "accepting connections");
     pcmk__notice("OCF resource agent search path is %s", PCMK__OCF_RA_PATH);
     g_main_loop_run(mainloop);
-
-    /* should never get here */
-    execd_cleanup();
+    g_clear_pointer(&mainloop, g_main_loop_unref);
 
 done:
+    execd_cleanup();
+
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {

--- a/daemons/execd/pacemaker-execd.c
+++ b/daemons/execd/pacemaker-execd.c
@@ -449,7 +449,10 @@ main(int argc, char **argv)
 
     rsc_list = pcmk__strkey_table(NULL, execd_free_rsc);
 
-    execd_ipc_init();
+    if (!execd_ipc_init()) {
+        execd.ec = CRM_EX_FATAL;
+        goto done;
+    }
 
 #ifdef PCMK__COMPILE_REMOTE
     if (lrmd_init_remote_tls_server() < 0) {

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -105,7 +105,7 @@ void lrmd_drain_alerts(GMainLoop *mloop);
 bool execd_invalid_msg(xmlNode *msg);
 void execd_handle_request(pcmk__request_t *request);
 
-void execd_ipc_init(void);
+bool execd_ipc_init(void);
 void execd_ipc_cleanup(void);
 
 xmlNode *execd_create_reply_as(const char *origin, int rc, int call_id);

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -12,7 +12,6 @@
 
 #include <stdbool.h>                // bool
 #include <stdint.h>                 // uint32_t
-#include <time.h>                   // time_t
 
 #include <glib.h>                   // GList, GHashTable, GMainLoop
 #include <libxml/tree.h>            // xmlNode
@@ -23,7 +22,6 @@
 
 extern GHashTable *rsc_list;
 extern pcmk__daemon_t execd;
-extern time_t start_time;
 
 typedef struct {
     char *rsc_id;

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -23,6 +23,7 @@
 
 extern GHashTable *rsc_list;
 extern time_t start_time;
+extern crm_exit_t exit_code;
 
 typedef struct {
     char *rsc_id;
@@ -86,7 +87,7 @@ stonith_t *execd_get_fencer_connection(void);
 void execd_fencer_connection_failed(void);
 
 #ifdef PCMK__COMPILE_REMOTE
-void ipc_proxy_init(void);
+bool ipc_proxy_init(void);
 void ipc_proxy_cleanup(void);
 void ipc_proxy_add_provider(pcmk__client_t *client);
 void ipc_proxy_remove_provider(pcmk__client_t *client);

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -22,8 +22,8 @@
 #include <crm/stonith-ng.h>         // stonith_t
 
 extern GHashTable *rsc_list;
+extern pcmk__daemon_t execd;
 extern time_t start_time;
-extern crm_exit_t exit_code;
 
 typedef struct {
     char *rsc_id;

--- a/daemons/execd/pacemaker-execd.h
+++ b/daemons/execd/pacemaker-execd.h
@@ -71,7 +71,7 @@ void execd_free_rsc(void *data);
 
 void handle_shutdown_ack(void);
 
-void handle_shutdown_nack(void);
+int handle_shutdown_nack(void);
 
 void lrmd_client_destroy(pcmk__client_t *client);
 

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -514,23 +514,29 @@ ipc_proxy_remove_provider(pcmk__client_t *ipc_proxy)
     g_list_free(remove_these);
 }
 
-void
+bool
 ipc_proxy_init(void)
 {
     ipc_clients = pcmk__strkey_table(NULL, NULL);
 
     pcmk__serve_based_ipc(&cib_ro, &cib_rw, &cib_proxy_callbacks_ro,
                           &cib_proxy_callbacks_rw);
+
     pcmk__serve_attrd_ipc(&attrd_ipcs, &attrd_proxy_callbacks);
+    if (attrd_ipcs == NULL) {
+        exit_code = CRM_EX_FATAL;
+        return false;
+    }
 
     pcmk__serve_controld_ipc(&controld_ipcs, &crmd_proxy_callbacks);
     if (controld_ipcs == NULL) {
-        // Error already logged
-        crm_exit(CRM_EX_FATAL);
+        exit_code = CRM_EX_FATAL;
+        return false;
     }
 
     pcmk__serve_fenced_ipc(&fencer_ipcs, &fencer_proxy_callbacks);
     pcmk__serve_pacemakerd_ipc(&pacemakerd_ipcs, &pacemakerd_proxy_callbacks);
+    return true;
 }
 
 void

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -523,13 +523,13 @@ ipc_proxy_init(void)
 
     pcmk__serve_attrd_ipc(&attrd_ipcs, &attrd_proxy_callbacks);
     if (attrd_ipcs == NULL) {
-        exit_code = CRM_EX_FATAL;
+        execd.ec = CRM_EX_FATAL;
         return false;
     }
 
     pcmk__serve_controld_ipc(&controld_ipcs, &crmd_proxy_callbacks);
     if (controld_ipcs == NULL) {
-        exit_code = CRM_EX_FATAL;
+        execd.ec = CRM_EX_FATAL;
         return false;
     }
 

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -534,6 +534,11 @@ ipc_proxy_init(void)
     }
 
     pcmk__serve_fenced_ipc(&fencer_ipcs, &fencer_proxy_callbacks);
+    if (fencer_ipcs == NULL) {
+        execd.ec = CRM_EX_FATAL;
+        return false;
+    }
+
     pcmk__serve_pacemakerd_ipc(&pacemakerd_ipcs, &pacemakerd_proxy_callbacks);
     return true;
 }

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -176,8 +176,7 @@ ipc_proxy_forward_client(pcmk__client_t *ipc_proxy, xmlNode *xml)
     }
 
     if (pcmk__str_eq(msg_type, LRMD_IPC_OP_SHUTDOWN_NACK, pcmk__str_casei)) {
-        handle_shutdown_nack();
-        return rc;
+        return handle_shutdown_nack();
     }
 
     ipc_client = pcmk__find_client_by_id(session);

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -540,6 +540,11 @@ ipc_proxy_init(void)
     }
 
     pcmk__serve_pacemakerd_ipc(&pacemakerd_ipcs, &pacemakerd_proxy_callbacks);
+    if (pacemakerd_ipcs == NULL) {
+        execd.ec = CRM_EX_OSERR;
+        return false;
+    }
+
     return true;
 }
 

--- a/daemons/execd/remoted_proxy.c
+++ b/daemons/execd/remoted_proxy.c
@@ -520,6 +520,10 @@ ipc_proxy_init(void)
 
     pcmk__serve_based_ipc(&cib_ro, &cib_rw, &cib_proxy_callbacks_ro,
                           &cib_proxy_callbacks_rw);
+    if ((cib_ro == NULL) || (cib_rw == NULL)) {
+        execd.ec = CRM_EX_FATAL;
+        return false;
+    }
 
     pcmk__serve_attrd_ipc(&attrd_ipcs, &attrd_proxy_callbacks);
     if (attrd_ipcs == NULL) {

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -586,15 +586,17 @@ init_cib_cache_cb(xmlNode * msg, int call_id, int rc, xmlNode * output, void *us
 static void
 cib_connection_destroy(void *user_data)
 {
-    if (stonith_shutdown_flag) {
+    if (fenced.shutting_down) {
         pcmk__info("Connection to the CIB manager closed");
         return;
-    } else {
-        pcmk__crit("Lost connection to the CIB manager, shutting down");
     }
+
+    pcmk__crit("Lost connection to the CIB manager, shutting down");
+
     if (cib_api) {
         cib_api->cmds->signoff(cib_api);
     }
+
     stonith_shutdown(0);
 }
 

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -367,10 +367,9 @@ watchdog_device_update(void)
             rc = fenced_device_register(xml, true);
             pcmk__xml_free(xml);
             if (rc != pcmk_rc_ok) {
-                fenced.ec = CRM_EX_FATAL;
                 pcmk__crit("Cannot register watchdog pseudo fence agent: %s",
                            pcmk_rc_str(rc));
-                stonith_shutdown(0);
+                pcmk__daemon_quit(&fenced, CRM_EX_FATAL);
             }
         }
 
@@ -597,7 +596,7 @@ cib_connection_destroy(void *user_data)
         cib_api->cmds->signoff(cib_api);
     }
 
-    stonith_shutdown(0);
+    pcmk__daemon_quit(&fenced, CRM_EX_DISCONNECT);
 }
 
 /*!

--- a/daemons/fenced/fenced_cib.c
+++ b/daemons/fenced/fenced_cib.c
@@ -367,7 +367,7 @@ watchdog_device_update(void)
             rc = fenced_device_register(xml, true);
             pcmk__xml_free(xml);
             if (rc != pcmk_rc_ok) {
-                exit_code = CRM_EX_FATAL;
+                fenced.ec = CRM_EX_FATAL;
                 pcmk__crit("Cannot register watchdog pseudo fence agent: %s",
                            pcmk_rc_str(rc));
                 stonith_shutdown(0);

--- a/daemons/fenced/fenced_commands.c
+++ b/daemons/fenced/fenced_commands.c
@@ -69,7 +69,6 @@ struct device_search_s {
     uint32_t support_action_only;
 };
 
-static gboolean stonith_device_dispatch(void *user_data);
 static void st_child_done(int pid, const pcmk__action_result_t *result,
                           void *user_data);
 

--- a/daemons/fenced/fenced_corosync.c
+++ b/daemons/fenced/fenced_corosync.c
@@ -170,7 +170,7 @@ static void
 fenced_cpg_destroy(void *unused)
 {
     pcmk__crit("Lost connection to cluster layer, shutting down");
-    stonith_shutdown(0);
+    pcmk__daemon_quit(&fenced, CRM_EX_DISCONNECT);
 }
 #endif // SUPPORT_COROSYNC
 

--- a/daemons/fenced/fenced_corosync.c
+++ b/daemons/fenced/fenced_corosync.c
@@ -198,7 +198,10 @@ fenced_cluster_connect(void)
     pcmk__cluster_set_status_callback(&fenced_peer_change_cb);
 
     rc = pcmk_cluster_connect(fenced_cluster);
-    if (rc != pcmk_rc_ok) {
+
+    if (rc == pcmk_rc_ok) {
+        pcmk__info("Cluster connection active");
+    } else {
         pcmk__err("Cluster connection failed");
     }
 

--- a/daemons/fenced/fenced_ipc.c
+++ b/daemons/fenced/fenced_ipc.c
@@ -65,7 +65,7 @@ static int32_t
 fenced_ipc_accept(qb_ipcs_connection_t *c, uid_t uid, gid_t gid)
 {
     pcmk__trace("New client connection %p", c);
-    if (stonith_shutdown_flag) {
+    if (fenced.shutting_down) {
         pcmk__info("Ignoring new connection from pid %d during shutdown",
                    pcmk__client_pid(c));
         return -ECONNREFUSED;

--- a/daemons/fenced/fenced_ipc.c
+++ b/daemons/fenced/fenced_ipc.c
@@ -276,8 +276,9 @@ fenced_ipc_cleanup(void)
  * \internal
  * \brief Set up fenced IPC communication
  */
-void
+bool
 fenced_ipc_init(void)
 {
     pcmk__serve_fenced_ipc(&ipcs, &ipc_callbacks);
+    return ipcs != NULL;
 }

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -61,7 +61,6 @@ pcmk__supported_format_t formats[] = {
 };
 
 static struct {
-    gboolean stand_alone;
     gchar **log_files;
 } options;
 
@@ -292,7 +291,7 @@ fencer_metadata(void)
 
 static GOptionEntry entries[] = {
     { "stand-alone", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
-      &options.stand_alone, N_("Intended for use in regression testing only"),
+      &fenced.stand_alone, N_("Intended for use in regression testing only"),
       NULL },
 
     { "logfile", 'l', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME_ARRAY,
@@ -449,7 +448,7 @@ main(int argc, char **argv)
 
     fenced_set_local_node(fenced_cluster->priv->node_name);
 
-    if (!options.stand_alone) {
+    if (!fenced.stand_alone) {
         setup_cib();
     }
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -420,8 +420,6 @@ main(int argc, char **argv)
         goto done;
     }
 
-    pcmk__info("Cluster connection active");
-
     fenced_set_local_node(fenced_cluster->priv->node_name);
 
     if (!fenced.stand_alone) {

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -49,8 +49,6 @@ GList *stonith_watchdog_targets = NULL;
 
 static GMainLoop *mainloop = NULL;
 
-gboolean stonith_shutdown_flag = FALSE;
-
 static pcmk__output_t *out = NULL;
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
@@ -267,7 +265,7 @@ void
 stonith_shutdown(int nsig)
 {
     pcmk__info("Terminating with %d clients", pcmk__ipc_client_count());
-    stonith_shutdown_flag = TRUE;
+    fenced.shutting_down = true;
     if (mainloop != NULL && g_main_loop_is_running(mainloop)) {
         g_main_loop_quit(mainloop);
     }
@@ -466,6 +464,13 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
 done:
+    /* If we got here through any of the "goto done" calls instead of by the
+     * main loop quitting on SIGTERM, shutting_down will still be false.  Set
+     * it here so fenced_cleanup -> fenced_cib_cleanup -> cib_connection_destroy
+     * doesn't call pcmk__daemon_quit with no main loop.
+     */
+    fenced.shutting_down = true;
+
     fenced_cleanup();
 
     pcmk__output_and_clear_error(&error, out);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -50,6 +50,7 @@ GList *stonith_watchdog_targets = NULL;
 static pcmk__output_t *out = NULL;
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
+static gchar **log_files = NULL;
 
 pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
@@ -57,10 +58,6 @@ pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_XML,
     { NULL, NULL, NULL }
 };
-
-static struct {
-    gchar **log_files;
-} options;
 
 void
 do_local_reply(const xmlNode *notify_src, pcmk__client_t *client,
@@ -283,7 +280,7 @@ static GOptionEntry entries[] = {
       NULL },
 
     { "logfile", 'l', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME_ARRAY,
-      &options.log_files, N_("Send logs to the additional named logfile"), NULL },
+      &log_files, N_("Send logs to the additional named logfile"), NULL },
 
     { NULL }
 };
@@ -330,7 +327,7 @@ fenced_cleanup_cmdline(void)
 {
     g_clear_pointer(&processed_args, g_strfreev);
     g_clear_pointer(&context, g_option_context_free);
-    g_clear_pointer(&options.log_files, g_strfreev);
+    g_clear_pointer(&log_files, g_strfreev);
 }
 
 /*!
@@ -414,7 +411,7 @@ main(int argc, char **argv)
     }
 
     // Open additional log files
-    pcmk__add_logfiles(options.log_files, out);
+    pcmk__add_logfiles(log_files, out);
 
     crm_log_init(NULL, LOG_INFO + args->verbosity, TRUE,
                  (args->verbosity > 0), argc, argv, FALSE);

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -37,9 +37,14 @@
 
 #define SUMMARY "daemon for executing fencing devices in a Pacemaker cluster"
 
+static pcmk__daemon_ipc_fns_t ipc_fns = {
+    .already_running = pcmk__generic_ipc_running,
+};
+
 pcmk__daemon_t fenced = {
     .type = pcmk_ipc_fenced,
     .ec = CRM_EX_OK,
+    .ipc_fns = &ipc_fns,
 };
 
 // @TODO This should be unsigned int
@@ -295,33 +300,6 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group)
     return context;
 }
 
-static bool
-ipc_already_running(void)
-{
-    crm_ipc_t *old_instance = NULL;
-    int rc = pcmk_rc_ok;
-
-    old_instance = crm_ipc_new("stonith-ng", 0);
-    if (old_instance == NULL) {
-        /* This is an error - memory allocation failed, etc. - but crm_ipc_new
-         * will have already logged an error message.
-         */
-        return false;
-    }
-
-    rc = pcmk__connect_generic_ipc(old_instance);
-    if (rc != pcmk_rc_ok) {
-        pcmk__debug("No existing stonith-ng instance found: %s",
-                    pcmk_rc_str(rc));
-        crm_ipc_destroy(old_instance);
-        return false;
-    }
-
-    crm_ipc_close(old_instance);
-    crm_ipc_destroy(old_instance);
-    return true;
-}
-
 static void
 fenced_cleanup_cmdline(void)
 {
@@ -416,14 +394,14 @@ main(int argc, char **argv)
     crm_log_init(NULL, LOG_INFO + args->verbosity, TRUE,
                  (args->verbosity > 0), argc, argv, FALSE);
 
-    pcmk__notice("Starting Pacemaker fencer");
-
-    if (ipc_already_running()) {
+    if (fenced.ipc_fns->already_running(&fenced)) {
         g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
                     "Aborting start-up because a fencer instance is already active");
         pcmk__crit("%s", error->message);
         goto done;
     }
+
+    pcmk__notice("Starting Pacemaker fencer");
 
     pcmk__cluster_init_node_caches();
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -64,8 +64,6 @@ static struct {
 
 crm_exit_t exit_code = CRM_EX_OK;
 
-static void stonith_cleanup(void);
-
 void
 do_local_reply(const xmlNode *notify_src, pcmk__client_t *client,
                int call_options)
@@ -272,17 +270,6 @@ stonith_shutdown(int nsig)
     }
 }
 
-static void
-stonith_cleanup(void)
-{
-    fenced_cib_cleanup();
-    fenced_ipc_cleanup();
-    free_stonith_remote_op_list();
-    free_topology_list();
-    fenced_free_device_table();
-    free_metadata_cache();
-}
-
 /* @COMPAT Deprecated since 2.1.8. Use pcmk_list_fence_attrs() or
  * crm_resource --list-options=fencing instead of querying daemon metadata.
  *
@@ -356,6 +343,21 @@ fenced_cleanup_cmdline(void)
     g_clear_pointer(&processed_args, g_strfreev);
     g_clear_pointer(&context, g_option_context_free);
     g_clear_pointer(&options.log_files, g_strfreev);
+}
+
+static void
+fenced_cleanup(void)
+{
+    fenced_cib_cleanup();
+    fenced_ipc_cleanup();
+    fenced_unregister_handlers();
+    fenced_cluster_disconnect();
+    fenced_scheduler_cleanup();
+
+    free_stonith_remote_op_list();
+    free_topology_list();
+    fenced_free_device_table();
+    free_metadata_cache();
 }
 
 int
@@ -462,10 +464,7 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
 done:
-    stonith_cleanup();
-    fenced_cluster_disconnect();
-    fenced_unregister_handlers();
-    fenced_scheduler_cleanup();
+    fenced_cleanup();
 
     pcmk__output_and_clear_error(&error, out);
 

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -37,6 +37,11 @@
 
 #define SUMMARY "daemon for executing fencing devices in a Pacemaker cluster"
 
+pcmk__daemon_t fenced = {
+    .type = pcmk_ipc_fenced,
+    .ec = CRM_EX_OK,
+};
+
 // @TODO This should be unsigned int
 long long fencing_watchdog_timeout_ms = 0;
 
@@ -61,8 +66,6 @@ static struct {
     gboolean stand_alone;
     gchar **log_files;
 } options;
-
-crm_exit_t exit_code = CRM_EX_OK;
 
 void
 do_local_reply(const xmlNode *notify_src, pcmk__client_t *client,
@@ -380,14 +383,14 @@ main(int argc, char **argv)
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
-        exit_code = CRM_EX_USAGE;
+        fenced.ec = CRM_EX_USAGE;
         goto done;
     }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if ((rc != pcmk_rc_ok) || (out == NULL)) {
-        exit_code = CRM_EX_ERROR;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+        fenced.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
                     "Error creating output format %s: %s",
                     args->output_ty, pcmk_rc_str(rc));
         goto done;
@@ -403,8 +406,8 @@ main(int argc, char **argv)
 
         rc = fencer_metadata();
         if (rc != pcmk_rc_ok) {
-            exit_code = CRM_EX_FATAL;
-            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+            fenced.ec = CRM_EX_FATAL;
+            g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
                         "Unable to display metadata: %s", pcmk_rc_str(rc));
         }
         goto done;
@@ -419,8 +422,7 @@ main(int argc, char **argv)
     pcmk__notice("Starting Pacemaker fencer");
 
     if (ipc_already_running()) {
-        exit_code = CRM_EX_OK;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+        g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
                     "Aborting start-up because a fencer instance is already active");
         pcmk__crit("%s", error->message);
         goto done;
@@ -432,15 +434,15 @@ main(int argc, char **argv)
 
     rc = fenced_scheduler_init();
     if (rc != pcmk_rc_ok) {
-        exit_code = CRM_EX_FATAL;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+        fenced.ec = CRM_EX_FATAL;
+        g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
                     "Error initializing scheduler data: %s", pcmk_rc_str(rc));
         goto done;
     }
 
     if (fenced_cluster_connect() != pcmk_rc_ok) {
-        exit_code = CRM_EX_FATAL;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+        fenced.ec = CRM_EX_FATAL;
+        g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
                     "Could not connect to the cluster");
         goto done;
     }
@@ -469,10 +471,10 @@ done:
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
-        out->finish(out, exit_code, true, NULL);
+        out->finish(out, fenced.ec, true, NULL);
         pcmk__output_free(out);
     }
 
     pcmk__unregister_formats();
-    crm_exit(exit_code);
+    crm_exit(fenced.ec);
 }

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -47,6 +47,8 @@ static GMainLoop *mainloop = NULL;
 gboolean stonith_shutdown_flag = FALSE;
 
 static pcmk__output_t *out = NULL;
+static gchar **processed_args = NULL;
+static GOptionContext *context = NULL;
 
 pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
@@ -348,6 +350,14 @@ ipc_already_running(void)
     return true;
 }
 
+static void
+fenced_cleanup_cmdline(void)
+{
+    g_clear_pointer(&processed_args, g_strfreev);
+    g_clear_pointer(&context, g_option_context_free);
+    g_clear_pointer(&options.log_files, g_strfreev);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -356,9 +366,13 @@ main(int argc, char **argv)
     GError *error = NULL;
 
     GOptionGroup *output_group = NULL;
-    pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
-    gchar **processed_args = pcmk__cmdline_preproc(argv, "l");
-    GOptionContext *context = build_arg_context(args, &output_group);
+    pcmk__common_args_t *args = NULL;
+
+    atexit(fenced_cleanup_cmdline);
+
+    args = pcmk__new_common_args(SUMMARY);
+    processed_args = pcmk__cmdline_preproc(argv, "l");
+    context = build_arg_context(args, &output_group);
 
     crm_log_preinit(NULL, argc, argv);
 
@@ -448,11 +462,6 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
 done:
-    g_strfreev(processed_args);
-    pcmk__free_arg_context(context);
-
-    g_strfreev(options.log_files);
-
     stonith_cleanup();
     fenced_cluster_disconnect();
     fenced_unregister_handlers();

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -47,8 +47,6 @@ long long fencing_watchdog_timeout_ms = 0;
 
 GList *stonith_watchdog_targets = NULL;
 
-static GMainLoop *mainloop = NULL;
-
 static pcmk__output_t *out = NULL;
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
@@ -260,16 +258,6 @@ node_does_watchdog_fencing(const char *node)
             pcmk__str_in_list(node, stonith_watchdog_targets, pcmk__str_casei));
 }
 
-void
-stonith_shutdown(int nsig)
-{
-    pcmk__info("Terminating with %d clients", pcmk__ipc_client_count());
-    fenced.shutting_down = true;
-    if (mainloop != NULL && g_main_loop_is_running(mainloop)) {
-        g_main_loop_quit(mainloop);
-    }
-}
-
 /* @COMPAT Deprecated since 2.1.8. Use pcmk_list_fence_attrs() or
  * crm_resource --list-options=fencing instead of querying daemon metadata.
  *
@@ -343,6 +331,21 @@ fenced_cleanup_cmdline(void)
     g_clear_pointer(&processed_args, g_strfreev);
     g_clear_pointer(&context, g_option_context_free);
     g_clear_pointer(&options.log_files, g_strfreev);
+}
+
+/*!
+ * \internal
+ * \brief  Quit the main loop and set the exit code to \c CRM_EX_OK
+ *
+ * \param[in] nsig  Ignored
+ *
+ * \note This is a main loop signal handler function.
+ */
+static void
+fenced_shutdown(int nsig)
+{
+    pcmk__info("Terminating with %d clients", pcmk__ipc_client_count());
+    pcmk__daemon_quit(&fenced, CRM_EX_OK);
 }
 
 static void
@@ -425,8 +428,6 @@ main(int argc, char **argv)
         goto done;
     }
 
-    mainloop_add_signal(SIGTERM, stonith_shutdown);
-
     pcmk__cluster_init_node_caches();
 
     rc = fenced_scheduler_init();
@@ -456,11 +457,18 @@ main(int argc, char **argv)
     init_topology_list();
     fenced_ipc_init();
 
-    // Create the mainloop and run it...
-    mainloop = g_main_loop_new(NULL, FALSE);
-    pcmk__notice("Pacemaker fencer successfully started and accepting "
-                 "connections");
-    g_main_loop_run(mainloop);
+    rc = pcmk__daemon_init(&fenced);
+    if (rc != pcmk_rc_ok) {
+        fenced.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, fenced.ec,
+                    "Error initializing daemon object: %s",
+                    pcmk_rc_str(rc));
+        goto done;
+    }
+
+    mainloop_add_signal(SIGTERM, fenced_shutdown);
+
+    pcmk__daemon_run(&fenced);
 
 done:
     /* If we got here through any of the "goto done" calls instead of by the

--- a/daemons/fenced/pacemaker-fenced.c
+++ b/daemons/fenced/pacemaker-fenced.c
@@ -428,7 +428,11 @@ main(int argc, char **argv)
 
     fenced_init_device_table();
     init_topology_list();
-    fenced_ipc_init();
+
+    if (!fenced_ipc_init()) {
+        fenced.ec = CRM_EX_FATAL;
+        goto done;
+    }
 
     rc = pcmk__daemon_init(&fenced);
     if (rc != pcmk_rc_ok) {

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -373,7 +373,7 @@ const char *fenced_get_local_node(void);
 void fenced_scheduler_cleanup(void);
 void fenced_scheduler_run(xmlNode *cib);
 
-void fenced_ipc_init(void);
+bool fenced_ipc_init(void);
 void fenced_ipc_cleanup(void);
 
 int fenced_cluster_connect(void);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -405,6 +405,6 @@ extern GHashTable *topology;
 extern long long fencing_watchdog_timeout_ms;
 extern GList *stonith_watchdog_targets;
 extern GHashTable *stonith_remote_op_list;
-extern crm_exit_t exit_code;
 extern gboolean stonith_shutdown_flag;
 extern pcmk_cluster_t *fenced_cluster;
+extern pcmk__daemon_t fenced;

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -295,8 +295,6 @@ typedef struct {
 
 } stonith_topology_t;
 
-void stonith_shutdown(int nsig);
-
 void fenced_init_device_table(void);
 void fenced_free_device_table(void);
 bool fenced_has_watchdog_device(void);

--- a/daemons/fenced/pacemaker-fenced.h
+++ b/daemons/fenced/pacemaker-fenced.h
@@ -405,6 +405,5 @@ extern GHashTable *topology;
 extern long long fencing_watchdog_timeout_ms;
 extern GList *stonith_watchdog_targets;
 extern GHashTable *stonith_remote_op_list;
-extern gboolean stonith_shutdown_flag;
 extern pcmk_cluster_t *fenced_cluster;
 extern pcmk__daemon_t fenced;

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -350,6 +350,17 @@ pacemakerd_cleanup_cmdline(void)
     g_clear_pointer(&context, g_option_context_free);
 }
 
+static void
+pacemakerd_cleanup(void)
+{
+    pacemakerd_ipc_cleanup();
+    pacemakerd_unregister_handlers();
+
+#if SUPPORT_COROSYNC
+    cluster_disconnect_cfg();
+#endif
+}
+
 int
 main(int argc, char **argv)
 {
@@ -496,15 +507,11 @@ main(int argc, char **argv)
     pcmk__notice("Pacemaker daemon successfully started and accepting "
                  "connections");
     g_main_loop_run(mainloop);
-    pacemakerd_ipc_cleanup();
-    pacemakerd_unregister_handlers();
-
     g_main_loop_unref(mainloop);
-#if SUPPORT_COROSYNC
-    cluster_disconnect_cfg();
-#endif
 
 done:
+    pacemakerd_cleanup();
+
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -344,17 +344,6 @@ done:
     return rc;
 }
 
-void
-pacemakerd_quit_main_loop(crm_exit_t ec)
-{
-    /* There's no way to get to this function without the main loop running,
-     * but check just in case someone adds one in the future
-     */
-    CRM_CHECK((mainloop != NULL) && g_main_loop_is_running(mainloop), return);
-
-    g_main_loop_quit(mainloop);
-}
-
 static void
 pacemakerd_cleanup_cmdline(void)
 {
@@ -394,8 +383,6 @@ main(int argc, char **argv)
     setenv("LC_ALL", "C", 1); // Ensure logs are in a common language
 
     crm_log_preinit(NULL, argc, argv);
-    mainloop_add_signal(SIGHUP, pcmk_ignore);
-    mainloop_add_signal(SIGQUIT, pcmk_sigquit);
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
@@ -467,7 +454,6 @@ main(int argc, char **argv)
 
     pcmk__notice("Starting Pacemaker " PACEMAKER_VERSION " "
                  QB_XS " build=" BUILD_VERSION " features:" CRM_FEATURES);
-    mainloop = g_main_loop_new(NULL, FALSE);
 
     remove_core_file_limit();
     if (create_pcmk_dirs() != pcmk_rc_ok) {
@@ -499,9 +485,6 @@ main(int argc, char **argv)
             goto done;
     };
 
-    mainloop_add_signal(SIGTERM, pcmk_shutdown);
-    mainloop_add_signal(SIGINT, pcmk_shutdown);
-
     if ((running_with_sbd) && pcmk__get_sbd_sync_resource_startup()) {
         pcmk__notice("Waiting for startup-trigger from SBD");
         pacemakerd_state = PCMK__VALUE_WAIT_FOR_PING;
@@ -516,10 +499,21 @@ main(int argc, char **argv)
         init_children_processes(NULL);
     }
 
-    pcmk__notice("Pacemaker daemon successfully started and accepting "
-                 "connections");
-    g_main_loop_run(mainloop);
-    g_clear_pointer(&mainloop, g_main_loop_unref);
+    rc = pcmk__daemon_init(&pacemakerd);
+    if (rc != pcmk_rc_ok) {
+        pacemakerd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, pacemakerd.ec,
+                    "Error initializing daemon object: %s",
+                    pcmk_rc_str(rc));
+        goto done;
+    }
+
+    mainloop_add_signal(SIGHUP, pcmk_ignore);
+    mainloop_add_signal(SIGINT, pcmk_shutdown);
+    mainloop_add_signal(SIGQUIT, pcmk_sigquit);
+    mainloop_add_signal(SIGTERM, pcmk_shutdown);
+
+    pcmk__daemon_run(&pacemakerd);
 
 done:
     pacemakerd_cleanup();

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -155,7 +155,7 @@ pacemakerd_chown(const char *path, uid_t uid, gid_t gid)
     }
 }
 
-static void
+static int
 create_pcmk_dirs(void)
 {
     uid_t pcmk_uid = 0;
@@ -174,7 +174,7 @@ create_pcmk_dirs(void)
     if (pcmk__daemon_user(&pcmk_uid, &pcmk_gid) != pcmk_rc_ok) {
         pcmk__err("Cluster user " CRM_DAEMON_USER " does not exist, aborting "
                   "Pacemaker startup");
-        crm_exit(CRM_EX_NOUSER);
+        return EINVAL;
     }
 
     // Used by some resource agents
@@ -195,6 +195,8 @@ create_pcmk_dirs(void)
             pacemakerd_chown(dirs[i], pcmk_uid, pcmk_gid);
         }
     }
+
+    return pcmk_rc_ok;
 }
 
 static void
@@ -444,7 +446,10 @@ main(int argc, char **argv)
     mainloop = g_main_loop_new(NULL, FALSE);
 
     remove_core_file_limit();
-    create_pcmk_dirs();
+    if (create_pcmk_dirs() != pcmk_rc_ok) {
+        exit_code = CRM_EX_NOUSER;
+        goto done;
+    }
     pacemakerd_ipc_init();
 
 #if SUPPORT_COROSYNC

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -460,7 +460,11 @@ main(int argc, char **argv)
         pacemakerd.ec = CRM_EX_NOUSER;
         goto done;
     }
-    pacemakerd_ipc_init();
+
+    if (!pacemakerd_ipc_init()) {
+        pacemakerd.ec = CRM_EX_OSERR;
+        goto done;
+    }
 
 #if SUPPORT_COROSYNC
     /* Allows us to block shutdown */

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -47,6 +47,8 @@ struct {
 } options;
 
 static pcmk__output_t *out = NULL;
+static gchar **processed_args = NULL;
+static GOptionContext *context = NULL;
 
 static pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
@@ -339,6 +341,13 @@ done:
     return rc;
 }
 
+static void
+pacemakerd_cleanup_cmdline(void)
+{
+    g_clear_pointer(&processed_args, g_strfreev);
+    g_clear_pointer(&context, g_option_context_free);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -348,9 +357,13 @@ main(int argc, char **argv)
     GError *error = NULL;
 
     GOptionGroup *output_group = NULL;
-    pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
-    gchar **processed_args = pcmk__cmdline_preproc(argv, "p");
-    GOptionContext *context = build_arg_context(args, &output_group);
+    pcmk__common_args_t * args = NULL;
+
+    atexit(pacemakerd_cleanup_cmdline);
+
+    args = pcmk__new_common_args(SUMMARY);
+    processed_args = pcmk__cmdline_preproc(argv, "p");
+    context = build_arg_context(args, &output_group);
 
     subdaemon_check_progress = time(NULL);
 
@@ -486,8 +499,6 @@ main(int argc, char **argv)
 #endif
 
 done:
-    g_strfreev(processed_args);
-    pcmk__free_arg_context(context);
 
     pcmk__output_and_clear_error(&error, out);
 

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -339,6 +339,17 @@ done:
     return rc;
 }
 
+void
+pacemakerd_quit_main_loop(crm_exit_t ec)
+{
+    /* There's no way to get to this function without the main loop running,
+     * but check just in case someone adds one in the future
+     */
+    CRM_CHECK((mainloop != NULL) && g_main_loop_is_running(mainloop), return);
+
+    g_main_loop_quit(mainloop);
+}
+
 static void
 pacemakerd_cleanup_cmdline(void)
 {
@@ -503,7 +514,7 @@ main(int argc, char **argv)
     pcmk__notice("Pacemaker daemon successfully started and accepting "
                  "connections");
     g_main_loop_run(mainloop);
-    g_main_loop_unref(mainloop);
+    g_clear_pointer(&mainloop, g_main_loop_unref);
 
 done:
     pacemakerd_cleanup();

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -247,12 +247,8 @@ pacemakerd_event_cb(pcmk_ipc_api_t *pacemakerd_api,
 {
     pcmk_pacemakerd_api_reply_t *reply = event_data;
 
-    switch (event_type) {
-        case pcmk_ipc_event_reply:
-            break;
-
-        default:
-            return;
+    if (event_type != pcmk_ipc_event_reply) {
+        return;
     }
 
     if (status != CRM_EX_OK) {

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -426,7 +426,7 @@ main(int argc, char **argv)
     }
 
 #if SUPPORT_COROSYNC
-    if (pacemakerd_read_config() == FALSE) {
+    if (!pcmkd_read_config()) {
         crm_exit(CRM_EX_UNAVAILABLE);
     }
 #endif

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -39,6 +39,11 @@
 
 #define SUMMARY "pacemakerd - primary Pacemaker daemon that launches and monitors all subsidiary Pacemaker daemons"
 
+pcmk__daemon_t pacemakerd = {
+    .type = pcmk_ipc_pacemakerd,
+    .ec = CRM_EX_OK,
+};
+
 struct {
     gboolean features;
     gboolean foreground;
@@ -372,7 +377,6 @@ int
 main(int argc, char **argv)
 {
     int rc = pcmk_rc_ok;
-    crm_exit_t exit_code = CRM_EX_OK;
 
     GError *error = NULL;
 
@@ -395,14 +399,15 @@ main(int argc, char **argv)
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
-        exit_code = CRM_EX_USAGE;
+        pacemakerd.ec = CRM_EX_USAGE;
         goto done;
     }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if ((rc != pcmk_rc_ok) || (out == NULL)) {
-        exit_code = CRM_EX_ERROR;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code, "Error creating output format %s: %s",
+        pacemakerd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, pacemakerd.ec,
+                    "Error creating output format %s: %s",
                     args->output_ty, pcmk_rc_str(rc));
         goto done;
     }
@@ -411,7 +416,7 @@ main(int argc, char **argv)
 
     if (options.features) {
         out->message(out, "features");
-        exit_code = CRM_EX_OK;
+        pacemakerd.ec = CRM_EX_OK;
         goto done;
     }
 
@@ -430,22 +435,22 @@ main(int argc, char **argv)
     if ((rc == pcmk_rc_ok) && options.shutdown) {
         goto done;
     } else if (rc == pcmk_rc_already) {
-        exit_code = CRM_EX_FATAL;
+        pacemakerd.ec = CRM_EX_FATAL;
         goto done;
     } else if (rc != pcmk_rc_ok) {
-        exit_code = pcmk_rc2exitc(rc);
+        pacemakerd.ec = pcmk_rc2exitc(rc);
         goto done;
     }
 
     /* Don't allow any accidental output after this point. */
     if (out != NULL) {
-        out->finish(out, exit_code, true, NULL);
+        out->finish(out, pacemakerd.ec, true, NULL);
         g_clear_pointer(&out, pcmk__output_free);
     }
 
 #if SUPPORT_COROSYNC
     if (!pcmkd_read_config()) {
-        exit_code = CRM_EX_UNAVAILABLE;
+        pacemakerd.ec = CRM_EX_UNAVAILABLE;
         goto done;
     }
 #endif
@@ -466,7 +471,7 @@ main(int argc, char **argv)
 
     remove_core_file_limit();
     if (create_pcmk_dirs() != pcmk_rc_ok) {
-        exit_code = CRM_EX_NOUSER;
+        pacemakerd.ec = CRM_EX_NOUSER;
         goto done;
     }
     pacemakerd_ipc_init();
@@ -474,7 +479,7 @@ main(int argc, char **argv)
 #if SUPPORT_COROSYNC
     /* Allows us to block shutdown */
     if (!cluster_connect_cfg()) {
-        exit_code = CRM_EX_PROTOCOL;
+        pacemakerd.ec = CRM_EX_PROTOCOL;
         goto done;
     }
 #endif
@@ -487,10 +492,10 @@ main(int argc, char **argv)
         case pcmk_rc_ok:
             break;
         case pcmk_rc_ipc_unauthorized:
-            exit_code = CRM_EX_CANTCREAT;
+            pacemakerd.ec = CRM_EX_CANTCREAT;
             goto done;
         default:
-            exit_code = CRM_EX_FATAL;
+            pacemakerd.ec = CRM_EX_FATAL;
             goto done;
     };
 
@@ -522,9 +527,9 @@ done:
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {
-        out->finish(out, exit_code, true, NULL);
+        out->finish(out, pacemakerd.ec, true, NULL);
         pcmk__output_free(out);
     }
     pcmk__unregister_formats();
-    crm_exit(exit_code);
+    crm_exit(pacemakerd.ec);
 }

--- a/daemons/pacemakerd/pacemakerd.c
+++ b/daemons/pacemakerd/pacemakerd.c
@@ -427,7 +427,8 @@ main(int argc, char **argv)
 
 #if SUPPORT_COROSYNC
     if (!pcmkd_read_config()) {
-        crm_exit(CRM_EX_UNAVAILABLE);
+        exit_code = CRM_EX_UNAVAILABLE;
+        goto done;
     }
 #endif
 
@@ -504,7 +505,6 @@ main(int argc, char **argv)
 #endif
 
 done:
-
     pcmk__output_and_clear_error(&error, out);
 
     if (out != NULL) {

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -30,7 +30,7 @@ gboolean init_children_processes(void *user_data);
 void pcmk_shutdown(int nsig);
 void restart_cluster_subdaemons(void);
 
-void pacemakerd_ipc_init(void);
+bool pacemakerd_ipc_init(void);
 void pacemakerd_ipc_cleanup(void);
 void pacemakerd_unregister_handlers(void);
 void pacemakerd_handle_request(pcmk__request_t *request);

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 the Pacemaker project contributors
+ * Copyright 2010-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -29,6 +29,7 @@ int find_and_track_existing_processes(void);
 gboolean init_children_processes(void *user_data);
 void pcmk_shutdown(int nsig);
 void restart_cluster_subdaemons(void);
+void pacemakerd_quit_main_loop(crm_exit_t ec);
 
 void pacemakerd_ipc_init(void);
 void pacemakerd_ipc_cleanup(void);

--- a/daemons/pacemakerd/pacemakerd.h
+++ b/daemons/pacemakerd/pacemakerd.h
@@ -16,7 +16,6 @@
 
 #define MAX_RESPAWN		100
 
-extern GMainLoop *mainloop;
 extern const char *pacemakerd_state;
 extern bool running_with_sbd;
 extern bool shutdown_complete_state_reported_client_closed;
@@ -24,12 +23,12 @@ extern unsigned int shutdown_complete_state_reported_to;
 extern crm_trigger_t *shutdown_trigger;
 extern crm_trigger_t *startup_trigger;
 extern time_t subdaemon_check_progress;
+extern pcmk__daemon_t pacemakerd;
 
 int find_and_track_existing_processes(void);
 gboolean init_children_processes(void *user_data);
 void pcmk_shutdown(int nsig);
 void restart_cluster_subdaemons(void);
-void pacemakerd_quit_main_loop(crm_exit_t ec);
 
 void pacemakerd_ipc_init(void);
 void pacemakerd_ipc_cleanup(void);

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -288,6 +288,7 @@ pcmkd_read_config(void)
     gid_t found_gid = 0;
     pid_t found_pid = 0;
     int rv;
+    bool success = false;
     enum pcmk_cluster_layer cluster_layer = pcmk_cluster_layer_unknown;
     const char *cluster_layer_s = NULL;
 
@@ -308,15 +309,14 @@ pcmkd_read_config(void)
     if (cs_rc != CS_OK) {
         pcmk__crit("Could not connect to Corosync CMAP: %s "
                    QB_XS " rc=%d", pcmk_rc_str(pcmk__corosync2rc(cs_rc)), cs_rc);
-        return false;
+        return success;
     }
 
     cs_rc = cmap_fd_get(local_handle, &fd);
     if (cs_rc != CS_OK) {
         pcmk__crit("Could not get Corosync CMAP descriptor: %s " QB_XS " rc=%d",
                    pcmk_rc_str(pcmk__corosync2rc(cs_rc)), cs_rc);
-        cmap_finalize(local_handle);
-        return false;
+        goto done;
     }
 
     /* CMAP provider run as root (in given user namespace, anyway)? */
@@ -327,15 +327,13 @@ pcmkd_read_config(void)
                    "is running as uid %lld gid %lld, not root",
                    (long long) PCMK__SPECIAL_PID_AS_0(found_pid),
                    (long long) found_uid, (long long) found_gid);
-        cmap_finalize(local_handle);
-        return false;
+        goto done;
     }
 
     if (rv < 0) {
         pcmk__crit("Could not authenticate Corosync CMAP provider: %s "
                    QB_XS " rc=%d", strerror(-rv), -rv);
-        cmap_finalize(local_handle);
-        return false;
+        goto done;
     }
 
     cluster_layer = pcmk_get_cluster_layer();
@@ -345,7 +343,7 @@ pcmkd_read_config(void)
         pcmk__crit("Expected Corosync cluster layer but detected %s "
                    QB_XS " cluster_layer=%d",
                    cluster_layer_s, cluster_layer);
-        return false;
+        goto done;
     }
 
     pcmk__info("Reading configuration for %s cluster layer", cluster_layer_s);
@@ -393,6 +391,9 @@ pcmkd_read_config(void)
         }
     }
 
+    success = true;
+
+done:
     cmap_finalize(local_handle);
-    return true;
+    return success;
 }

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -279,7 +279,7 @@ get_config_opt(uint64_t unused, cmap_handle_t object_handle, const char *key, ch
 bool
 pcmkd_read_config(void)
 {
-    cs_error_t rc = CS_OK;
+    cs_error_t cs_rc = CS_OK;
     int retries = 0;
     cmap_handle_t local_handle;
     uint64_t config = 0;
@@ -293,28 +293,28 @@ pcmkd_read_config(void)
 
     // There can be only one possibility
     do {
-        rc = pcmk__init_cmap(&local_handle);
-        if (rc == CS_OK) {
+        cs_rc = pcmk__init_cmap(&local_handle);
+        if (cs_rc == CS_OK) {
             break;
         }
 
         retries++;
         pcmk__info("Could not connect to Corosync CMAP: %s "
                    "(retrying in %ds) " QB_XS " rc=%d",
-                   pcmk_rc_str(pcmk__corosync2rc(rc)), retries, rc);
+                   pcmk_rc_str(pcmk__corosync2rc(cs_rc)), retries, cs_rc);
         sleep(retries);
     } while (retries < 5);
 
-    if (rc != CS_OK) {
+    if (cs_rc != CS_OK) {
         pcmk__crit("Could not connect to Corosync CMAP: %s "
-                   QB_XS " rc=%d", pcmk_rc_str(pcmk__corosync2rc(rc)), rc);
+                   QB_XS " rc=%d", pcmk_rc_str(pcmk__corosync2rc(cs_rc)), cs_rc);
         return false;
     }
 
-    rc = cmap_fd_get(local_handle, &fd);
-    if (rc != CS_OK) {
+    cs_rc = cmap_fd_get(local_handle, &fd);
+    if (cs_rc != CS_OK) {
         pcmk__crit("Could not get Corosync CMAP descriptor: %s " QB_XS " rc=%d",
-                   pcmk_rc_str(pcmk__corosync2rc(rc)), rc);
+                   pcmk_rc_str(pcmk__corosync2rc(cs_rc)), cs_rc);
         cmap_finalize(local_handle);
         return false;
     }
@@ -382,13 +382,13 @@ pcmkd_read_config(void)
             char *key = pcmk__assert_asprintf("uidgid.gid.%lld",
                                               (long long) gid);
 
-            rc = cmap_set_uint8(local_handle, key, 1);
+            cs_rc = cmap_set_uint8(local_handle, key, 1);
             free(key);
 
-            if (rc != CS_OK) {
+            if (cs_rc != CS_OK) {
                 pcmk__warn("Could not authorize group with Corosync: %s "
                            QB_XS " group=%u rc=%d",
-                           pcmk_rc_str(pcmk__corosync2rc(rc)), gid, rc);
+                           pcmk_rc_str(pcmk__corosync2rc(cs_rc)), gid, cs_rc);
             }
         }
     }

--- a/daemons/pacemakerd/pcmkd_corosync.c
+++ b/daemons/pacemakerd/pcmkd_corosync.c
@@ -98,13 +98,14 @@ cluster_reconnect_cb(void *data)
     if (cluster_connect_cfg()) {
         g_clear_pointer(&reconnect_timer, mainloop_timer_del);
         pcmk__notice("Cluster reconnect succeeded");
-        pacemakerd_read_config();
+        pcmkd_read_config();
         restart_cluster_subdaemons();
         return G_SOURCE_REMOVE;
-    } else {
-        pcmk__info("Cluster reconnect failed (connection will be reattempted "
-                   "once per second)");
     }
+
+    pcmk__info("Cluster reconnect failed (connection will be reattempted "
+               "once per second)");
+
     /*
      * In theory this will continue forever. In practice the CIB connection from
      * attrd will timeout and shut down Pacemaker when it gets bored.
@@ -275,8 +276,8 @@ get_config_opt(uint64_t unused, cmap_handle_t object_handle, const char *key, ch
     return rc;
 }
 
-gboolean
-pacemakerd_read_config(void)
+bool
+pcmkd_read_config(void)
 {
     cs_error_t rc = CS_OK;
     int retries = 0;
@@ -293,23 +294,21 @@ pacemakerd_read_config(void)
     // There can be only one possibility
     do {
         rc = pcmk__init_cmap(&local_handle);
-        if (rc != CS_OK) {
-            retries++;
-            pcmk__info("Could not connect to Corosync CMAP: %s "
-                       "(retrying in %ds) " QB_XS " rc=%d",
-                       pcmk_rc_str(pcmk__corosync2rc(rc)), retries, rc);
-            sleep(retries);
-
-        } else {
+        if (rc == CS_OK) {
             break;
         }
 
+        retries++;
+        pcmk__info("Could not connect to Corosync CMAP: %s "
+                   "(retrying in %ds) " QB_XS " rc=%d",
+                   pcmk_rc_str(pcmk__corosync2rc(rc)), retries, rc);
+        sleep(retries);
     } while (retries < 5);
 
     if (rc != CS_OK) {
         pcmk__crit("Could not connect to Corosync CMAP: %s "
                    QB_XS " rc=%d", pcmk_rc_str(pcmk__corosync2rc(rc)), rc);
-        return FALSE;
+        return false;
     }
 
     rc = cmap_fd_get(local_handle, &fd);
@@ -317,23 +316,26 @@ pacemakerd_read_config(void)
         pcmk__crit("Could not get Corosync CMAP descriptor: %s " QB_XS " rc=%d",
                    pcmk_rc_str(pcmk__corosync2rc(rc)), rc);
         cmap_finalize(local_handle);
-        return FALSE;
+        return false;
     }
 
     /* CMAP provider run as root (in given user namespace, anyway)? */
-    if (!(rv = crm_ipc_is_authentic_process(fd, (uid_t) 0,(gid_t) 0, &found_pid,
-                                            &found_uid, &found_gid))) {
+    rv = crm_ipc_is_authentic_process(fd, (uid_t) 0,(gid_t) 0, &found_pid,
+                                      &found_uid, &found_gid);
+    if (rv == 0) {
         pcmk__crit("Rejecting Corosync CMAP provider because process %lld "
                    "is running as uid %lld gid %lld, not root",
                    (long long) PCMK__SPECIAL_PID_AS_0(found_pid),
                    (long long) found_uid, (long long) found_gid);
         cmap_finalize(local_handle);
-        return FALSE;
-    } else if (rv < 0) {
+        return false;
+    }
+
+    if (rv < 0) {
         pcmk__crit("Could not authenticate Corosync CMAP provider: %s "
                    QB_XS " rc=%d", strerror(-rv), -rv);
         cmap_finalize(local_handle);
-        return FALSE;
+        return false;
     }
 
     cluster_layer = pcmk_get_cluster_layer();
@@ -343,7 +345,7 @@ pacemakerd_read_config(void)
         pcmk__crit("Expected Corosync cluster layer but detected %s "
                    QB_XS " cluster_layer=%d",
                    cluster_layer_s, cluster_layer);
-        return FALSE;
+        return false;
     }
 
     pcmk__info("Reading configuration for %s cluster layer", cluster_layer_s);
@@ -369,8 +371,9 @@ pacemakerd_read_config(void)
         free(debug_enabled);
     }
 
-    if(local_handle){
+    if (local_handle) {
         gid_t gid = 0;
+
         if (pcmk__daemon_user(NULL, &gid) != pcmk_rc_ok) {
             pcmk__warn("Could not authorize group with Corosync "
                        QB_XS " No group found for user " CRM_DAEMON_USER);
@@ -389,7 +392,7 @@ pacemakerd_read_config(void)
             }
         }
     }
-    cmap_finalize(local_handle);
 
-    return TRUE;
+    cmap_finalize(local_handle);
+    return true;
 }

--- a/daemons/pacemakerd/pcmkd_corosync.h
+++ b/daemons/pacemakerd/pcmkd_corosync.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 the Pacemaker project contributors
+ * Copyright 2010-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -13,6 +13,6 @@
 
 gboolean cluster_connect_cfg(void);
 void cluster_disconnect_cfg(void);
-gboolean pacemakerd_read_config(void);
+bool pcmkd_read_config(void);
 bool pcmkd_corosync_connected(void);
 void pcmkd_shutdown_corosync(void);

--- a/daemons/pacemakerd/pcmkd_ipc.c
+++ b/daemons/pacemakerd/pcmkd_ipc.c
@@ -199,8 +199,9 @@ pacemakerd_ipc_cleanup(void)
  * \internal
  * \brief Set up pacemakerd IPC communication
  */
-void
+bool
 pacemakerd_ipc_init(void)
 {
     pcmk__serve_pacemakerd_ipc(&ipcs, &ipc_callbacks);
+    return ipcs != NULL;
 }

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -97,8 +97,6 @@ bool shutdown_complete_state_reported_client_closed = false;
 const char *pacemakerd_state = PCMK__VALUE_INIT;
 bool running_with_sbd = false;
 
-GMainLoop *mainloop = NULL;
-
 static bool fatal_error = false;
 
 static int child_liveness(pcmkd_child_t *child);
@@ -223,7 +221,7 @@ check_next_subdaemon(void *user_data)
             pcmk_process_exit(child);
             break;
         default:
-            pacemakerd_quit_main_loop(CRM_EX_FATAL);
+            pcmk__daemon_quit(&pacemakerd, CRM_EX_FATAL);
             return G_SOURCE_REMOVE;
     }
 
@@ -409,8 +407,8 @@ pcmk_shutdown_worker(void *user_data)
     }
 
     if (fatal_error) {
-        pacemakerd_quit_main_loop(CRM_EX_FATAL);
         pcmk__notice("Shutting down and staying down after fatal error");
+        pcmk__daemon_quit(&pacemakerd, CRM_EX_FATAL);
 
 #if SUPPORT_COROSYNC
         /* @FIXME Should this be moved to pacemakerd_cleanup?  This is the only
@@ -419,7 +417,7 @@ pcmk_shutdown_worker(void *user_data)
         pcmkd_shutdown_corosync();
 #endif
     } else {
-        pacemakerd_quit_main_loop(CRM_EX_OK);
+        pcmk__daemon_quit(&pacemakerd, CRM_EX_OK);
     }
 
     return G_SOURCE_REMOVE;

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -537,9 +537,15 @@ start_child(pcmkd_child_t * child)
         execlp(path, path, (char *) NULL);
     }
 
+    /* If we reach this point, execlp has failed.  It's okay to call crm_exit
+     * here to prevent the fork()ed child process from returning and continuing
+     * to run.
+     */
     free(path);
     pcmk__crit("Could not execute subdaemon %s: %s", name, strerror(errno));
     crm_exit(CRM_EX_FATAL);
+
+    // Never reached, but makes static analysis happy
     return pcmk_rc_ok;  // Never reached
 }
 

--- a/daemons/pacemakerd/pcmkd_subdaemons.c
+++ b/daemons/pacemakerd/pcmkd_subdaemons.c
@@ -107,7 +107,6 @@ static int start_child(pcmkd_child_t *child);
 static void pcmk_child_exit(mainloop_child_t *p, int core, int signo,
                             int exitcode);
 static void pcmk_process_exit(pcmkd_child_t *child);
-static gboolean pcmk_shutdown_worker(void *user_data);
 static void stop_child(pcmkd_child_t *child, int signal);
 
 static void
@@ -224,8 +223,8 @@ check_next_subdaemon(void *user_data)
             pcmk_process_exit(child);
             break;
         default:
-            crm_exit(CRM_EX_FATAL);
-            break;  /* static analysis/noreturn */
+            pacemakerd_quit_main_loop(CRM_EX_FATAL);
+            return G_SOURCE_REMOVE;
     }
 
     if (++next_child >= PCMK__NELEM(pcmk_children)) {
@@ -409,17 +408,21 @@ pcmk_shutdown_worker(void *user_data)
         return G_SOURCE_CONTINUE;
     }
 
-    g_main_loop_quit(mainloop);
-
     if (fatal_error) {
+        pacemakerd_quit_main_loop(CRM_EX_FATAL);
         pcmk__notice("Shutting down and staying down after fatal error");
+
 #if SUPPORT_COROSYNC
+        /* @FIXME Should this be moved to pacemakerd_cleanup?  This is the only
+         * caller, so maybe not.
+         */
         pcmkd_shutdown_corosync();
 #endif
-        crm_exit(CRM_EX_FATAL);
+    } else {
+        pacemakerd_quit_main_loop(CRM_EX_OK);
     }
 
-    return G_SOURCE_CONTINUE;
+    return G_SOURCE_REMOVE;
 }
 
 /* TODO once libqb is taught to juggle with IPC end-points carried over as

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -174,7 +174,10 @@ main(int argc, char **argv)
         goto done;
     }
 
-    schedulerd_ipc_init();
+    if (!schedulerd_ipc_init()) {
+        schedulerd.ec = CRM_EX_FATAL;
+        goto done;
+    }
 
     if (pcmk__log_output_new(&logger_out) != pcmk_rc_ok) {
         schedulerd.ec = CRM_EX_FATAL;

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -39,7 +39,6 @@ pcmk__output_t *logger_out = NULL;
 static pcmk__output_t *out = NULL;
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
-static GMainLoop *mainloop = NULL;
 static gchar **remainder = NULL;
 
 pcmk__supported_format_t formats[] = {
@@ -99,7 +98,7 @@ schedulerd_cleanup(void)
 static void
 schedulerd_shutdown(int nsig)
 {
-    g_main_loop_quit(mainloop);
+    pcmk__daemon_quit(&schedulerd, CRM_EX_OK);
 }
 
 int
@@ -118,7 +117,6 @@ main(int argc, char **argv)
     context = build_arg_context(args, &output_group);
 
     crm_log_preinit(NULL, argc, argv);
-    mainloop_add_signal(SIGTERM, schedulerd_shutdown);
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
@@ -186,12 +184,18 @@ main(int argc, char **argv)
     pcmk__register_lib_messages(logger_out);
     pcmk__output_set_log_level(logger_out, LOG_TRACE);
 
-    /* Create the mainloop and run it... */
-    mainloop = g_main_loop_new(NULL, FALSE);
-    pcmk__notice("Pacemaker scheduler successfully started and accepting "
-                 "connections");
-    g_main_loop_run(mainloop);
-    g_clear_pointer(&mainloop, g_main_loop_unref);
+    rc = pcmk__daemon_init(&schedulerd);
+    if (rc != pcmk_rc_ok) {
+        schedulerd.ec = CRM_EX_ERROR;
+        g_set_error(&error, PCMK__EXITC_ERROR, schedulerd.ec,
+                    "Error initializing daemon object: %s",
+                    pcmk_rc_str(rc));
+        goto done;
+    }
+
+    mainloop_add_signal(SIGTERM, schedulerd_shutdown);
+
+    pcmk__daemon_run(&schedulerd);
 
 done:
     schedulerd_cleanup();

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -36,6 +36,8 @@ struct {
 pcmk__output_t *logger_out = NULL;
 
 static pcmk__output_t *out = NULL;
+static gchar **processed_args = NULL;
+static GOptionContext *context = NULL;
 static GMainLoop *mainloop = NULL;
 static crm_exit_t exit_code = CRM_EX_OK;
 
@@ -80,6 +82,14 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     return context;
 }
 
+static void
+schedulerd_cleanup_cmdline(void)
+{
+    g_clear_pointer(&processed_args, g_strfreev);
+    g_clear_pointer(&context, g_option_context_free);
+    g_clear_pointer(&options.remainder, g_strfreev);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -87,9 +97,13 @@ main(int argc, char **argv)
     int rc = pcmk_rc_ok;
 
     GOptionGroup *output_group = NULL;
-    pcmk__common_args_t *args = pcmk__new_common_args(SUMMARY);
-    gchar **processed_args = pcmk__cmdline_preproc(argv, NULL);
-    GOptionContext *context = build_arg_context(args, &output_group);
+    pcmk__common_args_t *args = NULL;
+
+    atexit(schedulerd_cleanup_cmdline);
+
+    args = pcmk__new_common_args(SUMMARY);
+    processed_args = pcmk__cmdline_preproc(argv, NULL);
+    context = build_arg_context(args, &output_group);
 
     crm_log_preinit(NULL, argc, argv);
     mainloop_add_signal(SIGTERM, pengine_shutdown);
@@ -166,9 +180,6 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
 done:
-    g_strfreev(options.remainder);
-    g_strfreev(processed_args);
-    pcmk__free_arg_context(context);
 
     pcmk__output_and_clear_error(&error, out);
     pengine_shutdown(0);

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -29,13 +29,17 @@
 #define SUMMARY PCMK__SERVER_SCHEDULERD " - daemon for calculating a " \
                 "Pacemaker cluster's response to events"
 
+static pcmk__daemon_t schedulerd = {
+    .type = pcmk_ipc_schedulerd,
+    .ec = CRM_EX_OK,
+};
+
 pcmk__output_t *logger_out = NULL;
 
 static pcmk__output_t *out = NULL;
 static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
 static GMainLoop *mainloop = NULL;
-static crm_exit_t exit_code = CRM_EX_OK;
 static gchar **remainder = NULL;
 
 pcmk__supported_format_t formats[] = {
@@ -118,14 +122,15 @@ main(int argc, char **argv)
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
-        exit_code = CRM_EX_USAGE;
+        schedulerd.ec = CRM_EX_USAGE;
         goto done;
     }
 
     rc = pcmk__output_new(&out, args->output_ty, args->output_dest, argv);
     if ((rc != pcmk_rc_ok) || (out == NULL)) {
-        exit_code = CRM_EX_FATAL;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code, "Error creating output format %s: %s",
+        schedulerd.ec = CRM_EX_FATAL;
+        g_set_error(&error, PCMK__EXITC_ERROR, schedulerd.ec,
+                    "Error creating output format %s: %s",
                     args->output_ty, pcmk_rc_str(rc));
         goto done;
     }
@@ -139,14 +144,14 @@ main(int argc, char **argv)
 
             rc = scheduler_metadata(out);
             if (rc != pcmk_rc_ok) {
-                exit_code = CRM_EX_FATAL;
-                g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+                schedulerd.ec = CRM_EX_FATAL;
+                g_set_error(&error, PCMK__EXITC_ERROR, schedulerd.ec,
                             "Unable to display metadata: %s", pcmk_rc_str(rc));
             }
 
         } else {
-            exit_code = CRM_EX_USAGE;
-            g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+            schedulerd.ec = CRM_EX_USAGE;
+            g_set_error(&error, PCMK__EXITC_ERROR, schedulerd.ec,
                         "Unsupported extra command line parameters");
         }
         goto done;
@@ -164,8 +169,8 @@ main(int argc, char **argv)
     if (pcmk__daemon_can_write(PCMK_SCHEDULER_INPUT_DIR, NULL) == FALSE) {
         pcmk__err("Terminating due to bad permissions on "
                   PCMK_SCHEDULER_INPUT_DIR);
-        exit_code = CRM_EX_FATAL;
-        g_set_error(&error, PCMK__EXITC_ERROR, exit_code,
+        schedulerd.ec = CRM_EX_FATAL;
+        g_set_error(&error, PCMK__EXITC_ERROR, schedulerd.ec,
                     "ERROR: Bad permissions on %s (see logs for details)",
                     PCMK_SCHEDULER_INPUT_DIR);
         goto done;
@@ -174,7 +179,7 @@ main(int argc, char **argv)
     schedulerd_ipc_init();
 
     if (pcmk__log_output_new(&logger_out) != pcmk_rc_ok) {
-        exit_code = CRM_EX_FATAL;
+        schedulerd.ec = CRM_EX_FATAL;
         goto done;
     }
     pe__register_messages(logger_out);
@@ -194,15 +199,15 @@ done:
     pcmk__output_and_clear_error(&error, out);
 
     if (logger_out != NULL) {
-        logger_out->finish(logger_out, exit_code, true, NULL);
+        logger_out->finish(logger_out, schedulerd.ec, true, NULL);
         g_clear_pointer(&logger_out, pcmk__output_free);
     }
 
     if (out != NULL) {
-        out->finish(out, exit_code, true, NULL);
+        out->finish(out, schedulerd.ec, true, NULL);
         g_clear_pointer(&out, pcmk__output_free);
     }
 
     pcmk__unregister_formats();
-    crm_exit(exit_code);
+    crm_exit(schedulerd.ec);
 }

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -48,8 +48,6 @@ pcmk__supported_format_t formats[] = {
     { NULL, NULL, NULL }
 };
 
-void pengine_shutdown(int nsig);
-
 /* @COMPAT Deprecated since 2.1.8. Use pcmk_list_cluster_options() or
  * crm_attribute --list-options=cluster instead of querying daemon metadata.
  *
@@ -97,6 +95,12 @@ schedulerd_cleanup(void)
     schedulerd_unregister_handlers();
 }
 
+static void
+schedulerd_shutdown(int nsig)
+{
+    g_main_loop_quit(mainloop);
+}
+
 int
 main(int argc, char **argv)
 {
@@ -113,7 +117,7 @@ main(int argc, char **argv)
     context = build_arg_context(args, &output_group);
 
     crm_log_preinit(NULL, argc, argv);
-    mainloop_add_signal(SIGTERM, pengine_shutdown);
+    mainloop_add_signal(SIGTERM, schedulerd_shutdown);
 
     pcmk__register_formats(output_group, formats);
     if (!g_option_context_parse_strv(context, &processed_args, &error)) {
@@ -185,17 +189,13 @@ main(int argc, char **argv)
     pcmk__notice("Pacemaker scheduler successfully started and accepting "
                  "connections");
     g_main_loop_run(mainloop);
+    g_clear_pointer(&mainloop, g_main_loop_unref);
 
 done:
     schedulerd_cleanup();
 
     pcmk__output_and_clear_error(&error, out);
-    pengine_shutdown(0);
-}
 
-void
-pengine_shutdown(int nsig)
-{
     if (logger_out != NULL) {
         logger_out->finish(logger_out, exit_code, true, NULL);
         g_clear_pointer(&logger_out, pcmk__output_free);

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -90,6 +90,13 @@ schedulerd_cleanup_cmdline(void)
     g_clear_pointer(&options.remainder, g_strfreev);
 }
 
+static void
+schedulerd_cleanup(void)
+{
+    schedulerd_ipc_cleanup();
+    schedulerd_unregister_handlers();
+}
+
 int
 main(int argc, char **argv)
 {
@@ -180,6 +187,7 @@ main(int argc, char **argv)
     g_main_loop_run(mainloop);
 
 done:
+    schedulerd_cleanup();
 
     pcmk__output_and_clear_error(&error, out);
     pengine_shutdown(0);
@@ -188,9 +196,6 @@ done:
 void
 pengine_shutdown(int nsig)
 {
-    schedulerd_ipc_cleanup();
-    schedulerd_unregister_handlers();
-
     if (logger_out != NULL) {
         logger_out->finish(logger_out, exit_code, true, NULL);
         g_clear_pointer(&logger_out, pcmk__output_free);

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -29,10 +29,6 @@
 #define SUMMARY PCMK__SERVER_SCHEDULERD " - daemon for calculating a " \
                 "Pacemaker cluster's response to events"
 
-struct {
-    gchar **remainder;
-} options;
-
 pcmk__output_t *logger_out = NULL;
 
 static pcmk__output_t *out = NULL;
@@ -40,6 +36,7 @@ static gchar **processed_args = NULL;
 static GOptionContext *context = NULL;
 static GMainLoop *mainloop = NULL;
 static crm_exit_t exit_code = CRM_EX_OK;
+static gchar **remainder = NULL;
 
 pcmk__supported_format_t formats[] = {
     PCMK__SUPPORTED_FORMAT_NONE,
@@ -68,7 +65,7 @@ build_arg_context(pcmk__common_args_t *args, GOptionGroup **group) {
     GOptionContext *context = NULL;
 
     GOptionEntry extra_prog_entries[] = {
-        { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY, &options.remainder,
+        { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY, &remainder,
           NULL,
           NULL },
 
@@ -85,7 +82,7 @@ schedulerd_cleanup_cmdline(void)
 {
     g_clear_pointer(&processed_args, g_strfreev);
     g_clear_pointer(&context, g_option_context_free);
-    g_clear_pointer(&options.remainder, g_strfreev);
+    g_clear_pointer(&remainder, g_strfreev);
 }
 
 static void
@@ -136,9 +133,9 @@ main(int argc, char **argv)
     pe__register_messages(out);
     pcmk__register_lib_messages(out);
 
-    if (options.remainder) {
-        if (g_strv_length(options.remainder) == 1 &&
-            pcmk__str_eq("metadata", options.remainder[0], pcmk__str_casei)) {
+    if (remainder != NULL) {
+        if (g_strv_length(remainder) == 1 &&
+            pcmk__str_eq("metadata", remainder[0], pcmk__str_casei)) {
 
             rc = scheduler_metadata(out);
             if (rc != pcmk_rc_ok) {

--- a/daemons/schedulerd/pacemaker-schedulerd.c
+++ b/daemons/schedulerd/pacemaker-schedulerd.c
@@ -29,9 +29,14 @@
 #define SUMMARY PCMK__SERVER_SCHEDULERD " - daemon for calculating a " \
                 "Pacemaker cluster's response to events"
 
+static pcmk__daemon_ipc_fns_t ipc_fns = {
+    .already_running = pcmk__daemon_ipc_running,
+};
+
 static pcmk__daemon_t schedulerd = {
     .type = pcmk_ipc_schedulerd,
     .ec = CRM_EX_OK,
+    .ipc_fns = &ipc_fns,
 };
 
 pcmk__output_t *logger_out = NULL;
@@ -162,6 +167,16 @@ main(int argc, char **argv)
 
     pcmk__cli_init_logging(PCMK__SERVER_SCHEDULERD, args->verbosity);
     crm_log_init(NULL, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
+
+    if (schedulerd.ipc_fns->already_running(&schedulerd)) {
+        schedulerd.ec = CRM_EX_OK;
+        g_set_error(&error, PCMK__EXITC_ERROR, schedulerd.ec,
+                    "Aborting start-up because a scheduler instance is "
+                    "already active");
+        pcmk__crit("%s", error->message);
+        goto done;
+    }
+
     pcmk__notice("Starting Pacemaker scheduler");
 
     if (pcmk__daemon_can_write(PCMK_SCHEDULER_INPUT_DIR, NULL) == FALSE) {

--- a/daemons/schedulerd/pacemaker-schedulerd.h
+++ b/daemons/schedulerd/pacemaker-schedulerd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2025 the Pacemaker project contributors
+ * Copyright 2004-2026 the Pacemaker project contributors
  *
  * The version control history for this file may have further details.
  *
@@ -14,7 +14,7 @@
 
 extern pcmk__output_t *logger_out;
 
-void schedulerd_ipc_init(void);
+bool schedulerd_ipc_init(void);
 void schedulerd_ipc_cleanup(void);
 void schedulerd_unregister_handlers(void);
 void schedulerd_handle_request(pcmk__request_t *request);

--- a/daemons/schedulerd/schedulerd_ipc.c
+++ b/daemons/schedulerd/schedulerd_ipc.c
@@ -206,8 +206,9 @@ schedulerd_ipc_cleanup(void)
  * \internal
  * \brief Set up schedulerd IPC communication
  */
-void
+bool
 schedulerd_ipc_init(void)
 {
     pcmk__serve_schedulerd_ipc(&ipcs, &ipc_callbacks);
+    return ipcs != NULL;
 }

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -35,6 +35,10 @@ typedef struct {
     //! Is the daemon currently shutting down?
     bool shutting_down;
 
+    // NOTE: This is set by glib command line processing, hence gboolean
+    //! Is the daemon running in stand alone mode?
+    gboolean stand_alone;
+
     //! Main loop
     GMainLoop *mainloop;
 } pcmk__daemon_t;

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -25,11 +25,30 @@
 extern "C" {
 #endif
 
+typedef struct pcmk__daemon_s pcmk__daemon_t;
+
+/*!
+ * \internal
+ * \brief Daemon-specific IPC operations
+ */
+typedef struct {
+    /*!
+     * \internal
+     * \brief Determine if an instance of an IPC server is already running
+     *
+     * \param[in,out] d The daemon object
+     *
+     * \return \c true if an instance of the daemon is already running, and
+     *         \c false if not
+     */
+    bool (*already_running)(pcmk__daemon_t *);
+} pcmk__daemon_ipc_fns_t;
+
 /*!
  * \internal
  * \brief This structure describes and manages a single pacemaker daemon
  */
-typedef struct {
+struct pcmk__daemon_s {
     //! Daemon type, indexed by the IPC enum
     enum pcmk_ipc_server type;
 
@@ -45,7 +64,13 @@ typedef struct {
 
     //! Main loop
     GMainLoop *mainloop;
-} pcmk__daemon_t;
+
+    const pcmk__daemon_ipc_fns_t *ipc_fns;
+};
+
+// IPC functions
+
+bool pcmk__daemon_ipc_running(pcmk__daemon_t *srv);
 
 // Mainloop management functions
 

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#ifndef PCMK__INCLUDED_CRM_COMMON_INTERNAL_H
+#error "Include <crm/common/internal.h> instead of <daemon_internal.h> directly"
+#endif
+
+#ifndef PCMK__CRM_COMMON_DAEMON_INTERNAL__H
+#define PCMK__CRM_COMMON_DAEMON_INTERNAL__H
+
+#include <glib.h>               // GMainLoop
+
+#include <crm/common/ipc.h>     // pcmk_ipc_server
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*!
+ * \internal
+ * \brief This structure describes and manages a single pacemaker daemon
+ */
+typedef struct {
+    //! Daemon type, indexed by the IPC enum
+    enum pcmk_ipc_server type;
+
+    //! Main loop
+    GMainLoop *mainloop;
+} pcmk__daemon_t;
+
+// Mainloop management functions
+
+int pcmk__daemon_init(pcmk__daemon_t *srv);
+void pcmk__daemon_quit(pcmk__daemon_t *srv);
+void pcmk__daemon_run(pcmk__daemon_t *srv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCMK__CRM_COMMON_DAEMON_INTERNAL__H

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -29,6 +29,27 @@ typedef struct pcmk__daemon_s pcmk__daemon_t;
 
 /*!
  * \internal
+ * \brief Daemon-specific general operations
+ */
+typedef struct {
+    /*!
+     * \internal
+     * \brief Perform daemon-specific quitting tasks
+     *
+     * This function should not perform any cleanup or memory freeing tasks.
+     * It is meant to terminate anything that needs to happen before the
+     * main loop quits, as well as to determine whether or not that happens
+     * at all.
+     *
+     * \param[in,out] srv The daemon object
+     *
+     * \return \c true if quitting should continue, and \c false if not
+     */
+    bool (*quit)(pcmk__daemon_t *);
+} pcmk__daemon_fns_t;
+
+/*!
+ * \internal
  * \brief Daemon-specific IPC operations
  */
 typedef struct {
@@ -64,6 +85,8 @@ struct pcmk__daemon_s {
 
     //! Main loop
     GMainLoop *mainloop;
+
+    const pcmk__daemon_fns_t *fns;
 
     const pcmk__daemon_ipc_fns_t *ipc_fns;
 };

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -19,6 +19,7 @@
 #include <glib.h>               // GMainLoop
 
 #include <crm/common/ipc.h>     // pcmk_ipc_server
+#include <crm/common/results.h> // crm_exit_t
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,6 +39,9 @@ typedef struct {
     // NOTE: This is set by glib command line processing, hence gboolean
     //! Is the daemon running in stand alone mode?
     gboolean stand_alone;
+
+    //! What is the exit code of the daemon?
+    crm_exit_t ec;
 
     //! Main loop
     GMainLoop *mainloop;

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -15,6 +15,7 @@
 #define PCMK__CRM_COMMON_DAEMON_INTERNAL__H
 
 #include <stdbool.h>            // bool
+#include <time.h>               // time_t
 
 #include <glib.h>               // GMainLoop
 
@@ -79,6 +80,9 @@ struct pcmk__daemon_s {
     // NOTE: This is set by glib command line processing, hence gboolean
     //! Is the daemon running in stand alone mode?
     gboolean stand_alone;
+
+    //! When did the daemon start running?
+    time_t start_time;
 
     //! What is the exit code of the daemon?
     crm_exit_t ec;

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -50,7 +50,7 @@ typedef struct {
 // Mainloop management functions
 
 int pcmk__daemon_init(pcmk__daemon_t *srv);
-void pcmk__daemon_quit(pcmk__daemon_t *srv);
+void pcmk__daemon_quit(pcmk__daemon_t *srv, crm_exit_t ec);
 void pcmk__daemon_run(pcmk__daemon_t *srv);
 
 #ifdef __cplusplus

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -14,6 +14,8 @@
 #ifndef PCMK__CRM_COMMON_DAEMON_INTERNAL__H
 #define PCMK__CRM_COMMON_DAEMON_INTERNAL__H
 
+#include <stdbool.h>            // bool
+
 #include <glib.h>               // GMainLoop
 
 #include <crm/common/ipc.h>     // pcmk_ipc_server
@@ -29,6 +31,9 @@ extern "C" {
 typedef struct {
     //! Daemon type, indexed by the IPC enum
     enum pcmk_ipc_server type;
+
+    //! Is the daemon currently shutting down?
+    bool shutting_down;
 
     //! Main loop
     GMainLoop *mainloop;

--- a/include/crm/common/daemon_internal.h
+++ b/include/crm/common/daemon_internal.h
@@ -98,6 +98,7 @@ struct pcmk__daemon_s {
 // IPC functions
 
 bool pcmk__daemon_ipc_running(pcmk__daemon_t *srv);
+bool pcmk__generic_ipc_running(pcmk__daemon_t *srv);
 
 // Mainloop management functions
 

--- a/include/crm/common/internal.h
+++ b/include/crm/common/internal.h
@@ -23,6 +23,7 @@
 #include <crm/common/cib_secrets_internal.h>
 #include <crm/common/clone_internal.h>
 #include <crm/common/cmdline_internal.h>
+#include <crm/common/daemon_internal.h>
 #include <crm/common/digest_internal.h>
 #include <crm/common/failcounts_internal.h>
 #include <crm/common/flags_internal.h>

--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -56,6 +56,7 @@ if BUILD_CIBSECRETS
 libcrmcommon_la_SOURCES	+= cib_secrets.c
 endif
 libcrmcommon_la_SOURCES	+= cmdline.c
+libcrmcommon_la_SOURCES	+= daemon.c
 libcrmcommon_la_SOURCES	+= digest.c
 libcrmcommon_la_SOURCES	+= health.c
 libcrmcommon_la_SOURCES	+= io.c

--- a/lib/common/daemon.c
+++ b/lib/common/daemon.c
@@ -9,6 +9,7 @@
 
 #include <crm_internal.h>
 
+#include <signal.h>                 // SIG*
 #include <stdbool.h>                // false
 #include <stddef.h>                 // NULL
 
@@ -36,11 +37,31 @@ pcmk__daemon_init(pcmk__daemon_t *srv)
  * \internal
  * \brief Quit the daemon's main loop
  *
- * \param[in,out] srv The daemon object
+ * \param[in,out] srv  The daemon object
+ * \param[in]     ec   The exit code to assign to the daemon
  */
 void
-pcmk__daemon_quit(pcmk__daemon_t *srv)
+pcmk__daemon_quit(pcmk__daemon_t *srv, crm_exit_t ec)
 {
+    if (srv->shutting_down) {
+        return;
+    }
+
+    pcmk__info("Shutting down %s", pcmk__server_log_name(srv->type));
+
+    // Tell various functions not to do anything
+    srv->shutting_down = true;
+
+    srv->ec = ec;
+
+    // Don't respond to signals while shutting down
+    mainloop_destroy_signal(SIGTERM);
+    mainloop_destroy_signal(SIGCHLD);
+    mainloop_destroy_signal(SIGPIPE);
+    mainloop_destroy_signal(SIGUSR1);
+    mainloop_destroy_signal(SIGUSR2);
+    mainloop_destroy_signal(SIGTRAP);
+
     CRM_CHECK((srv->mainloop != NULL) && g_main_loop_is_running(srv->mainloop),
               return);
 

--- a/lib/common/daemon.c
+++ b/lib/common/daemon.c
@@ -12,6 +12,7 @@
 #include <signal.h>                 // SIG*
 #include <stddef.h>                 // NULL
 #include <stdbool.h>                // bool, false, true
+#include <time.h>                   // time
 
 #include <glib.h>                   // g_clear_pointer, g_main_loop_*
 
@@ -30,6 +31,8 @@
 int
 pcmk__daemon_init(pcmk__daemon_t *srv)
 {
+    srv->start_time = time(NULL);
+
     srv->mainloop = g_main_loop_new(NULL, false);
     return pcmk_rc_ok;
 }

--- a/lib/common/daemon.c
+++ b/lib/common/daemon.c
@@ -16,7 +16,7 @@
 
 #include <glib.h>                   // g_clear_pointer, g_main_loop_*
 
-#include <crm/common/ipc.h>         // pcmk_ipc_api_t, pcmk_*_ipc_api
+#include <crm/common/ipc.h>         // crm_ipc_*, pcmk_ipc_api_t, pcmk_*_ipc_api
 #include <crm/common/logging.h>     // CRM_CHECK
 #include <crm/common/results.h>     // CRM_EX_*, crm_exit, pcmk_rc_*
 
@@ -130,4 +130,44 @@ pcmk__daemon_run(pcmk__daemon_t *srv)
                  pcmk__server_log_name(srv->type));
     g_main_loop_run(srv->mainloop);
     g_clear_pointer(&srv->mainloop, g_main_loop_unref);
+}
+
+/*!
+ * \internal
+ * \brief Determine if an instance of an IPC server is already running
+ *
+ * \param[in,out] srv The daemon object
+ *
+ * \return \c true if an instance of \p srv is already running, and \c false if not
+ *
+ * \note This function only works for older daemons that have not yet been
+ *       converted to use the \c pcmk_ipc_api_t client interface.  Once all have
+ *       been updated, this function can be removed.
+ */
+bool
+pcmk__generic_ipc_running(pcmk__daemon_t *srv)
+{
+    const char *ipc_name = pcmk__server_ipc_name(srv->type);
+    crm_ipc_t *old_instance = NULL;
+    int rc = pcmk_rc_ok;
+
+    old_instance = crm_ipc_new(ipc_name, 0);
+    if (old_instance == NULL) {
+        /* This is an error - memory allocation failed, etc. - but crm_ipc_new
+         * will have already logged an error message.
+         */
+        return false;
+    }
+
+    rc = pcmk__connect_generic_ipc(old_instance);
+    if (rc != pcmk_rc_ok) {
+        pcmk__debug("No existing %s instance found: %s", ipc_name,
+                    pcmk_rc_str(rc));
+        crm_ipc_destroy(old_instance);
+        return false;
+    }
+
+    crm_ipc_close(old_instance);
+    crm_ipc_destroy(old_instance);
+    return true;
 }

--- a/lib/common/daemon.c
+++ b/lib/common/daemon.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the Pacemaker project contributors
+ *
+ * The version control history for this file may have further details.
+ *
+ * This source code is licensed under the GNU Lesser General Public License
+ * version 2.1 or later (LGPLv2.1+) WITHOUT ANY WARRANTY.
+ */
+
+#include <crm_internal.h>
+
+#include <stdbool.h>                // false
+#include <stddef.h>                 // NULL
+
+#include <glib.h>                   // g_clear_pointer, g_main_loop_*
+
+#include <crm/common/logging.h>     // CRM_CHECK
+#include <crm/common/results.h>     // CRM_EX_*, crm_exit, pcmk_rc_*
+
+/*!
+ * \internal
+ * \brief Initialize a previously allocated daemon object
+ *
+ * \param[in,out] srv The daemon object
+ *
+ * \return Standard Pacemaker return code
+ */
+int
+pcmk__daemon_init(pcmk__daemon_t *srv)
+{
+    srv->mainloop = g_main_loop_new(NULL, false);
+    return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Quit the daemon's main loop
+ *
+ * \param[in,out] srv The daemon object
+ */
+void
+pcmk__daemon_quit(pcmk__daemon_t *srv)
+{
+    CRM_CHECK((srv->mainloop != NULL) && g_main_loop_is_running(srv->mainloop),
+              return);
+
+    g_main_loop_quit(srv->mainloop);
+}
+
+/*!
+ * \internal
+ * \brief Run a daemon
+ *
+ * \param[in,out] srv The daemon object
+ */
+void
+pcmk__daemon_run(pcmk__daemon_t *srv)
+{
+    pcmk__notice("Pacemaker %s successfully started and accepting connections",
+                 pcmk__server_log_name(srv->type));
+    g_main_loop_run(srv->mainloop);
+    g_clear_pointer(&srv->mainloop, g_main_loop_unref);
+}

--- a/lib/common/daemon.c
+++ b/lib/common/daemon.c
@@ -87,6 +87,12 @@ pcmk__daemon_quit(pcmk__daemon_t *srv, crm_exit_t ec)
         return;
     }
 
+    if ((srv->fns != NULL) && (srv->fns->quit != NULL)) {
+        if (!srv->fns->quit(srv)) {
+            return;
+        }
+    }
+
     pcmk__info("Shutting down %s", pcmk__server_log_name(srv->type));
 
     // Tell various functions not to do anything

--- a/lib/common/daemon.c
+++ b/lib/common/daemon.c
@@ -10,11 +10,12 @@
 #include <crm_internal.h>
 
 #include <signal.h>                 // SIG*
-#include <stdbool.h>                // false
 #include <stddef.h>                 // NULL
+#include <stdbool.h>                // bool, false, true
 
 #include <glib.h>                   // g_clear_pointer, g_main_loop_*
 
+#include <crm/common/ipc.h>         // pcmk_ipc_api_t, pcmk_*_ipc_api
 #include <crm/common/logging.h>     // CRM_CHECK
 #include <crm/common/results.h>     // CRM_EX_*, crm_exit, pcmk_rc_*
 
@@ -31,6 +32,45 @@ pcmk__daemon_init(pcmk__daemon_t *srv)
 {
     srv->mainloop = g_main_loop_new(NULL, false);
     return pcmk_rc_ok;
+}
+
+/*!
+ * \internal
+ * \brief Determine if an instance of an IPC server is already running
+ *
+ * \param[in,out] srv The daemon object
+ *
+ * \return \c true if an instance of \p srv is already running, and \c false if not
+ *
+ * \note This function can be used to determine if a daemon is up and running
+ *       since all daemons use IPC.
+ *
+ * \note This function only works for those daemons that have been converted
+ *       to use \c pcmk_ipc_api_t as the client interface.  Older daemons will
+ *       have to use their own daemon specific method to figure this out.
+ */
+bool
+pcmk__daemon_ipc_running(pcmk__daemon_t *srv)
+{
+    pcmk_ipc_api_t *old_instance = NULL;
+    int rc = pcmk_rc_ok;
+
+    rc = pcmk_new_ipc_api(&old_instance, srv->type);
+    if (rc != pcmk_rc_ok) {
+        return false;
+    }
+
+    rc = pcmk__connect_ipc(old_instance, pcmk_ipc_dispatch_sync, 2);
+    if (rc != pcmk_rc_ok) {
+        pcmk__debug("No existing %s instance found: %s",
+                    pcmk_ipc_name(old_instance, true), pcmk_rc_str(rc));
+        pcmk_free_ipc_api(old_instance);
+        return false;
+    }
+
+    pcmk_disconnect_ipc(old_instance);
+    pcmk_free_ipc_api(old_instance);
+    return true;
 }
 
 /*!

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1217,9 +1217,6 @@ pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
  *
  * \param[out] ipcs  Where to store newly created IPC server
  * \param[in]  cb    IPC callbacks
- *
- * \return Newly created IPC server
- * \note This function exits fatally on error.
  */
 void
 pcmk__serve_schedulerd_ipc(qb_ipcs_service_t **ipcs,
@@ -1233,6 +1230,5 @@ pcmk__serve_schedulerd_ipc(qb_ipcs_service_t **ipcs,
     if (*ipcs == NULL) {
         pcmk__crit("Failed to create %s IPC server; shutting down",
                    pcmk__server_log_name(pcmk_ipc_schedulerd));
-        crm_exit(CRM_EX_FATAL);
     }
 }

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1169,8 +1169,6 @@ pcmk__serve_execd_ipc(qb_ipcs_service_t **ipcs,
  *
  * \param[out] ipcs  Where to store newly created IPC server
  * \param[in]  cb    IPC callbacks
- *
- * \note This function exits fatally on error.
  */
 void
 pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
@@ -1186,7 +1184,6 @@ pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
                    pcmk__server_log_name(pcmk_ipc_fenced));
         pcmk__crit("Verify pacemaker and pacemaker_remote are not both "
                    "enabled");
-        crm_exit(CRM_EX_FATAL);
     }
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1193,8 +1193,6 @@ pcmk__serve_fenced_ipc(qb_ipcs_service_t **ipcs,
  *
  * \param[out] ipcs  Where to store newly created IPC server
  * \param[in]  cb    IPC callbacks
- *
- * \note This function exits with CRM_EX_OSERR on error.
  */
 void
 pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
@@ -1210,13 +1208,6 @@ pcmk__serve_pacemakerd_ipc(qb_ipcs_service_t **ipcs,
                    pcmk__server_log_name(pcmk_ipc_pacemakerd));
         pcmk__crit("Verify pacemaker and pacemaker_remote are not both "
                    "enabled");
-
-        /* sub-daemons are observed by pacemakerd. Thus we exit CRM_EX_FATAL
-         * if we want to prevent pacemakerd from restarting them.
-         * With pacemakerd we leave the exit-code shown to e.g. systemd
-         * to what it was prior to moving the code here from pacemakerd.c
-         */
-        crm_exit(CRM_EX_OSERR);
     }
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1065,8 +1065,6 @@ pcmk__ipc_send_ack_as(const char *function, int line, pcmk__client_t *c,
  * \param[out] ipcs_rw   New IPC server for read/write CIB manager API
  * \param[in]  ro_cb     IPC callbacks for read-only API
  * \param[in]  rw_cb     IPC callbacks for read/write and shared-memory APIs
- *
- * \note This function exits fatally on error.
  */
 void
 pcmk__serve_based_ipc(qb_ipcs_service_t **ipcs_ro, qb_ipcs_service_t **ipcs_rw,
@@ -1087,7 +1085,6 @@ pcmk__serve_based_ipc(qb_ipcs_service_t **ipcs_ro, qb_ipcs_service_t **ipcs_rw,
                    pcmk__server_log_name(pcmk_ipc_based));
         pcmk__crit("Verify pacemaker and pacemaker_remote are not both "
                    "enabled");
-        crm_exit(CRM_EX_FATAL);
     }
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1125,8 +1125,6 @@ pcmk__serve_controld_ipc(qb_ipcs_service_t **ipcs,
  *
  * \param[out] ipcs  Where to store newly created IPC server
  * \param[in]  cb    IPC callbacks
- *
- * \note This function exits fatally on error.
  */
 void
 pcmk__serve_attrd_ipc(qb_ipcs_service_t **ipcs,
@@ -1142,7 +1140,6 @@ pcmk__serve_attrd_ipc(qb_ipcs_service_t **ipcs,
                    pcmk__server_log_name(pcmk_ipc_attrd));
         pcmk__crit("Verify pacemaker and pacemaker_remote are not both "
                    "enabled");
-        crm_exit(CRM_EX_FATAL);
     }
 }
 

--- a/lib/common/ipc_server.c
+++ b/lib/common/ipc_server.c
@@ -1149,8 +1149,6 @@ pcmk__serve_attrd_ipc(qb_ipcs_service_t **ipcs,
  *
  * \param[out] ipcs  Where to store newly created IPC server
  * \param[in]  cb    IPC callbacks
- *
- * \note This function exits fatally on error.
  */
 void
 pcmk__serve_execd_ipc(qb_ipcs_service_t **ipcs,
@@ -1162,7 +1160,6 @@ pcmk__serve_execd_ipc(qb_ipcs_service_t **ipcs,
     if (*ipcs == NULL) {
         pcmk__crit("Failed to create %s IPC server; shutting down",
                    pcmk__server_log_name(pcmk_ipc_execd));
-        crm_exit(CRM_EX_FATAL);
     }
 }
 


### PR DESCRIPTION
This is the beginnings of condensing all the IPC/CPG code across daemons.  I haven't touched based (given #4011) or controld (given we haven't started on that), but all other daemons are addressed.  This will need some modification in light of #4154, but that doesn't prevent the rest from being reviewed.