### PR TITLE
Fix: controller: Avoid double-free from fail_pending_op()

### DIFF
--- a/daemons/controld/controld_execd_state.c
+++ b/daemons/controld/controld_execd_state.c
@@ -73,7 +73,7 @@ fail_pending_op(void *key, void *value, void *user_data)
 
     event->call_id = op->call_id;
     event->remote_nodename = pcmk__str_copy(lrm_state->node_name);
-    event->params = op->params;
+    event->params = pcmk__str_table_dup(op->params);
 
     process_lrm_event(lrm_state, event, op, NULL);
     lrmd_free_event(event);


### PR DESCRIPTION
This fixes a regression introduced by e23d1b6. It has not made it into any release.

As of that commit, `event` in `fail_pending_op()` takes shared ownership of `op->params`. When `lrmd_free_event()` frees `event`, it destroys the `event->params` table (which is also the `op->params` table).

However, `fail_pending_op()` returns `TRUE`, which tells `g_hash_table_foreach_remove()` to free `op` after `fail_pending_op()` returns. It does this by calling `free_recurring_op()`, which destroys the `op->params` table again.

This double free causes a GLib memory error, and the program terminates. Below is a partial backtrace to illustrate the issue.

```
g_malloc0 (n_bytes=11828847412100) at ../glib/gmem.c:138
g_hash_table_resize (hash_table=0x561590a468d0 = {...}) at ../glib/ghash.c:832
g_hash_table_destroy (hash_table=0x561590a468d0 = {...}) at ../glib/ghash.c:1463
free_recurring_op (value=0x561590b61a10) at daemons/controld/controld_execd_state.c:51
g_hash_table_foreach_remove_or_steal (hash_table=0x561590b47a10 = {...}, func=func@entry=0x56157e300000 <fail_pending_op>,
    user_data=user_data@entry=0x561590a38740, notify=notify@entry=1) at ../glib/ghash.c:2011
g_hash_table_foreach_remove (hash_table=<optimized out>, func=func@entry=0x56157e300000 <fail_pending_op>,
    user_data=user_data@entry=0x561590a38740) at ../glib/ghash.c:2055
lrm_state_disconnect_only (lrm_state=0x561590a38740)
    at daemons/controld/controld_execd_state.c:249
lrm_state_disconnect (lrm_state=0x561590a38740)
    at daemons/controld/controld_execd_state.c:259
```

We observed this issue in the `RemoteStonithd` cts-lab test.