### PR TITLE
F46 issues

### DIFF
--- a/lib/common/Makefile.am
+++ b/lib/common/Makefile.am
@@ -124,6 +124,7 @@ libcrmcommon_test_la_SOURCES	+= unittest.c
 libcrmcommon_test_la_LDFLAGS = $(libcrmcommon_la_LDFLAGS)
 libcrmcommon_test_la_LDFLAGS += -rpath $(libdir)
 libcrmcommon_test_la_LDFLAGS += $(LDFLAGS_WRAP)
+libcrmcommon_test_la_LDFLAGS += -Wno-error=aggregate-return
 
 # If GCC emits a builtin function in place of something we've mocked up, that will
 # get used instead of the mocked version which leads to unexpected test results.  So
@@ -134,6 +135,7 @@ libcrmcommon_test_la_CFLAGS = $(libcrmcommon_la_CFLAGS)
 libcrmcommon_test_la_CFLAGS += -DPCMK__UNIT_TESTING
 libcrmcommon_test_la_CFLAGS += -fno-builtin
 libcrmcommon_test_la_CFLAGS += -fno-inline
+libcrmcommon_test_la_CFLAGS += -Wno-error=aggregate-return
 
 # If -fno-builtin is used, -lm also needs to be added.  See the comment at
 # BUILD_PROFILING above.


### PR DESCRIPTION
address build issues coming up with recent Fedora builds

- cmocka uses aggregate returns and thus with new build flag -Waggregate-return build is failing
- the py3_... macros are deprecated and should have disappeared by Fedora 45 - still working in current rawhide (46) ...